### PR TITLE
fix(il): nest generated function object wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ For older release lines, browse [`docs/archive/changelog/Index.md`](docs/archive
 
 ## Unreleased
 
+- compiler/IL: nest generated function-object wrappers under their canonical
+  callable or class owner type, eliminating detached `FunctionObjects.*`
+  namespaces for ordinary functions and class methods.
 - compiler/IL: emit each generated arrow function wrapper as a readable
   `FunctionObject` nested under its canonical `ArrowFunction_*` owner instead
   of a standalone hashed `FunctionObjects.*` type.

--- a/src/Compiler/Services/TwoPhaseCompilation/GeneratedFunctionObjectEmitter.cs
+++ b/src/Compiler/Services/TwoPhaseCompilation/GeneratedFunctionObjectEmitter.cs
@@ -108,9 +108,7 @@ internal sealed class GeneratedFunctionObjectEmitter
                 : default;
 
             var typeHandle = typeBuilder.AddTypeDefinition(
-                (plan.Callable.Kind == CallableKind.Arrow
-                    ? TypeAttributes.NestedPublic
-                    : TypeAttributes.NotPublic)
+                TypeAttributes.NestedPublic
                 | TypeAttributes.Class
                 | TypeAttributes.Sealed
                 | TypeAttributes.BeforeFieldInit,
@@ -127,10 +125,7 @@ internal sealed class GeneratedFunctionObjectEmitter
 
             var canonicalBody = (MethodDefinitionHandle)bodyToken;
             var ownerType = ResolveCanonicalOwnerType(plan);
-            if (plan.Callable.Kind == CallableKind.Arrow)
-            {
-                _nestedTypeRegistry.Add(typeHandle, ownerType);
-            }
+            _nestedTypeRegistry.Add(typeHandle, ownerType);
             _functionObjectRegistry.SetMetadata(new GeneratedFunctionObjectMetadata
             {
                 Plan = plan,

--- a/src/Compiler/Services/TwoPhaseCompilation/GeneratedFunctionObjectPlanner.cs
+++ b/src/Compiler/Services/TwoPhaseCompilation/GeneratedFunctionObjectPlanner.cs
@@ -20,9 +20,7 @@ internal static class GeneratedFunctionObjectPlanner
         {
             Callable = callable,
             Signature = signature,
-            Namespace = callable.Kind == CallableKind.Arrow
-                ? string.Empty
-                : $"FunctionObjects.{Sanitize(symbolTable.Root.Name)}_{StableSuffix(symbolTable.Root.Name)}",
+            Namespace = string.Empty,
             ModuleName = symbolTable.Root.Name,
             TypeName = callable.Kind == CallableKind.Arrow
                 ? GeneratedFunctionObjectNaming.WrapperTypeName

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262Bootstrap.verified.txt
@@ -195,6 +195,119 @@
 
 		} // end of class Scope_For_L18C7
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5527
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/parseArgs/FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5536
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5539
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x553c
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/parseArgs/FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Compile_Scripts_Test262Bootstrap/parseArgs::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5555
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/parseArgs/FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Compile_Scripts_Test262Bootstrap/parseArgs::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x556a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs
+
 
 		// Methods
 		.method public hidebysig static 
@@ -513,6 +626,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CEC314BF_printHelp
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5579
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_CEC314BF_printHelp::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5581
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CEC314BF_printHelp::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5584
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CEC314BF_printHelp::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5587
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Compile_Scripts_Test262Bootstrap/printHelp::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_CEC314BF_printHelp::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5593
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Compile_Scripts_Test262Bootstrap/printHelp::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_CEC314BF_printHelp::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x559b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_CEC314BF_printHelp::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_CEC314BF_printHelp
+
 
 		// Methods
 		.method public hidebysig static 
@@ -622,6 +830,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_67E87462_defaultPinPath
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x55aa
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath/FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x55b9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x55bc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x55bf
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath/FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x55d1
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath/FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x55df
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_67E87462_defaultPinPath
 
 
 		// Methods
@@ -770,6 +1085,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x55ee
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd/FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x55fd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5600
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5603
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd/FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x561c
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd/FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5631
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd
+
 
 		// Methods
 		.method public hidebysig static 
@@ -894,6 +1322,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5640
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5648
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x564b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x564e
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5661
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5670
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath
+
 
 		// Methods
 		.method public hidebysig static 
@@ -956,6 +1485,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x567f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath/FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x568e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5691
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5694
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath/FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x56ad
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath/FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x56c2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath
 
 
 		// Methods
@@ -1071,6 +1713,115 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_90DD1216_ensureString
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x56d1
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_90DD1216_ensureString::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x56d9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_90DD1216_ensureString::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x56dc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_90DD1216_ensureString::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x56df
+				// Header size: 1
+				// Code size: 30 (0x1e)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0018: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, string)
+				IL_001d: ret
+			} // end of method FunctionObject_FunctionDeclaration_90DD1216_ensureString::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x56fe
+				// Header size: 1
+				// Code size: 26 (0x1a)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0014: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, string)
+				IL_0019: ret
+			} // end of method FunctionObject_FunctionDeclaration_90DD1216_ensureString::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5719
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_90DD1216_ensureString::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_90DD1216_ensureString
 
 
 		// Methods
@@ -1279,6 +2030,115 @@
 			} // end of method Scope_ForOf_L106C7::.ctor
 
 		} // end of class Scope_ForOf_L106C7
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5728
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5730
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5733
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5736
+				// Header size: 1
+				// Code size: 30 (0x1e)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0018: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, string)
+				IL_001d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5755
+				// Header size: 1
+				// Code size: 26 (0x1a)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0014: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, string)
+				IL_0019: ret
+			} // end of method FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5770
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray
 
 
 		// Methods
@@ -1587,6 +2447,119 @@
 
 		} // end of class Scope_ForOf_L116C7
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x577f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x578e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5791
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5794
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x57ad
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x57c2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1800,6 +2773,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4A573BF6_validatePin
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x57d1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/validatePin/FunctionObject_FunctionDeclaration_4A573BF6_validatePin::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4A573BF6_validatePin::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x57e0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4A573BF6_validatePin::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x57e3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4A573BF6_validatePin::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x57e6
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/validatePin/FunctionObject_FunctionDeclaration_4A573BF6_validatePin::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Compile_Scripts_Test262Bootstrap/validatePin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_4A573BF6_validatePin::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x57ff
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/validatePin/FunctionObject_FunctionDeclaration_4A573BF6_validatePin::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Compile_Scripts_Test262Bootstrap/validatePin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_4A573BF6_validatePin::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5814
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4A573BF6_validatePin::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_4A573BF6_validatePin
 
 
 		// Methods
@@ -2356,6 +3442,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_62753EAC_loadPin
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5823
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/loadPin/FunctionObject_FunctionDeclaration_62753EAC_loadPin::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_62753EAC_loadPin::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5832
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_62753EAC_loadPin::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5835
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_62753EAC_loadPin::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5838
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/loadPin/FunctionObject_FunctionDeclaration_62753EAC_loadPin::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Compile_Scripts_Test262Bootstrap/loadPin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_62753EAC_loadPin::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5851
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/loadPin/FunctionObject_FunctionDeclaration_62753EAC_loadPin::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Compile_Scripts_Test262Bootstrap/loadPin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_62753EAC_loadPin::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5866
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_62753EAC_loadPin::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_62753EAC_loadPin
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2456,6 +3655,125 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5875
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot/FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5884
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5887
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x588a
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot/FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x58aa
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot/FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x58c6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot
 
 
 		// Methods
@@ -2576,6 +3894,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x58d5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel/FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x58e4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x58e7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x58ea
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel/FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5903
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel/FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5918
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel
 
 
 		// Methods
@@ -2719,6 +4150,125 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5927
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot/FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5936
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5939
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x593c
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot/FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x595c
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot/FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5978
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot
 
 
 		// Methods
@@ -2899,6 +4449,125 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5987
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/describePlan/FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5996
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5999
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x599c
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/describePlan/FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Compile_Scripts_Test262Bootstrap/describePlan::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x59bc
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/describePlan/FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Compile_Scripts_Test262Bootstrap/describePlan::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x59d8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan
 
 
 		// Methods
@@ -3344,6 +5013,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x59e7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/ensureDir/FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x59f6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x59f9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x59fc
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/ensureDir/FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Compile_Scripts_Test262Bootstrap/ensureDir::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5a15
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/ensureDir/FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Compile_Scripts_Test262Bootstrap/ensureDir::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5a2a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir
+
 
 		// Methods
 		.method public hidebysig static 
@@ -3454,6 +5236,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_313C5150_removeDir
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5a39
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/removeDir/FunctionObject_FunctionDeclaration_313C5150_removeDir::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_313C5150_removeDir::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5a48
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_313C5150_removeDir::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5a4b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_313C5150_removeDir::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5a4e
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/removeDir/FunctionObject_FunctionDeclaration_313C5150_removeDir::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Compile_Scripts_Test262Bootstrap/removeDir::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_313C5150_removeDir::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5a67
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/removeDir/FunctionObject_FunctionDeclaration_313C5150_removeDir::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Compile_Scripts_Test262Bootstrap/removeDir::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_313C5150_removeDir::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5a7c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_313C5150_removeDir::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_313C5150_removeDir
 
 
 		// Methods
@@ -3627,6 +5522,125 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C8C56586_runGit
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5a8b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/runGit/FunctionObject_FunctionDeclaration_C8C56586_runGit::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8C56586_runGit::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5a9a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8C56586_runGit::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5a9d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8C56586_runGit::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5aa0
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/runGit/FunctionObject_FunctionDeclaration_C8C56586_runGit::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8C56586_runGit::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5ac0
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/runGit/FunctionObject_FunctionDeclaration_C8C56586_runGit::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8C56586_runGit::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5adc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8C56586_runGit::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C8C56586_runGit
 
 
 		// Methods
@@ -4023,6 +6037,119 @@
 			} // end of method Scope_ForOf_L251C7::.ctor
 
 		} // end of class Scope_ForOf_L251C7
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5aeb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns/FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5afa
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5afd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5b00
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns/FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5b19
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns/FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5b2e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns
 
 
 		// Methods
@@ -4469,6 +6596,125 @@
 			} // end of method Scope_ForOf_L271C7::.ctor
 
 		} // end of class Scope_ForOf_L271C7
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5b3d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5b4c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5b4f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5b52
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5b72
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5b8e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot
 
 
 		// Methods
@@ -5316,6 +7562,131 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5b9d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5bac
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5baf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5bb2
+				// Header size: 1
+				// Code size: 38 (0x26)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: call object Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
+				IL_0025: ret
+			} // end of method FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5bd9
+				// Header size: 1
+				// Code size: 34 (0x22)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: ldarg.2
+				IL_0016: ldc.i4.2
+				IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001c: call object Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
+				IL_0021: ret
+			} // end of method FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5bfc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout
+
 
 		// Methods
 		.method public hidebysig static 
@@ -5829,6 +8200,131 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5c0b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5c1a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5c1d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5c20
+				// Header size: 1
+				// Code size: 38 (0x26)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: call object Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
+				IL_0025: ret
+			} // end of method FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5c47
+				// Header size: 1
+				// Code size: 34 (0x22)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: ldarg.2
+				IL_0016: ldc.i4.2
+				IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001c: call object Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
+				IL_0021: ret
+			} // end of method FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5c6a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot
+
 
 		// Methods
 		.method public hidebysig static 
@@ -6061,6 +8557,131 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5c79
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot/FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5c88
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5c8b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5c8e
+				// Header size: 1
+				// Code size: 38 (0x26)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot/FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: call object Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
+				IL_0025: ret
+			} // end of method FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5cb5
+				// Header size: 1
+				// Code size: 34 (0x22)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot/FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: ldarg.2
+				IL_0016: ldc.i4.2
+				IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001c: call object Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
+				IL_0021: ret
+			} // end of method FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5cd8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot
 
 
 		// Methods
@@ -6317,6 +8938,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DE0B7594_main
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5ce7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/main/FunctionObject_FunctionDeclaration_DE0B7594_main::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DE0B7594_main::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5cf6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DE0B7594_main::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5cf9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DE0B7594_main::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5cfc
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/main/FunctionObject_FunctionDeclaration_DE0B7594_main::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Scripts_Test262Bootstrap/main::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_DE0B7594_main::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5d0e
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope Modules.Compile_Scripts_Test262Bootstrap/main/FunctionObject_FunctionDeclaration_DE0B7594_main::_environment0_Compile_Scripts_Test262Bootstrap
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Scripts_Test262Bootstrap/main::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_DE0B7594_main::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5d1c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DE0B7594_main::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_DE0B7594_main
 
 
 		// Methods
@@ -6686,7 +9414,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_Test262Bootstrap/Scope,
-			[1] class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_DE0B7594_main,
+			[1] class Modules.Compile_Scripts_Test262Bootstrap/main/FunctionObject_FunctionDeclaration_DE0B7594_main,
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
@@ -6694,29 +9422,29 @@
 			[6] object,
 			[7] object,
 			[8] object[],
-			[9] class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs,
-			[10] class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_CEC314BF_printHelp,
-			[11] class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_67E87462_defaultPinPath,
-			[12] class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd,
-			[13] class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath,
-			[14] class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath,
-			[15] class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_90DD1216_ensureString,
-			[16] class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray,
-			[17] class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp,
-			[18] class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_4A573BF6_validatePin,
-			[19] class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_62753EAC_loadPin,
-			[20] class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot,
-			[21] class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel,
-			[22] class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot,
-			[23] class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan,
-			[24] class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir,
-			[25] class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_313C5150_removeDir,
-			[26] class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_C8C56586_runGit,
-			[27] class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns,
-			[28] class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot,
-			[29] class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout,
-			[30] class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot,
-			[31] class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot,
+			[9] class Modules.Compile_Scripts_Test262Bootstrap/parseArgs/FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs,
+			[10] class Modules.Compile_Scripts_Test262Bootstrap/printHelp/FunctionObject_FunctionDeclaration_CEC314BF_printHelp,
+			[11] class Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath/FunctionObject_FunctionDeclaration_67E87462_defaultPinPath,
+			[12] class Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd/FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd,
+			[13] class Modules.Compile_Scripts_Test262Bootstrap/toPortablePath/FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath,
+			[14] class Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath/FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath,
+			[15] class Modules.Compile_Scripts_Test262Bootstrap/ensureString/FunctionObject_FunctionDeclaration_90DD1216_ensureString,
+			[16] class Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray/FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray,
+			[17] class Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp,
+			[18] class Modules.Compile_Scripts_Test262Bootstrap/validatePin/FunctionObject_FunctionDeclaration_4A573BF6_validatePin,
+			[19] class Modules.Compile_Scripts_Test262Bootstrap/loadPin/FunctionObject_FunctionDeclaration_62753EAC_loadPin,
+			[20] class Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot/FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot,
+			[21] class Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel/FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel,
+			[22] class Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot/FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot,
+			[23] class Modules.Compile_Scripts_Test262Bootstrap/describePlan/FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan,
+			[24] class Modules.Compile_Scripts_Test262Bootstrap/ensureDir/FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir,
+			[25] class Modules.Compile_Scripts_Test262Bootstrap/removeDir/FunctionObject_FunctionDeclaration_313C5150_removeDir,
+			[26] class Modules.Compile_Scripts_Test262Bootstrap/runGit/FunctionObject_FunctionDeclaration_C8C56586_runGit,
+			[27] class Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns/FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns,
+			[28] class Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot,
+			[29] class Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout,
+			[30] class Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot,
+			[31] class Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot/FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot,
 			[32] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule,
 			[33] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
 			[34] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule,
@@ -6753,13 +9481,13 @@
 		IL_001c: ldc.i4.0
 		IL_001d: ldelem.ref
 		IL_001e: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_0023: newobj instance void FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_0023: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/parseArgs/FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_0028: ldc.i4.1
 		IL_0029: conv.r8
 		IL_002a: ldstr "parseArgs"
 		IL_002f: ldc.i4.0
 		IL_0030: ldc.i4.1
-		IL_0031: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs>(!!0, float64, string, bool, bool)
+		IL_0031: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/parseArgs/FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs>(!!0, float64, string, bool, bool)
 		IL_0036: stloc.s 9
 		IL_0038: ldloc.0
 		IL_0039: ldloc.s 9
@@ -6771,13 +9499,13 @@
 		IL_0048: ldloc.0
 		IL_0049: stelem.ref
 		IL_004a: stloc.s 8
-		IL_004c: newobj instance void FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_CEC314BF_printHelp::.ctor()
+		IL_004c: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/printHelp/FunctionObject_FunctionDeclaration_CEC314BF_printHelp::.ctor()
 		IL_0051: ldc.i4.0
 		IL_0052: conv.r8
 		IL_0053: ldstr "printHelp"
 		IL_0058: ldc.i4.0
 		IL_0059: ldc.i4.1
-		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_CEC314BF_printHelp>(!!0, float64, string, bool, bool)
+		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/printHelp/FunctionObject_FunctionDeclaration_CEC314BF_printHelp>(!!0, float64, string, bool, bool)
 		IL_005f: stloc.s 10
 		IL_0061: ldloc.0
 		IL_0062: ldloc.s 10
@@ -6793,13 +9521,13 @@
 		IL_0077: ldc.i4.0
 		IL_0078: ldelem.ref
 		IL_0079: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_007e: newobj instance void FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_007e: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath/FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_0083: ldc.i4.0
 		IL_0084: conv.r8
 		IL_0085: ldstr "defaultPinPath"
 		IL_008a: ldc.i4.0
 		IL_008b: ldc.i4.1
-		IL_008c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_67E87462_defaultPinPath>(!!0, float64, string, bool, bool)
+		IL_008c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath/FunctionObject_FunctionDeclaration_67E87462_defaultPinPath>(!!0, float64, string, bool, bool)
 		IL_0091: stloc.s 11
 		IL_0093: ldloc.0
 		IL_0094: ldloc.s 11
@@ -6815,13 +9543,13 @@
 		IL_00a9: ldc.i4.0
 		IL_00aa: ldelem.ref
 		IL_00ab: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_00b0: newobj instance void FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_00b0: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd/FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_00b5: ldc.i4.1
 		IL_00b6: conv.r8
 		IL_00b7: ldstr "resolvePathFromCwd"
 		IL_00bc: ldc.i4.0
 		IL_00bd: ldc.i4.1
-		IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd>(!!0, float64, string, bool, bool)
+		IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd/FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd>(!!0, float64, string, bool, bool)
 		IL_00c3: stloc.s 12
 		IL_00c5: ldloc.0
 		IL_00c6: ldloc.s 12
@@ -6833,13 +9561,13 @@
 		IL_00d5: ldloc.0
 		IL_00d6: stelem.ref
 		IL_00d7: stloc.s 8
-		IL_00d9: newobj instance void FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath::.ctor()
+		IL_00d9: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/toPortablePath/FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath::.ctor()
 		IL_00de: ldc.i4.1
 		IL_00df: conv.r8
 		IL_00e0: ldstr "toPortablePath"
 		IL_00e5: ldc.i4.0
 		IL_00e6: ldc.i4.1
-		IL_00e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath>(!!0, float64, string, bool, bool)
+		IL_00e7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/toPortablePath/FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath>(!!0, float64, string, bool, bool)
 		IL_00ec: stloc.s 13
 		IL_00ee: ldloc.0
 		IL_00ef: ldloc.s 13
@@ -6855,13 +9583,13 @@
 		IL_0104: ldc.i4.0
 		IL_0105: ldelem.ref
 		IL_0106: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_010b: newobj instance void FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_010b: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath/FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_0110: ldc.i4.1
 		IL_0111: conv.r8
 		IL_0112: ldstr "normalizeSpecPath"
 		IL_0117: ldc.i4.0
 		IL_0118: ldc.i4.1
-		IL_0119: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath>(!!0, float64, string, bool, bool)
+		IL_0119: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath/FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath>(!!0, float64, string, bool, bool)
 		IL_011e: stloc.s 14
 		IL_0120: ldloc.0
 		IL_0121: ldloc.s 14
@@ -6873,13 +9601,13 @@
 		IL_0130: ldloc.0
 		IL_0131: stelem.ref
 		IL_0132: stloc.s 8
-		IL_0134: newobj instance void FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_90DD1216_ensureString::.ctor()
+		IL_0134: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/ensureString/FunctionObject_FunctionDeclaration_90DD1216_ensureString::.ctor()
 		IL_0139: ldc.i4.2
 		IL_013a: conv.r8
 		IL_013b: ldstr "ensureString"
 		IL_0140: ldc.i4.0
 		IL_0141: ldc.i4.1
-		IL_0142: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_90DD1216_ensureString>(!!0, float64, string, bool, bool)
+		IL_0142: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/ensureString/FunctionObject_FunctionDeclaration_90DD1216_ensureString>(!!0, float64, string, bool, bool)
 		IL_0147: stloc.s 15
 		IL_0149: ldloc.0
 		IL_014a: ldloc.s 15
@@ -6891,13 +9619,13 @@
 		IL_0159: ldloc.0
 		IL_015a: stelem.ref
 		IL_015b: stloc.s 8
-		IL_015d: newobj instance void FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray::.ctor()
+		IL_015d: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray/FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray::.ctor()
 		IL_0162: ldc.i4.2
 		IL_0163: conv.r8
 		IL_0164: ldstr "ensureStringArray"
 		IL_0169: ldc.i4.0
 		IL_016a: ldc.i4.1
-		IL_016b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray>(!!0, float64, string, bool, bool)
+		IL_016b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray/FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray>(!!0, float64, string, bool, bool)
 		IL_0170: stloc.s 16
 		IL_0172: ldloc.0
 		IL_0173: ldloc.s 16
@@ -6913,13 +9641,13 @@
 		IL_0188: ldc.i4.0
 		IL_0189: ldelem.ref
 		IL_018a: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_018f: newobj instance void FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_018f: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_0194: ldc.i4.1
 		IL_0195: conv.r8
 		IL_0196: ldstr "validateExcludedFromMvp"
 		IL_019b: ldc.i4.0
 		IL_019c: ldc.i4.1
-		IL_019d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp>(!!0, float64, string, bool, bool)
+		IL_019d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp/FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp>(!!0, float64, string, bool, bool)
 		IL_01a2: stloc.s 17
 		IL_01a4: ldloc.0
 		IL_01a5: ldloc.s 17
@@ -6935,13 +9663,13 @@
 		IL_01ba: ldc.i4.0
 		IL_01bb: ldelem.ref
 		IL_01bc: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_01c1: newobj instance void FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_4A573BF6_validatePin::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_01c1: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validatePin/FunctionObject_FunctionDeclaration_4A573BF6_validatePin::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_01c6: ldc.i4.1
 		IL_01c7: conv.r8
 		IL_01c8: ldstr "validatePin"
 		IL_01cd: ldc.i4.0
 		IL_01ce: ldc.i4.1
-		IL_01cf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_4A573BF6_validatePin>(!!0, float64, string, bool, bool)
+		IL_01cf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/validatePin/FunctionObject_FunctionDeclaration_4A573BF6_validatePin>(!!0, float64, string, bool, bool)
 		IL_01d4: stloc.s 18
 		IL_01d6: ldloc.0
 		IL_01d7: ldloc.s 18
@@ -6957,13 +9685,13 @@
 		IL_01ec: ldc.i4.0
 		IL_01ed: ldelem.ref
 		IL_01ee: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_01f3: newobj instance void FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_62753EAC_loadPin::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_01f3: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/loadPin/FunctionObject_FunctionDeclaration_62753EAC_loadPin::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_01f8: ldc.i4.1
 		IL_01f9: conv.r8
 		IL_01fa: ldstr "loadPin"
 		IL_01ff: ldc.i4.0
 		IL_0200: ldc.i4.1
-		IL_0201: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_62753EAC_loadPin>(!!0, float64, string, bool, bool)
+		IL_0201: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/loadPin/FunctionObject_FunctionDeclaration_62753EAC_loadPin>(!!0, float64, string, bool, bool)
 		IL_0206: stloc.s 19
 		IL_0208: ldloc.0
 		IL_0209: ldloc.s 19
@@ -6979,13 +9707,13 @@
 		IL_021e: ldc.i4.0
 		IL_021f: ldelem.ref
 		IL_0220: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_0225: newobj instance void FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_0225: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot/FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_022a: ldc.i4.2
 		IL_022b: conv.r8
 		IL_022c: ldstr "resolveManagedCheckoutRoot"
 		IL_0231: ldc.i4.0
 		IL_0232: ldc.i4.1
-		IL_0233: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot>(!!0, float64, string, bool, bool)
+		IL_0233: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot/FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot>(!!0, float64, string, bool, bool)
 		IL_0238: stloc.s 20
 		IL_023a: ldloc.0
 		IL_023b: ldloc.s 20
@@ -7001,13 +9729,13 @@
 		IL_0250: ldc.i4.0
 		IL_0251: ldelem.ref
 		IL_0252: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_0257: newobj instance void FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_0257: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel/FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_025c: ldc.i4.1
 		IL_025d: conv.r8
 		IL_025e: ldstr "resolveManagedCheckoutLabel"
 		IL_0263: ldc.i4.0
 		IL_0264: ldc.i4.1
-		IL_0265: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel>(!!0, float64, string, bool, bool)
+		IL_0265: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel/FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel>(!!0, float64, string, bool, bool)
 		IL_026a: stloc.s 21
 		IL_026c: ldloc.0
 		IL_026d: ldloc.s 21
@@ -7023,13 +9751,13 @@
 		IL_0282: ldc.i4.0
 		IL_0283: ldelem.ref
 		IL_0284: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_0289: newobj instance void FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_0289: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot/FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_028e: ldc.i4.2
 		IL_028f: conv.r8
 		IL_0290: ldstr "resolveOverrideRoot"
 		IL_0295: ldc.i4.0
 		IL_0296: ldc.i4.1
-		IL_0297: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot>(!!0, float64, string, bool, bool)
+		IL_0297: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot/FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot>(!!0, float64, string, bool, bool)
 		IL_029c: stloc.s 22
 		IL_029e: ldloc.0
 		IL_029f: ldloc.s 22
@@ -7045,13 +9773,13 @@
 		IL_02b4: ldc.i4.0
 		IL_02b5: ldelem.ref
 		IL_02b6: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_02bb: newobj instance void FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_02bb: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/describePlan/FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_02c0: ldc.i4.2
 		IL_02c1: conv.r8
 		IL_02c2: ldstr "describePlan"
 		IL_02c7: ldc.i4.0
 		IL_02c8: ldc.i4.1
-		IL_02c9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan>(!!0, float64, string, bool, bool)
+		IL_02c9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/describePlan/FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan>(!!0, float64, string, bool, bool)
 		IL_02ce: stloc.s 23
 		IL_02d0: ldloc.0
 		IL_02d1: ldloc.s 23
@@ -7067,13 +9795,13 @@
 		IL_02e6: ldc.i4.0
 		IL_02e7: ldelem.ref
 		IL_02e8: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_02ed: newobj instance void FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_02ed: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/ensureDir/FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_02f2: ldc.i4.1
 		IL_02f3: conv.r8
 		IL_02f4: ldstr "ensureDir"
 		IL_02f9: ldc.i4.0
 		IL_02fa: ldc.i4.1
-		IL_02fb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir>(!!0, float64, string, bool, bool)
+		IL_02fb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/ensureDir/FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir>(!!0, float64, string, bool, bool)
 		IL_0300: stloc.s 24
 		IL_0302: ldloc.0
 		IL_0303: ldloc.s 24
@@ -7089,13 +9817,13 @@
 		IL_0318: ldc.i4.0
 		IL_0319: ldelem.ref
 		IL_031a: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_031f: newobj instance void FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_313C5150_removeDir::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_031f: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/removeDir/FunctionObject_FunctionDeclaration_313C5150_removeDir::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_0324: ldc.i4.1
 		IL_0325: conv.r8
 		IL_0326: ldstr "removeDir"
 		IL_032b: ldc.i4.0
 		IL_032c: ldc.i4.1
-		IL_032d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_313C5150_removeDir>(!!0, float64, string, bool, bool)
+		IL_032d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/removeDir/FunctionObject_FunctionDeclaration_313C5150_removeDir>(!!0, float64, string, bool, bool)
 		IL_0332: stloc.s 25
 		IL_0334: ldloc.0
 		IL_0335: ldloc.s 25
@@ -7111,13 +9839,13 @@
 		IL_034a: ldc.i4.0
 		IL_034b: ldelem.ref
 		IL_034c: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_0351: newobj instance void FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_C8C56586_runGit::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_0351: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/runGit/FunctionObject_FunctionDeclaration_C8C56586_runGit::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_0356: ldc.i4.2
 		IL_0357: conv.r8
 		IL_0358: ldstr "runGit"
 		IL_035d: ldc.i4.0
 		IL_035e: ldc.i4.1
-		IL_035f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_C8C56586_runGit>(!!0, float64, string, bool, bool)
+		IL_035f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/runGit/FunctionObject_FunctionDeclaration_C8C56586_runGit>(!!0, float64, string, bool, bool)
 		IL_0364: stloc.s 26
 		IL_0366: ldloc.0
 		IL_0367: ldloc.s 26
@@ -7133,13 +9861,13 @@
 		IL_037c: ldc.i4.0
 		IL_037d: ldelem.ref
 		IL_037e: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_0383: newobj instance void FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_0383: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns/FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_0388: ldc.i4.1
 		IL_0389: conv.r8
 		IL_038a: ldstr "buildSparsePatterns"
 		IL_038f: ldc.i4.0
 		IL_0390: ldc.i4.1
-		IL_0391: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns>(!!0, float64, string, bool, bool)
+		IL_0391: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns/FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns>(!!0, float64, string, bool, bool)
 		IL_0396: stloc.s 27
 		IL_0398: ldloc.0
 		IL_0399: ldloc.s 27
@@ -7155,13 +9883,13 @@
 		IL_03ae: ldc.i4.0
 		IL_03af: ldelem.ref
 		IL_03b0: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_03b5: newobj instance void FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_03b5: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_03ba: ldc.i4.2
 		IL_03bb: conv.r8
 		IL_03bc: ldstr "validateResolvedRoot"
 		IL_03c1: ldc.i4.0
 		IL_03c2: ldc.i4.1
-		IL_03c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot>(!!0, float64, string, bool, bool)
+		IL_03c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot/FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot>(!!0, float64, string, bool, bool)
 		IL_03c8: stloc.s 28
 		IL_03ca: ldloc.0
 		IL_03cb: ldloc.s 28
@@ -7177,13 +9905,13 @@
 		IL_03e0: ldc.i4.0
 		IL_03e1: ldelem.ref
 		IL_03e2: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_03e7: newobj instance void FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_03e7: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_03ec: ldc.i4.3
 		IL_03ed: conv.r8
 		IL_03ee: ldstr "ensureManagedCheckout"
 		IL_03f3: ldc.i4.0
 		IL_03f4: ldc.i4.1
-		IL_03f5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout>(!!0, float64, string, bool, bool)
+		IL_03f5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout/FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout>(!!0, float64, string, bool, bool)
 		IL_03fa: stloc.s 29
 		IL_03fc: ldloc.0
 		IL_03fd: ldloc.s 29
@@ -7199,13 +9927,13 @@
 		IL_0412: ldc.i4.0
 		IL_0413: ldelem.ref
 		IL_0414: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_0419: newobj instance void FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_0419: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_041e: ldc.i4.3
 		IL_041f: conv.r8
 		IL_0420: ldstr "resolveBootstrapRoot"
 		IL_0425: ldc.i4.0
 		IL_0426: ldc.i4.1
-		IL_0427: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot>(!!0, float64, string, bool, bool)
+		IL_0427: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot/FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot>(!!0, float64, string, bool, bool)
 		IL_042c: stloc.s 30
 		IL_042e: ldloc.0
 		IL_042f: ldloc.s 30
@@ -7221,13 +9949,13 @@
 		IL_0444: ldc.i4.0
 		IL_0445: ldelem.ref
 		IL_0446: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_044b: newobj instance void FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_044b: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot/FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_0450: ldc.i4.3
 		IL_0451: conv.r8
 		IL_0452: ldstr "printResolvedRoot"
 		IL_0457: ldc.i4.0
 		IL_0458: ldc.i4.1
-		IL_0459: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot>(!!0, float64, string, bool, bool)
+		IL_0459: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot/FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot>(!!0, float64, string, bool, bool)
 		IL_045e: stloc.s 31
 		IL_0460: ldloc.0
 		IL_0461: ldloc.s 31
@@ -7243,13 +9971,13 @@
 		IL_0476: ldc.i4.0
 		IL_0477: ldelem.ref
 		IL_0478: castclass Modules.Compile_Scripts_Test262Bootstrap/Scope
-		IL_047d: newobj instance void FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_DE0B7594_main::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
+		IL_047d: newobj instance void Modules.Compile_Scripts_Test262Bootstrap/main/FunctionObject_FunctionDeclaration_DE0B7594_main::.ctor(class Modules.Compile_Scripts_Test262Bootstrap/Scope)
 		IL_0482: ldc.i4.0
 		IL_0483: conv.r8
 		IL_0484: ldstr "main"
 		IL_0489: ldc.i4.0
 		IL_048a: ldc.i4.1
-		IL_048b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_DE0B7594_main>(!!0, float64, string, bool, bool)
+		IL_048b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262Bootstrap/main/FunctionObject_FunctionDeclaration_DE0B7594_main>(!!0, float64, string, bool, bool)
 		IL_0490: stloc.1
 		IL_0491: nop
 		IL_0492: ldarg.1
@@ -7481,2734 +10209,6 @@
 	} // end of method Compile_Scripts_Test262Bootstrap::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_Test262Bootstrap
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5527
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5536
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5539
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x553c
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Compile_Scripts_Test262Bootstrap/parseArgs::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5555
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Compile_Scripts_Test262Bootstrap/parseArgs::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x556a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_AFDBDC15_parseArgs
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_CEC314BF_printHelp
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x5579
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_CEC314BF_printHelp::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5581
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CEC314BF_printHelp::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5584
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CEC314BF_printHelp::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5587
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Compile_Scripts_Test262Bootstrap/printHelp::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_CEC314BF_printHelp::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5593
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Compile_Scripts_Test262Bootstrap/printHelp::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_CEC314BF_printHelp::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x559b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_CEC314BF_printHelp::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_CEC314BF_printHelp
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_67E87462_defaultPinPath
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x55aa
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x55b9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x55bc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x55bf
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x55d1
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Scripts_Test262Bootstrap/defaultPinPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x55df
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_67E87462_defaultPinPath::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_67E87462_defaultPinPath
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x55ee
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x55fd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5600
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5603
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x561c
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Compile_Scripts_Test262Bootstrap/resolvePathFromCwd::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5631
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_E344E582_resolvePathFromCwd
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x5640
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5648
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x564b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x564e
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5661
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Compile_Scripts_Test262Bootstrap/toPortablePath::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5670
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_BCF8DFE0_toPortablePath
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x567f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x568e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5691
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5694
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x56ad
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Compile_Scripts_Test262Bootstrap/normalizeSpecPath::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x56c2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_34440FA4_normalizeSpecPath
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_90DD1216_ensureString
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x56d1
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_90DD1216_ensureString::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x56d9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_90DD1216_ensureString::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x56dc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_90DD1216_ensureString::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x56df
-		// Header size: 1
-		// Code size: 30 (0x1e)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0018: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, string)
-		IL_001d: ret
-	} // end of method FunctionObject_FunctionDeclaration_90DD1216_ensureString::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x56fe
-		// Header size: 1
-		// Code size: 26 (0x1a)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0014: call object Modules.Compile_Scripts_Test262Bootstrap/ensureString::__js_call__(object, object, string)
-		IL_0019: ret
-	} // end of method FunctionObject_FunctionDeclaration_90DD1216_ensureString::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5719
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_90DD1216_ensureString::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_90DD1216_ensureString
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x5728
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5730
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5733
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5736
-		// Header size: 1
-		// Code size: 30 (0x1e)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0018: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, string)
-		IL_001d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5755
-		// Header size: 1
-		// Code size: 26 (0x1a)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0014: call object Modules.Compile_Scripts_Test262Bootstrap/ensureStringArray::__js_call__(object, object, string)
-		IL_0019: ret
-	} // end of method FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5770
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_DBA2B93F_ensureStringArray
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x577f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x578e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5791
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5794
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x57ad
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Compile_Scripts_Test262Bootstrap/validateExcludedFromMvp::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x57c2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_FC89A2CE_validateExcludedFromMvp
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_4A573BF6_validatePin
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x57d1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_4A573BF6_validatePin::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4A573BF6_validatePin::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x57e0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4A573BF6_validatePin::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x57e3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4A573BF6_validatePin::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x57e6
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_4A573BF6_validatePin::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Compile_Scripts_Test262Bootstrap/validatePin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_4A573BF6_validatePin::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x57ff
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_4A573BF6_validatePin::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Compile_Scripts_Test262Bootstrap/validatePin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_4A573BF6_validatePin::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5814
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4A573BF6_validatePin::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_4A573BF6_validatePin
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_62753EAC_loadPin
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5823
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_62753EAC_loadPin::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_62753EAC_loadPin::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5832
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_62753EAC_loadPin::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5835
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_62753EAC_loadPin::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5838
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_62753EAC_loadPin::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Compile_Scripts_Test262Bootstrap/loadPin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_62753EAC_loadPin::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5851
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_62753EAC_loadPin::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Compile_Scripts_Test262Bootstrap/loadPin::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_62753EAC_loadPin::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5866
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_62753EAC_loadPin::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_62753EAC_loadPin
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5875
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5884
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5887
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x588a
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x58aa
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x58c6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_4D5A1160_resolveManagedCheckoutRoot
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x58d5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x58e4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x58e7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x58ea
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5903
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Compile_Scripts_Test262Bootstrap/resolveManagedCheckoutLabel::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5918
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_3BC41736_resolveManagedCheckoutLabel
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5927
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5936
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5939
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x593c
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x595c
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Compile_Scripts_Test262Bootstrap/resolveOverrideRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5978
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_E5BDAD33_resolveOverrideRoot
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5987
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5996
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5999
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x599c
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Compile_Scripts_Test262Bootstrap/describePlan::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x59bc
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Compile_Scripts_Test262Bootstrap/describePlan::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x59d8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_B4C8EDFF_describePlan
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x59e7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x59f6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x59f9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x59fc
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Compile_Scripts_Test262Bootstrap/ensureDir::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5a15
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Compile_Scripts_Test262Bootstrap/ensureDir::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5a2a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_A62E7CD2_ensureDir
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_313C5150_removeDir
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5a39
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_313C5150_removeDir::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_313C5150_removeDir::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5a48
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_313C5150_removeDir::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5a4b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_313C5150_removeDir::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5a4e
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_313C5150_removeDir::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Compile_Scripts_Test262Bootstrap/removeDir::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_313C5150_removeDir::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5a67
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_313C5150_removeDir::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Compile_Scripts_Test262Bootstrap/removeDir::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_313C5150_removeDir::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5a7c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_313C5150_removeDir::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_313C5150_removeDir
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_C8C56586_runGit
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5a8b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_C8C56586_runGit::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8C56586_runGit::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5a9a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8C56586_runGit::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5a9d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8C56586_runGit::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5aa0
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_C8C56586_runGit::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8C56586_runGit::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5ac0
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_C8C56586_runGit::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Compile_Scripts_Test262Bootstrap/runGit::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8C56586_runGit::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5adc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8C56586_runGit::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_C8C56586_runGit
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5aeb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5afa
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5afd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5b00
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5b19
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_Test262Bootstrap/buildSparsePatterns::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5b2e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_28E9BBD8_buildSparsePatterns
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5b3d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5b4c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5b4f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5b52
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5b72
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Compile_Scripts_Test262Bootstrap/validateResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5b8e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_72A0360B_validateResolvedRoot
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5b9d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5bac
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5baf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5bb2
-		// Header size: 1
-		// Code size: 38 (0x26)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: call object Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
-		IL_0025: ret
-	} // end of method FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5bd9
-		// Header size: 1
-		// Code size: 34 (0x22)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: ldarg.2
-		IL_0016: ldc.i4.2
-		IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001c: call object Modules.Compile_Scripts_Test262Bootstrap/ensureManagedCheckout::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
-		IL_0021: ret
-	} // end of method FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5bfc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_9BB52D9C_ensureManagedCheckout
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5c0b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5c1a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5c1d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5c20
-		// Header size: 1
-		// Code size: 38 (0x26)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: call object Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
-		IL_0025: ret
-	} // end of method FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5c47
-		// Header size: 1
-		// Code size: 34 (0x22)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: ldarg.2
-		IL_0016: ldc.i4.2
-		IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001c: call object Modules.Compile_Scripts_Test262Bootstrap/resolveBootstrapRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
-		IL_0021: ret
-	} // end of method FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5c6a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_02DDE84F_resolveBootstrapRoot
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5c79
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5c88
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5c8b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5c8e
-		// Header size: 1
-		// Code size: 38 (0x26)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: call object Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
-		IL_0025: ret
-	} // end of method FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5cb5
-		// Header size: 1
-		// Code size: 34 (0x22)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: ldarg.2
-		IL_0016: ldc.i4.2
-		IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001c: call object Modules.Compile_Scripts_Test262Bootstrap/printResolvedRoot::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object, object, object, object)
-		IL_0021: ret
-	} // end of method FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5cd8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_CE429F04_printResolvedRoot
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_DE0B7594_main
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_Test262Bootstrap/Scope _environment0_Compile_Scripts_Test262Bootstrap
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_Test262Bootstrap/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5ce7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_DE0B7594_main::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DE0B7594_main::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5cf6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DE0B7594_main::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5cf9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DE0B7594_main::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5cfc
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_DE0B7594_main::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Scripts_Test262Bootstrap/main::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_DE0B7594_main::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5d0e
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262Bootstrap/Scope FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_DE0B7594_main::_environment0_Compile_Scripts_Test262Bootstrap
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Scripts_Test262Bootstrap/main::__js_call__(class Modules.Compile_Scripts_Test262Bootstrap/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_DE0B7594_main::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5d1c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DE0B7594_main::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262Bootstrap_5D09C542.FunctionObject_FunctionDeclaration_DE0B7594_main
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
+++ b/tests/Jroc.Test262.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_Test262MetadataParser.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8862F24A_quoteString
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x69aa
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_8862F24A_quoteString::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x69b2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8862F24A_quoteString::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x69b5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8862F24A_quoteString::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x69b8
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Compile_Scripts_Test262MetadataParser/quoteString::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_8862F24A_quoteString::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x69cb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Compile_Scripts_Test262MetadataParser/quoteString::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8862F24A_quoteString::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x69da
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8862F24A_quoteString::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_8862F24A_quoteString
+
 
 		// Methods
 		.method public hidebysig static 
@@ -204,6 +305,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_Test262MetadataParser/Scope _environment0_Compile_Scripts_Test262MetadataParser
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_Test262MetadataParser/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x69e9
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/formatScalar/FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::_environment0_Compile_Scripts_Test262MetadataParser
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x69f8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x69fb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x69fe
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/formatScalar/FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::_environment0_Compile_Scripts_Test262MetadataParser
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6a17
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/formatScalar/FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::_environment0_Compile_Scripts_Test262MetadataParser
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6a2c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar
+
 
 		// Methods
 		.method public hidebysig static 
@@ -326,6 +540,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_Test262MetadataParser/Scope _environment0_Compile_Scripts_Test262MetadataParser
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_Test262MetadataParser/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6a3b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/formatNegative/FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::_environment0_Compile_Scripts_Test262MetadataParser
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6a4a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6a4d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6a50
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/formatNegative/FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::_environment0_Compile_Scripts_Test262MetadataParser
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Compile_Scripts_Test262MetadataParser/formatNegative::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6a69
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/formatNegative/FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::_environment0_Compile_Scripts_Test262MetadataParser
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Compile_Scripts_Test262MetadataParser/formatNegative::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6a7e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative
 
 
 		// Methods
@@ -464,6 +791,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_Test262MetadataParser/Scope _environment0_Compile_Scripts_Test262MetadataParser
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_Test262MetadataParser/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6a8d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/formatIssue/FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::_environment0_Compile_Scripts_Test262MetadataParser
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6a9c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6a9f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6aa2
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/formatIssue/FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::_environment0_Compile_Scripts_Test262MetadataParser
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6abb
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/formatIssue/FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::_environment0_Compile_Scripts_Test262MetadataParser
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6ad0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue
 
 
 		// Methods
@@ -605,6 +1045,127 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_Test262MetadataParser/Scope _environment0_Compile_Scripts_Test262MetadataParser
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_Test262MetadataParser/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6adf
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult/FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::_environment0_Compile_Scripts_Test262MetadataParser
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6aee
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6af1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6af4
+				// Header size: 1
+				// Code size: 36 (0x24)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult/FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::_environment0_Compile_Scripts_Test262MetadataParser
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0017: ldarg.2
+				IL_0018: ldc.i4.1
+				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001e: call object Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, string, object)
+				IL_0023: ret
+			} // end of method FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6b19
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult/FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::_environment0_Compile_Scripts_Test262MetadataParser
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.1
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, string, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6b3a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult
 
 
 		// Methods
@@ -2489,7 +3050,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_Test262MetadataParser/Scope,
-			[1] class FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult,
+			[1] class Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult/FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult,
 			[2] object,
 			[3] object,
 			[4] object,
@@ -2497,10 +3058,10 @@
 			[6] object,
 			[7] object,
 			[8] object[],
-			[9] class FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_8862F24A_quoteString,
-			[10] class FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar,
-			[11] class FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative,
-			[12] class FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue,
+			[9] class Modules.Compile_Scripts_Test262MetadataParser/quoteString/FunctionObject_FunctionDeclaration_8862F24A_quoteString,
+			[10] class Modules.Compile_Scripts_Test262MetadataParser/formatScalar/FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar,
+			[11] class Modules.Compile_Scripts_Test262MetadataParser/formatNegative/FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative,
+			[12] class Modules.Compile_Scripts_Test262MetadataParser/formatIssue/FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue,
 			[13] object,
 			[14] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
@@ -2514,13 +3075,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 8
-		IL_0012: newobj instance void FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_8862F24A_quoteString::.ctor()
+		IL_0012: newobj instance void Modules.Compile_Scripts_Test262MetadataParser/quoteString/FunctionObject_FunctionDeclaration_8862F24A_quoteString::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "quoteString"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_8862F24A_quoteString>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262MetadataParser/quoteString/FunctionObject_FunctionDeclaration_8862F24A_quoteString>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.s 9
 		IL_0027: ldloc.0
 		IL_0028: ldloc.s 9
@@ -2536,13 +3097,13 @@
 		IL_003d: ldc.i4.0
 		IL_003e: ldelem.ref
 		IL_003f: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-		IL_0044: newobj instance void FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::.ctor(class Modules.Compile_Scripts_Test262MetadataParser/Scope)
+		IL_0044: newobj instance void Modules.Compile_Scripts_Test262MetadataParser/formatScalar/FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::.ctor(class Modules.Compile_Scripts_Test262MetadataParser/Scope)
 		IL_0049: ldc.i4.1
 		IL_004a: conv.r8
 		IL_004b: ldstr "formatScalar"
 		IL_0050: ldc.i4.0
 		IL_0051: ldc.i4.1
-		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar>(!!0, float64, string, bool, bool)
+		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262MetadataParser/formatScalar/FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar>(!!0, float64, string, bool, bool)
 		IL_0057: stloc.s 10
 		IL_0059: ldloc.0
 		IL_005a: ldloc.s 10
@@ -2558,13 +3119,13 @@
 		IL_006f: ldc.i4.0
 		IL_0070: ldelem.ref
 		IL_0071: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-		IL_0076: newobj instance void FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::.ctor(class Modules.Compile_Scripts_Test262MetadataParser/Scope)
+		IL_0076: newobj instance void Modules.Compile_Scripts_Test262MetadataParser/formatNegative/FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::.ctor(class Modules.Compile_Scripts_Test262MetadataParser/Scope)
 		IL_007b: ldc.i4.1
 		IL_007c: conv.r8
 		IL_007d: ldstr "formatNegative"
 		IL_0082: ldc.i4.0
 		IL_0083: ldc.i4.1
-		IL_0084: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative>(!!0, float64, string, bool, bool)
+		IL_0084: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262MetadataParser/formatNegative/FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative>(!!0, float64, string, bool, bool)
 		IL_0089: stloc.s 11
 		IL_008b: ldloc.0
 		IL_008c: ldloc.s 11
@@ -2580,13 +3141,13 @@
 		IL_00a1: ldc.i4.0
 		IL_00a2: ldelem.ref
 		IL_00a3: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-		IL_00a8: newobj instance void FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::.ctor(class Modules.Compile_Scripts_Test262MetadataParser/Scope)
+		IL_00a8: newobj instance void Modules.Compile_Scripts_Test262MetadataParser/formatIssue/FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::.ctor(class Modules.Compile_Scripts_Test262MetadataParser/Scope)
 		IL_00ad: ldc.i4.1
 		IL_00ae: conv.r8
 		IL_00af: ldstr "formatIssue"
 		IL_00b4: ldc.i4.0
 		IL_00b5: ldc.i4.1
-		IL_00b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue>(!!0, float64, string, bool, bool)
+		IL_00b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262MetadataParser/formatIssue/FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue>(!!0, float64, string, bool, bool)
 		IL_00bb: stloc.s 12
 		IL_00bd: ldloc.0
 		IL_00be: ldloc.s 12
@@ -2602,13 +3163,13 @@
 		IL_00d3: ldc.i4.0
 		IL_00d4: ldelem.ref
 		IL_00d5: castclass Modules.Compile_Scripts_Test262MetadataParser/Scope
-		IL_00da: newobj instance void FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::.ctor(class Modules.Compile_Scripts_Test262MetadataParser/Scope)
+		IL_00da: newobj instance void Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult/FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::.ctor(class Modules.Compile_Scripts_Test262MetadataParser/Scope)
 		IL_00df: ldc.i4.2
 		IL_00e0: conv.r8
 		IL_00e1: ldstr "writeParsedResult"
 		IL_00e6: ldc.i4.0
 		IL_00e7: ldc.i4.1
-		IL_00e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult>(!!0, float64, string, bool, bool)
+		IL_00e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult/FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult>(!!0, float64, string, bool, bool)
 		IL_00ed: stloc.1
 		IL_00ee: nop
 		IL_00ef: ldarg.1
@@ -2807,6 +3368,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x6b49
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6b51
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6b54
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6b57
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.test262_metadataParser/normalizeLineEndings::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6b6a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.test262_metadataParser/normalizeLineEndings::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6b79
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2930,6 +3592,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C06E48FC_countIndent
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.test262_metadataParser/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6b88
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/countIndent/FunctionObject_FunctionDeclaration_C06E48FC_countIndent::_environment0_test262_metadataParser
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C06E48FC_countIndent::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6b97
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C06E48FC_countIndent::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6b9a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C06E48FC_countIndent::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6b9d
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/countIndent/FunctionObject_FunctionDeclaration_C06E48FC_countIndent::_environment0_test262_metadataParser
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.test262_metadataParser/countIndent::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_C06E48FC_countIndent::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6bb6
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/countIndent/FunctionObject_FunctionDeclaration_C06E48FC_countIndent::_environment0_test262_metadataParser
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.test262_metadataParser/countIndent::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_C06E48FC_countIndent::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6bcb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C06E48FC_countIndent::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C06E48FC_countIndent
 
 
 		// Methods
@@ -3095,6 +3870,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6CFFAA1C_unquote
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.test262_metadataParser/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6bda
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/unquote/FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::_environment0_test262_metadataParser
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6be9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6bec
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6bef
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/unquote/FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::_environment0_test262_metadataParser
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.test262_metadataParser/unquote::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6c08
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/unquote/FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::_environment0_test262_metadataParser
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.test262_metadataParser/unquote::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6c1d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_6CFFAA1C_unquote
 
 
 		// Methods
@@ -3370,6 +4258,119 @@
 
 		} // end of class Scope_For_L69C7
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.test262_metadataParser/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6c2c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseInlineList/FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::_environment0_test262_metadataParser
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6c3b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6c3e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6c41
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseInlineList/FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::_environment0_test262_metadataParser
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/parseInlineList::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6c5a
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseInlineList/FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::_environment0_test262_metadataParser
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/parseInlineList::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6c6f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList
+
 
 		// Methods
 		.method public hidebysig static 
@@ -3556,6 +4557,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.test262_metadataParser/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6c7e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseInlineValue/FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::_environment0_test262_metadataParser
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6c8d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6c90
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6c93
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseInlineValue/FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::_environment0_test262_metadataParser
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.test262_metadataParser/parseInlineValue::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6cac
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseInlineValue/FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::_environment0_test262_metadataParser
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.test262_metadataParser/parseInlineValue::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6cc1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue
 
 
 		// Methods
@@ -3809,6 +4923,121 @@
 
 		} // end of class Scope_For_L92C7
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.test262_metadataParser/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6cd0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/foldBlockLines/FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::_environment0_test262_metadataParser
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6cdf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6ce2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6ce5
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/foldBlockLines/FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::_environment0_test262_metadataParser
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0017: call object Modules.test262_metadataParser/foldBlockLines::__js_call__(class Modules.test262_metadataParser/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+				IL_001c: ret
+			} // end of method FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6d03
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/foldBlockLines/FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::_environment0_test262_metadataParser
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0013: call object Modules.test262_metadataParser/foldBlockLines::__js_call__(class Modules.test262_metadataParser/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6d1d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines
+
 
 		// Methods
 		.method public hidebysig static 
@@ -4060,6 +5289,139 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.test262_metadataParser/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6d2c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseBlockScalar/FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::_environment0_test262_metadataParser
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6d3b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6d3e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6d41
+				// Header size: 1
+				// Code size: 50 (0x32)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseBlockScalar/FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::_environment0_test262_metadataParser
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0025: ldarg.2
+				IL_0026: ldc.i4.3
+				IL_0027: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_002c: call object Modules.test262_metadataParser/parseBlockScalar::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64, object)
+				IL_0031: ret
+			} // end of method FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6d74
+				// Header size: 1
+				// Code size: 46 (0x2e)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseBlockScalar/FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::_environment0_test262_metadataParser
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: ldarg.2
+				IL_0016: ldc.i4.2
+				IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0021: ldarg.2
+				IL_0022: ldc.i4.3
+				IL_0023: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0028: call object Modules.test262_metadataParser/parseBlockScalar::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64, object)
+				IL_002d: ret
+			} // end of method FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6da3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar
 
 
 		// Methods
@@ -4350,6 +5712,133 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.test262_metadataParser/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6db2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseIndentedValue/FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::_environment0_test262_metadataParser
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6dc1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6dc4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6dc7
+				// Header size: 1
+				// Code size: 43 (0x2b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseIndentedValue/FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::_environment0_test262_metadataParser
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0025: call object Modules.test262_metadataParser/parseIndentedValue::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64)
+				IL_002a: ret
+			} // end of method FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6df3
+				// Header size: 1
+				// Code size: 39 (0x27)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseIndentedValue/FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::_environment0_test262_metadataParser
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: ldarg.2
+				IL_0016: ldc.i4.2
+				IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0021: call object Modules.test262_metadataParser/parseIndentedValue::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64)
+				IL_0026: ret
+			} // end of method FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6e1b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue
 
 
 		// Methods
@@ -4735,6 +6224,133 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.test262_metadataParser/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6e2a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseYamlSubsetLines/FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::_environment0_test262_metadataParser
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6e39
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6e3c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6e3f
+				// Header size: 1
+				// Code size: 43 (0x2b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseYamlSubsetLines/FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::_environment0_test262_metadataParser
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0025: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64)
+				IL_002a: ret
+			} // end of method FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6e6b
+				// Header size: 1
+				// Code size: 39 (0x27)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseYamlSubsetLines/FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::_environment0_test262_metadataParser
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: ldarg.2
+				IL_0016: ldc.i4.2
+				IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0021: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64)
+				IL_0026: ret
+			} // end of method FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6e93
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines
 
 
 		// Methods
@@ -5133,6 +6749,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.test262_metadataParser/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6ea2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseTest262Frontmatter/FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::_environment0_test262_metadataParser
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6eb1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6eb4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6eb7
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseTest262Frontmatter/FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::_environment0_test262_metadataParser
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.test262_metadataParser/parseTest262Frontmatter::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6ed0
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseTest262Frontmatter/FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::_environment0_test262_metadataParser
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.test262_metadataParser/parseTest262Frontmatter::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6ee5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter
+
 
 		// Methods
 		.method public hidebysig static 
@@ -5294,6 +7023,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.test262_metadataParser/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6ef4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/extractTest262Frontmatter/FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::_environment0_test262_metadataParser
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6f03
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6f06
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6f09
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/extractTest262Frontmatter/FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::_environment0_test262_metadataParser
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.test262_metadataParser/extractTest262Frontmatter::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6f22
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/extractTest262Frontmatter/FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::_environment0_test262_metadataParser
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.test262_metadataParser/extractTest262Frontmatter::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6f37
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter
+
 
 		// Methods
 		.method public hidebysig static 
@@ -5452,6 +7294,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5155C561_normalizePath
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x6f46
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_5155C561_normalizePath::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6f4e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5155C561_normalizePath::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6f51
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5155C561_normalizePath::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6f54
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.test262_metadataParser/normalizePath::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_5155C561_normalizePath::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6f67
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.test262_metadataParser/normalizePath::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5155C561_normalizePath::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6f76
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5155C561_normalizePath::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_5155C561_normalizePath
+
 
 		// Methods
 		.method public hidebysig static 
@@ -5553,6 +7496,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_512395F4_getFileName
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x6f85
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_512395F4_getFileName::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6f8d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_512395F4_getFileName::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6f90
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_512395F4_getFileName::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6f93
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.test262_metadataParser/getFileName::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_512395F4_getFileName::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6fa6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.test262_metadataParser/getFileName::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_512395F4_getFileName::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6fb5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_512395F4_getFileName::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_512395F4_getFileName
+
 
 		// Methods
 		.method public hidebysig static 
@@ -5645,6 +7689,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D59C98DE_contains
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x6fc4
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_D59C98DE_contains::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6fcc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D59C98DE_contains::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6fcf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D59C98DE_contains::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6fd2
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_D59C98DE_contains::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6fec
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_D59C98DE_contains::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x7002
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D59C98DE_contains::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_D59C98DE_contains
+
 
 		// Methods
 		.method public hidebysig static 
@@ -5706,6 +7857,129 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x7011
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x7019
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x701c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x701f
+				// Header size: 1
+				// Code size: 49 (0x31)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_001d: ldarg.2
+				IL_001e: ldc.i4.2
+				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0024: ldarg.2
+				IL_0025: ldc.i4.3
+				IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_002b: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, string, object, object)
+				IL_0030: ret
+			} // end of method FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x7051
+				// Header size: 1
+				// Code size: 45 (0x2d)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: ldarg.2
+				IL_0021: ldc.i4.3
+				IL_0022: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0027: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, string, object, object)
+				IL_002c: ret
+			} // end of method FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x707f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue
 
 
 		// Methods
@@ -5882,6 +8156,135 @@
 			} // end of method Scope_For_L267C7::.ctor
 
 		} // end of class Scope_For_L267C7
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_02368D80_toStringArray
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.test262_metadataParser/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x708e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/toStringArray/FunctionObject_FunctionDeclaration_02368D80_toStringArray::_environment0_test262_metadataParser
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_02368D80_toStringArray::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x709d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_02368D80_toStringArray::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x70a0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_02368D80_toStringArray::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x70a3
+				// Header size: 1
+				// Code size: 48 (0x30)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/toStringArray/FunctionObject_FunctionDeclaration_02368D80_toStringArray::_environment0_test262_metadataParser
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_001e: ldarg.2
+				IL_001f: ldc.i4.2
+				IL_0020: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0025: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_002a: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+				IL_002f: ret
+			} // end of method FunctionObject_FunctionDeclaration_02368D80_toStringArray::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x70d4
+				// Header size: 1
+				// Code size: 44 (0x2c)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/toStringArray/FunctionObject_FunctionDeclaration_02368D80_toStringArray::_environment0_test262_metadataParser
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_001a: ldarg.2
+				IL_001b: ldc.i4.2
+				IL_001c: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0021: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0026: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+				IL_002b: ret
+			} // end of method FunctionObject_FunctionDeclaration_02368D80_toStringArray::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x7101
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_02368D80_toStringArray::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_02368D80_toStringArray
 
 
 		// Methods
@@ -6192,6 +8595,135 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.test262_metadataParser/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x7110
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/toNullableString/FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::_environment0_test262_metadataParser
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x711f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x7122
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x7125
+				// Header size: 1
+				// Code size: 48 (0x30)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/toNullableString/FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::_environment0_test262_metadataParser
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_001e: ldarg.2
+				IL_001f: ldc.i4.2
+				IL_0020: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0025: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_002a: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+				IL_002f: ret
+			} // end of method FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x7156
+				// Header size: 1
+				// Code size: 44 (0x2c)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/toNullableString/FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::_environment0_test262_metadataParser
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_001a: ldarg.2
+				IL_001b: ldc.i4.2
+				IL_001c: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0021: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0026: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+				IL_002b: ret
+			} // end of method FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x7183
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString
 
 
 		// Methods
@@ -6510,6 +9042,127 @@
 			} // end of method Scope_For_L312C7::.ctor
 
 		} // end of class Scope_For_L312C7
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.test262_metadataParser/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x7192
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/normalizeNegative/FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::_environment0_test262_metadataParser
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x71a1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x71a4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x71a7
+				// Header size: 1
+				// Code size: 36 (0x24)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/normalizeNegative/FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::_environment0_test262_metadataParser
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_001e: call object Modules.test262_metadataParser/normalizeNegative::__js_call__(class Modules.test262_metadataParser/Scope, object, object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+				IL_0023: ret
+			} // end of method FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x71cc
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/normalizeNegative/FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::_environment0_test262_metadataParser
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_001a: call object Modules.test262_metadataParser/normalizeNegative::__js_call__(class Modules.test262_metadataParser/Scope, object, object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x71ed
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative
 
 
 		// Methods
@@ -7266,6 +9919,135 @@
 			} // end of method Scope_For_L364C7::.ctor
 
 		} // end of class Scope_For_L364C7
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.test262_metadataParser/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x71fc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/buildExecutionMetadata/FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::_environment0_test262_metadataParser
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x720b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x720e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x7211
+				// Header size: 1
+				// Code size: 48 (0x30)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/buildExecutionMetadata/FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::_environment0_test262_metadataParser
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0017: ldarg.2
+				IL_0018: ldc.i4.1
+				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0023: ldarg.2
+				IL_0024: ldc.i4.2
+				IL_0025: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_002a: call object Modules.test262_metadataParser/buildExecutionMetadata::__js_call__(class Modules.test262_metadataParser/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array, object)
+				IL_002f: ret
+			} // end of method FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x7242
+				// Header size: 1
+				// Code size: 44 (0x2c)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/buildExecutionMetadata/FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::_environment0_test262_metadataParser
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.1
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_001f: ldarg.2
+				IL_0020: ldc.i4.2
+				IL_0021: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0026: call object Modules.test262_metadataParser/buildExecutionMetadata::__js_call__(class Modules.test262_metadataParser/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array, object)
+				IL_002b: ret
+			} // end of method FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x726f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata
 
 
 		// Methods
@@ -8093,6 +10875,131 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.test262_metadataParser/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x727e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/buildMvpBlockers/FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::_environment0_test262_metadataParser
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x728d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x7290
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x7293
+				// Header size: 1
+				// Code size: 38 (0x26)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/buildMvpBlockers/FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::_environment0_test262_metadataParser
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/buildMvpBlockers::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+				IL_0025: ret
+			} // end of method FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x72ba
+				// Header size: 1
+				// Code size: 34 (0x22)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/buildMvpBlockers/FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::_environment0_test262_metadataParser
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: ldarg.2
+				IL_0016: ldc.i4.2
+				IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001c: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/buildMvpBlockers::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
+				IL_0021: ret
+			} // end of method FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x72dd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers
+
 
 		// Methods
 		.method public hidebysig static 
@@ -8669,6 +11576,125 @@
 			} // end of method Scope_For_L455C7::.ctor
 
 		} // end of class Scope_For_L455C7
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.test262_metadataParser/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x72ec
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseTest262Metadata/FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::_environment0_test262_metadataParser
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x72fb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x72fe
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x7301
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseTest262Metadata/FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::_environment0_test262_metadataParser
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.test262_metadataParser/parseTest262Metadata::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x7321
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseTest262Metadata/FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::_environment0_test262_metadataParser
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.test262_metadataParser/parseTest262Metadata::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x733d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata
 
 
 		// Methods
@@ -9463,6 +12489,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.test262_metadataParser/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x734c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseTest262File/FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::_environment0_test262_metadataParser
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x735b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x735e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x7361
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseTest262File/FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::_environment0_test262_metadataParser
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.test262_metadataParser/parseTest262File::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x737a
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.test262_metadataParser/Scope Modules.test262_metadataParser/parseTest262File/FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::_environment0_test262_metadataParser
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.test262_metadataParser/parseTest262File::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x738f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File
+
 
 		// Methods
 		.method public hidebysig static 
@@ -9613,29 +12752,29 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.test262_metadataParser/Scope,
-			[1] class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File,
+			[1] class Modules.test262_metadataParser/parseTest262File/FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File,
 			[2] object[],
-			[3] class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings,
-			[4] class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_C06E48FC_countIndent,
-			[5] class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_6CFFAA1C_unquote,
-			[6] class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList,
-			[7] class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue,
-			[8] class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines,
-			[9] class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar,
-			[10] class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue,
-			[11] class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines,
-			[12] class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter,
-			[13] class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter,
-			[14] class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_5155C561_normalizePath,
-			[15] class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_512395F4_getFileName,
-			[16] class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_D59C98DE_contains,
-			[17] class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue,
-			[18] class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_02368D80_toStringArray,
-			[19] class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString,
-			[20] class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative,
-			[21] class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata,
-			[22] class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers,
-			[23] class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata,
+			[3] class Modules.test262_metadataParser/normalizeLineEndings/FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings,
+			[4] class Modules.test262_metadataParser/countIndent/FunctionObject_FunctionDeclaration_C06E48FC_countIndent,
+			[5] class Modules.test262_metadataParser/unquote/FunctionObject_FunctionDeclaration_6CFFAA1C_unquote,
+			[6] class Modules.test262_metadataParser/parseInlineList/FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList,
+			[7] class Modules.test262_metadataParser/parseInlineValue/FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue,
+			[8] class Modules.test262_metadataParser/foldBlockLines/FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines,
+			[9] class Modules.test262_metadataParser/parseBlockScalar/FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar,
+			[10] class Modules.test262_metadataParser/parseIndentedValue/FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue,
+			[11] class Modules.test262_metadataParser/parseYamlSubsetLines/FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines,
+			[12] class Modules.test262_metadataParser/parseTest262Frontmatter/FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter,
+			[13] class Modules.test262_metadataParser/extractTest262Frontmatter/FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter,
+			[14] class Modules.test262_metadataParser/normalizePath/FunctionObject_FunctionDeclaration_5155C561_normalizePath,
+			[15] class Modules.test262_metadataParser/getFileName/FunctionObject_FunctionDeclaration_512395F4_getFileName,
+			[16] class Modules.test262_metadataParser/contains/FunctionObject_FunctionDeclaration_D59C98DE_contains,
+			[17] class Modules.test262_metadataParser/pushIssue/FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue,
+			[18] class Modules.test262_metadataParser/toStringArray/FunctionObject_FunctionDeclaration_02368D80_toStringArray,
+			[19] class Modules.test262_metadataParser/toNullableString/FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString,
+			[20] class Modules.test262_metadataParser/normalizeNegative/FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative,
+			[21] class Modules.test262_metadataParser/buildExecutionMetadata/FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata,
+			[22] class Modules.test262_metadataParser/buildMvpBlockers/FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers,
+			[23] class Modules.test262_metadataParser/parseTest262Metadata/FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata,
 			[24] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
 			[25] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[26] object,
@@ -9653,13 +12792,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings::.ctor()
+		IL_0011: newobj instance void Modules.test262_metadataParser/normalizeLineEndings/FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "normalizeLineEndings"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/normalizeLineEndings/FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.3
 		IL_0025: ldloc.0
 		IL_0026: ldloc.3
@@ -9675,13 +12814,13 @@
 		IL_0038: ldc.i4.0
 		IL_0039: ldelem.ref
 		IL_003a: castclass Modules.test262_metadataParser/Scope
-		IL_003f: newobj instance void FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_C06E48FC_countIndent::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_003f: newobj instance void Modules.test262_metadataParser/countIndent/FunctionObject_FunctionDeclaration_C06E48FC_countIndent::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_0044: ldc.i4.1
 		IL_0045: conv.r8
 		IL_0046: ldstr "countIndent"
 		IL_004b: ldc.i4.0
 		IL_004c: ldc.i4.1
-		IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_C06E48FC_countIndent>(!!0, float64, string, bool, bool)
+		IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/countIndent/FunctionObject_FunctionDeclaration_C06E48FC_countIndent>(!!0, float64, string, bool, bool)
 		IL_0052: stloc.s 4
 		IL_0054: ldloc.0
 		IL_0055: ldloc.s 4
@@ -9697,13 +12836,13 @@
 		IL_0068: ldc.i4.0
 		IL_0069: ldelem.ref
 		IL_006a: castclass Modules.test262_metadataParser/Scope
-		IL_006f: newobj instance void FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_006f: newobj instance void Modules.test262_metadataParser/unquote/FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_0074: ldc.i4.1
 		IL_0075: conv.r8
 		IL_0076: ldstr "unquote"
 		IL_007b: ldc.i4.0
 		IL_007c: ldc.i4.1
-		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_6CFFAA1C_unquote>(!!0, float64, string, bool, bool)
+		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/unquote/FunctionObject_FunctionDeclaration_6CFFAA1C_unquote>(!!0, float64, string, bool, bool)
 		IL_0082: stloc.s 5
 		IL_0084: ldloc.0
 		IL_0085: ldloc.s 5
@@ -9719,13 +12858,13 @@
 		IL_0098: ldc.i4.0
 		IL_0099: ldelem.ref
 		IL_009a: castclass Modules.test262_metadataParser/Scope
-		IL_009f: newobj instance void FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_009f: newobj instance void Modules.test262_metadataParser/parseInlineList/FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_00a4: ldc.i4.1
 		IL_00a5: conv.r8
 		IL_00a6: ldstr "parseInlineList"
 		IL_00ab: ldc.i4.0
 		IL_00ac: ldc.i4.1
-		IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList>(!!0, float64, string, bool, bool)
+		IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/parseInlineList/FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList>(!!0, float64, string, bool, bool)
 		IL_00b2: stloc.s 6
 		IL_00b4: ldloc.0
 		IL_00b5: ldloc.s 6
@@ -9741,13 +12880,13 @@
 		IL_00c8: ldc.i4.0
 		IL_00c9: ldelem.ref
 		IL_00ca: castclass Modules.test262_metadataParser/Scope
-		IL_00cf: newobj instance void FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_00cf: newobj instance void Modules.test262_metadataParser/parseInlineValue/FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_00d4: ldc.i4.1
 		IL_00d5: conv.r8
 		IL_00d6: ldstr "parseInlineValue"
 		IL_00db: ldc.i4.0
 		IL_00dc: ldc.i4.1
-		IL_00dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue>(!!0, float64, string, bool, bool)
+		IL_00dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/parseInlineValue/FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue>(!!0, float64, string, bool, bool)
 		IL_00e2: stloc.s 7
 		IL_00e4: ldloc.0
 		IL_00e5: ldloc.s 7
@@ -9763,13 +12902,13 @@
 		IL_00f8: ldc.i4.0
 		IL_00f9: ldelem.ref
 		IL_00fa: castclass Modules.test262_metadataParser/Scope
-		IL_00ff: newobj instance void FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_00ff: newobj instance void Modules.test262_metadataParser/foldBlockLines/FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_0104: ldc.i4.1
 		IL_0105: conv.r8
 		IL_0106: ldstr "foldBlockLines"
 		IL_010b: ldc.i4.0
 		IL_010c: ldc.i4.1
-		IL_010d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines>(!!0, float64, string, bool, bool)
+		IL_010d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/foldBlockLines/FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines>(!!0, float64, string, bool, bool)
 		IL_0112: stloc.s 8
 		IL_0114: ldloc.0
 		IL_0115: ldloc.s 8
@@ -9785,13 +12924,13 @@
 		IL_0128: ldc.i4.0
 		IL_0129: ldelem.ref
 		IL_012a: castclass Modules.test262_metadataParser/Scope
-		IL_012f: newobj instance void FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_012f: newobj instance void Modules.test262_metadataParser/parseBlockScalar/FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_0134: ldc.i4.4
 		IL_0135: conv.r8
 		IL_0136: ldstr "parseBlockScalar"
 		IL_013b: ldc.i4.0
 		IL_013c: ldc.i4.1
-		IL_013d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar>(!!0, float64, string, bool, bool)
+		IL_013d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/parseBlockScalar/FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar>(!!0, float64, string, bool, bool)
 		IL_0142: stloc.s 9
 		IL_0144: ldloc.0
 		IL_0145: ldloc.s 9
@@ -9807,13 +12946,13 @@
 		IL_0158: ldc.i4.0
 		IL_0159: ldelem.ref
 		IL_015a: castclass Modules.test262_metadataParser/Scope
-		IL_015f: newobj instance void FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_015f: newobj instance void Modules.test262_metadataParser/parseIndentedValue/FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_0164: ldc.i4.3
 		IL_0165: conv.r8
 		IL_0166: ldstr "parseIndentedValue"
 		IL_016b: ldc.i4.0
 		IL_016c: ldc.i4.1
-		IL_016d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue>(!!0, float64, string, bool, bool)
+		IL_016d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/parseIndentedValue/FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue>(!!0, float64, string, bool, bool)
 		IL_0172: stloc.s 10
 		IL_0174: ldloc.0
 		IL_0175: ldloc.s 10
@@ -9829,13 +12968,13 @@
 		IL_0188: ldc.i4.0
 		IL_0189: ldelem.ref
 		IL_018a: castclass Modules.test262_metadataParser/Scope
-		IL_018f: newobj instance void FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_018f: newobj instance void Modules.test262_metadataParser/parseYamlSubsetLines/FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_0194: ldc.i4.3
 		IL_0195: conv.r8
 		IL_0196: ldstr "parseYamlSubsetLines"
 		IL_019b: ldc.i4.0
 		IL_019c: ldc.i4.1
-		IL_019d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines>(!!0, float64, string, bool, bool)
+		IL_019d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/parseYamlSubsetLines/FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines>(!!0, float64, string, bool, bool)
 		IL_01a2: stloc.s 11
 		IL_01a4: ldloc.0
 		IL_01a5: ldloc.s 11
@@ -9851,13 +12990,13 @@
 		IL_01b8: ldc.i4.0
 		IL_01b9: ldelem.ref
 		IL_01ba: castclass Modules.test262_metadataParser/Scope
-		IL_01bf: newobj instance void FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_01bf: newobj instance void Modules.test262_metadataParser/parseTest262Frontmatter/FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_01c4: ldc.i4.1
 		IL_01c5: conv.r8
 		IL_01c6: ldstr "parseTest262Frontmatter"
 		IL_01cb: ldc.i4.0
 		IL_01cc: ldc.i4.1
-		IL_01cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter>(!!0, float64, string, bool, bool)
+		IL_01cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/parseTest262Frontmatter/FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter>(!!0, float64, string, bool, bool)
 		IL_01d2: stloc.s 12
 		IL_01d4: ldloc.0
 		IL_01d5: ldloc.s 12
@@ -9873,13 +13012,13 @@
 		IL_01e8: ldc.i4.0
 		IL_01e9: ldelem.ref
 		IL_01ea: castclass Modules.test262_metadataParser/Scope
-		IL_01ef: newobj instance void FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_01ef: newobj instance void Modules.test262_metadataParser/extractTest262Frontmatter/FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_01f4: ldc.i4.1
 		IL_01f5: conv.r8
 		IL_01f6: ldstr "extractTest262Frontmatter"
 		IL_01fb: ldc.i4.0
 		IL_01fc: ldc.i4.1
-		IL_01fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter>(!!0, float64, string, bool, bool)
+		IL_01fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/extractTest262Frontmatter/FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter>(!!0, float64, string, bool, bool)
 		IL_0202: stloc.s 13
 		IL_0204: ldloc.0
 		IL_0205: ldloc.s 13
@@ -9891,13 +13030,13 @@
 		IL_0214: ldloc.0
 		IL_0215: stelem.ref
 		IL_0216: stloc.2
-		IL_0217: newobj instance void FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_5155C561_normalizePath::.ctor()
+		IL_0217: newobj instance void Modules.test262_metadataParser/normalizePath/FunctionObject_FunctionDeclaration_5155C561_normalizePath::.ctor()
 		IL_021c: ldc.i4.1
 		IL_021d: conv.r8
 		IL_021e: ldstr "normalizePath"
 		IL_0223: ldc.i4.0
 		IL_0224: ldc.i4.1
-		IL_0225: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_5155C561_normalizePath>(!!0, float64, string, bool, bool)
+		IL_0225: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/normalizePath/FunctionObject_FunctionDeclaration_5155C561_normalizePath>(!!0, float64, string, bool, bool)
 		IL_022a: stloc.s 14
 		IL_022c: ldloc.0
 		IL_022d: ldloc.s 14
@@ -9909,13 +13048,13 @@
 		IL_023c: ldloc.0
 		IL_023d: stelem.ref
 		IL_023e: stloc.2
-		IL_023f: newobj instance void FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_512395F4_getFileName::.ctor()
+		IL_023f: newobj instance void Modules.test262_metadataParser/getFileName/FunctionObject_FunctionDeclaration_512395F4_getFileName::.ctor()
 		IL_0244: ldc.i4.1
 		IL_0245: conv.r8
 		IL_0246: ldstr "getFileName"
 		IL_024b: ldc.i4.0
 		IL_024c: ldc.i4.1
-		IL_024d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_512395F4_getFileName>(!!0, float64, string, bool, bool)
+		IL_024d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/getFileName/FunctionObject_FunctionDeclaration_512395F4_getFileName>(!!0, float64, string, bool, bool)
 		IL_0252: stloc.s 15
 		IL_0254: ldloc.0
 		IL_0255: ldloc.s 15
@@ -9927,13 +13066,13 @@
 		IL_0264: ldloc.0
 		IL_0265: stelem.ref
 		IL_0266: stloc.2
-		IL_0267: newobj instance void FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_D59C98DE_contains::.ctor()
+		IL_0267: newobj instance void Modules.test262_metadataParser/contains/FunctionObject_FunctionDeclaration_D59C98DE_contains::.ctor()
 		IL_026c: ldc.i4.2
 		IL_026d: conv.r8
 		IL_026e: ldstr "contains"
 		IL_0273: ldc.i4.0
 		IL_0274: ldc.i4.1
-		IL_0275: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_D59C98DE_contains>(!!0, float64, string, bool, bool)
+		IL_0275: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/contains/FunctionObject_FunctionDeclaration_D59C98DE_contains>(!!0, float64, string, bool, bool)
 		IL_027a: stloc.s 16
 		IL_027c: ldloc.0
 		IL_027d: ldloc.s 16
@@ -9945,13 +13084,13 @@
 		IL_028c: ldloc.0
 		IL_028d: stelem.ref
 		IL_028e: stloc.2
-		IL_028f: newobj instance void FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue::.ctor()
+		IL_028f: newobj instance void Modules.test262_metadataParser/pushIssue/FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue::.ctor()
 		IL_0294: ldc.i4.4
 		IL_0295: conv.r8
 		IL_0296: ldstr "pushIssue"
 		IL_029b: ldc.i4.0
 		IL_029c: ldc.i4.1
-		IL_029d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue>(!!0, float64, string, bool, bool)
+		IL_029d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/pushIssue/FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue>(!!0, float64, string, bool, bool)
 		IL_02a2: stloc.s 17
 		IL_02a4: ldloc.0
 		IL_02a5: ldloc.s 17
@@ -9967,13 +13106,13 @@
 		IL_02b8: ldc.i4.0
 		IL_02b9: ldelem.ref
 		IL_02ba: castclass Modules.test262_metadataParser/Scope
-		IL_02bf: newobj instance void FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_02368D80_toStringArray::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_02bf: newobj instance void Modules.test262_metadataParser/toStringArray/FunctionObject_FunctionDeclaration_02368D80_toStringArray::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_02c4: ldc.i4.3
 		IL_02c5: conv.r8
 		IL_02c6: ldstr "toStringArray"
 		IL_02cb: ldc.i4.0
 		IL_02cc: ldc.i4.1
-		IL_02cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_02368D80_toStringArray>(!!0, float64, string, bool, bool)
+		IL_02cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/toStringArray/FunctionObject_FunctionDeclaration_02368D80_toStringArray>(!!0, float64, string, bool, bool)
 		IL_02d2: stloc.s 18
 		IL_02d4: ldloc.0
 		IL_02d5: ldloc.s 18
@@ -9989,13 +13128,13 @@
 		IL_02e8: ldc.i4.0
 		IL_02e9: ldelem.ref
 		IL_02ea: castclass Modules.test262_metadataParser/Scope
-		IL_02ef: newobj instance void FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_02ef: newobj instance void Modules.test262_metadataParser/toNullableString/FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_02f4: ldc.i4.3
 		IL_02f5: conv.r8
 		IL_02f6: ldstr "toNullableString"
 		IL_02fb: ldc.i4.0
 		IL_02fc: ldc.i4.1
-		IL_02fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString>(!!0, float64, string, bool, bool)
+		IL_02fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/toNullableString/FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString>(!!0, float64, string, bool, bool)
 		IL_0302: stloc.s 19
 		IL_0304: ldloc.0
 		IL_0305: ldloc.s 19
@@ -10011,13 +13150,13 @@
 		IL_0318: ldc.i4.0
 		IL_0319: ldelem.ref
 		IL_031a: castclass Modules.test262_metadataParser/Scope
-		IL_031f: newobj instance void FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_031f: newobj instance void Modules.test262_metadataParser/normalizeNegative/FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_0324: ldc.i4.2
 		IL_0325: conv.r8
 		IL_0326: ldstr "normalizeNegative"
 		IL_032b: ldc.i4.0
 		IL_032c: ldc.i4.1
-		IL_032d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative>(!!0, float64, string, bool, bool)
+		IL_032d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/normalizeNegative/FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative>(!!0, float64, string, bool, bool)
 		IL_0332: stloc.s 20
 		IL_0334: ldloc.0
 		IL_0335: ldloc.s 20
@@ -10033,13 +13172,13 @@
 		IL_0348: ldc.i4.0
 		IL_0349: ldelem.ref
 		IL_034a: castclass Modules.test262_metadataParser/Scope
-		IL_034f: newobj instance void FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_034f: newobj instance void Modules.test262_metadataParser/buildExecutionMetadata/FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_0354: ldc.i4.3
 		IL_0355: conv.r8
 		IL_0356: ldstr "buildExecutionMetadata"
 		IL_035b: ldc.i4.0
 		IL_035c: ldc.i4.1
-		IL_035d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata>(!!0, float64, string, bool, bool)
+		IL_035d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/buildExecutionMetadata/FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata>(!!0, float64, string, bool, bool)
 		IL_0362: stloc.s 21
 		IL_0364: ldloc.0
 		IL_0365: ldloc.s 21
@@ -10055,13 +13194,13 @@
 		IL_0378: ldc.i4.0
 		IL_0379: ldelem.ref
 		IL_037a: castclass Modules.test262_metadataParser/Scope
-		IL_037f: newobj instance void FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_037f: newobj instance void Modules.test262_metadataParser/buildMvpBlockers/FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_0384: ldc.i4.3
 		IL_0385: conv.r8
 		IL_0386: ldstr "buildMvpBlockers"
 		IL_038b: ldc.i4.0
 		IL_038c: ldc.i4.1
-		IL_038d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers>(!!0, float64, string, bool, bool)
+		IL_038d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/buildMvpBlockers/FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers>(!!0, float64, string, bool, bool)
 		IL_0392: stloc.s 22
 		IL_0394: ldloc.0
 		IL_0395: ldloc.s 22
@@ -10077,13 +13216,13 @@
 		IL_03a8: ldc.i4.0
 		IL_03a9: ldelem.ref
 		IL_03aa: castclass Modules.test262_metadataParser/Scope
-		IL_03af: newobj instance void FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_03af: newobj instance void Modules.test262_metadataParser/parseTest262Metadata/FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_03b4: ldc.i4.2
 		IL_03b5: conv.r8
 		IL_03b6: ldstr "parseTest262Metadata"
 		IL_03bb: ldc.i4.0
 		IL_03bc: ldc.i4.1
-		IL_03bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata>(!!0, float64, string, bool, bool)
+		IL_03bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/parseTest262Metadata/FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata>(!!0, float64, string, bool, bool)
 		IL_03c2: stloc.s 23
 		IL_03c4: ldloc.0
 		IL_03c5: ldloc.s 23
@@ -10099,13 +13238,13 @@
 		IL_03d8: ldc.i4.0
 		IL_03d9: ldelem.ref
 		IL_03da: castclass Modules.test262_metadataParser/Scope
-		IL_03df: newobj instance void FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::.ctor(class Modules.test262_metadataParser/Scope)
+		IL_03df: newobj instance void Modules.test262_metadataParser/parseTest262File/FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::.ctor(class Modules.test262_metadataParser/Scope)
 		IL_03e4: ldc.i4.1
 		IL_03e5: conv.r8
 		IL_03e6: ldstr "parseTest262File"
 		IL_03eb: ldc.i4.0
 		IL_03ec: ldc.i4.1
-		IL_03ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File>(!!0, float64, string, bool, bool)
+		IL_03ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.test262_metadataParser/parseTest262File/FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File>(!!0, float64, string, bool, bool)
 		IL_03f2: stloc.1
 		IL_03f3: nop
 		IL_03f4: ldarg.1
@@ -10264,3145 +13403,6 @@
 	} // end of method test262_metadataParser::__js_module_init__
 
 } // end of class Modules.test262_metadataParser
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_8862F24A_quoteString
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x69aa
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_8862F24A_quoteString::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x69b2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8862F24A_quoteString::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x69b5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8862F24A_quoteString::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x69b8
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Compile_Scripts_Test262MetadataParser/quoteString::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_8862F24A_quoteString::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x69cb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Compile_Scripts_Test262MetadataParser/quoteString::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8862F24A_quoteString::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x69da
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8862F24A_quoteString::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_8862F24A_quoteString
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_Test262MetadataParser/Scope _environment0_Compile_Scripts_Test262MetadataParser
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_Test262MetadataParser/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x69e9
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_Test262MetadataParser/Scope FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::_environment0_Compile_Scripts_Test262MetadataParser
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x69f8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x69fb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x69fe
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::_environment0_Compile_Scripts_Test262MetadataParser
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6a17
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::_environment0_Compile_Scripts_Test262MetadataParser
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Compile_Scripts_Test262MetadataParser/formatScalar::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6a2c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_5E79CB4A_formatScalar
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_Test262MetadataParser/Scope _environment0_Compile_Scripts_Test262MetadataParser
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_Test262MetadataParser/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6a3b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_Test262MetadataParser/Scope FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::_environment0_Compile_Scripts_Test262MetadataParser
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6a4a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6a4d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6a50
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::_environment0_Compile_Scripts_Test262MetadataParser
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Compile_Scripts_Test262MetadataParser/formatNegative::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6a69
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::_environment0_Compile_Scripts_Test262MetadataParser
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Compile_Scripts_Test262MetadataParser/formatNegative::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6a7e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_E6C75A5D_formatNegative
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_Test262MetadataParser/Scope _environment0_Compile_Scripts_Test262MetadataParser
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_Test262MetadataParser/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6a8d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_Test262MetadataParser/Scope FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::_environment0_Compile_Scripts_Test262MetadataParser
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6a9c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6a9f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6aa2
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::_environment0_Compile_Scripts_Test262MetadataParser
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6abb
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::_environment0_Compile_Scripts_Test262MetadataParser
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Compile_Scripts_Test262MetadataParser/formatIssue::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6ad0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_8C08C0C9_formatIssue
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_Test262MetadataParser/Scope _environment0_Compile_Scripts_Test262MetadataParser
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_Test262MetadataParser/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6adf
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_Test262MetadataParser/Scope FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::_environment0_Compile_Scripts_Test262MetadataParser
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6aee
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6af1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6af4
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::_environment0_Compile_Scripts_Test262MetadataParser
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0017: ldarg.2
-		IL_0018: ldc.i4.1
-		IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001e: call object Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, string, object)
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6b19
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_Test262MetadataParser/Scope FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::_environment0_Compile_Scripts_Test262MetadataParser
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.1
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.Compile_Scripts_Test262MetadataParser/writeParsedResult::__js_call__(class Modules.Compile_Scripts_Test262MetadataParser/Scope, object, string, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6b3a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_Test262MetadataParser_5CA7E16E.FunctionObject_FunctionDeclaration_E76CBB84_writeParsedResult
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x6b49
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6b51
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6b54
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6b57
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.test262_metadataParser/normalizeLineEndings::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6b6a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.test262_metadataParser/normalizeLineEndings::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6b79
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings::ConstructCore
-
-} // end of class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_5A90CE88_normalizeLineEndings
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_C06E48FC_countIndent
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.test262_metadataParser/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6b88
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_C06E48FC_countIndent::_environment0_test262_metadataParser
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C06E48FC_countIndent::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6b97
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C06E48FC_countIndent::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6b9a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C06E48FC_countIndent::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6b9d
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_C06E48FC_countIndent::_environment0_test262_metadataParser
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.test262_metadataParser/countIndent::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_C06E48FC_countIndent::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6bb6
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_C06E48FC_countIndent::_environment0_test262_metadataParser
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.test262_metadataParser/countIndent::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_C06E48FC_countIndent::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6bcb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C06E48FC_countIndent::ConstructCore
-
-} // end of class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_C06E48FC_countIndent
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_6CFFAA1C_unquote
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.test262_metadataParser/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6bda
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::_environment0_test262_metadataParser
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6be9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6bec
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6bef
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::_environment0_test262_metadataParser
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.test262_metadataParser/unquote::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6c08
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::_environment0_test262_metadataParser
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.test262_metadataParser/unquote::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6c1d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6CFFAA1C_unquote::ConstructCore
-
-} // end of class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_6CFFAA1C_unquote
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.test262_metadataParser/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6c2c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::_environment0_test262_metadataParser
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6c3b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6c3e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6c41
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::_environment0_test262_metadataParser
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/parseInlineList::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6c5a
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::_environment0_test262_metadataParser
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/parseInlineList::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6c6f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList::ConstructCore
-
-} // end of class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_E6EBF08F_parseInlineList
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.test262_metadataParser/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6c7e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::_environment0_test262_metadataParser
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6c8d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6c90
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6c93
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::_environment0_test262_metadataParser
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.test262_metadataParser/parseInlineValue::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6cac
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::_environment0_test262_metadataParser
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.test262_metadataParser/parseInlineValue::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6cc1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue::ConstructCore
-
-} // end of class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_5DBCE4DC_parseInlineValue
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.test262_metadataParser/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6cd0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::_environment0_test262_metadataParser
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6cdf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6ce2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6ce5
-		// Header size: 1
-		// Code size: 29 (0x1d)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::_environment0_test262_metadataParser
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0017: call object Modules.test262_metadataParser/foldBlockLines::__js_call__(class Modules.test262_metadataParser/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-		IL_001c: ret
-	} // end of method FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6d03
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::_environment0_test262_metadataParser
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0013: call object Modules.test262_metadataParser/foldBlockLines::__js_call__(class Modules.test262_metadataParser/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6d1d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines::ConstructCore
-
-} // end of class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_1DD94F54_foldBlockLines
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.test262_metadataParser/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6d2c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::_environment0_test262_metadataParser
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6d3b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6d3e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6d41
-		// Header size: 1
-		// Code size: 50 (0x32)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::_environment0_test262_metadataParser
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0025: ldarg.2
-		IL_0026: ldc.i4.3
-		IL_0027: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_002c: call object Modules.test262_metadataParser/parseBlockScalar::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64, object)
-		IL_0031: ret
-	} // end of method FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6d74
-		// Header size: 1
-		// Code size: 46 (0x2e)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::_environment0_test262_metadataParser
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: ldarg.2
-		IL_0016: ldc.i4.2
-		IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0021: ldarg.2
-		IL_0022: ldc.i4.3
-		IL_0023: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0028: call object Modules.test262_metadataParser/parseBlockScalar::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64, object)
-		IL_002d: ret
-	} // end of method FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6da3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar::ConstructCore
-
-} // end of class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_FAF5EA13_parseBlockScalar
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.test262_metadataParser/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6db2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::_environment0_test262_metadataParser
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6dc1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6dc4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6dc7
-		// Header size: 1
-		// Code size: 43 (0x2b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::_environment0_test262_metadataParser
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0025: call object Modules.test262_metadataParser/parseIndentedValue::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64)
-		IL_002a: ret
-	} // end of method FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6df3
-		// Header size: 1
-		// Code size: 39 (0x27)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::_environment0_test262_metadataParser
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: ldarg.2
-		IL_0016: ldc.i4.2
-		IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0021: call object Modules.test262_metadataParser/parseIndentedValue::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64)
-		IL_0026: ret
-	} // end of method FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6e1b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue::ConstructCore
-
-} // end of class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_6F898EDE_parseIndentedValue
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.test262_metadataParser/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6e2a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::_environment0_test262_metadataParser
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6e39
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6e3c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6e3f
-		// Header size: 1
-		// Code size: 43 (0x2b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::_environment0_test262_metadataParser
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0025: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64)
-		IL_002a: ret
-	} // end of method FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6e6b
-		// Header size: 1
-		// Code size: 39 (0x27)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::_environment0_test262_metadataParser
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: ldarg.2
-		IL_0016: ldc.i4.2
-		IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0021: call object Modules.test262_metadataParser/parseYamlSubsetLines::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, float64)
-		IL_0026: ret
-	} // end of method FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6e93
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines::ConstructCore
-
-} // end of class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_A5B7E43A_parseYamlSubsetLines
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.test262_metadataParser/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6ea2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::_environment0_test262_metadataParser
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6eb1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6eb4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6eb7
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::_environment0_test262_metadataParser
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.test262_metadataParser/parseTest262Frontmatter::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6ed0
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::_environment0_test262_metadataParser
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.test262_metadataParser/parseTest262Frontmatter::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6ee5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter::ConstructCore
-
-} // end of class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_E92F4B56_parseTest262Frontmatter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.test262_metadataParser/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6ef4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::_environment0_test262_metadataParser
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6f03
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6f06
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6f09
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::_environment0_test262_metadataParser
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.test262_metadataParser/extractTest262Frontmatter::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6f22
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::_environment0_test262_metadataParser
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.test262_metadataParser/extractTest262Frontmatter::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6f37
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter::ConstructCore
-
-} // end of class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_92D9D8E4_extractTest262Frontmatter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_5155C561_normalizePath
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x6f46
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_5155C561_normalizePath::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6f4e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5155C561_normalizePath::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6f51
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5155C561_normalizePath::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6f54
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.test262_metadataParser/normalizePath::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_5155C561_normalizePath::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6f67
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.test262_metadataParser/normalizePath::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5155C561_normalizePath::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6f76
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5155C561_normalizePath::ConstructCore
-
-} // end of class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_5155C561_normalizePath
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_512395F4_getFileName
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x6f85
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_512395F4_getFileName::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6f8d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_512395F4_getFileName::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6f90
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_512395F4_getFileName::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6f93
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.test262_metadataParser/getFileName::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_512395F4_getFileName::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6fa6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.test262_metadataParser/getFileName::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_512395F4_getFileName::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6fb5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_512395F4_getFileName::ConstructCore
-
-} // end of class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_512395F4_getFileName
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_D59C98DE_contains
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x6fc4
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_D59C98DE_contains::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6fcc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D59C98DE_contains::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6fcf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D59C98DE_contains::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6fd2
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_D59C98DE_contains::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6fec
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.test262_metadataParser/contains::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_D59C98DE_contains::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x7002
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D59C98DE_contains::ConstructCore
-
-} // end of class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_D59C98DE_contains
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x7011
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x7019
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x701c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x701f
-		// Header size: 1
-		// Code size: 49 (0x31)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_001d: ldarg.2
-		IL_001e: ldc.i4.2
-		IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0024: ldarg.2
-		IL_0025: ldc.i4.3
-		IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_002b: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, string, object, object)
-		IL_0030: ret
-	} // end of method FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x7051
-		// Header size: 1
-		// Code size: 45 (0x2d)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: ldarg.2
-		IL_0021: ldc.i4.3
-		IL_0022: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0027: call object Modules.test262_metadataParser/pushIssue::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, string, object, object)
-		IL_002c: ret
-	} // end of method FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x707f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue::ConstructCore
-
-} // end of class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_D5AE1D4A_pushIssue
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_02368D80_toStringArray
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.test262_metadataParser/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x708e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_02368D80_toStringArray::_environment0_test262_metadataParser
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_02368D80_toStringArray::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x709d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_02368D80_toStringArray::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x70a0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_02368D80_toStringArray::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x70a3
-		// Header size: 1
-		// Code size: 48 (0x30)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_02368D80_toStringArray::_environment0_test262_metadataParser
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_001e: ldarg.2
-		IL_001f: ldc.i4.2
-		IL_0020: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0025: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_002a: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-		IL_002f: ret
-	} // end of method FunctionObject_FunctionDeclaration_02368D80_toStringArray::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x70d4
-		// Header size: 1
-		// Code size: 44 (0x2c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_02368D80_toStringArray::_environment0_test262_metadataParser
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_001a: ldarg.2
-		IL_001b: ldc.i4.2
-		IL_001c: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0021: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0026: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/toStringArray::__js_call__(class Modules.test262_metadataParser/Scope, object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-		IL_002b: ret
-	} // end of method FunctionObject_FunctionDeclaration_02368D80_toStringArray::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x7101
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_02368D80_toStringArray::ConstructCore
-
-} // end of class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_02368D80_toStringArray
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.test262_metadataParser/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x7110
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::_environment0_test262_metadataParser
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x711f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x7122
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x7125
-		// Header size: 1
-		// Code size: 48 (0x30)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::_environment0_test262_metadataParser
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_001e: ldarg.2
-		IL_001f: ldc.i4.2
-		IL_0020: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0025: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_002a: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-		IL_002f: ret
-	} // end of method FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x7156
-		// Header size: 1
-		// Code size: 44 (0x2c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::_environment0_test262_metadataParser
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_001a: ldarg.2
-		IL_001b: ldc.i4.2
-		IL_001c: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0021: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0026: call object Modules.test262_metadataParser/toNullableString::__js_call__(class Modules.test262_metadataParser/Scope, object, object, string, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-		IL_002b: ret
-	} // end of method FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x7183
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString::ConstructCore
-
-} // end of class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_7BAAA11A_toNullableString
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.test262_metadataParser/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x7192
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::_environment0_test262_metadataParser
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x71a1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x71a4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x71a7
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::_environment0_test262_metadataParser
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_001e: call object Modules.test262_metadataParser/normalizeNegative::__js_call__(class Modules.test262_metadataParser/Scope, object, object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x71cc
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::_environment0_test262_metadataParser
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_001a: call object Modules.test262_metadataParser/normalizeNegative::__js_call__(class Modules.test262_metadataParser/Scope, object, object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x71ed
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative::ConstructCore
-
-} // end of class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_BAA56065_normalizeNegative
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.test262_metadataParser/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x71fc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::_environment0_test262_metadataParser
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x720b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x720e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x7211
-		// Header size: 1
-		// Code size: 48 (0x30)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::_environment0_test262_metadataParser
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0017: ldarg.2
-		IL_0018: ldc.i4.1
-		IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0023: ldarg.2
-		IL_0024: ldc.i4.2
-		IL_0025: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_002a: call object Modules.test262_metadataParser/buildExecutionMetadata::__js_call__(class Modules.test262_metadataParser/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array, object)
-		IL_002f: ret
-	} // end of method FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x7242
-		// Header size: 1
-		// Code size: 44 (0x2c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::_environment0_test262_metadataParser
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.1
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_001f: ldarg.2
-		IL_0020: ldc.i4.2
-		IL_0021: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0026: call object Modules.test262_metadataParser/buildExecutionMetadata::__js_call__(class Modules.test262_metadataParser/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array, object)
-		IL_002b: ret
-	} // end of method FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x726f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata::ConstructCore
-
-} // end of class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_C0FDC4F8_buildExecutionMetadata
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.test262_metadataParser/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x727e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::_environment0_test262_metadataParser
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x728d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x7290
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x7293
-		// Header size: 1
-		// Code size: 38 (0x26)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::_environment0_test262_metadataParser
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/buildMvpBlockers::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-		IL_0025: ret
-	} // end of method FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x72ba
-		// Header size: 1
-		// Code size: 34 (0x22)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::_environment0_test262_metadataParser
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: ldarg.2
-		IL_0016: ldc.i4.2
-		IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001c: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.test262_metadataParser/buildMvpBlockers::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object, object)
-		IL_0021: ret
-	} // end of method FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x72dd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers::ConstructCore
-
-} // end of class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_75B70B19_buildMvpBlockers
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.test262_metadataParser/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x72ec
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::_environment0_test262_metadataParser
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x72fb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x72fe
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x7301
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::_environment0_test262_metadataParser
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.test262_metadataParser/parseTest262Metadata::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x7321
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::_environment0_test262_metadataParser
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.test262_metadataParser/parseTest262Metadata::__js_call__(class Modules.test262_metadataParser/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x733d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata::ConstructCore
-
-} // end of class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_92F3DC1D_parseTest262Metadata
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.test262_metadataParser/Scope _environment0_test262_metadataParser
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.test262_metadataParser/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x734c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::_environment0_test262_metadataParser
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x735b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x735e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x7361
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::_environment0_test262_metadataParser
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.test262_metadataParser/parseTest262File::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x737a
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.test262_metadataParser/Scope FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::_environment0_test262_metadataParser
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.test262_metadataParser/parseTest262File::__js_call__(class Modules.test262_metadataParser/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x738f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File::ConstructCore
-
-} // end of class FunctionObjects.test262_metadataParser_5B031DA0.FunctionObject_FunctionDeclaration_CB6DE95E_parseTest262File
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_AsArray_Ternary.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_AsArray_Ternary.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4E5144CC_asArray
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x217f
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_4E5144CC_asArray::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2187
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4E5144CC_asArray::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x218a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4E5144CC_asArray::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x218d
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Array_AsArray_Ternary/asArray::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_4E5144CC_asArray::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21a0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Array_AsArray_Ternary/asArray::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4E5144CC_asArray::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21af
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4E5144CC_asArray::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_4E5144CC_asArray
+
 
 		// Methods
 		.method public hidebysig static 
@@ -128,7 +229,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_AsArray_Ternary/Scope,
-			[1] class FunctionObjects.Array_AsArray_Ternary_72A2319C.FunctionObject_FunctionDeclaration_4E5144CC_asArray,
+			[1] class Modules.Array_AsArray_Ternary/asArray/FunctionObject_FunctionDeclaration_4E5144CC_asArray,
 			[2] object,
 			[3] object,
 			[4] object[],
@@ -146,13 +247,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 4
-		IL_0012: newobj instance void FunctionObjects.Array_AsArray_Ternary_72A2319C.FunctionObject_FunctionDeclaration_4E5144CC_asArray::.ctor()
+		IL_0012: newobj instance void Modules.Array_AsArray_Ternary/asArray/FunctionObject_FunctionDeclaration_4E5144CC_asArray::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "asArray"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_AsArray_Ternary_72A2319C.FunctionObject_FunctionDeclaration_4E5144CC_asArray>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_AsArray_Ternary/asArray/FunctionObject_FunctionDeclaration_4E5144CC_asArray>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: nop
@@ -207,107 +308,6 @@
 	} // end of method Array_AsArray_Ternary::__js_module_init__
 
 } // end of class Modules.Array_AsArray_Ternary
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_AsArray_Ternary_72A2319C.FunctionObject_FunctionDeclaration_4E5144CC_asArray
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x217f
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_4E5144CC_asArray::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2187
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4E5144CC_asArray::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x218a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4E5144CC_asArray::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x218d
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Array_AsArray_Ternary/asArray::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_4E5144CC_asArray::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21a0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Array_AsArray_Ternary/asArray::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4E5144CC_asArray::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21af
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4E5144CC_asArray::ConstructCore
-
-} // end of class FunctionObjects.Array_AsArray_Ternary_72A2319C.FunctionObject_FunctionDeclaration_4E5144CC_asArray
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_CallbackOps_Basic.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_CallbackOps_Basic.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_637AD77B_L6C11
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x23eb
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_637AD77B_L6C11::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x23f3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_637AD77B_L6C11::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x23f6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_637AD77B_L6C11::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x23f9
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Array_CallbackOps_Basic/FunctionExpression_L6C10::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_637AD77B_L6C11::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x240c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Array_CallbackOps_Basic/FunctionExpression_L6C10::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_637AD77B_L6C11::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x241b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_637AD77B_L6C11::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_637AD77B_L6C11
+
 
 		// Methods
 		.method public hidebysig static 
@@ -84,6 +185,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7342AA0E_L9C22
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x242a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_7342AA0E_L9C22::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2432
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7342AA0E_L9C22::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2435
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7342AA0E_L9C22::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2438
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Array_CallbackOps_Basic/FunctionExpression_evens::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_7342AA0E_L9C22::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x244b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Array_CallbackOps_Basic/FunctionExpression_evens::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_7342AA0E_L9C22::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x245a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_7342AA0E_L9C22::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_7342AA0E_L9C22
+
 
 		// Methods
 		.method public hidebysig static 
@@ -136,6 +338,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_52BEDCC4_L11C21
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2469
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_52BEDCC4_L11C21::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2471
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_52BEDCC4_L11C21::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2474
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_52BEDCC4_L11C21::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2477
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Array_CallbackOps_Basic/FunctionExpression_L11C20::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_52BEDCC4_L11C21::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x248a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Array_CallbackOps_Basic/FunctionExpression_L11C20::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_52BEDCC4_L11C21::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2499
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_52BEDCC4_L11C21::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_52BEDCC4_L11C21
+
 
 		// Methods
 		.method public hidebysig static 
@@ -185,6 +488,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1DB110D6_L12C22
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x24a8
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_1DB110D6_L12C22::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24b0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_1DB110D6_L12C22::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24b3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_1DB110D6_L12C22::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24b6
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Array_CallbackOps_Basic/FunctionExpression_L12C21::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionExpression_1DB110D6_L12C22::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24d0
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Array_CallbackOps_Basic/FunctionExpression_L12C21::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionExpression_1DB110D6_L12C22::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24e6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_1DB110D6_L12C22::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_1DB110D6_L12C22
 
 
 		// Methods
@@ -240,6 +650,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0F06B6BC_L13C27
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x24f5
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_0F06B6BC_L13C27::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24fd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_0F06B6BC_L13C27::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2500
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_0F06B6BC_L13C27::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2503
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Array_CallbackOps_Basic/FunctionExpression_L13C26::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionExpression_0F06B6BC_L13C27::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x251d
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Array_CallbackOps_Basic/FunctionExpression_L13C26::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionExpression_0F06B6BC_L13C27::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2533
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_0F06B6BC_L13C27::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_0F06B6BC_L13C27
+
 
 		// Methods
 		.method public hidebysig static 
@@ -291,6 +808,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FB505DFD_L15C31
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2542
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_FB505DFD_L15C31::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x254a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_FB505DFD_L15C31::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x254d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_FB505DFD_L15C31::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2550
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Array_CallbackOps_Basic/FunctionExpression_L15C30::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_FB505DFD_L15C31::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2563
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Array_CallbackOps_Basic/FunctionExpression_L15C30::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_FB505DFD_L15C31::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2572
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_FB505DFD_L15C31::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_FB505DFD_L15C31
 
 
 		// Methods
@@ -362,18 +980,18 @@
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[4] object[],
-			[5] class FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_637AD77B_L6C11,
-			[6] class FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_7342AA0E_L9C22,
+			[5] class Modules.Array_CallbackOps_Basic/FunctionExpression_L6C10/FunctionObject_FunctionExpression_637AD77B_L6C11,
+			[6] class Modules.Array_CallbackOps_Basic/FunctionExpression_evens/FunctionObject_FunctionExpression_7342AA0E_L9C22,
 			[7] object,
 			[8] string,
-			[9] class FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_52BEDCC4_L11C21,
+			[9] class Modules.Array_CallbackOps_Basic/FunctionExpression_L11C20/FunctionObject_FunctionExpression_52BEDCC4_L11C21,
 			[10] bool,
 			[11] object,
-			[12] class FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_1DB110D6_L12C22,
+			[12] class Modules.Array_CallbackOps_Basic/FunctionExpression_L12C21/FunctionObject_FunctionExpression_1DB110D6_L12C22,
 			[13] object,
-			[14] class FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_0F06B6BC_L13C27,
+			[14] class Modules.Array_CallbackOps_Basic/FunctionExpression_L13C26/FunctionObject_FunctionExpression_0F06B6BC_L13C27,
 			[15] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[16] class FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_FB505DFD_L15C31
+			[16] class Modules.Array_CallbackOps_Basic/FunctionExpression_L15C30/FunctionObject_FunctionExpression_FB505DFD_L15C31
 		)
 
 		IL_0000: newobj instance void Modules.Array_CallbackOps_Basic/Scope::.ctor()
@@ -398,13 +1016,13 @@
 		IL_0043: ldloc.0
 		IL_0044: stelem.ref
 		IL_0045: stloc.s 4
-		IL_0047: newobj instance void FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_637AD77B_L6C11::.ctor()
+		IL_0047: newobj instance void Modules.Array_CallbackOps_Basic/FunctionExpression_L6C10/FunctionObject_FunctionExpression_637AD77B_L6C11::.ctor()
 		IL_004c: ldc.i4.1
 		IL_004d: conv.r8
 		IL_004e: ldstr ""
 		IL_0053: ldc.i4.0
 		IL_0054: ldc.i4.1
-		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_637AD77B_L6C11>(!!0, float64, string, bool, bool)
+		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_CallbackOps_Basic/FunctionExpression_L6C10/FunctionObject_FunctionExpression_637AD77B_L6C11>(!!0, float64, string, bool, bool)
 		IL_005a: stloc.s 5
 		IL_005c: ldloc.1
 		IL_005d: ldc.i4.1
@@ -437,13 +1055,13 @@
 		IL_00b9: ldloc.0
 		IL_00ba: stelem.ref
 		IL_00bb: stloc.s 4
-		IL_00bd: newobj instance void FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_7342AA0E_L9C22::.ctor()
+		IL_00bd: newobj instance void Modules.Array_CallbackOps_Basic/FunctionExpression_evens/FunctionObject_FunctionExpression_7342AA0E_L9C22::.ctor()
 		IL_00c2: ldc.i4.1
 		IL_00c3: conv.r8
 		IL_00c4: ldstr ""
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_7342AA0E_L9C22>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_CallbackOps_Basic/FunctionExpression_evens/FunctionObject_FunctionExpression_7342AA0E_L9C22>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 6
 		IL_00d2: ldloc.2
 		IL_00d3: ldc.i4.1
@@ -477,13 +1095,13 @@
 		IL_0125: ldloc.0
 		IL_0126: stelem.ref
 		IL_0127: stloc.s 4
-		IL_0129: newobj instance void FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_52BEDCC4_L11C21::.ctor()
+		IL_0129: newobj instance void Modules.Array_CallbackOps_Basic/FunctionExpression_L11C20/FunctionObject_FunctionExpression_52BEDCC4_L11C21::.ctor()
 		IL_012e: ldc.i4.1
 		IL_012f: conv.r8
 		IL_0130: ldstr ""
 		IL_0135: ldc.i4.0
 		IL_0136: ldc.i4.1
-		IL_0137: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_52BEDCC4_L11C21>(!!0, float64, string, bool, bool)
+		IL_0137: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_CallbackOps_Basic/FunctionExpression_L11C20/FunctionObject_FunctionExpression_52BEDCC4_L11C21>(!!0, float64, string, bool, bool)
 		IL_013c: stloc.s 9
 		IL_013e: ldloc.2
 		IL_013f: ldc.i4.1
@@ -513,13 +1131,13 @@
 		IL_0182: ldloc.0
 		IL_0183: stelem.ref
 		IL_0184: stloc.s 4
-		IL_0186: newobj instance void FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_1DB110D6_L12C22::.ctor()
+		IL_0186: newobj instance void Modules.Array_CallbackOps_Basic/FunctionExpression_L12C21/FunctionObject_FunctionExpression_1DB110D6_L12C22::.ctor()
 		IL_018b: ldc.i4.2
 		IL_018c: conv.r8
 		IL_018d: ldstr ""
 		IL_0192: ldc.i4.0
 		IL_0193: ldc.i4.1
-		IL_0194: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_1DB110D6_L12C22>(!!0, float64, string, bool, bool)
+		IL_0194: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_CallbackOps_Basic/FunctionExpression_L12C21/FunctionObject_FunctionExpression_1DB110D6_L12C22>(!!0, float64, string, bool, bool)
 		IL_0199: stloc.s 12
 		IL_019b: ldloc.2
 		IL_019c: ldc.i4.2
@@ -551,13 +1169,13 @@
 		IL_01e7: ldloc.0
 		IL_01e8: stelem.ref
 		IL_01e9: stloc.s 4
-		IL_01eb: newobj instance void FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_0F06B6BC_L13C27::.ctor()
+		IL_01eb: newobj instance void Modules.Array_CallbackOps_Basic/FunctionExpression_L13C26/FunctionObject_FunctionExpression_0F06B6BC_L13C27::.ctor()
 		IL_01f0: ldc.i4.2
 		IL_01f1: conv.r8
 		IL_01f2: ldstr ""
 		IL_01f7: ldc.i4.0
 		IL_01f8: ldc.i4.1
-		IL_01f9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_0F06B6BC_L13C27>(!!0, float64, string, bool, bool)
+		IL_01f9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_CallbackOps_Basic/FunctionExpression_L13C26/FunctionObject_FunctionExpression_0F06B6BC_L13C27>(!!0, float64, string, bool, bool)
 		IL_01fe: stloc.s 14
 		IL_0200: ldloc.2
 		IL_0201: ldc.i4.1
@@ -596,13 +1214,13 @@
 		IL_0270: ldloc.0
 		IL_0271: stelem.ref
 		IL_0272: stloc.s 4
-		IL_0274: newobj instance void FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_FB505DFD_L15C31::.ctor()
+		IL_0274: newobj instance void Modules.Array_CallbackOps_Basic/FunctionExpression_L15C30/FunctionObject_FunctionExpression_FB505DFD_L15C31::.ctor()
 		IL_0279: ldc.i4.1
 		IL_027a: conv.r8
 		IL_027b: ldstr ""
 		IL_0280: ldc.i4.0
 		IL_0281: ldc.i4.1
-		IL_0282: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_FB505DFD_L15C31>(!!0, float64, string, bool, bool)
+		IL_0282: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_CallbackOps_Basic/FunctionExpression_L15C30/FunctionObject_FunctionExpression_FB505DFD_L15C31>(!!0, float64, string, bool, bool)
 		IL_0287: stloc.s 16
 		IL_0289: ldloc.s 15
 		IL_028b: ldc.i4.1
@@ -625,624 +1243,6 @@
 	} // end of method Array_CallbackOps_Basic::__js_module_init__
 
 } // end of class Modules.Array_CallbackOps_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_637AD77B_L6C11
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x23eb
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_637AD77B_L6C11::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23f3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_637AD77B_L6C11::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23f6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_637AD77B_L6C11::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23f9
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Array_CallbackOps_Basic/FunctionExpression_L6C10::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_637AD77B_L6C11::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x240c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Array_CallbackOps_Basic/FunctionExpression_L6C10::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_637AD77B_L6C11::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x241b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_637AD77B_L6C11::ConstructCore
-
-} // end of class FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_637AD77B_L6C11
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_7342AA0E_L9C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x242a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_7342AA0E_L9C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2432
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7342AA0E_L9C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2435
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7342AA0E_L9C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2438
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Array_CallbackOps_Basic/FunctionExpression_evens::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_7342AA0E_L9C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x244b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Array_CallbackOps_Basic/FunctionExpression_evens::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7342AA0E_L9C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x245a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7342AA0E_L9C22::ConstructCore
-
-} // end of class FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_7342AA0E_L9C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_52BEDCC4_L11C21
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2469
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_52BEDCC4_L11C21::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2471
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_52BEDCC4_L11C21::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2474
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_52BEDCC4_L11C21::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2477
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Array_CallbackOps_Basic/FunctionExpression_L11C20::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_52BEDCC4_L11C21::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x248a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Array_CallbackOps_Basic/FunctionExpression_L11C20::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_52BEDCC4_L11C21::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2499
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_52BEDCC4_L11C21::ConstructCore
-
-} // end of class FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_52BEDCC4_L11C21
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_1DB110D6_L12C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x24a8
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_1DB110D6_L12C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24b0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1DB110D6_L12C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24b3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1DB110D6_L12C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24b6
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Array_CallbackOps_Basic/FunctionExpression_L12C21::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_1DB110D6_L12C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24d0
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Array_CallbackOps_Basic/FunctionExpression_L12C21::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_1DB110D6_L12C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24e6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1DB110D6_L12C22::ConstructCore
-
-} // end of class FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_1DB110D6_L12C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_0F06B6BC_L13C27
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x24f5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_0F06B6BC_L13C27::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24fd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_0F06B6BC_L13C27::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2500
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_0F06B6BC_L13C27::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2503
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Array_CallbackOps_Basic/FunctionExpression_L13C26::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_0F06B6BC_L13C27::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x251d
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Array_CallbackOps_Basic/FunctionExpression_L13C26::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_0F06B6BC_L13C27::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2533
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_0F06B6BC_L13C27::ConstructCore
-
-} // end of class FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_0F06B6BC_L13C27
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_FB505DFD_L15C31
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2542
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_FB505DFD_L15C31::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x254a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FB505DFD_L15C31::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x254d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FB505DFD_L15C31::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2550
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Array_CallbackOps_Basic/FunctionExpression_L15C30::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_FB505DFD_L15C31::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2563
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Array_CallbackOps_Basic/FunctionExpression_L15C30::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_FB505DFD_L15C31::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2572
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_FB505DFD_L15C31::ConstructCore
-
-} // end of class FunctionObjects.Array_CallbackOps_Basic_ED55EFC5.FunctionObject_FunctionExpression_FB505DFD_L15C31
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_DenseFastPath_Guards.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_DenseFastPath_Guards.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_EA166462_L5C14
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Array_DenseFastPath_Guards/Scope _environment0_Array_DenseFastPath_Guards
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Array_DenseFastPath_Guards/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x25d1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_freezingLength/FunctionObject_FunctionExpression_EA166462_L5C14::_environment0_Array_DenseFastPath_Guards
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_EA166462_L5C14::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x25e0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_EA166462_L5C14::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x25e3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_EA166462_L5C14::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x25e6
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_freezingLength/FunctionObject_FunctionExpression_EA166462_L5C14::_environment0_Array_DenseFastPath_Guards
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Array_DenseFastPath_Guards/FunctionExpression_freezingLength::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_EA166462_L5C14::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25f8
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_freezingLength/FunctionObject_FunctionExpression_EA166462_L5C14::_environment0_Array_DenseFastPath_Guards
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Array_DenseFastPath_Guards/FunctionExpression_freezingLength::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_EA166462_L5C14::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2606
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_EA166462_L5C14::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_EA166462_L5C14
+
 
 		// Methods
 		.method public hidebysig static 
@@ -88,6 +195,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_4F2CEFAB_L19C14
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Array_DenseFastPath_Guards/Scope _environment0_Array_DenseFastPath_Guards
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Array_DenseFastPath_Guards/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2615
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_clearingStart/FunctionObject_FunctionExpression_4F2CEFAB_L19C14::_environment0_Array_DenseFastPath_Guards
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_4F2CEFAB_L19C14::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2624
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_4F2CEFAB_L19C14::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2627
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_4F2CEFAB_L19C14::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x262a
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_clearingStart/FunctionObject_FunctionExpression_4F2CEFAB_L19C14::_environment0_Array_DenseFastPath_Guards
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Array_DenseFastPath_Guards/FunctionExpression_clearingStart::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_4F2CEFAB_L19C14::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x263c
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_clearingStart/FunctionObject_FunctionExpression_4F2CEFAB_L19C14::_environment0_Array_DenseFastPath_Guards
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Array_DenseFastPath_Guards/FunctionExpression_clearingStart::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_4F2CEFAB_L19C14::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x264a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_4F2CEFAB_L19C14::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_4F2CEFAB_L19C14
 
 
 		// Methods
@@ -148,6 +362,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3704D58D_L31C10
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Array_DenseFastPath_Guards/Scope _environment0_Array_DenseFastPath_Guards
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Array_DenseFastPath_Guards/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2659
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_L31C9/FunctionObject_FunctionExpression_3704D58D_L31C10::_environment0_Array_DenseFastPath_Guards
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_3704D58D_L31C10::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2668
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_3704D58D_L31C10::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x266b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_3704D58D_L31C10::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x266e
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_L31C9/FunctionObject_FunctionExpression_3704D58D_L31C10::_environment0_Array_DenseFastPath_Guards
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Array_DenseFastPath_Guards/FunctionExpression_L31C9::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_3704D58D_L31C10::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2687
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_L31C9/FunctionObject_FunctionExpression_3704D58D_L31C10::_environment0_Array_DenseFastPath_Guards
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Array_DenseFastPath_Guards/FunctionExpression_L31C9::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_3704D58D_L31C10::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x269c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_3704D58D_L31C10::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_3704D58D_L31C10
+
 
 		// Methods
 		.method public hidebysig static 
@@ -199,6 +526,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2B8CF3A7_L42C10
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Array_DenseFastPath_Guards/Scope _environment0_Array_DenseFastPath_Guards
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Array_DenseFastPath_Guards/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x26ab
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_L42C9/FunctionObject_FunctionExpression_2B8CF3A7_L42C10::_environment0_Array_DenseFastPath_Guards
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_2B8CF3A7_L42C10::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x26ba
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_2B8CF3A7_L42C10::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x26bd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_2B8CF3A7_L42C10::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x26c0
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_L42C9/FunctionObject_FunctionExpression_2B8CF3A7_L42C10::_environment0_Array_DenseFastPath_Guards
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Array_DenseFastPath_Guards/FunctionExpression_L42C9::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_2B8CF3A7_L42C10::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26d9
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope Modules.Array_DenseFastPath_Guards/FunctionExpression_L42C9/FunctionObject_FunctionExpression_2B8CF3A7_L42C10::_environment0_Array_DenseFastPath_Guards
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Array_DenseFastPath_Guards/FunctionExpression_L42C9::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_2B8CF3A7_L42C10::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26ee
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_2B8CF3A7_L42C10::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_2B8CF3A7_L42C10
 
 
 		// Methods
@@ -339,18 +779,18 @@
 			[12] object,
 			[13] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[14] object[],
-			[15] class FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_EA166462_L5C14,
+			[15] class Modules.Array_DenseFastPath_Guards/FunctionExpression_freezingLength/FunctionObject_FunctionExpression_EA166462_L5C14,
 			[16] object,
 			[17] object,
 			[18] object,
 			[19] string,
-			[20] class FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_4F2CEFAB_L19C14,
+			[20] class Modules.Array_DenseFastPath_Guards/FunctionExpression_clearingStart/FunctionObject_FunctionExpression_4F2CEFAB_L19C14,
 			[21] object,
-			[22] class FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_3704D58D_L31C10,
+			[22] class Modules.Array_DenseFastPath_Guards/FunctionExpression_L31C9/FunctionObject_FunctionExpression_3704D58D_L31C10,
 			[23] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[24] object,
 			[25] bool,
-			[26] class FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_2B8CF3A7_L42C10
+			[26] class Modules.Array_DenseFastPath_Guards/FunctionExpression_L42C9/FunctionObject_FunctionExpression_2B8CF3A7_L42C10
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -380,13 +820,13 @@
 		IL_0048: ldc.i4.0
 		IL_0049: ldelem.ref
 		IL_004a: castclass Modules.Array_DenseFastPath_Guards/Scope
-		IL_004f: newobj instance void FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_EA166462_L5C14::.ctor(class Modules.Array_DenseFastPath_Guards/Scope)
+		IL_004f: newobj instance void Modules.Array_DenseFastPath_Guards/FunctionExpression_freezingLength/FunctionObject_FunctionExpression_EA166462_L5C14::.ctor(class Modules.Array_DenseFastPath_Guards/Scope)
 		IL_0054: ldc.i4.0
 		IL_0055: conv.r8
 		IL_0056: ldstr ""
 		IL_005b: ldc.i4.0
 		IL_005c: ldc.i4.1
-		IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_EA166462_L5C14>(!!0, float64, string, bool, bool)
+		IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_DenseFastPath_Guards/FunctionExpression_freezingLength/FunctionObject_FunctionExpression_EA166462_L5C14>(!!0, float64, string, bool, bool)
 		IL_0062: stloc.s 15
 		IL_0064: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0069: dup
@@ -498,13 +938,13 @@
 		IL_0187: ldc.i4.0
 		IL_0188: ldelem.ref
 		IL_0189: castclass Modules.Array_DenseFastPath_Guards/Scope
-		IL_018e: newobj instance void FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_4F2CEFAB_L19C14::.ctor(class Modules.Array_DenseFastPath_Guards/Scope)
+		IL_018e: newobj instance void Modules.Array_DenseFastPath_Guards/FunctionExpression_clearingStart/FunctionObject_FunctionExpression_4F2CEFAB_L19C14::.ctor(class Modules.Array_DenseFastPath_Guards/Scope)
 		IL_0193: ldc.i4.0
 		IL_0194: conv.r8
 		IL_0195: ldstr ""
 		IL_019a: ldc.i4.0
 		IL_019b: ldc.i4.1
-		IL_019c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_4F2CEFAB_L19C14>(!!0, float64, string, bool, bool)
+		IL_019c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_DenseFastPath_Guards/FunctionExpression_clearingStart/FunctionObject_FunctionExpression_4F2CEFAB_L19C14>(!!0, float64, string, bool, bool)
 		IL_01a1: stloc.s 20
 		IL_01a3: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_01a8: dup
@@ -565,13 +1005,13 @@
 		IL_0263: ldc.i4.0
 		IL_0264: ldelem.ref
 		IL_0265: castclass Modules.Array_DenseFastPath_Guards/Scope
-		IL_026a: newobj instance void FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_3704D58D_L31C10::.ctor(class Modules.Array_DenseFastPath_Guards/Scope)
+		IL_026a: newobj instance void Modules.Array_DenseFastPath_Guards/FunctionExpression_L31C9/FunctionObject_FunctionExpression_3704D58D_L31C10::.ctor(class Modules.Array_DenseFastPath_Guards/Scope)
 		IL_026f: ldc.i4.1
 		IL_0270: conv.r8
 		IL_0271: ldstr ""
 		IL_0276: ldc.i4.0
 		IL_0277: ldc.i4.1
-		IL_0278: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_3704D58D_L31C10>(!!0, float64, string, bool, bool)
+		IL_0278: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_DenseFastPath_Guards/FunctionExpression_L31C9/FunctionObject_FunctionExpression_3704D58D_L31C10>(!!0, float64, string, bool, bool)
 		IL_027d: stloc.s 22
 		IL_027f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0284: dup
@@ -646,13 +1086,13 @@
 		IL_036f: ldc.i4.0
 		IL_0370: ldelem.ref
 		IL_0371: castclass Modules.Array_DenseFastPath_Guards/Scope
-		IL_0376: newobj instance void FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_2B8CF3A7_L42C10::.ctor(class Modules.Array_DenseFastPath_Guards/Scope)
+		IL_0376: newobj instance void Modules.Array_DenseFastPath_Guards/FunctionExpression_L42C9/FunctionObject_FunctionExpression_2B8CF3A7_L42C10::.ctor(class Modules.Array_DenseFastPath_Guards/Scope)
 		IL_037b: ldc.i4.1
 		IL_037c: conv.r8
 		IL_037d: ldstr ""
 		IL_0382: ldc.i4.0
 		IL_0383: ldc.i4.1
-		IL_0384: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_2B8CF3A7_L42C10>(!!0, float64, string, bool, bool)
+		IL_0384: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_DenseFastPath_Guards/FunctionExpression_L42C9/FunctionObject_FunctionExpression_2B8CF3A7_L42C10>(!!0, float64, string, bool, bool)
 		IL_0389: stloc.s 26
 		IL_038b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0390: dup
@@ -745,446 +1185,6 @@
 	} // end of method Array_DenseFastPath_Guards::__js_module_init__
 
 } // end of class Modules.Array_DenseFastPath_Guards
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_EA166462_L5C14
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Array_DenseFastPath_Guards/Scope _environment0_Array_DenseFastPath_Guards
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Array_DenseFastPath_Guards/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x25d1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Array_DenseFastPath_Guards/Scope FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_EA166462_L5C14::_environment0_Array_DenseFastPath_Guards
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_EA166462_L5C14::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x25e0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_EA166462_L5C14::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x25e3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_EA166462_L5C14::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x25e6
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_EA166462_L5C14::_environment0_Array_DenseFastPath_Guards
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Array_DenseFastPath_Guards/FunctionExpression_freezingLength::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_EA166462_L5C14::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25f8
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_EA166462_L5C14::_environment0_Array_DenseFastPath_Guards
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Array_DenseFastPath_Guards/FunctionExpression_freezingLength::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_EA166462_L5C14::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2606
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_EA166462_L5C14::ConstructCore
-
-} // end of class FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_EA166462_L5C14
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_4F2CEFAB_L19C14
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Array_DenseFastPath_Guards/Scope _environment0_Array_DenseFastPath_Guards
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Array_DenseFastPath_Guards/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2615
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Array_DenseFastPath_Guards/Scope FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_4F2CEFAB_L19C14::_environment0_Array_DenseFastPath_Guards
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_4F2CEFAB_L19C14::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2624
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_4F2CEFAB_L19C14::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2627
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_4F2CEFAB_L19C14::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x262a
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_4F2CEFAB_L19C14::_environment0_Array_DenseFastPath_Guards
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Array_DenseFastPath_Guards/FunctionExpression_clearingStart::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_4F2CEFAB_L19C14::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x263c
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_4F2CEFAB_L19C14::_environment0_Array_DenseFastPath_Guards
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Array_DenseFastPath_Guards/FunctionExpression_clearingStart::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_4F2CEFAB_L19C14::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x264a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_4F2CEFAB_L19C14::ConstructCore
-
-} // end of class FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_4F2CEFAB_L19C14
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_3704D58D_L31C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Array_DenseFastPath_Guards/Scope _environment0_Array_DenseFastPath_Guards
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Array_DenseFastPath_Guards/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2659
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Array_DenseFastPath_Guards/Scope FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_3704D58D_L31C10::_environment0_Array_DenseFastPath_Guards
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3704D58D_L31C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2668
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3704D58D_L31C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x266b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3704D58D_L31C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x266e
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_3704D58D_L31C10::_environment0_Array_DenseFastPath_Guards
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Array_DenseFastPath_Guards/FunctionExpression_L31C9::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_3704D58D_L31C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2687
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_3704D58D_L31C10::_environment0_Array_DenseFastPath_Guards
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Array_DenseFastPath_Guards/FunctionExpression_L31C9::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_3704D58D_L31C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x269c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3704D58D_L31C10::ConstructCore
-
-} // end of class FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_3704D58D_L31C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_2B8CF3A7_L42C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Array_DenseFastPath_Guards/Scope _environment0_Array_DenseFastPath_Guards
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Array_DenseFastPath_Guards/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x26ab
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Array_DenseFastPath_Guards/Scope FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_2B8CF3A7_L42C10::_environment0_Array_DenseFastPath_Guards
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2B8CF3A7_L42C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x26ba
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2B8CF3A7_L42C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x26bd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2B8CF3A7_L42C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x26c0
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_2B8CF3A7_L42C10::_environment0_Array_DenseFastPath_Guards
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Array_DenseFastPath_Guards/FunctionExpression_L42C9::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_2B8CF3A7_L42C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26d9
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_DenseFastPath_Guards/Scope FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_2B8CF3A7_L42C10::_environment0_Array_DenseFastPath_Guards
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Array_DenseFastPath_Guards/FunctionExpression_L42C9::__js_call__(class Modules.Array_DenseFastPath_Guards/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_2B8CF3A7_L42C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26ee
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2B8CF3A7_L42C10::ConstructCore
-
-} // end of class FunctionObjects.Array_DenseFastPath_Guards_5212A692.FunctionObject_FunctionExpression_2B8CF3A7_L42C10
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Exotic_Property_Descriptors.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Exotic_Property_Descriptors.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DD911CFC_L23C10
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Array_Exotic_Property_Descriptors/Scope _environment0_Array_Exotic_Property_Descriptors
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Array_Exotic_Property_Descriptors/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3681
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Array_Exotic_Property_Descriptors/Scope Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9/FunctionObject_FunctionExpression_DD911CFC_L23C10::_environment0_Array_Exotic_Property_Descriptors
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_DD911CFC_L23C10::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3690
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_DD911CFC_L23C10::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3693
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_DD911CFC_L23C10::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3696
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_Exotic_Property_Descriptors/Scope Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9/FunctionObject_FunctionExpression_DD911CFC_L23C10::_environment0_Array_Exotic_Property_Descriptors
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9::__js_call__(class Modules.Array_Exotic_Property_Descriptors/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_DD911CFC_L23C10::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x36a8
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_Exotic_Property_Descriptors/Scope Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9/FunctionObject_FunctionExpression_DD911CFC_L23C10::_environment0_Array_Exotic_Property_Descriptors
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9::__js_call__(class Modules.Array_Exotic_Property_Descriptors/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_DD911CFC_L23C10::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x36b6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_DD911CFC_L23C10::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_DD911CFC_L23C10
+
 
 		// Methods
 		.method public hidebysig static 
@@ -79,6 +186,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5BEC1E07_L24C10
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Array_Exotic_Property_Descriptors/Scope _environment0_Array_Exotic_Property_Descriptors
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Array_Exotic_Property_Descriptors/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x36c5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Array_Exotic_Property_Descriptors/Scope Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9/FunctionObject_FunctionExpression_5BEC1E07_L24C10::_environment0_Array_Exotic_Property_Descriptors
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_5BEC1E07_L24C10::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x36d4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5BEC1E07_L24C10::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x36d7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5BEC1E07_L24C10::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x36da
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_Exotic_Property_Descriptors/Scope Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9/FunctionObject_FunctionExpression_5BEC1E07_L24C10::_environment0_Array_Exotic_Property_Descriptors
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9::__js_call__(class Modules.Array_Exotic_Property_Descriptors/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_5BEC1E07_L24C10::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x36f3
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_Exotic_Property_Descriptors/Scope Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9/FunctionObject_FunctionExpression_5BEC1E07_L24C10::_environment0_Array_Exotic_Property_Descriptors
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9::__js_call__(class Modules.Array_Exotic_Property_Descriptors/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_5BEC1E07_L24C10::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3708
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_5BEC1E07_L24C10::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_5BEC1E07_L24C10
 
 
 		// Methods
@@ -144,6 +364,109 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C8ECECDF_clearArray
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3717
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8ECECDF_clearArray::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x371f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8ECECDF_clearArray::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3722
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8ECECDF_clearArray::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3725
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0011: call object Modules.Array_Exotic_Property_Descriptors/clearArray::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8ECECDF_clearArray::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x373d
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_000d: call object Modules.Array_Exotic_Property_Descriptors/clearArray::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8ECECDF_clearArray::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3751
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8ECECDF_clearArray::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C8ECECDF_clearArray
+
 
 		// Methods
 		.method public hidebysig static 
@@ -193,6 +516,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3D5ECCF2_L165C15
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Array_Exotic_Property_Descriptors/Scope _environment0_Array_Exotic_Property_Descriptors
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Array_Exotic_Property_Descriptors/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3760
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Array_Exotic_Property_Descriptors/Scope Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject/FunctionObject_FunctionExpression_3D5ECCF2_L165C15::_environment0_Array_Exotic_Property_Descriptors
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_3D5ECCF2_L165C15::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x376f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_3D5ECCF2_L165C15::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3772
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_3D5ECCF2_L165C15::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3775
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_Exotic_Property_Descriptors/Scope Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject/FunctionObject_FunctionExpression_3D5ECCF2_L165C15::_environment0_Array_Exotic_Property_Descriptors
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject::__js_call__(class Modules.Array_Exotic_Property_Descriptors/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_3D5ECCF2_L165C15::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3787
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_Exotic_Property_Descriptors/Scope Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject/FunctionObject_FunctionExpression_3D5ECCF2_L165C15::_environment0_Array_Exotic_Property_Descriptors
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject::__js_call__(class Modules.Array_Exotic_Property_Descriptors/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_3D5ECCF2_L165C15::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3795
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_3D5ECCF2_L165C15::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_3D5ECCF2_L165C15
 
 
 		// Methods
@@ -807,7 +1237,7 @@
 		.maxstack 9
 		.locals init (
 			[0] class Modules.Array_Exotic_Property_Descriptors/Scope,
-			[1] class FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionDeclaration_C8ECECDF_clearArray,
+			[1] class Modules.Array_Exotic_Property_Descriptors/clearArray/FunctionObject_FunctionDeclaration_C8ECECDF_clearArray,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] object,
 			[4] class [System.Runtime]System.Exception,
@@ -878,8 +1308,8 @@
 			[69] object,
 			[70] object,
 			[71] object,
-			[72] class FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionExpression_DD911CFC_L23C10,
-			[73] class FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionExpression_5BEC1E07_L24C10,
+			[72] class Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9/FunctionObject_FunctionExpression_DD911CFC_L23C10,
+			[73] class Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9/FunctionObject_FunctionExpression_5BEC1E07_L24C10,
 			[74] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[75] object,
 			[76] object,
@@ -887,7 +1317,7 @@
 			[78] string,
 			[79] float64,
 			[80] object,
-			[81] class FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionExpression_3D5ECCF2_L165C15
+			[81] class Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject/FunctionObject_FunctionExpression_3D5ECCF2_L165C15
 		)
 
 		IL_0000: newobj instance void Modules.Array_Exotic_Property_Descriptors/Scope::.ctor()
@@ -899,13 +1329,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 64
-		IL_0012: newobj instance void FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionDeclaration_C8ECECDF_clearArray::.ctor()
+		IL_0012: newobj instance void Modules.Array_Exotic_Property_Descriptors/clearArray/FunctionObject_FunctionDeclaration_C8ECECDF_clearArray::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "clearArray"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionDeclaration_C8ECECDF_clearArray>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Exotic_Property_Descriptors/clearArray/FunctionObject_FunctionDeclaration_C8ECECDF_clearArray>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: ldc.i4.3
@@ -1097,13 +1527,13 @@
 		IL_0267: ldc.i4.0
 		IL_0268: ldelem.ref
 		IL_0269: castclass Modules.Array_Exotic_Property_Descriptors/Scope
-		IL_026e: newobj instance void FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionExpression_DD911CFC_L23C10::.ctor(class Modules.Array_Exotic_Property_Descriptors/Scope)
+		IL_026e: newobj instance void Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9/FunctionObject_FunctionExpression_DD911CFC_L23C10::.ctor(class Modules.Array_Exotic_Property_Descriptors/Scope)
 		IL_0273: ldc.i4.0
 		IL_0274: conv.r8
 		IL_0275: ldstr ""
 		IL_027a: ldc.i4.0
 		IL_027b: ldc.i4.1
-		IL_027c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionExpression_DD911CFC_L23C10>(!!0, float64, string, bool, bool)
+		IL_027c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9/FunctionObject_FunctionExpression_DD911CFC_L23C10>(!!0, float64, string, bool, bool)
 		IL_0281: stloc.s 72
 		IL_0283: ldc.i4.1
 		IL_0284: newarr [System.Runtime]System.Object
@@ -1116,13 +1546,13 @@
 		IL_0291: ldc.i4.0
 		IL_0292: ldelem.ref
 		IL_0293: castclass Modules.Array_Exotic_Property_Descriptors/Scope
-		IL_0298: newobj instance void FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionExpression_5BEC1E07_L24C10::.ctor(class Modules.Array_Exotic_Property_Descriptors/Scope)
+		IL_0298: newobj instance void Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9/FunctionObject_FunctionExpression_5BEC1E07_L24C10::.ctor(class Modules.Array_Exotic_Property_Descriptors/Scope)
 		IL_029d: ldc.i4.1
 		IL_029e: conv.r8
 		IL_029f: ldstr ""
 		IL_02a4: ldc.i4.0
 		IL_02a5: ldc.i4.1
-		IL_02a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionExpression_5BEC1E07_L24C10>(!!0, float64, string, bool, bool)
+		IL_02a6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9/FunctionObject_FunctionExpression_5BEC1E07_L24C10>(!!0, float64, string, bool, bool)
 		IL_02ab: stloc.s 73
 		IL_02ad: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_02b2: dup
@@ -2443,13 +2873,13 @@
 		IL_12c3: ldc.i4.0
 		IL_12c4: ldelem.ref
 		IL_12c5: castclass Modules.Array_Exotic_Property_Descriptors/Scope
-		IL_12ca: newobj instance void FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionExpression_3D5ECCF2_L165C15::.ctor(class Modules.Array_Exotic_Property_Descriptors/Scope)
+		IL_12ca: newobj instance void Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject/FunctionObject_FunctionExpression_3D5ECCF2_L165C15::.ctor(class Modules.Array_Exotic_Property_Descriptors/Scope)
 		IL_12cf: ldc.i4.0
 		IL_12d0: conv.r8
 		IL_12d1: ldstr ""
 		IL_12d6: ldc.i4.0
 		IL_12d7: ldc.i4.1
-		IL_12d8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionExpression_3D5ECCF2_L165C15>(!!0, float64, string, bool, bool)
+		IL_12d8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject/FunctionObject_FunctionExpression_3D5ECCF2_L165C15>(!!0, float64, string, bool, bool)
 		IL_12dd: stloc.s 81
 		IL_12df: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_12e4: dup
@@ -2550,436 +2980,6 @@
 	} // end of method Array_Exotic_Property_Descriptors::__js_module_init__
 
 } // end of class Modules.Array_Exotic_Property_Descriptors
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionExpression_DD911CFC_L23C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Array_Exotic_Property_Descriptors/Scope _environment0_Array_Exotic_Property_Descriptors
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Array_Exotic_Property_Descriptors/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3681
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Array_Exotic_Property_Descriptors/Scope FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionExpression_DD911CFC_L23C10::_environment0_Array_Exotic_Property_Descriptors
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DD911CFC_L23C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3690
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DD911CFC_L23C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3693
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DD911CFC_L23C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3696
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_Exotic_Property_Descriptors/Scope FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionExpression_DD911CFC_L23C10::_environment0_Array_Exotic_Property_Descriptors
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9::__js_call__(class Modules.Array_Exotic_Property_Descriptors/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_DD911CFC_L23C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x36a8
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_Exotic_Property_Descriptors/Scope FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionExpression_DD911CFC_L23C10::_environment0_Array_Exotic_Property_Descriptors
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L23C9::__js_call__(class Modules.Array_Exotic_Property_Descriptors/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_DD911CFC_L23C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x36b6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DD911CFC_L23C10::ConstructCore
-
-} // end of class FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionExpression_DD911CFC_L23C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionExpression_5BEC1E07_L24C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Array_Exotic_Property_Descriptors/Scope _environment0_Array_Exotic_Property_Descriptors
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Array_Exotic_Property_Descriptors/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x36c5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Array_Exotic_Property_Descriptors/Scope FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionExpression_5BEC1E07_L24C10::_environment0_Array_Exotic_Property_Descriptors
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5BEC1E07_L24C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x36d4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5BEC1E07_L24C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x36d7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5BEC1E07_L24C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x36da
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_Exotic_Property_Descriptors/Scope FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionExpression_5BEC1E07_L24C10::_environment0_Array_Exotic_Property_Descriptors
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9::__js_call__(class Modules.Array_Exotic_Property_Descriptors/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_5BEC1E07_L24C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x36f3
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_Exotic_Property_Descriptors/Scope FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionExpression_5BEC1E07_L24C10::_environment0_Array_Exotic_Property_Descriptors
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Array_Exotic_Property_Descriptors/FunctionExpression_L24C9::__js_call__(class Modules.Array_Exotic_Property_Descriptors/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_5BEC1E07_L24C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3708
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5BEC1E07_L24C10::ConstructCore
-
-} // end of class FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionExpression_5BEC1E07_L24C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionDeclaration_C8ECECDF_clearArray
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3717
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8ECECDF_clearArray::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x371f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8ECECDF_clearArray::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3722
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8ECECDF_clearArray::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3725
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0011: call object Modules.Array_Exotic_Property_Descriptors/clearArray::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8ECECDF_clearArray::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x373d
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_000d: call object Modules.Array_Exotic_Property_Descriptors/clearArray::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8ECECDF_clearArray::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3751
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8ECECDF_clearArray::ConstructCore
-
-} // end of class FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionDeclaration_C8ECECDF_clearArray
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionExpression_3D5ECCF2_L165C15
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Array_Exotic_Property_Descriptors/Scope _environment0_Array_Exotic_Property_Descriptors
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Array_Exotic_Property_Descriptors/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3760
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Array_Exotic_Property_Descriptors/Scope FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionExpression_3D5ECCF2_L165C15::_environment0_Array_Exotic_Property_Descriptors
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3D5ECCF2_L165C15::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x376f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3D5ECCF2_L165C15::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3772
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3D5ECCF2_L165C15::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3775
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_Exotic_Property_Descriptors/Scope FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionExpression_3D5ECCF2_L165C15::_environment0_Array_Exotic_Property_Descriptors
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject::__js_call__(class Modules.Array_Exotic_Property_Descriptors/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_3D5ECCF2_L165C15::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3787
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_Exotic_Property_Descriptors/Scope FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionExpression_3D5ECCF2_L165C15::_environment0_Array_Exotic_Property_Descriptors
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Array_Exotic_Property_Descriptors/FunctionExpression_keyObject::__js_call__(class Modules.Array_Exotic_Property_Descriptors/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_3D5ECCF2_L165C15::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3795
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3D5ECCF2_L165C15::ConstructCore
-
-} // end of class FunctionObjects.Array_Exotic_Property_Descriptors_484D7292.FunctionObject_FunctionExpression_3D5ECCF2_L165C15
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Exotic_Sloppy_Assignment.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Exotic_Sloppy_Assignment.verified.txt
@@ -31,6 +31,128 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_70743D8E_L19C14
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Array_Exotic_Sloppy_Assignment/Scope _environment0_Array_Exotic_Sloppy_Assignment
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Array_Exotic_Sloppy_Assignment/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x235d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Array_Exotic_Sloppy_Assignment/Scope Modules.Array_Exotic_Sloppy_Assignment/FunctionExpression_rhs/FunctionObject_FunctionExpression_70743D8E_L19C14::_environment0_Array_Exotic_Sloppy_Assignment
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_70743D8E_L19C14::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x236c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_70743D8E_L19C14::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x236f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_70743D8E_L19C14::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2372
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_70743D8E_L19C14::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x237a
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_Exotic_Sloppy_Assignment/Scope Modules.Array_Exotic_Sloppy_Assignment/FunctionExpression_rhs/FunctionObject_FunctionExpression_70743D8E_L19C14::_environment0_Array_Exotic_Sloppy_Assignment
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Array_Exotic_Sloppy_Assignment/FunctionExpression_rhs::__js_call__(class Modules.Array_Exotic_Sloppy_Assignment/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_70743D8E_L19C14::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x238c
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_Exotic_Sloppy_Assignment/Scope Modules.Array_Exotic_Sloppy_Assignment/FunctionExpression_rhs/FunctionObject_FunctionExpression_70743D8E_L19C14::_environment0_Array_Exotic_Sloppy_Assignment
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Array_Exotic_Sloppy_Assignment/FunctionExpression_rhs::__js_call__(class Modules.Array_Exotic_Sloppy_Assignment/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_70743D8E_L19C14::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x239a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_70743D8E_L19C14::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_70743D8E_L19C14
+
 
 		// Methods
 		.method public hidebysig static 
@@ -127,7 +249,7 @@
 			[9] object,
 			[10] object,
 			[11] object[],
-			[12] class FunctionObjects.Array_Exotic_Sloppy_Assignment_C606A9F7.FunctionObject_FunctionExpression_70743D8E_L19C14,
+			[12] class Modules.Array_Exotic_Sloppy_Assignment/FunctionExpression_rhs/FunctionObject_FunctionExpression_70743D8E_L19C14,
 			[13] object
 		)
 
@@ -275,13 +397,13 @@
 		IL_0205: ldc.i4.0
 		IL_0206: ldelem.ref
 		IL_0207: castclass Modules.Array_Exotic_Sloppy_Assignment/Scope
-		IL_020c: newobj instance void FunctionObjects.Array_Exotic_Sloppy_Assignment_C606A9F7.FunctionObject_FunctionExpression_70743D8E_L19C14::.ctor(class Modules.Array_Exotic_Sloppy_Assignment/Scope)
+		IL_020c: newobj instance void Modules.Array_Exotic_Sloppy_Assignment/FunctionExpression_rhs/FunctionObject_FunctionExpression_70743D8E_L19C14::.ctor(class Modules.Array_Exotic_Sloppy_Assignment/Scope)
 		IL_0211: ldc.i4.0
 		IL_0212: conv.r8
 		IL_0213: ldstr ""
 		IL_0218: ldc.i4.0
 		IL_0219: ldc.i4.0
-		IL_021a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_Exotic_Sloppy_Assignment_C606A9F7.FunctionObject_FunctionExpression_70743D8E_L19C14>(!!0, float64, string, bool, bool)
+		IL_021a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Exotic_Sloppy_Assignment/FunctionExpression_rhs/FunctionObject_FunctionExpression_70743D8E_L19C14>(!!0, float64, string, bool, bool)
 		IL_021f: stloc.s 12
 		IL_0221: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0226: dup
@@ -329,128 +451,6 @@
 	} // end of method Array_Exotic_Sloppy_Assignment::__js_module_init__
 
 } // end of class Modules.Array_Exotic_Sloppy_Assignment
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_Exotic_Sloppy_Assignment_C606A9F7.FunctionObject_FunctionExpression_70743D8E_L19C14
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Array_Exotic_Sloppy_Assignment/Scope _environment0_Array_Exotic_Sloppy_Assignment
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Array_Exotic_Sloppy_Assignment/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x235d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Array_Exotic_Sloppy_Assignment/Scope FunctionObjects.Array_Exotic_Sloppy_Assignment_C606A9F7.FunctionObject_FunctionExpression_70743D8E_L19C14::_environment0_Array_Exotic_Sloppy_Assignment
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_70743D8E_L19C14::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x236c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_70743D8E_L19C14::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x236f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_70743D8E_L19C14::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2372
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_70743D8E_L19C14::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x237a
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_Exotic_Sloppy_Assignment/Scope FunctionObjects.Array_Exotic_Sloppy_Assignment_C606A9F7.FunctionObject_FunctionExpression_70743D8E_L19C14::_environment0_Array_Exotic_Sloppy_Assignment
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Array_Exotic_Sloppy_Assignment/FunctionExpression_rhs::__js_call__(class Modules.Array_Exotic_Sloppy_Assignment/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_70743D8E_L19C14::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x238c
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_Exotic_Sloppy_Assignment/Scope FunctionObjects.Array_Exotic_Sloppy_Assignment_C606A9F7.FunctionObject_FunctionExpression_70743D8E_L19C14::_environment0_Array_Exotic_Sloppy_Assignment
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Array_Exotic_Sloppy_Assignment/FunctionExpression_rhs::__js_call__(class Modules.Array_Exotic_Sloppy_Assignment/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_70743D8E_L19C14::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x239a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_70743D8E_L19C14::ConstructCore
-
-} // end of class FunctionObjects.Array_Exotic_Sloppy_Assignment_C606A9F7.FunctionObject_FunctionExpression_70743D8E_L19C14
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Find_Basic.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Find_Basic.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3461D0C8_L5C24
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x218e
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_3461D0C8_L5C24::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2196
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_3461D0C8_L5C24::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2199
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_3461D0C8_L5C24::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x219c
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Array_Find_Basic/FunctionExpression_found::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_3461D0C8_L5C24::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21af
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Array_Find_Basic/FunctionExpression_found::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_3461D0C8_L5C24::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21be
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_3461D0C8_L5C24::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_3461D0C8_L5C24
+
 
 		// Methods
 		.method public hidebysig static 
@@ -80,6 +181,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E33B8407_L10C27
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21cd
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_E33B8407_L10C27::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21d5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E33B8407_L10C27::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21d8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E33B8407_L10C27::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21db
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Array_Find_Basic/FunctionExpression_notFound::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_E33B8407_L10C27::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21ee
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Array_Find_Basic/FunctionExpression_notFound::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E33B8407_L10C27::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21fd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E33B8407_L10C27::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_E33B8407_L10C27
 
 
 		// Methods
@@ -148,8 +350,8 @@
 			[2] object,
 			[3] object,
 			[4] object[],
-			[5] class FunctionObjects.Array_Find_Basic_2B59B81D.FunctionObject_FunctionExpression_3461D0C8_L5C24,
-			[6] class FunctionObjects.Array_Find_Basic_2B59B81D.FunctionObject_FunctionExpression_E33B8407_L10C27
+			[5] class Modules.Array_Find_Basic/FunctionExpression_found/FunctionObject_FunctionExpression_3461D0C8_L5C24,
+			[6] class Modules.Array_Find_Basic/FunctionExpression_notFound/FunctionObject_FunctionExpression_E33B8407_L10C27
 		)
 
 		IL_0000: newobj instance void Modules.Array_Find_Basic/Scope::.ctor()
@@ -177,13 +379,13 @@
 		IL_0052: ldloc.0
 		IL_0053: stelem.ref
 		IL_0054: stloc.s 4
-		IL_0056: newobj instance void FunctionObjects.Array_Find_Basic_2B59B81D.FunctionObject_FunctionExpression_3461D0C8_L5C24::.ctor()
+		IL_0056: newobj instance void Modules.Array_Find_Basic/FunctionExpression_found/FunctionObject_FunctionExpression_3461D0C8_L5C24::.ctor()
 		IL_005b: ldc.i4.1
 		IL_005c: conv.r8
 		IL_005d: ldstr ""
 		IL_0062: ldc.i4.0
 		IL_0063: ldc.i4.1
-		IL_0064: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_Find_Basic_2B59B81D.FunctionObject_FunctionExpression_3461D0C8_L5C24>(!!0, float64, string, bool, bool)
+		IL_0064: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Find_Basic/FunctionExpression_found/FunctionObject_FunctionExpression_3461D0C8_L5C24>(!!0, float64, string, bool, bool)
 		IL_0069: stloc.s 5
 		IL_006b: ldloc.1
 		IL_006c: ldc.i4.1
@@ -208,13 +410,13 @@
 		IL_00a0: ldloc.0
 		IL_00a1: stelem.ref
 		IL_00a2: stloc.s 4
-		IL_00a4: newobj instance void FunctionObjects.Array_Find_Basic_2B59B81D.FunctionObject_FunctionExpression_E33B8407_L10C27::.ctor()
+		IL_00a4: newobj instance void Modules.Array_Find_Basic/FunctionExpression_notFound/FunctionObject_FunctionExpression_E33B8407_L10C27::.ctor()
 		IL_00a9: ldc.i4.1
 		IL_00aa: conv.r8
 		IL_00ab: ldstr ""
 		IL_00b0: ldc.i4.0
 		IL_00b1: ldc.i4.1
-		IL_00b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_Find_Basic_2B59B81D.FunctionObject_FunctionExpression_E33B8407_L10C27>(!!0, float64, string, bool, bool)
+		IL_00b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Find_Basic/FunctionExpression_notFound/FunctionObject_FunctionExpression_E33B8407_L10C27>(!!0, float64, string, bool, bool)
 		IL_00b7: stloc.s 6
 		IL_00b9: ldloc.1
 		IL_00ba: ldc.i4.1
@@ -236,208 +438,6 @@
 	} // end of method Array_Find_Basic::__js_module_init__
 
 } // end of class Modules.Array_Find_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_Find_Basic_2B59B81D.FunctionObject_FunctionExpression_3461D0C8_L5C24
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x218e
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_3461D0C8_L5C24::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2196
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3461D0C8_L5C24::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2199
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3461D0C8_L5C24::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x219c
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Array_Find_Basic/FunctionExpression_found::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_3461D0C8_L5C24::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21af
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Array_Find_Basic/FunctionExpression_found::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3461D0C8_L5C24::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21be
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3461D0C8_L5C24::ConstructCore
-
-} // end of class FunctionObjects.Array_Find_Basic_2B59B81D.FunctionObject_FunctionExpression_3461D0C8_L5C24
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_Find_Basic_2B59B81D.FunctionObject_FunctionExpression_E33B8407_L10C27
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21cd
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_E33B8407_L10C27::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21d5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E33B8407_L10C27::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21d8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E33B8407_L10C27::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21db
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Array_Find_Basic/FunctionExpression_notFound::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_E33B8407_L10C27::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ee
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Array_Find_Basic/FunctionExpression_notFound::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E33B8407_L10C27::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21fd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E33B8407_L10C27::ConstructCore
-
-} // end of class FunctionObjects.Array_Find_Basic_2B59B81D.FunctionObject_FunctionExpression_E33B8407_L10C27
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Iterator_Methods.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Iterator_Methods.verified.txt
@@ -57,6 +57,118 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DBFD1C9F_L44C11
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/Scope _environment1_FunctionExpression_L41C30
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x28a4
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/Scope Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10/FunctionObject_FunctionExpression_DBFD1C9F_L44C11::_environment1_FunctionExpression_L41C30
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10/FunctionObject_FunctionExpression_DBFD1C9F_L44C11::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionExpression_DBFD1C9F_L44C11::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x28ba
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_DBFD1C9F_L44C11::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x28bd
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_DBFD1C9F_L44C11::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x28c0
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10/FunctionObject_FunctionExpression_DBFD1C9F_L44C11::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_DBFD1C9F_L44C11::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x28d2
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10/FunctionObject_FunctionExpression_DBFD1C9F_L44C11::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_DBFD1C9F_L44C11::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x28e0
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_DBFD1C9F_L44C11::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_DBFD1C9F_L44C11
+
 
 			// Methods
 			.method public hidebysig static 
@@ -148,6 +260,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_733F3DEF_L41C31
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Array_Iterator_Methods/Scope _environment0_Array_Iterator_Methods
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Array_Iterator_Methods/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2860
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Array_Iterator_Methods/Scope Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionObject_FunctionExpression_733F3DEF_L41C31::_environment0_Array_Iterator_Methods
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_733F3DEF_L41C31::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x286f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_733F3DEF_L41C31::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2872
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_733F3DEF_L41C31::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2875
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_Iterator_Methods/Scope Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionObject_FunctionExpression_733F3DEF_L41C31::_environment0_Array_Iterator_Methods
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Array_Iterator_Methods/FunctionExpression_L41C30::__js_call__(class Modules.Array_Iterator_Methods/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_733F3DEF_L41C31::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2887
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_Iterator_Methods/Scope Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionObject_FunctionExpression_733F3DEF_L41C31::_environment0_Array_Iterator_Methods
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Array_Iterator_Methods/FunctionExpression_L41C30::__js_call__(class Modules.Array_Iterator_Methods/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_733F3DEF_L41C31::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2895
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_733F3DEF_L41C31::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_733F3DEF_L41C31
+
 
 		// Methods
 		.method public hidebysig static 
@@ -168,7 +387,7 @@
 			.locals init (
 				[0] class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/Scope,
 				[1] object[],
-				[2] class FunctionObjects.Array_Iterator_Methods_6A205F6C.FunctionObject_FunctionExpression_DBFD1C9F_L44C11,
+				[2] class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10/FunctionObject_FunctionExpression_DBFD1C9F_L44C11,
 				[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
@@ -194,13 +413,13 @@
 			IL_0023: ldelem.ref
 			IL_0024: castclass Modules.Array_Iterator_Methods/FunctionExpression_L41C30/Scope
 			IL_0029: ldloc.1
-			IL_002a: newobj instance void FunctionObjects.Array_Iterator_Methods_6A205F6C.FunctionObject_FunctionExpression_DBFD1C9F_L44C11::.ctor(class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/Scope, object[])
+			IL_002a: newobj instance void Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10/FunctionObject_FunctionExpression_DBFD1C9F_L44C11::.ctor(class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/Scope, object[])
 			IL_002f: ldc.i4.0
 			IL_0030: conv.r8
 			IL_0031: ldstr ""
 			IL_0036: ldc.i4.0
 			IL_0037: ldc.i4.1
-			IL_0038: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_Iterator_Methods_6A205F6C.FunctionObject_FunctionExpression_DBFD1C9F_L44C11>(!!0, float64, string, bool, bool)
+			IL_0038: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10/FunctionObject_FunctionExpression_DBFD1C9F_L44C11>(!!0, float64, string, bool, bool)
 			IL_003d: stloc.2
 			IL_003e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0043: dup
@@ -314,7 +533,7 @@
 			[19] bool,
 			[20] object,
 			[21] object[],
-			[22] class FunctionObjects.Array_Iterator_Methods_6A205F6C.FunctionObject_FunctionExpression_733F3DEF_L41C31,
+			[22] class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionObject_FunctionExpression_733F3DEF_L41C31,
 			[23] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[24] string
 		)
@@ -711,13 +930,13 @@
 		IL_05c2: ldc.i4.0
 		IL_05c3: ldelem.ref
 		IL_05c4: castclass Modules.Array_Iterator_Methods/Scope
-		IL_05c9: newobj instance void FunctionObjects.Array_Iterator_Methods_6A205F6C.FunctionObject_FunctionExpression_733F3DEF_L41C31::.ctor(class Modules.Array_Iterator_Methods/Scope)
+		IL_05c9: newobj instance void Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionObject_FunctionExpression_733F3DEF_L41C31::.ctor(class Modules.Array_Iterator_Methods/Scope)
 		IL_05ce: ldc.i4.0
 		IL_05cf: conv.r8
 		IL_05d0: ldstr ""
 		IL_05d5: ldc.i4.0
 		IL_05d6: ldc.i4.1
-		IL_05d7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_Iterator_Methods_6A205F6C.FunctionObject_FunctionExpression_733F3DEF_L41C31>(!!0, float64, string, bool, bool)
+		IL_05d7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionObject_FunctionExpression_733F3DEF_L41C31>(!!0, float64, string, bool, bool)
 		IL_05dc: stloc.s 22
 		IL_05de: ldloc.s 10
 		IL_05e0: ldloc.s 16
@@ -828,225 +1047,6 @@
 	} // end of method Array_Iterator_Methods::__js_module_init__
 
 } // end of class Modules.Array_Iterator_Methods
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_Iterator_Methods_6A205F6C.FunctionObject_FunctionExpression_733F3DEF_L41C31
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Array_Iterator_Methods/Scope _environment0_Array_Iterator_Methods
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Array_Iterator_Methods/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2860
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Array_Iterator_Methods/Scope FunctionObjects.Array_Iterator_Methods_6A205F6C.FunctionObject_FunctionExpression_733F3DEF_L41C31::_environment0_Array_Iterator_Methods
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_733F3DEF_L41C31::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x286f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_733F3DEF_L41C31::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2872
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_733F3DEF_L41C31::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2875
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_Iterator_Methods/Scope FunctionObjects.Array_Iterator_Methods_6A205F6C.FunctionObject_FunctionExpression_733F3DEF_L41C31::_environment0_Array_Iterator_Methods
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Array_Iterator_Methods/FunctionExpression_L41C30::__js_call__(class Modules.Array_Iterator_Methods/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_733F3DEF_L41C31::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2887
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_Iterator_Methods/Scope FunctionObjects.Array_Iterator_Methods_6A205F6C.FunctionObject_FunctionExpression_733F3DEF_L41C31::_environment0_Array_Iterator_Methods
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Array_Iterator_Methods/FunctionExpression_L41C30::__js_call__(class Modules.Array_Iterator_Methods/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_733F3DEF_L41C31::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2895
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_733F3DEF_L41C31::ConstructCore
-
-} // end of class FunctionObjects.Array_Iterator_Methods_6A205F6C.FunctionObject_FunctionExpression_733F3DEF_L41C31
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_Iterator_Methods_6A205F6C.FunctionObject_FunctionExpression_DBFD1C9F_L44C11
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/Scope _environment1_FunctionExpression_L41C30
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x28a4
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Array_Iterator_Methods/FunctionExpression_L41C30/Scope FunctionObjects.Array_Iterator_Methods_6A205F6C.FunctionObject_FunctionExpression_DBFD1C9F_L44C11::_environment1_FunctionExpression_L41C30
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Array_Iterator_Methods_6A205F6C.FunctionObject_FunctionExpression_DBFD1C9F_L44C11::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_DBFD1C9F_L44C11::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x28ba
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DBFD1C9F_L44C11::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x28bd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DBFD1C9F_L44C11::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x28c0
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Array_Iterator_Methods_6A205F6C.FunctionObject_FunctionExpression_DBFD1C9F_L44C11::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_DBFD1C9F_L44C11::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28d2
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Array_Iterator_Methods_6A205F6C.FunctionObject_FunctionExpression_DBFD1C9F_L44C11::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Array_Iterator_Methods/FunctionExpression_L41C30/FunctionExpression_L44C10::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_DBFD1C9F_L44C11::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28e0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DBFD1C9F_L44C11::ConstructCore
-
-} // end of class FunctionObjects.Array_Iterator_Methods_6A205F6C.FunctionObject_FunctionExpression_DBFD1C9F_L44C11
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_JsObject_NamedProperties.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_JsObject_NamedProperties.verified.txt
@@ -51,6 +51,89 @@
 
 		} // end of class Scope_ctor
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_B384E33B_DerivedArray
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x281f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Array_JsObject_NamedProperties/DerivedArray/FunctionObject_ClassConstructor_B384E33B_DerivedArray::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_B384E33B_DerivedArray::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x282e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_B384E33B_DerivedArray::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2831
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_B384E33B_DerivedArray::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2834
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_B384E33B_DerivedArray::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2840
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_B384E33B_DerivedArray::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_B384E33B_DerivedArray
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -739,89 +822,6 @@
 	} // end of method Array_JsObject_NamedProperties::__js_module_init__
 
 } // end of class Modules.Array_JsObject_NamedProperties
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_JsObject_NamedProperties_B3058DD4.FunctionObject_ClassConstructor_B384E33B_DerivedArray
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x281f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Array_JsObject_NamedProperties_B3058DD4.FunctionObject_ClassConstructor_B384E33B_DerivedArray::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_B384E33B_DerivedArray::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x282e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_B384E33B_DerivedArray::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2831
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_B384E33B_DerivedArray::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2834
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_B384E33B_DerivedArray::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2840
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_B384E33B_DerivedArray::ConstructCore
-
-} // end of class FunctionObjects.Array_JsObject_NamedProperties_B3058DD4.FunctionObject_ClassConstructor_B384E33B_DerivedArray
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Map_Basic.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Map_Basic.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B7CBC545_L4C23
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x214d
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_B7CBC545_L4C23::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2155
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_B7CBC545_L4C23::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2158
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_B7CBC545_L4C23::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x215b
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Array_Map_Basic/FunctionExpression_lengths::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_B7CBC545_L4C23::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x216e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Array_Map_Basic/FunctionExpression_lengths::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_B7CBC545_L4C23::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x217d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_B7CBC545_L4C23::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_B7CBC545_L4C23
+
 
 		// Methods
 		.method public hidebysig static 
@@ -123,7 +224,7 @@
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] float64,
 			[4] object[],
-			[5] class FunctionObjects.Array_Map_Basic_7A86786A.FunctionObject_FunctionExpression_B7CBC545_L4C23,
+			[5] class Modules.Array_Map_Basic/FunctionExpression_lengths/FunctionObject_FunctionExpression_B7CBC545_L4C23,
 			[6] float64,
 			[7] float64,
 			[8] object
@@ -151,13 +252,13 @@
 		IL_0037: ldloc.0
 		IL_0038: stelem.ref
 		IL_0039: stloc.s 4
-		IL_003b: newobj instance void FunctionObjects.Array_Map_Basic_7A86786A.FunctionObject_FunctionExpression_B7CBC545_L4C23::.ctor()
+		IL_003b: newobj instance void Modules.Array_Map_Basic/FunctionExpression_lengths/FunctionObject_FunctionExpression_B7CBC545_L4C23::.ctor()
 		IL_0040: ldc.i4.1
 		IL_0041: conv.r8
 		IL_0042: ldstr ""
 		IL_0047: ldc.i4.0
 		IL_0048: ldc.i4.1
-		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_Map_Basic_7A86786A.FunctionObject_FunctionExpression_B7CBC545_L4C23>(!!0, float64, string, bool, bool)
+		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Map_Basic/FunctionExpression_lengths/FunctionObject_FunctionExpression_B7CBC545_L4C23>(!!0, float64, string, bool, bool)
 		IL_004e: stloc.s 5
 		IL_0050: ldloc.1
 		IL_0051: ldc.i4.1
@@ -203,107 +304,6 @@
 	} // end of method Array_Map_Basic::__js_module_init__
 
 } // end of class Modules.Array_Map_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_Map_Basic_7A86786A.FunctionObject_FunctionExpression_B7CBC545_L4C23
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x214d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_B7CBC545_L4C23::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2155
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_B7CBC545_L4C23::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2158
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_B7CBC545_L4C23::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x215b
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Array_Map_Basic/FunctionExpression_lengths::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_B7CBC545_L4C23::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x216e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Array_Map_Basic/FunctionExpression_lengths::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_B7CBC545_L4C23::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x217d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_B7CBC545_L4C23::ConstructCore
-
-} // end of class FunctionObjects.Array_Map_Basic_7A86786A.FunctionObject_FunctionExpression_B7CBC545_L4C23
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Map_NestedParam.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Map_NestedParam.verified.txt
@@ -35,6 +35,124 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_FCCE10B1_inner
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Array_Map_NestedParam/outer/Scope _environment1_outer
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Array_Map_NestedParam/outer/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x227e
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Array_Map_NestedParam/outer/Scope Modules.Array_Map_NestedParam/outer/inner/FunctionObject_FunctionDeclaration_FCCE10B1_inner::_environment1_outer
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Array_Map_NestedParam/outer/inner/FunctionObject_FunctionDeclaration_FCCE10B1_inner::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionDeclaration_FCCE10B1_inner::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2294
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_FCCE10B1_inner::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2297
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_FCCE10B1_inner::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x229a
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Array_Map_NestedParam/outer/inner/FunctionObject_FunctionDeclaration_FCCE10B1_inner::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Array_Map_NestedParam/outer/inner::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionDeclaration_FCCE10B1_inner::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x22b3
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Array_Map_NestedParam/outer/inner/FunctionObject_FunctionDeclaration_FCCE10B1_inner::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Array_Map_NestedParam/outer/inner::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionDeclaration_FCCE10B1_inner::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x22c8
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionDeclaration_FCCE10B1_inner::ConstructCore
+
+			} // end of class FunctionObject_FunctionDeclaration_FCCE10B1_inner
+
 
 			// Methods
 			.method public hidebysig static 
@@ -221,6 +339,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_AEA8D026_outer
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Array_Map_NestedParam/Scope _environment0_Array_Map_NestedParam
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Array_Map_NestedParam/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x222c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Array_Map_NestedParam/Scope Modules.Array_Map_NestedParam/outer/FunctionObject_FunctionDeclaration_AEA8D026_outer::_environment0_Array_Map_NestedParam
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_AEA8D026_outer::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x223b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_AEA8D026_outer::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x223e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_AEA8D026_outer::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2241
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_Map_NestedParam/Scope Modules.Array_Map_NestedParam/outer/FunctionObject_FunctionDeclaration_AEA8D026_outer::_environment0_Array_Map_NestedParam
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Array_Map_NestedParam/outer::__js_call__(class Modules.Array_Map_NestedParam/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_AEA8D026_outer::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x225a
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_Map_NestedParam/Scope Modules.Array_Map_NestedParam/outer/FunctionObject_FunctionDeclaration_AEA8D026_outer::_environment0_Array_Map_NestedParam
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Array_Map_NestedParam/outer::__js_call__(class Modules.Array_Map_NestedParam/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_AEA8D026_outer::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x226f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_AEA8D026_outer::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_AEA8D026_outer
+
 
 		// Methods
 		.method public hidebysig static 
@@ -241,7 +472,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Array_Map_NestedParam/outer/Scope,
-				[1] class FunctionObjects.Array_Map_NestedParam_D550C81C.FunctionObject_FunctionDeclaration_FCCE10B1_inner,
+				[1] class Modules.Array_Map_NestedParam/outer/inner/FunctionObject_FunctionDeclaration_FCCE10B1_inner,
 				[2] object[],
 				[3] class Modules.Array_Map_NestedParam/outer/ArrowFunction_L9C16/FunctionObject
 			)
@@ -267,13 +498,13 @@
 			IL_001e: ldelem.ref
 			IL_001f: castclass Modules.Array_Map_NestedParam/outer/Scope
 			IL_0024: ldloc.2
-			IL_0025: newobj instance void FunctionObjects.Array_Map_NestedParam_D550C81C.FunctionObject_FunctionDeclaration_FCCE10B1_inner::.ctor(class Modules.Array_Map_NestedParam/outer/Scope, object[])
+			IL_0025: newobj instance void Modules.Array_Map_NestedParam/outer/inner/FunctionObject_FunctionDeclaration_FCCE10B1_inner::.ctor(class Modules.Array_Map_NestedParam/outer/Scope, object[])
 			IL_002a: ldc.i4.1
 			IL_002b: conv.r8
 			IL_002c: ldstr "inner"
 			IL_0031: ldc.i4.0
 			IL_0032: ldc.i4.1
-			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_Map_NestedParam_D550C81C.FunctionObject_FunctionDeclaration_FCCE10B1_inner>(!!0, float64, string, bool, bool)
+			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Map_NestedParam/outer/inner/FunctionObject_FunctionDeclaration_FCCE10B1_inner>(!!0, float64, string, bool, bool)
 			IL_0038: stloc.1
 			IL_0039: nop
 			IL_003a: ldc.i4.1
@@ -402,7 +633,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Array_Map_NestedParam/Scope,
-			[1] class FunctionObjects.Array_Map_NestedParam_D550C81C.FunctionObject_FunctionDeclaration_AEA8D026_outer,
+			[1] class Modules.Array_Map_NestedParam/outer/FunctionObject_FunctionDeclaration_AEA8D026_outer,
 			[2] object,
 			[3] float64,
 			[4] object[],
@@ -426,13 +657,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Array_Map_NestedParam/Scope
-		IL_001b: newobj instance void FunctionObjects.Array_Map_NestedParam_D550C81C.FunctionObject_FunctionDeclaration_AEA8D026_outer::.ctor(class Modules.Array_Map_NestedParam/Scope)
+		IL_001b: newobj instance void Modules.Array_Map_NestedParam/outer/FunctionObject_FunctionDeclaration_AEA8D026_outer::.ctor(class Modules.Array_Map_NestedParam/Scope)
 		IL_0020: ldc.i4.1
 		IL_0021: conv.r8
 		IL_0022: ldstr "outer"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_Map_NestedParam_D550C81C.FunctionObject_FunctionDeclaration_AEA8D026_outer>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Map_NestedParam/outer/FunctionObject_FunctionDeclaration_AEA8D026_outer>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: nop
 		IL_0030: nop
@@ -493,237 +724,6 @@
 	} // end of method Array_Map_NestedParam::__js_module_init__
 
 } // end of class Modules.Array_Map_NestedParam
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_Map_NestedParam_D550C81C.FunctionObject_FunctionDeclaration_AEA8D026_outer
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Array_Map_NestedParam/Scope _environment0_Array_Map_NestedParam
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Array_Map_NestedParam/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x222c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Array_Map_NestedParam/Scope FunctionObjects.Array_Map_NestedParam_D550C81C.FunctionObject_FunctionDeclaration_AEA8D026_outer::_environment0_Array_Map_NestedParam
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_AEA8D026_outer::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x223b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_AEA8D026_outer::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x223e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_AEA8D026_outer::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2241
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_Map_NestedParam/Scope FunctionObjects.Array_Map_NestedParam_D550C81C.FunctionObject_FunctionDeclaration_AEA8D026_outer::_environment0_Array_Map_NestedParam
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Array_Map_NestedParam/outer::__js_call__(class Modules.Array_Map_NestedParam/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_AEA8D026_outer::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x225a
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_Map_NestedParam/Scope FunctionObjects.Array_Map_NestedParam_D550C81C.FunctionObject_FunctionDeclaration_AEA8D026_outer::_environment0_Array_Map_NestedParam
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Array_Map_NestedParam/outer::__js_call__(class Modules.Array_Map_NestedParam/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_AEA8D026_outer::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x226f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_AEA8D026_outer::ConstructCore
-
-} // end of class FunctionObjects.Array_Map_NestedParam_D550C81C.FunctionObject_FunctionDeclaration_AEA8D026_outer
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_Map_NestedParam_D550C81C.FunctionObject_FunctionDeclaration_FCCE10B1_inner
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Array_Map_NestedParam/outer/Scope _environment1_outer
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Array_Map_NestedParam/outer/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x227e
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Array_Map_NestedParam/outer/Scope FunctionObjects.Array_Map_NestedParam_D550C81C.FunctionObject_FunctionDeclaration_FCCE10B1_inner::_environment1_outer
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Array_Map_NestedParam_D550C81C.FunctionObject_FunctionDeclaration_FCCE10B1_inner::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_FCCE10B1_inner::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2294
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_FCCE10B1_inner::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2297
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_FCCE10B1_inner::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x229a
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Array_Map_NestedParam_D550C81C.FunctionObject_FunctionDeclaration_FCCE10B1_inner::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Array_Map_NestedParam/outer/inner::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_FCCE10B1_inner::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22b3
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Array_Map_NestedParam_D550C81C.FunctionObject_FunctionDeclaration_FCCE10B1_inner::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Array_Map_NestedParam/outer/inner::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_FCCE10B1_inner::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22c8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_FCCE10B1_inner::ConstructCore
-
-} // end of class FunctionObjects.Array_Map_NestedParam_D550C81C.FunctionObject_FunctionDeclaration_FCCE10B1_inner
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_NonMutatingOps_Basic.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_NonMutatingOps_Basic.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_49940B4B_L14C24
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x23e3
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_49940B4B_L14C24::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x23eb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_49940B4B_L14C24::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x23ee
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_49940B4B_L14C24::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x23f1
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Array_NonMutatingOps_Basic/FunctionExpression_L14C23::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionExpression_49940B4B_L14C24::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x240b
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Array_NonMutatingOps_Basic/FunctionExpression_L14C23::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionExpression_49940B4B_L14C24::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2421
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_49940B4B_L14C24::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_49940B4B_L14C24
+
 
 		// Methods
 		.method public hidebysig static 
@@ -105,7 +212,7 @@
 			[7] object,
 			[8] string,
 			[9] object[],
-			[10] class FunctionObjects.Array_NonMutatingOps_Basic_A67BBE20.FunctionObject_FunctionExpression_49940B4B_L14C24
+			[10] class Modules.Array_NonMutatingOps_Basic/FunctionExpression_L14C23/FunctionObject_FunctionExpression_49940B4B_L14C24
 		)
 
 		IL_0000: newobj instance void Modules.Array_NonMutatingOps_Basic/Scope::.ctor()
@@ -247,13 +354,13 @@
 		IL_01d9: ldloc.0
 		IL_01da: stelem.ref
 		IL_01db: stloc.s 9
-		IL_01dd: newobj instance void FunctionObjects.Array_NonMutatingOps_Basic_A67BBE20.FunctionObject_FunctionExpression_49940B4B_L14C24::.ctor()
+		IL_01dd: newobj instance void Modules.Array_NonMutatingOps_Basic/FunctionExpression_L14C23/FunctionObject_FunctionExpression_49940B4B_L14C24::.ctor()
 		IL_01e2: ldc.i4.2
 		IL_01e3: conv.r8
 		IL_01e4: ldstr ""
 		IL_01e9: ldc.i4.0
 		IL_01ea: ldc.i4.1
-		IL_01eb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_NonMutatingOps_Basic_A67BBE20.FunctionObject_FunctionExpression_49940B4B_L14C24>(!!0, float64, string, bool, bool)
+		IL_01eb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_NonMutatingOps_Basic/FunctionExpression_L14C23/FunctionObject_FunctionExpression_49940B4B_L14C24>(!!0, float64, string, bool, bool)
 		IL_01f0: stloc.s 10
 		IL_01f2: ldloc.3
 		IL_01f3: ldc.i4.1
@@ -367,113 +474,6 @@
 	} // end of method Array_NonMutatingOps_Basic::__js_module_init__
 
 } // end of class Modules.Array_NonMutatingOps_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_NonMutatingOps_Basic_A67BBE20.FunctionObject_FunctionExpression_49940B4B_L14C24
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x23e3
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_49940B4B_L14C24::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23eb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_49940B4B_L14C24::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23ee
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_49940B4B_L14C24::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23f1
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Array_NonMutatingOps_Basic/FunctionExpression_L14C23::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_49940B4B_L14C24::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x240b
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Array_NonMutatingOps_Basic/FunctionExpression_L14C23::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_49940B4B_L14C24::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2421
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_49940B4B_L14C24::ConstructCore
-
-} // end of class FunctionObjects.Array_NonMutatingOps_Basic_A67BBE20.FunctionObject_FunctionExpression_49940B4B_L14C24
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_PrototypeMethods_ArrayLike_Call.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_PrototypeMethods_ArrayLike_Call.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5A6FB1D8_L8C54
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x238d
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_5A6FB1D8_L8C54::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2395
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5A6FB1D8_L8C54::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2398
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5A6FB1D8_L8C54::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x239b
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reduced::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionExpression_5A6FB1D8_L8C54::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23b5
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reduced::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionExpression_5A6FB1D8_L8C54::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23cb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_5A6FB1D8_L8C54::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_5A6FB1D8_L8C54
+
 
 		// Methods
 		.method public hidebysig static 
@@ -84,6 +191,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_47AD9F8D_L11C64
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x23da
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_47AD9F8D_L11C64::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x23e2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_47AD9F8D_L11C64::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x23e5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_47AD9F8D_L11C64::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x23e8
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reducedRight::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionExpression_47AD9F8D_L11C64::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2402
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reducedRight::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionExpression_47AD9F8D_L11C64::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2418
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_47AD9F8D_L11C64::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_47AD9F8D_L11C64
 
 
 		// Methods
@@ -157,8 +371,8 @@
 			[3] object,
 			[4] object,
 			[5] object[],
-			[6] class FunctionObjects.Array_PrototypeMethods_ArrayLike_Call_3BE70733.FunctionObject_FunctionExpression_5A6FB1D8_L8C54,
-			[7] class FunctionObjects.Array_PrototypeMethods_ArrayLike_Call_3BE70733.FunctionObject_FunctionExpression_47AD9F8D_L11C64,
+			[6] class Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reduced/FunctionObject_FunctionExpression_5A6FB1D8_L8C54,
+			[7] class Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reducedRight/FunctionObject_FunctionExpression_47AD9F8D_L11C64,
 			[8] object,
 			[9] float64,
 			[10] object
@@ -204,13 +418,13 @@
 		IL_0086: ldloc.0
 		IL_0087: stelem.ref
 		IL_0088: stloc.s 5
-		IL_008a: newobj instance void FunctionObjects.Array_PrototypeMethods_ArrayLike_Call_3BE70733.FunctionObject_FunctionExpression_5A6FB1D8_L8C54::.ctor()
+		IL_008a: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reduced/FunctionObject_FunctionExpression_5A6FB1D8_L8C54::.ctor()
 		IL_008f: ldc.i4.2
 		IL_0090: conv.r8
 		IL_0091: ldstr ""
 		IL_0096: ldc.i4.0
 		IL_0097: ldc.i4.1
-		IL_0098: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_PrototypeMethods_ArrayLike_Call_3BE70733.FunctionObject_FunctionExpression_5A6FB1D8_L8C54>(!!0, float64, string, bool, bool)
+		IL_0098: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reduced/FunctionObject_FunctionExpression_5A6FB1D8_L8C54>(!!0, float64, string, bool, bool)
 		IL_009d: stloc.s 6
 		IL_009f: ldloc.s 4
 		IL_00a1: ldstr "call"
@@ -245,13 +459,13 @@
 		IL_0104: ldloc.0
 		IL_0105: stelem.ref
 		IL_0106: stloc.s 5
-		IL_0108: newobj instance void FunctionObjects.Array_PrototypeMethods_ArrayLike_Call_3BE70733.FunctionObject_FunctionExpression_47AD9F8D_L11C64::.ctor()
+		IL_0108: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reducedRight/FunctionObject_FunctionExpression_47AD9F8D_L11C64::.ctor()
 		IL_010d: ldc.i4.2
 		IL_010e: conv.r8
 		IL_010f: ldstr ""
 		IL_0114: ldc.i4.0
 		IL_0115: ldc.i4.1
-		IL_0116: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_PrototypeMethods_ArrayLike_Call_3BE70733.FunctionObject_FunctionExpression_47AD9F8D_L11C64>(!!0, float64, string, bool, bool)
+		IL_0116: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reducedRight/FunctionObject_FunctionExpression_47AD9F8D_L11C64>(!!0, float64, string, bool, bool)
 		IL_011b: stloc.s 7
 		IL_011d: ldloc.s 4
 		IL_011f: ldstr "call"
@@ -380,220 +594,6 @@
 	} // end of method Array_PrototypeMethods_ArrayLike_Call::__js_module_init__
 
 } // end of class Modules.Array_PrototypeMethods_ArrayLike_Call
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_PrototypeMethods_ArrayLike_Call_3BE70733.FunctionObject_FunctionExpression_5A6FB1D8_L8C54
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x238d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_5A6FB1D8_L8C54::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2395
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5A6FB1D8_L8C54::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2398
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5A6FB1D8_L8C54::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x239b
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reduced::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_5A6FB1D8_L8C54::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23b5
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reduced::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_5A6FB1D8_L8C54::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23cb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5A6FB1D8_L8C54::ConstructCore
-
-} // end of class FunctionObjects.Array_PrototypeMethods_ArrayLike_Call_3BE70733.FunctionObject_FunctionExpression_5A6FB1D8_L8C54
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_PrototypeMethods_ArrayLike_Call_3BE70733.FunctionObject_FunctionExpression_47AD9F8D_L11C64
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x23da
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_47AD9F8D_L11C64::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23e2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_47AD9F8D_L11C64::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23e5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_47AD9F8D_L11C64::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23e8
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reducedRight::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_47AD9F8D_L11C64::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2402
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Array_PrototypeMethods_ArrayLike_Call/FunctionExpression_reducedRight::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_47AD9F8D_L11C64::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2418
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_47AD9F8D_L11C64::ConstructCore
-
-} // end of class FunctionObjects.Array_PrototypeMethods_ArrayLike_Call_3BE70733.FunctionObject_FunctionExpression_47AD9F8D_L11C64
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_PrototypeMethods_ArrayLike_EdgeCases.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_PrototypeMethods_ArrayLike_EdgeCases.verified.txt
@@ -31,6 +31,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_685C2912_L23C46
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope _environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2af9
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1/FunctionObject_FunctionExpression_685C2912_L23C46::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_685C2912_L23C46::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2b08
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_685C2912_L23C46::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2b0b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_685C2912_L23C46::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b0e
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1/FunctionObject_FunctionExpression_685C2912_L23C46::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionExpression_685C2912_L23C46::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b2e
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1/FunctionObject_FunctionExpression_685C2912_L23C46::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionExpression_685C2912_L23C46::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b4a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_685C2912_L23C46::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_685C2912_L23C46
+
 
 		// Methods
 		.method public hidebysig static 
@@ -101,6 +220,125 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E6591AFB_L31C46
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope _environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b59
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2/FunctionObject_FunctionExpression_E6591AFB_L31C46::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E6591AFB_L31C46::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2b68
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E6591AFB_L31C46::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2b6b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E6591AFB_L31C46::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b6e
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2/FunctionObject_FunctionExpression_E6591AFB_L31C46::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionExpression_E6591AFB_L31C46::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b8e
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2/FunctionObject_FunctionExpression_E6591AFB_L31C46::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionExpression_E6591AFB_L31C46::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2baa
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E6591AFB_L31C46::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_E6591AFB_L31C46
 
 
 		// Methods
@@ -173,6 +411,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0644002F_L39C51
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope _environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bb9
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3/FunctionObject_FunctionExpression_0644002F_L39C51::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_0644002F_L39C51::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2bc8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_0644002F_L39C51::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2bcb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_0644002F_L39C51::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bce
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3/FunctionObject_FunctionExpression_0644002F_L39C51::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionExpression_0644002F_L39C51::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bee
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3/FunctionObject_FunctionExpression_0644002F_L39C51::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionExpression_0644002F_L39C51::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c0a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_0644002F_L39C51::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_0644002F_L39C51
+
 
 		// Methods
 		.method public hidebysig static 
@@ -243,6 +600,125 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D7F309C8_L47C51
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope _environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c19
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4/FunctionObject_FunctionExpression_D7F309C8_L47C51::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_D7F309C8_L47C51::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2c28
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D7F309C8_L47C51::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2c2b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D7F309C8_L47C51::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c2e
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4/FunctionObject_FunctionExpression_D7F309C8_L47C51::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionExpression_D7F309C8_L47C51::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c4e
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4/FunctionObject_FunctionExpression_D7F309C8_L47C51::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionExpression_D7F309C8_L47C51::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c6a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_D7F309C8_L47C51::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_D7F309C8_L47C51
 
 
 		// Methods
@@ -315,6 +791,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C54EE51B_L57C38
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2c79
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_C54EE51B_L57C38::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2c81
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C54EE51B_L57C38::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2c84
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C54EE51B_L57C38::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c87
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L57C37::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionExpression_C54EE51B_L57C38::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ca1
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L57C37::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionExpression_C54EE51B_L57C38::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2cb7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_C54EE51B_L57C38::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_C54EE51B_L57C38
+
 
 		// Methods
 		.method public hidebysig static 
@@ -368,6 +951,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_CB86225F_L66C43
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2cc6
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_CB86225F_L66C43::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2cce
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_CB86225F_L66C43::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2cd1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_CB86225F_L66C43::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2cd4
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L66C42::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionExpression_CB86225F_L66C43::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2cee
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L66C42::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionExpression_CB86225F_L66C43::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d04
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_CB86225F_L66C43::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_CB86225F_L66C43
 
 
 		// Methods
@@ -629,12 +1319,12 @@
 			[22] object,
 			[23] object,
 			[24] object[],
-			[25] class FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_685C2912_L23C46,
-			[26] class FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_E6591AFB_L31C46,
-			[27] class FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_0644002F_L39C51,
-			[28] class FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_D7F309C8_L47C51,
-			[29] class FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_C54EE51B_L57C38,
-			[30] class FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_CB86225F_L66C43,
+			[25] class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1/FunctionObject_FunctionExpression_685C2912_L23C46,
+			[26] class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2/FunctionObject_FunctionExpression_E6591AFB_L31C46,
+			[27] class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3/FunctionObject_FunctionExpression_0644002F_L39C51,
+			[28] class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4/FunctionObject_FunctionExpression_D7F309C8_L47C51,
+			[29] class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L57C37/FunctionObject_FunctionExpression_C54EE51B_L57C38,
+			[30] class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L66C42/FunctionObject_FunctionExpression_CB86225F_L66C43,
 			[31] float64,
 			[32] object
 		)
@@ -820,13 +1510,13 @@
 		IL_0217: ldc.i4.0
 		IL_0218: ldelem.ref
 		IL_0219: castclass Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope
-		IL_021e: newobj instance void FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_685C2912_L23C46::.ctor(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope)
+		IL_021e: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1/FunctionObject_FunctionExpression_685C2912_L23C46::.ctor(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope)
 		IL_0223: ldc.i4.2
 		IL_0224: conv.r8
 		IL_0225: ldstr ""
 		IL_022a: ldc.i4.0
 		IL_022b: ldc.i4.1
-		IL_022c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_685C2912_L23C46>(!!0, float64, string, bool, bool)
+		IL_022c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1/FunctionObject_FunctionExpression_685C2912_L23C46>(!!0, float64, string, bool, bool)
 		IL_0231: stloc.s 25
 		IL_0233: ldloc.s 22
 		IL_0235: ldstr "call"
@@ -880,13 +1570,13 @@
 		IL_02d8: ldc.i4.0
 		IL_02d9: ldelem.ref
 		IL_02da: castclass Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope
-		IL_02df: newobj instance void FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_E6591AFB_L31C46::.ctor(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope)
+		IL_02df: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2/FunctionObject_FunctionExpression_E6591AFB_L31C46::.ctor(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope)
 		IL_02e4: ldc.i4.2
 		IL_02e5: conv.r8
 		IL_02e6: ldstr ""
 		IL_02eb: ldc.i4.0
 		IL_02ec: ldc.i4.1
-		IL_02ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_E6591AFB_L31C46>(!!0, float64, string, bool, bool)
+		IL_02ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2/FunctionObject_FunctionExpression_E6591AFB_L31C46>(!!0, float64, string, bool, bool)
 		IL_02f2: stloc.s 26
 		IL_02f4: ldloc.s 23
 		IL_02f6: ldstr "call"
@@ -941,13 +1631,13 @@
 		IL_039e: ldc.i4.0
 		IL_039f: ldelem.ref
 		IL_03a0: castclass Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope
-		IL_03a5: newobj instance void FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_0644002F_L39C51::.ctor(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope)
+		IL_03a5: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3/FunctionObject_FunctionExpression_0644002F_L39C51::.ctor(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope)
 		IL_03aa: ldc.i4.2
 		IL_03ab: conv.r8
 		IL_03ac: ldstr ""
 		IL_03b1: ldc.i4.0
 		IL_03b2: ldc.i4.1
-		IL_03b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_0644002F_L39C51>(!!0, float64, string, bool, bool)
+		IL_03b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3/FunctionObject_FunctionExpression_0644002F_L39C51>(!!0, float64, string, bool, bool)
 		IL_03b8: stloc.s 27
 		IL_03ba: ldloc.s 22
 		IL_03bc: ldstr "call"
@@ -1001,13 +1691,13 @@
 		IL_045f: ldc.i4.0
 		IL_0460: ldelem.ref
 		IL_0461: castclass Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope
-		IL_0466: newobj instance void FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_D7F309C8_L47C51::.ctor(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope)
+		IL_0466: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4/FunctionObject_FunctionExpression_D7F309C8_L47C51::.ctor(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope)
 		IL_046b: ldc.i4.2
 		IL_046c: conv.r8
 		IL_046d: ldstr ""
 		IL_0472: ldc.i4.0
 		IL_0473: ldc.i4.1
-		IL_0474: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_D7F309C8_L47C51>(!!0, float64, string, bool, bool)
+		IL_0474: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4/FunctionObject_FunctionExpression_D7F309C8_L47C51>(!!0, float64, string, bool, bool)
 		IL_0479: stloc.s 28
 		IL_047b: ldloc.s 23
 		IL_047d: ldstr "call"
@@ -1063,13 +1753,13 @@
 			IL_0527: ldloc.0
 			IL_0528: stelem.ref
 			IL_0529: stloc.s 24
-			IL_052b: newobj instance void FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_C54EE51B_L57C38::.ctor()
+			IL_052b: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L57C37/FunctionObject_FunctionExpression_C54EE51B_L57C38::.ctor()
 			IL_0530: ldc.i4.2
 			IL_0531: conv.r8
 			IL_0532: ldstr ""
 			IL_0537: ldc.i4.0
 			IL_0538: ldc.i4.1
-			IL_0539: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_C54EE51B_L57C38>(!!0, float64, string, bool, bool)
+			IL_0539: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L57C37/FunctionObject_FunctionExpression_C54EE51B_L57C38>(!!0, float64, string, bool, bool)
 			IL_053e: stloc.s 29
 			IL_0540: ldloc.s 22
 			IL_0542: ldstr "call"
@@ -1148,13 +1838,13 @@
 			IL_0610: ldloc.0
 			IL_0611: stelem.ref
 			IL_0612: stloc.s 24
-			IL_0614: newobj instance void FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_CB86225F_L66C43::.ctor()
+			IL_0614: newobj instance void Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L66C42/FunctionObject_FunctionExpression_CB86225F_L66C43::.ctor()
 			IL_0619: ldc.i4.2
 			IL_061a: conv.r8
 			IL_061b: ldstr ""
 			IL_0620: ldc.i4.0
 			IL_0621: ldc.i4.1
-			IL_0622: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_CB86225F_L66C43>(!!0, float64, string, bool, bool)
+			IL_0622: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L66C42/FunctionObject_FunctionExpression_CB86225F_L66C43>(!!0, float64, string, bool, bool)
 			IL_0627: stloc.s 30
 			IL_0629: ldloc.s 23
 			IL_062b: ldstr "call"
@@ -1350,696 +2040,6 @@
 	} // end of method Array_PrototypeMethods_ArrayLike_EdgeCases::__js_module_init__
 
 } // end of class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_685C2912_L23C46
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope _environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2af9
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_685C2912_L23C46::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_685C2912_L23C46::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2b08
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_685C2912_L23C46::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2b0b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_685C2912_L23C46::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b0e
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_685C2912_L23C46::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionExpression_685C2912_L23C46::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b2e
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_685C2912_L23C46::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r1::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionExpression_685C2912_L23C46::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b4a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_685C2912_L23C46::ConstructCore
-
-} // end of class FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_685C2912_L23C46
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_E6591AFB_L31C46
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope _environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b59
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_E6591AFB_L31C46::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E6591AFB_L31C46::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2b68
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E6591AFB_L31C46::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2b6b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E6591AFB_L31C46::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b6e
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_E6591AFB_L31C46::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionExpression_E6591AFB_L31C46::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b8e
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_E6591AFB_L31C46::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r2::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionExpression_E6591AFB_L31C46::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2baa
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E6591AFB_L31C46::ConstructCore
-
-} // end of class FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_E6591AFB_L31C46
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_0644002F_L39C51
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope _environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bb9
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_0644002F_L39C51::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_0644002F_L39C51::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2bc8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_0644002F_L39C51::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2bcb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_0644002F_L39C51::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bce
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_0644002F_L39C51::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionExpression_0644002F_L39C51::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bee
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_0644002F_L39C51::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r3::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionExpression_0644002F_L39C51::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c0a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_0644002F_L39C51::ConstructCore
-
-} // end of class FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_0644002F_L39C51
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_D7F309C8_L47C51
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope _environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c19
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_D7F309C8_L47C51::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D7F309C8_L47C51::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2c28
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D7F309C8_L47C51::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2c2b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D7F309C8_L47C51::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c2e
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_D7F309C8_L47C51::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionExpression_D7F309C8_L47C51::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c4e
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_D7F309C8_L47C51::_environment0_Array_PrototypeMethods_ArrayLike_EdgeCases
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_r4::__js_call__(class Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionExpression_D7F309C8_L47C51::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c6a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D7F309C8_L47C51::ConstructCore
-
-} // end of class FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_D7F309C8_L47C51
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_C54EE51B_L57C38
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2c79
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_C54EE51B_L57C38::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2c81
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C54EE51B_L57C38::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2c84
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C54EE51B_L57C38::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c87
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L57C37::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_C54EE51B_L57C38::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ca1
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L57C37::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_C54EE51B_L57C38::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cb7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C54EE51B_L57C38::ConstructCore
-
-} // end of class FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_C54EE51B_L57C38
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_CB86225F_L66C43
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2cc6
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_CB86225F_L66C43::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2cce
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_CB86225F_L66C43::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2cd1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_CB86225F_L66C43::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cd4
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L66C42::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_CB86225F_L66C43::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cee
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Array_PrototypeMethods_ArrayLike_EdgeCases/FunctionExpression_L66C42::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_CB86225F_L66C43::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d04
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_CB86225F_L66C43::ConstructCore
-
-} // end of class FunctionObjects.Array_PrototypeMethods_ArrayLike_EdgeCases_F0A8D473.FunctionObject_FunctionExpression_CB86225F_L66C43
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Prototype_CustomMethod_Dispatch.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_Prototype_CustomMethod_Dispatch.verified.txt
@@ -53,6 +53,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_EB6D1BE0_L3C35
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21fc
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_EB6D1BE0_L3C35::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2204
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_EB6D1BE0_L3C35::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2207
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_EB6D1BE0_L3C35::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x220a
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Array_Prototype_CustomMethod_Dispatch/FunctionExpression_L3C34::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_EB6D1BE0_L3C35::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x221d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Array_Prototype_CustomMethod_Dispatch/FunctionExpression_L3C34::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_EB6D1BE0_L3C35::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x222c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_EB6D1BE0_L3C35::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_EB6D1BE0_L3C35
+
 
 		// Methods
 		.method public hidebysig static 
@@ -161,7 +262,7 @@
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[2] object,
 			[3] object[],
-			[4] class FunctionObjects.Array_Prototype_CustomMethod_Dispatch_18E71685.FunctionObject_FunctionExpression_EB6D1BE0_L3C35,
+			[4] class Modules.Array_Prototype_CustomMethod_Dispatch/FunctionExpression_L3C34/FunctionObject_FunctionExpression_EB6D1BE0_L3C35,
 			[5] object,
 			[6] string
 		)
@@ -181,13 +282,13 @@
 		IL_0024: ldloc.0
 		IL_0025: stelem.ref
 		IL_0026: stloc.3
-		IL_0027: newobj instance void FunctionObjects.Array_Prototype_CustomMethod_Dispatch_18E71685.FunctionObject_FunctionExpression_EB6D1BE0_L3C35::.ctor()
+		IL_0027: newobj instance void Modules.Array_Prototype_CustomMethod_Dispatch/FunctionExpression_L3C34/FunctionObject_FunctionExpression_EB6D1BE0_L3C35::.ctor()
 		IL_002c: ldc.i4.1
 		IL_002d: conv.r8
 		IL_002e: ldstr ""
 		IL_0033: ldc.i4.1
 		IL_0034: ldc.i4.1
-		IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_Prototype_CustomMethod_Dispatch_18E71685.FunctionObject_FunctionExpression_EB6D1BE0_L3C35>(!!0, float64, string, bool, bool)
+		IL_0035: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_Prototype_CustomMethod_Dispatch/FunctionExpression_L3C34/FunctionObject_FunctionExpression_EB6D1BE0_L3C35>(!!0, float64, string, bool, bool)
 		IL_003a: stloc.s 4
 		IL_003c: ldloc.2
 		IL_003d: ldstr "removeGraphNode"
@@ -244,107 +345,6 @@
 	} // end of method Array_Prototype_CustomMethod_Dispatch::__js_module_init__
 
 } // end of class Modules.Array_Prototype_CustomMethod_Dispatch
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_Prototype_CustomMethod_Dispatch_18E71685.FunctionObject_FunctionExpression_EB6D1BE0_L3C35
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21fc
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_EB6D1BE0_L3C35::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2204
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_EB6D1BE0_L3C35::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2207
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_EB6D1BE0_L3C35::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x220a
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Array_Prototype_CustomMethod_Dispatch/FunctionExpression_L3C34::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_EB6D1BE0_L3C35::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x221d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Array_Prototype_CustomMethod_Dispatch/FunctionExpression_L3C34::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_EB6D1BE0_L3C35::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x222c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_EB6D1BE0_L3C35::ConstructCore
-
-} // end of class FunctionObjects.Array_Prototype_CustomMethod_Dispatch_18E71685.FunctionObject_FunctionExpression_EB6D1BE0_L3C35
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_SearchOps_Basic.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_SearchOps_Basic.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_157BCB7F_L8C27
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2410
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_157BCB7F_L8C27::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2418
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_157BCB7F_L8C27::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x241b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_157BCB7F_L8C27::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x241e
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Array_SearchOps_Basic/FunctionExpression_L8C26::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_157BCB7F_L8C27::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2431
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Array_SearchOps_Basic/FunctionExpression_L8C26::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_157BCB7F_L8C27::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2440
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_157BCB7F_L8C27::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_157BCB7F_L8C27
+
 
 		// Methods
 		.method public hidebysig static 
@@ -86,6 +187,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F9B75391_L9C26
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x244f
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_F9B75391_L9C26::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2457
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F9B75391_L9C26::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x245a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F9B75391_L9C26::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x245d
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Array_SearchOps_Basic/FunctionExpression_L9C25::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_F9B75391_L9C26::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2470
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Array_SearchOps_Basic/FunctionExpression_L9C25::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_F9B75391_L9C26::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x247f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_F9B75391_L9C26::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_F9B75391_L9C26
+
 
 		// Methods
 		.method public hidebysig static 
@@ -140,6 +342,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0718A511_L10C31
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x248e
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_0718A511_L10C31::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2496
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_0718A511_L10C31::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2499
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_0718A511_L10C31::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x249c
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Array_SearchOps_Basic/FunctionExpression_L10C30::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_0718A511_L10C31::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24af
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Array_SearchOps_Basic/FunctionExpression_L10C30::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_0718A511_L10C31::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24be
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_0718A511_L10C31::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_0718A511_L10C31
 
 
 		// Methods
@@ -215,10 +518,10 @@
 			[4] float64,
 			[5] object,
 			[6] object[],
-			[7] class FunctionObjects.Array_SearchOps_Basic_387B9E54.FunctionObject_FunctionExpression_157BCB7F_L8C27,
-			[8] class FunctionObjects.Array_SearchOps_Basic_387B9E54.FunctionObject_FunctionExpression_F9B75391_L9C26,
+			[7] class Modules.Array_SearchOps_Basic/FunctionExpression_L8C26/FunctionObject_FunctionExpression_157BCB7F_L8C27,
+			[8] class Modules.Array_SearchOps_Basic/FunctionExpression_L9C25/FunctionObject_FunctionExpression_F9B75391_L9C26,
 			[9] object,
-			[10] class FunctionObjects.Array_SearchOps_Basic_387B9E54.FunctionObject_FunctionExpression_0718A511_L10C31,
+			[10] class Modules.Array_SearchOps_Basic/FunctionExpression_L10C30/FunctionObject_FunctionExpression_0718A511_L10C31,
 			[11] bool,
 			[12] object
 		)
@@ -296,13 +599,13 @@
 		IL_00ee: ldloc.0
 		IL_00ef: stelem.ref
 		IL_00f0: stloc.s 6
-		IL_00f2: newobj instance void FunctionObjects.Array_SearchOps_Basic_387B9E54.FunctionObject_FunctionExpression_157BCB7F_L8C27::.ctor()
+		IL_00f2: newobj instance void Modules.Array_SearchOps_Basic/FunctionExpression_L8C26/FunctionObject_FunctionExpression_157BCB7F_L8C27::.ctor()
 		IL_00f7: ldc.i4.1
 		IL_00f8: conv.r8
 		IL_00f9: ldstr ""
 		IL_00fe: ldc.i4.0
 		IL_00ff: ldc.i4.1
-		IL_0100: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_SearchOps_Basic_387B9E54.FunctionObject_FunctionExpression_157BCB7F_L8C27>(!!0, float64, string, bool, bool)
+		IL_0100: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_SearchOps_Basic/FunctionExpression_L8C26/FunctionObject_FunctionExpression_157BCB7F_L8C27>(!!0, float64, string, bool, bool)
 		IL_0105: stloc.s 7
 		IL_0107: ldloc.1
 		IL_0108: ldc.i4.1
@@ -332,13 +635,13 @@
 		IL_0149: ldloc.0
 		IL_014a: stelem.ref
 		IL_014b: stloc.s 6
-		IL_014d: newobj instance void FunctionObjects.Array_SearchOps_Basic_387B9E54.FunctionObject_FunctionExpression_F9B75391_L9C26::.ctor()
+		IL_014d: newobj instance void Modules.Array_SearchOps_Basic/FunctionExpression_L9C25/FunctionObject_FunctionExpression_F9B75391_L9C26::.ctor()
 		IL_0152: ldc.i4.1
 		IL_0153: conv.r8
 		IL_0154: ldstr ""
 		IL_0159: ldc.i4.0
 		IL_015a: ldc.i4.1
-		IL_015b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_SearchOps_Basic_387B9E54.FunctionObject_FunctionExpression_F9B75391_L9C26>(!!0, float64, string, bool, bool)
+		IL_015b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_SearchOps_Basic/FunctionExpression_L9C25/FunctionObject_FunctionExpression_F9B75391_L9C26>(!!0, float64, string, bool, bool)
 		IL_0160: stloc.s 8
 		IL_0162: ldloc.1
 		IL_0163: ldc.i4.1
@@ -365,13 +668,13 @@
 		IL_019c: ldloc.0
 		IL_019d: stelem.ref
 		IL_019e: stloc.s 6
-		IL_01a0: newobj instance void FunctionObjects.Array_SearchOps_Basic_387B9E54.FunctionObject_FunctionExpression_0718A511_L10C31::.ctor()
+		IL_01a0: newobj instance void Modules.Array_SearchOps_Basic/FunctionExpression_L10C30/FunctionObject_FunctionExpression_0718A511_L10C31::.ctor()
 		IL_01a5: ldc.i4.1
 		IL_01a6: conv.r8
 		IL_01a7: ldstr ""
 		IL_01ac: ldc.i4.0
 		IL_01ad: ldc.i4.1
-		IL_01ae: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_SearchOps_Basic_387B9E54.FunctionObject_FunctionExpression_0718A511_L10C31>(!!0, float64, string, bool, bool)
+		IL_01ae: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_SearchOps_Basic/FunctionExpression_L10C30/FunctionObject_FunctionExpression_0718A511_L10C31>(!!0, float64, string, bool, bool)
 		IL_01b3: stloc.s 10
 		IL_01b5: ldloc.1
 		IL_01b6: ldc.i4.1
@@ -483,309 +786,6 @@
 	} // end of method Array_SearchOps_Basic::__js_module_init__
 
 } // end of class Modules.Array_SearchOps_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_SearchOps_Basic_387B9E54.FunctionObject_FunctionExpression_157BCB7F_L8C27
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2410
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_157BCB7F_L8C27::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2418
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_157BCB7F_L8C27::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x241b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_157BCB7F_L8C27::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x241e
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Array_SearchOps_Basic/FunctionExpression_L8C26::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_157BCB7F_L8C27::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2431
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Array_SearchOps_Basic/FunctionExpression_L8C26::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_157BCB7F_L8C27::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2440
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_157BCB7F_L8C27::ConstructCore
-
-} // end of class FunctionObjects.Array_SearchOps_Basic_387B9E54.FunctionObject_FunctionExpression_157BCB7F_L8C27
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_SearchOps_Basic_387B9E54.FunctionObject_FunctionExpression_F9B75391_L9C26
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x244f
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_F9B75391_L9C26::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2457
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F9B75391_L9C26::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x245a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F9B75391_L9C26::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x245d
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Array_SearchOps_Basic/FunctionExpression_L9C25::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_F9B75391_L9C26::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2470
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Array_SearchOps_Basic/FunctionExpression_L9C25::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F9B75391_L9C26::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x247f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F9B75391_L9C26::ConstructCore
-
-} // end of class FunctionObjects.Array_SearchOps_Basic_387B9E54.FunctionObject_FunctionExpression_F9B75391_L9C26
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_SearchOps_Basic_387B9E54.FunctionObject_FunctionExpression_0718A511_L10C31
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x248e
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_0718A511_L10C31::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2496
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_0718A511_L10C31::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2499
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_0718A511_L10C31::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x249c
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Array_SearchOps_Basic/FunctionExpression_L10C30::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_0718A511_L10C31::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24af
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Array_SearchOps_Basic/FunctionExpression_L10C30::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_0718A511_L10C31::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24be
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_0718A511_L10C31::ConstructCore
-
-} // end of class FunctionObjects.Array_SearchOps_Basic_387B9E54.FunctionObject_FunctionExpression_0718A511_L10C31
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_StableLoadReceiver_EvaluationOrder.verified.txt
+++ b/tests/Jroc.Tests/Array/Snapshots/GeneratorTests.Array_StableLoadReceiver_EvaluationOrder.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3434C852_L7C14
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope _environment0_Array_StableLoadReceiver_EvaluationOrder
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x22ad
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_nested/FunctionObject_FunctionExpression_3434C852_L7C14::_environment0_Array_StableLoadReceiver_EvaluationOrder
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_3434C852_L7C14::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22bc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_3434C852_L7C14::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22bf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_3434C852_L7C14::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22c2
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_nested/FunctionObject_FunctionExpression_3434C852_L7C14::_environment0_Array_StableLoadReceiver_EvaluationOrder
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_nested::__js_call__(class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_3434C852_L7C14::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22d4
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_nested/FunctionObject_FunctionExpression_3434C852_L7C14::_environment0_Array_StableLoadReceiver_EvaluationOrder
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_nested::__js_call__(class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_3434C852_L7C14::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22e2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_3434C852_L7C14::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_3434C852_L7C14
+
 
 		// Methods
 		.method public hidebysig static 
@@ -102,6 +209,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_52357B65_L16C8
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope _environment0_Array_StableLoadReceiver_EvaluationOrder
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x22f1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_L16C7/FunctionObject_FunctionExpression_52357B65_L16C8::_environment0_Array_StableLoadReceiver_EvaluationOrder
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_52357B65_L16C8::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2300
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_52357B65_L16C8::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2303
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_52357B65_L16C8::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2306
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_L16C7/FunctionObject_FunctionExpression_52357B65_L16C8::_environment0_Array_StableLoadReceiver_EvaluationOrder
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_L16C7::__js_call__(class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_52357B65_L16C8::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2318
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_L16C7/FunctionObject_FunctionExpression_52357B65_L16C8::_environment0_Array_StableLoadReceiver_EvaluationOrder
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_L16C7::__js_call__(class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_52357B65_L16C8::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2326
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_52357B65_L16C8::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_52357B65_L16C8
 
 
 		// Methods
@@ -207,7 +421,7 @@
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[4] object[],
-			[5] class FunctionObjects.Array_StableLoadReceiver_EvaluationOrder_073EC324.FunctionObject_FunctionExpression_3434C852_L7C14,
+			[5] class Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_nested/FunctionObject_FunctionExpression_3434C852_L7C14,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
 			[7] object,
 			[8] object,
@@ -245,16 +459,16 @@
 		IL_0051: ldc.i4.0
 		IL_0052: ldelem.ref
 		IL_0053: castclass Modules.Array_StableLoadReceiver_EvaluationOrder/Scope
-		IL_0058: newobj instance void FunctionObjects.Array_StableLoadReceiver_EvaluationOrder_073EC324.FunctionObject_FunctionExpression_3434C852_L7C14::.ctor(class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope)
+		IL_0058: newobj instance void Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_nested/FunctionObject_FunctionExpression_3434C852_L7C14::.ctor(class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope)
 		IL_005d: ldc.i4.0
 		IL_005e: conv.r8
 		IL_005f: ldstr ""
 		IL_0064: ldc.i4.0
 		IL_0065: ldc.i4.1
-		IL_0066: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Array_StableLoadReceiver_EvaluationOrder_073EC324.FunctionObject_FunctionExpression_3434C852_L7C14>(!!0, float64, string, bool, bool)
+		IL_0066: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_nested/FunctionObject_FunctionExpression_3434C852_L7C14>(!!0, float64, string, bool, bool)
 		IL_006b: stloc.s 5
 		IL_006d: ldloc.s 5
-		IL_006f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class FunctionObjects.Array_StableLoadReceiver_EvaluationOrder_073EC324.FunctionObject_FunctionExpression_3434C852_L7C14>(!!0)
+		IL_006f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_nested/FunctionObject_FunctionExpression_3434C852_L7C14>(!!0)
 		IL_0074: stloc.s 5
 		IL_0076: ldloc.3
 		IL_0077: ldstr "value"
@@ -349,220 +563,6 @@
 	} // end of method Array_StableLoadReceiver_EvaluationOrder::__js_module_init__
 
 } // end of class Modules.Array_StableLoadReceiver_EvaluationOrder
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_StableLoadReceiver_EvaluationOrder_073EC324.FunctionObject_FunctionExpression_3434C852_L7C14
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope _environment0_Array_StableLoadReceiver_EvaluationOrder
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x22ad
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope FunctionObjects.Array_StableLoadReceiver_EvaluationOrder_073EC324.FunctionObject_FunctionExpression_3434C852_L7C14::_environment0_Array_StableLoadReceiver_EvaluationOrder
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3434C852_L7C14::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22bc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3434C852_L7C14::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22bf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3434C852_L7C14::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22c2
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope FunctionObjects.Array_StableLoadReceiver_EvaluationOrder_073EC324.FunctionObject_FunctionExpression_3434C852_L7C14::_environment0_Array_StableLoadReceiver_EvaluationOrder
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_nested::__js_call__(class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_3434C852_L7C14::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22d4
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope FunctionObjects.Array_StableLoadReceiver_EvaluationOrder_073EC324.FunctionObject_FunctionExpression_3434C852_L7C14::_environment0_Array_StableLoadReceiver_EvaluationOrder
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_nested::__js_call__(class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_3434C852_L7C14::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22e2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3434C852_L7C14::ConstructCore
-
-} // end of class FunctionObjects.Array_StableLoadReceiver_EvaluationOrder_073EC324.FunctionObject_FunctionExpression_3434C852_L7C14
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Array_StableLoadReceiver_EvaluationOrder_073EC324.FunctionObject_FunctionExpression_52357B65_L16C8
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope _environment0_Array_StableLoadReceiver_EvaluationOrder
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x22f1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope FunctionObjects.Array_StableLoadReceiver_EvaluationOrder_073EC324.FunctionObject_FunctionExpression_52357B65_L16C8::_environment0_Array_StableLoadReceiver_EvaluationOrder
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_52357B65_L16C8::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2300
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_52357B65_L16C8::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2303
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_52357B65_L16C8::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2306
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope FunctionObjects.Array_StableLoadReceiver_EvaluationOrder_073EC324.FunctionObject_FunctionExpression_52357B65_L16C8::_environment0_Array_StableLoadReceiver_EvaluationOrder
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_L16C7::__js_call__(class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_52357B65_L16C8::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2318
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope FunctionObjects.Array_StableLoadReceiver_EvaluationOrder_073EC324.FunctionObject_FunctionExpression_52357B65_L16C8::_environment0_Array_StableLoadReceiver_EvaluationOrder
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Array_StableLoadReceiver_EvaluationOrder/FunctionExpression_L16C7::__js_call__(class Modules.Array_StableLoadReceiver_EvaluationOrder/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_52357B65_L16C8::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2326
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_52357B65_L16C8::ConstructCore
-
-} // end of class FunctionObjects.Array_StableLoadReceiver_EvaluationOrder_073EC324.FunctionObject_FunctionExpression_52357B65_L16C8
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ClosureMutatesOuterVariable.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_ClosureMutatesOuterVariable.verified.txt
@@ -182,6 +182,121 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_61C7CF9F_createCounter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope _environment0_ArrowFunction_ClosureMutatesOuterVariable
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2201
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter/FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::_environment0_ArrowFunction_ClosureMutatesOuterVariable
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2210
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2213
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2216
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter/FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::_environment0_ArrowFunction_ClosureMutatesOuterVariable
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: call object Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter::__js_call__(class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope, object, float64)
+				IL_001c: ret
+			} // end of method FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2234
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter/FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::_environment0_ArrowFunction_ClosureMutatesOuterVariable
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0013: call object Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter::__js_call__(class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope, object, float64)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x224e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_61C7CF9F_createCounter
+
 
 		// Methods
 		.method public hidebysig static 
@@ -293,7 +408,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope,
-			[1] class FunctionObjects.ArrowFunction_ClosureMutatesOuterVariable_CDEC60F2.FunctionObject_FunctionDeclaration_61C7CF9F_createCounter,
+			[1] class Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter/FunctionObject_FunctionDeclaration_61C7CF9F_createCounter,
 			[2] object,
 			[3] object[],
 			[4] object,
@@ -313,13 +428,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope
-		IL_0019: newobj instance void FunctionObjects.ArrowFunction_ClosureMutatesOuterVariable_CDEC60F2.FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::.ctor(class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope)
+		IL_0019: newobj instance void Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter/FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::.ctor(class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope)
 		IL_001e: ldc.i4.1
 		IL_001f: conv.r8
 		IL_0020: ldstr "createCounter"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ArrowFunction_ClosureMutatesOuterVariable_CDEC60F2.FunctionObject_FunctionDeclaration_61C7CF9F_createCounter>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter/FunctionObject_FunctionDeclaration_61C7CF9F_createCounter>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
@@ -377,121 +492,6 @@
 	} // end of method ArrowFunction_ClosureMutatesOuterVariable::__js_module_init__
 
 } // end of class Modules.ArrowFunction_ClosureMutatesOuterVariable
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ArrowFunction_ClosureMutatesOuterVariable_CDEC60F2.FunctionObject_FunctionDeclaration_61C7CF9F_createCounter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope _environment0_ArrowFunction_ClosureMutatesOuterVariable
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2201
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope FunctionObjects.ArrowFunction_ClosureMutatesOuterVariable_CDEC60F2.FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::_environment0_ArrowFunction_ClosureMutatesOuterVariable
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2210
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2213
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2216
-		// Header size: 1
-		// Code size: 29 (0x1d)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope FunctionObjects.ArrowFunction_ClosureMutatesOuterVariable_CDEC60F2.FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::_environment0_ArrowFunction_ClosureMutatesOuterVariable
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0017: call object Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter::__js_call__(class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope, object, float64)
-		IL_001c: ret
-	} // end of method FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2234
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope FunctionObjects.ArrowFunction_ClosureMutatesOuterVariable_CDEC60F2.FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::_environment0_ArrowFunction_ClosureMutatesOuterVariable
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0013: call object Modules.ArrowFunction_ClosureMutatesOuterVariable/createCounter::__js_call__(class Modules.ArrowFunction_ClosureMutatesOuterVariable/Scope, object, float64)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x224e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_61C7CF9F_createCounter::ConstructCore
-
-} // end of class FunctionObjects.ArrowFunction_ClosureMutatesOuterVariable_CDEC60F2.FunctionObject_FunctionDeclaration_61C7CF9F_createCounter
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_GeneratedFunctionObjectSurface.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_GeneratedFunctionObjectSurface.verified.txt
@@ -192,6 +192,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_83EB34AC_makeArrow
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x24a0
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_83EB34AC_makeArrow::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24a8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_83EB34AC_makeArrow::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24ab
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_83EB34AC_makeArrow::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24ae
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.ArrowFunction_GeneratedFunctionObjectSurface/makeArrow::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_83EB34AC_makeArrow::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24ba
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.ArrowFunction_GeneratedFunctionObjectSurface/makeArrow::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_83EB34AC_makeArrow::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24c2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_83EB34AC_makeArrow::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_83EB34AC_makeArrow
+
 
 		// Methods
 		.method public hidebysig static 
@@ -318,7 +413,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ArrowFunction_GeneratedFunctionObjectSurface/Scope,
-			[1] class FunctionObjects.ArrowFunction_GeneratedFunctionObjectSurface_832750F6.FunctionObject_FunctionDeclaration_83EB34AC_makeArrow,
+			[1] class Modules.ArrowFunction_GeneratedFunctionObjectSurface/makeArrow/FunctionObject_FunctionDeclaration_83EB34AC_makeArrow,
 			[2] object,
 			[3] object,
 			[4] object,
@@ -346,13 +441,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 9
-		IL_0012: newobj instance void FunctionObjects.ArrowFunction_GeneratedFunctionObjectSurface_832750F6.FunctionObject_FunctionDeclaration_83EB34AC_makeArrow::.ctor()
+		IL_0012: newobj instance void Modules.ArrowFunction_GeneratedFunctionObjectSurface/makeArrow/FunctionObject_FunctionDeclaration_83EB34AC_makeArrow::.ctor()
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "makeArrow"
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ArrowFunction_GeneratedFunctionObjectSurface_832750F6.FunctionObject_FunctionDeclaration_83EB34AC_makeArrow>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ArrowFunction_GeneratedFunctionObjectSurface/makeArrow/FunctionObject_FunctionDeclaration_83EB34AC_makeArrow>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: nop
@@ -620,101 +715,6 @@
 	} // end of method ArrowFunction_GeneratedFunctionObjectSurface::__js_module_init__
 
 } // end of class Modules.ArrowFunction_GeneratedFunctionObjectSurface
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ArrowFunction_GeneratedFunctionObjectSurface_832750F6.FunctionObject_FunctionDeclaration_83EB34AC_makeArrow
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x24a0
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_83EB34AC_makeArrow::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24a8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_83EB34AC_makeArrow::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24ab
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_83EB34AC_makeArrow::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24ae
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.ArrowFunction_GeneratedFunctionObjectSurface/makeArrow::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_83EB34AC_makeArrow::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24ba
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.ArrowFunction_GeneratedFunctionObjectSurface/makeArrow::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_83EB34AC_makeArrow::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24c2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_83EB34AC_makeArrow::ConstructCore
-
-} // end of class FunctionObjects.ArrowFunction_GeneratedFunctionObjectSurface_832750F6.FunctionObject_FunctionDeclaration_83EB34AC_makeArrow
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalSuper_MethodAndConstructor.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalSuper_MethodAndConstructor.verified.txt
@@ -411,6 +411,149 @@
 
 		} // end of class Scope_read
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_3C0F3AD3_Base
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x24ac
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base/FunctionObject_ClassConstructor_3C0F3AD3_Base::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_3C0F3AD3_Base::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24bb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_3C0F3AD3_Base::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24be
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_3C0F3AD3_Base::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24c1
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_3C0F3AD3_Base::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24cd
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_3C0F3AD3_Base::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_3C0F3AD3_Base
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_CB6C7DBA_Base_read
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x24d9
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_CB6C7DBA_Base_read::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24e1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_CB6C7DBA_Base_read::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24e4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_CB6C7DBA_Base_read::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24e7
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base
+				IL_0006: call instance object Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base::read()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_CB6C7DBA_Base_read::CallCore
+
+		} // end of class FunctionObject_ClassMethod_CB6C7DBA_Base_read
+
 
 		// Fields
 		.field public object 'value'
@@ -518,6 +661,149 @@
 			} // end of method Scope_makeReader::.ctor
 
 		} // end of class Scope_makeReader
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_FE3E82D3_Derived
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x24f4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived/FunctionObject_ClassConstructor_FE3E82D3_Derived::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_FE3E82D3_Derived::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2503
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_FE3E82D3_Derived::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2506
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_FE3E82D3_Derived::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2509
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_FE3E82D3_Derived::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2515
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_FE3E82D3_Derived::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_FE3E82D3_Derived
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_66614F7D_Derived_makeReader
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2521
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_66614F7D_Derived_makeReader::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2529
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_66614F7D_Derived_makeReader::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x252c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_66614F7D_Derived_makeReader::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x252f
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
+				IL_0006: call instance object Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived::makeReader()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_66614F7D_Derived_makeReader::CallCore
+
+		} // end of class FunctionObject_ClassMethod_66614F7D_Derived_makeReader
 
 
 		// Fields
@@ -955,292 +1241,6 @@
 	} // end of method ArrowFunction_LexicalSuper_MethodAndConstructor::__js_module_init__
 
 } // end of class Modules.ArrowFunction_LexicalSuper_MethodAndConstructor
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ArrowFunction_LexicalSuper_MethodAndConstructor_E081A85B.FunctionObject_ClassConstructor_3C0F3AD3_Base
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x24ac
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.ArrowFunction_LexicalSuper_MethodAndConstructor_E081A85B.FunctionObject_ClassConstructor_3C0F3AD3_Base::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_3C0F3AD3_Base::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24bb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_3C0F3AD3_Base::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24be
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_3C0F3AD3_Base::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24c1
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_3C0F3AD3_Base::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24cd
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_3C0F3AD3_Base::ConstructCore
-
-} // end of class FunctionObjects.ArrowFunction_LexicalSuper_MethodAndConstructor_E081A85B.FunctionObject_ClassConstructor_3C0F3AD3_Base
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ArrowFunction_LexicalSuper_MethodAndConstructor_E081A85B.FunctionObject_ClassMethod_CB6C7DBA_Base_read
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x24d9
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_CB6C7DBA_Base_read::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24e1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_CB6C7DBA_Base_read::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24e4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_CB6C7DBA_Base_read::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24e7
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base
-		IL_0006: call instance object Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Base::read()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_CB6C7DBA_Base_read::CallCore
-
-} // end of class FunctionObjects.ArrowFunction_LexicalSuper_MethodAndConstructor_E081A85B.FunctionObject_ClassMethod_CB6C7DBA_Base_read
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ArrowFunction_LexicalSuper_MethodAndConstructor_E081A85B.FunctionObject_ClassConstructor_FE3E82D3_Derived
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x24f4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.ArrowFunction_LexicalSuper_MethodAndConstructor_E081A85B.FunctionObject_ClassConstructor_FE3E82D3_Derived::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_FE3E82D3_Derived::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2503
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_FE3E82D3_Derived::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2506
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_FE3E82D3_Derived::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2509
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_FE3E82D3_Derived::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2515
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_FE3E82D3_Derived::ConstructCore
-
-} // end of class FunctionObjects.ArrowFunction_LexicalSuper_MethodAndConstructor_E081A85B.FunctionObject_ClassConstructor_FE3E82D3_Derived
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ArrowFunction_LexicalSuper_MethodAndConstructor_E081A85B.FunctionObject_ClassMethod_66614F7D_Derived_makeReader
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2521
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_66614F7D_Derived_makeReader::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2529
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_66614F7D_Derived_makeReader::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x252c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_66614F7D_Derived_makeReader::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x252f
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived
-		IL_0006: call instance object Modules.ArrowFunction_LexicalSuper_MethodAndConstructor/Derived::makeReader()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_66614F7D_Derived_makeReader::CallCore
-
-} // end of class FunctionObjects.ArrowFunction_LexicalSuper_MethodAndConstructor_E081A85B.FunctionObject_ClassMethod_66614F7D_Derived_makeReader
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_ConstructorAssigned.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_ConstructorAssigned.verified.txt
@@ -181,6 +181,89 @@
 
 		} // end of class Scope_ctor
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_74E2BB29_Counter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x221f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.ArrowFunction_LexicalThis_ConstructorAssigned/Counter/FunctionObject_ClassConstructor_74E2BB29_Counter::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_74E2BB29_Counter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x222e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_74E2BB29_Counter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2231
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_74E2BB29_Counter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2234
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_74E2BB29_Counter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2240
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_74E2BB29_Counter::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_74E2BB29_Counter
+
 
 		// Fields
 		.field private object[] _scopes
@@ -389,89 +472,6 @@
 	} // end of method ArrowFunction_LexicalThis_ConstructorAssigned::__js_module_init__
 
 } // end of class Modules.ArrowFunction_LexicalThis_ConstructorAssigned
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ArrowFunction_LexicalThis_ConstructorAssigned_E45A13E6.FunctionObject_ClassConstructor_74E2BB29_Counter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x221f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.ArrowFunction_LexicalThis_ConstructorAssigned_E45A13E6.FunctionObject_ClassConstructor_74E2BB29_Counter::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_74E2BB29_Counter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x222e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_74E2BB29_Counter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2231
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_74E2BB29_Counter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2234
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_74E2BB29_Counter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2240
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_74E2BB29_Counter::ConstructCore
-
-} // end of class FunctionObjects.ArrowFunction_LexicalThis_ConstructorAssigned_E45A13E6.FunctionObject_ClassConstructor_74E2BB29_Counter
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_CreatedInMethod.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_CreatedInMethod.verified.txt
@@ -201,6 +201,149 @@
 
 		} // end of class Scope_makeGetter
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_AB3D4F93_Counter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x220d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.ArrowFunction_LexicalThis_CreatedInMethod/Counter/FunctionObject_ClassConstructor_AB3D4F93_Counter::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_AB3D4F93_Counter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x221c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_AB3D4F93_Counter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x221f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_AB3D4F93_Counter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2222
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_AB3D4F93_Counter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x222e
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_AB3D4F93_Counter::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_AB3D4F93_Counter
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_FCF9BEEF_Counter_makeGetter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x223a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_FCF9BEEF_Counter_makeGetter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2242
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_FCF9BEEF_Counter_makeGetter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2245
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_FCF9BEEF_Counter_makeGetter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2248
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.ArrowFunction_LexicalThis_CreatedInMethod/Counter
+				IL_0006: call instance object Modules.ArrowFunction_LexicalThis_CreatedInMethod/Counter::makeGetter()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_FCF9BEEF_Counter_makeGetter::CallCore
+
+		} // end of class FunctionObject_ClassMethod_FCF9BEEF_Counter_makeGetter
+
 
 		// Fields
 		.field public float64 x
@@ -401,149 +544,6 @@
 	} // end of method ArrowFunction_LexicalThis_CreatedInMethod::__js_module_init__
 
 } // end of class Modules.ArrowFunction_LexicalThis_CreatedInMethod
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ArrowFunction_LexicalThis_CreatedInMethod_8FEE7D30.FunctionObject_ClassConstructor_AB3D4F93_Counter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x220d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.ArrowFunction_LexicalThis_CreatedInMethod_8FEE7D30.FunctionObject_ClassConstructor_AB3D4F93_Counter::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_AB3D4F93_Counter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x221c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_AB3D4F93_Counter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x221f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_AB3D4F93_Counter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2222
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_AB3D4F93_Counter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x222e
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_AB3D4F93_Counter::ConstructCore
-
-} // end of class FunctionObjects.ArrowFunction_LexicalThis_CreatedInMethod_8FEE7D30.FunctionObject_ClassConstructor_AB3D4F93_Counter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ArrowFunction_LexicalThis_CreatedInMethod_8FEE7D30.FunctionObject_ClassMethod_FCF9BEEF_Counter_makeGetter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x223a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_FCF9BEEF_Counter_makeGetter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2242
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_FCF9BEEF_Counter_makeGetter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2245
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_FCF9BEEF_Counter_makeGetter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2248
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.ArrowFunction_LexicalThis_CreatedInMethod/Counter
-		IL_0006: call instance object Modules.ArrowFunction_LexicalThis_CreatedInMethod/Counter::makeGetter()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_FCF9BEEF_Counter_makeGetter::CallCore
-
-} // end of class FunctionObjects.ArrowFunction_LexicalThis_CreatedInMethod_8FEE7D30.FunctionObject_ClassMethod_FCF9BEEF_Counter_makeGetter
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_ObjectLiteralProperty.verified.txt
+++ b/tests/Jroc.Tests/ArrowFunction/Snapshots/GeneratorTests.ArrowFunction_LexicalThis_ObjectLiteralProperty.verified.txt
@@ -201,6 +201,149 @@
 
 		} // end of class Scope_make
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_85FC1835_C
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty/C/FunctionObject_ClassConstructor_85FC1835_C::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_85FC1835_C::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2205
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_85FC1835_C::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2208
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_85FC1835_C::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x220b
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_85FC1835_C::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2217
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_85FC1835_C::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_85FC1835_C
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_79440680_C_make
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2223
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_79440680_C_make::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x222b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_79440680_C_make::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x222e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_79440680_C_make::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2231
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty/C
+				IL_0006: call instance object Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty/C::make()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_79440680_C_make::CallCore
+
+		} // end of class FunctionObject_ClassMethod_79440680_C_make
+
 
 		// Fields
 		.field private object[] _scopes
@@ -413,149 +556,6 @@
 	} // end of method ArrowFunction_LexicalThis_ObjectLiteralProperty::__js_module_init__
 
 } // end of class Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ArrowFunction_LexicalThis_ObjectLiteralProperty_DA57BF8D.FunctionObject_ClassConstructor_85FC1835_C
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.ArrowFunction_LexicalThis_ObjectLiteralProperty_DA57BF8D.FunctionObject_ClassConstructor_85FC1835_C::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_85FC1835_C::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2205
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_85FC1835_C::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2208
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_85FC1835_C::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x220b
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_85FC1835_C::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2217
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_85FC1835_C::ConstructCore
-
-} // end of class FunctionObjects.ArrowFunction_LexicalThis_ObjectLiteralProperty_DA57BF8D.FunctionObject_ClassConstructor_85FC1835_C
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ArrowFunction_LexicalThis_ObjectLiteralProperty_DA57BF8D.FunctionObject_ClassMethod_79440680_C_make
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2223
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_79440680_C_make::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x222b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_79440680_C_make::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x222e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_79440680_C_make::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2231
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty/C
-		IL_0006: call instance object Modules.ArrowFunction_LexicalThis_ObjectLiteralProperty/C::make()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_79440680_C_make::CallCore
-
-} // end of class FunctionObjects.ArrowFunction_LexicalThis_ObjectLiteralProperty_DA57BF8D.FunctionObject_ClassMethod_79440680_C_make
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ArrowFunction_LexicalThis.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ArrowFunction_LexicalThis.verified.txt
@@ -469,6 +469,149 @@
 
 		} // end of class Scope_makeGetter
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_48958275_Counter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2373
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Async_ArrowFunction_LexicalThis/Counter/FunctionObject_ClassConstructor_48958275_Counter::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_48958275_Counter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2382
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_48958275_Counter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2385
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_48958275_Counter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2388
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_48958275_Counter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2394
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_48958275_Counter::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_48958275_Counter
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_020123DD_Counter_makeGetter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x23a0
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_020123DD_Counter_makeGetter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x23a8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_020123DD_Counter_makeGetter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x23ab
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_020123DD_Counter_makeGetter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x23ae
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Async_ArrowFunction_LexicalThis/Counter
+				IL_0006: call instance object Modules.Async_ArrowFunction_LexicalThis/Counter::makeGetter()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_020123DD_Counter_makeGetter::CallCore
+
+		} // end of class FunctionObject_ClassMethod_020123DD_Counter_makeGetter
+
 
 		// Fields
 		.field public float64 x
@@ -668,149 +811,6 @@
 	} // end of method Async_ArrowFunction_LexicalThis::__js_module_init__
 
 } // end of class Modules.Async_ArrowFunction_LexicalThis
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_ArrowFunction_LexicalThis_00D7EEF2.FunctionObject_ClassConstructor_48958275_Counter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2373
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Async_ArrowFunction_LexicalThis_00D7EEF2.FunctionObject_ClassConstructor_48958275_Counter::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_48958275_Counter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2382
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_48958275_Counter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2385
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_48958275_Counter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2388
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_48958275_Counter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2394
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_48958275_Counter::ConstructCore
-
-} // end of class FunctionObjects.Async_ArrowFunction_LexicalThis_00D7EEF2.FunctionObject_ClassConstructor_48958275_Counter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_ArrowFunction_LexicalThis_00D7EEF2.FunctionObject_ClassMethod_020123DD_Counter_makeGetter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x23a0
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_020123DD_Counter_makeGetter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23a8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_020123DD_Counter_makeGetter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23ab
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_020123DD_Counter_makeGetter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23ae
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Async_ArrowFunction_LexicalThis/Counter
-		IL_0006: call instance object Modules.Async_ArrowFunction_LexicalThis/Counter::makeGetter()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_020123DD_Counter_makeGetter::CallCore
-
-} // end of class FunctionObjects.Async_ArrowFunction_LexicalThis_00D7EEF2.FunctionObject_ClassMethod_020123DD_Counter_makeGetter
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_Calls_Module_Function_Before_Await.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_Calls_Module_Function_Before_Await.verified.txt
@@ -31,6 +31,109 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_638020D9_formatSection
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2315
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_638020D9_formatSection::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x231d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_638020D9_formatSection::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2320
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_638020D9_formatSection::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2323
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0011: call object Modules.Async_Calls_Module_Function_Before_Await/formatSection::__js_call__(object, string)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_638020D9_formatSection::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x233b
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: call object Modules.Async_Calls_Module_Function_Before_Await/formatSection::__js_call__(object, string)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_638020D9_formatSection::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x234f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_638020D9_formatSection::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_638020D9_formatSection
+
 
 		// Methods
 		.method public hidebysig static 
@@ -88,6 +191,99 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C5F6260C_main
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Async_Calls_Module_Function_Before_Await/Scope _environment0_Async_Calls_Module_Function_Before_Await
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Async_Calls_Module_Function_Before_Await/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x235e
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Async_Calls_Module_Function_Before_Await/Scope Modules.Async_Calls_Module_Function_Before_Await/main/FunctionObject_FunctionDeclaration_C5F6260C_main::_environment0_Async_Calls_Module_Function_Before_Await
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.Async_Calls_Module_Function_Before_Await/main/FunctionObject_FunctionDeclaration_C5F6260C_main::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_C5F6260C_main::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2374
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C5F6260C_main::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2377
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C5F6260C_main::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x237a
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_Calls_Module_Function_Before_Await/main/FunctionObject_FunctionDeclaration_C5F6260C_main::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Async_Calls_Module_Function_Before_Await/main::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_C5F6260C_main::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x238c
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_Calls_Module_Function_Before_Await/main/FunctionObject_FunctionDeclaration_C5F6260C_main::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Async_Calls_Module_Function_Before_Await/main::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_C5F6260C_main::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C5F6260C_main
 
 
 		// Methods
@@ -478,7 +674,7 @@
 			[0] class Modules.Async_Calls_Module_Function_Before_Await/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
 			[2] object[],
-			[3] class FunctionObjects.Async_Calls_Module_Function_Before_Await_172A3CDA.FunctionObject_FunctionDeclaration_638020D9_formatSection,
+			[3] class Modules.Async_Calls_Module_Function_Before_Await/formatSection/FunctionObject_FunctionDeclaration_638020D9_formatSection,
 			[4] object,
 			[5] class Modules.Async_Calls_Module_Function_Before_Await/ArrowFunction_L13C14/FunctionObject
 		)
@@ -492,13 +688,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.Async_Calls_Module_Function_Before_Await_172A3CDA.FunctionObject_FunctionDeclaration_638020D9_formatSection::.ctor()
+		IL_0011: newobj instance void Modules.Async_Calls_Module_Function_Before_Await/formatSection/FunctionObject_FunctionDeclaration_638020D9_formatSection::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "formatSection"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Async_Calls_Module_Function_Before_Await_172A3CDA.FunctionObject_FunctionDeclaration_638020D9_formatSection>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_Calls_Module_Function_Before_Await/formatSection/FunctionObject_FunctionDeclaration_638020D9_formatSection>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.3
 		IL_0025: ldloc.0
 		IL_0026: ldloc.3
@@ -556,202 +752,6 @@
 	} // end of method Async_Calls_Module_Function_Before_Await::__js_module_init__
 
 } // end of class Modules.Async_Calls_Module_Function_Before_Await
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_Calls_Module_Function_Before_Await_172A3CDA.FunctionObject_FunctionDeclaration_638020D9_formatSection
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2315
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_638020D9_formatSection::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x231d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_638020D9_formatSection::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2320
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_638020D9_formatSection::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2323
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0011: call object Modules.Async_Calls_Module_Function_Before_Await/formatSection::__js_call__(object, string)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_638020D9_formatSection::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x233b
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_000d: call object Modules.Async_Calls_Module_Function_Before_Await/formatSection::__js_call__(object, string)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_638020D9_formatSection::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x234f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_638020D9_formatSection::ConstructCore
-
-} // end of class FunctionObjects.Async_Calls_Module_Function_Before_Await_172A3CDA.FunctionObject_FunctionDeclaration_638020D9_formatSection
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_Calls_Module_Function_Before_Await_172A3CDA.FunctionObject_FunctionDeclaration_C5F6260C_main
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Async_Calls_Module_Function_Before_Await/Scope _environment0_Async_Calls_Module_Function_Before_Await
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Async_Calls_Module_Function_Before_Await/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x235e
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Async_Calls_Module_Function_Before_Await/Scope FunctionObjects.Async_Calls_Module_Function_Before_Await_172A3CDA.FunctionObject_FunctionDeclaration_C5F6260C_main::_environment0_Async_Calls_Module_Function_Before_Await
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Async_Calls_Module_Function_Before_Await_172A3CDA.FunctionObject_FunctionDeclaration_C5F6260C_main::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_C5F6260C_main::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2374
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C5F6260C_main::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2377
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C5F6260C_main::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x237a
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_Calls_Module_Function_Before_Await_172A3CDA.FunctionObject_FunctionDeclaration_C5F6260C_main::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Async_Calls_Module_Function_Before_Await/main::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_C5F6260C_main::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x238c
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_Calls_Module_Function_Before_Await_172A3CDA.FunctionObject_FunctionDeclaration_C5F6260C_main::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Async_Calls_Module_Function_Before_Await/main::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_C5F6260C_main::ConstructBodyCore
-
-} // end of class FunctionObjects.Async_Calls_Module_Function_Before_Await_172A3CDA.FunctionObject_FunctionDeclaration_C5F6260C_main
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_CallsOtherAsync.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_CallsOtherAsync.verified.txt
@@ -215,6 +215,209 @@
 
 		} // end of class Scope_processData
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_C5820907_Service
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x248c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Async_ClassMethod_CallsOtherAsync/Service/FunctionObject_ClassConstructor_C5820907_Service::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_C5820907_Service::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x249b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_C5820907_Service::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x249e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_C5820907_Service::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24a1
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_C5820907_Service::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24ad
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_C5820907_Service::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_C5820907_Service
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_94242E88_Service_fetchData
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x24b9
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_94242E88_Service_fetchData::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24c1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_94242E88_Service_fetchData::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24c4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_94242E88_Service_fetchData::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24c7
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Async_ClassMethod_CallsOtherAsync/Service
+				IL_0006: call instance object Modules.Async_ClassMethod_CallsOtherAsync/Service::fetchData(object[], object)
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_94242E88_Service_fetchData::CallCore
+
+		} // end of class FunctionObject_ClassMethod_94242E88_Service_fetchData
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_D1758AD5_Service_processData
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x24d4
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_D1758AD5_Service_processData::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24dc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_D1758AD5_Service_processData::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24df
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_D1758AD5_Service_processData::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24e2
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Async_ClassMethod_CallsOtherAsync/Service
+				IL_0006: call instance object Modules.Async_ClassMethod_CallsOtherAsync/Service::processData(object[], object)
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_D1758AD5_Service_processData::CallCore
+
+		} // end of class FunctionObject_ClassMethod_D1758AD5_Service_processData
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -738,209 +941,6 @@
 	} // end of method Async_ClassMethod_CallsOtherAsync::__js_module_init__
 
 } // end of class Modules.Async_ClassMethod_CallsOtherAsync
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_ClassMethod_CallsOtherAsync_B88200CD.FunctionObject_ClassConstructor_C5820907_Service
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x248c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Async_ClassMethod_CallsOtherAsync_B88200CD.FunctionObject_ClassConstructor_C5820907_Service::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_C5820907_Service::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x249b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_C5820907_Service::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x249e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_C5820907_Service::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24a1
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_C5820907_Service::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24ad
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_C5820907_Service::ConstructCore
-
-} // end of class FunctionObjects.Async_ClassMethod_CallsOtherAsync_B88200CD.FunctionObject_ClassConstructor_C5820907_Service
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_ClassMethod_CallsOtherAsync_B88200CD.FunctionObject_ClassMethod_94242E88_Service_fetchData
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x24b9
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_94242E88_Service_fetchData::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24c1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_94242E88_Service_fetchData::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24c4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_94242E88_Service_fetchData::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24c7
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Async_ClassMethod_CallsOtherAsync/Service
-		IL_0006: call instance object Modules.Async_ClassMethod_CallsOtherAsync/Service::fetchData(object[], object)
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_94242E88_Service_fetchData::CallCore
-
-} // end of class FunctionObjects.Async_ClassMethod_CallsOtherAsync_B88200CD.FunctionObject_ClassMethod_94242E88_Service_fetchData
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_ClassMethod_CallsOtherAsync_B88200CD.FunctionObject_ClassMethod_D1758AD5_Service_processData
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x24d4
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_D1758AD5_Service_processData::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24dc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_D1758AD5_Service_processData::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24df
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_D1758AD5_Service_processData::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24e2
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Async_ClassMethod_CallsOtherAsync/Service
-		IL_0006: call instance object Modules.Async_ClassMethod_CallsOtherAsync/Service::processData(object[], object)
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_D1758AD5_Service_processData::CallCore
-
-} // end of class FunctionObjects.Async_ClassMethod_CallsOtherAsync_B88200CD.FunctionObject_ClassMethod_D1758AD5_Service_processData
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_MultipleAwaits.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_MultipleAwaits.verified.txt
@@ -189,6 +189,152 @@
 
 		} // end of class Scope_process
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_23495614_Processor
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x23a1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Async_ClassMethod_MultipleAwaits/Processor/FunctionObject_ClassConstructor_23495614_Processor::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_23495614_Processor::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x23b0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_23495614_Processor::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x23b3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_23495614_Processor::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x23b6
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_23495614_Processor::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23c2
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_23495614_Processor::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_23495614_Processor
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_A33ABC2A_Processor_process
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x23ce
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_A33ABC2A_Processor_process::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x23d6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_A33ABC2A_Processor_process::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x23d9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_A33ABC2A_Processor_process::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x23dc
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Async_ClassMethod_MultipleAwaits/Processor
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.Async_ClassMethod_MultipleAwaits/Processor::process(object[], object, object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassMethod_A33ABC2A_Processor_process::CallCore
+
+		} // end of class FunctionObject_ClassMethod_A33ABC2A_Processor_process
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -602,152 +748,6 @@
 	} // end of method Async_ClassMethod_MultipleAwaits::__js_module_init__
 
 } // end of class Modules.Async_ClassMethod_MultipleAwaits
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_ClassMethod_MultipleAwaits_C4D32C91.FunctionObject_ClassConstructor_23495614_Processor
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x23a1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Async_ClassMethod_MultipleAwaits_C4D32C91.FunctionObject_ClassConstructor_23495614_Processor::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_23495614_Processor::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23b0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_23495614_Processor::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23b3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_23495614_Processor::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23b6
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_23495614_Processor::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23c2
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_23495614_Processor::ConstructCore
-
-} // end of class FunctionObjects.Async_ClassMethod_MultipleAwaits_C4D32C91.FunctionObject_ClassConstructor_23495614_Processor
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_ClassMethod_MultipleAwaits_C4D32C91.FunctionObject_ClassMethod_A33ABC2A_Processor_process
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x23ce
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_A33ABC2A_Processor_process::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23d6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_A33ABC2A_Processor_process::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23d9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_A33ABC2A_Processor_process::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23dc
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Async_ClassMethod_MultipleAwaits/Processor
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.Async_ClassMethod_MultipleAwaits/Processor::process(object[], object, object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassMethod_A33ABC2A_Processor_process::CallCore
-
-} // end of class FunctionObjects.Async_ClassMethod_MultipleAwaits_C4D32C91.FunctionObject_ClassMethod_A33ABC2A_Processor_process
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_SimpleAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_SimpleAwait.verified.txt
@@ -184,6 +184,155 @@
 
 		} // end of class Scope_add
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_83149DA3_Calculator
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x231b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Async_ClassMethod_SimpleAwait/Calculator/FunctionObject_ClassConstructor_83149DA3_Calculator::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_83149DA3_Calculator::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x232a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_83149DA3_Calculator::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x232d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_83149DA3_Calculator::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2330
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_83149DA3_Calculator::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x233c
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_83149DA3_Calculator::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_83149DA3_Calculator
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_4CA51A8F_Calculator_add
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2348
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_4CA51A8F_Calculator_add::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2350
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_4CA51A8F_Calculator_add::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2353
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_4CA51A8F_Calculator_add::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2356
+				// Header size: 1
+				// Code size: 26 (0x1a)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Async_ClassMethod_SimpleAwait/Calculator
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call instance object Modules.Async_ClassMethod_SimpleAwait/Calculator::'add'(object[], object, object, object)
+				IL_0019: ret
+			} // end of method FunctionObject_ClassMethod_4CA51A8F_Calculator_add::CallCore
+
+		} // end of class FunctionObject_ClassMethod_4CA51A8F_Calculator_add
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -529,155 +678,6 @@
 	} // end of method Async_ClassMethod_SimpleAwait::__js_module_init__
 
 } // end of class Modules.Async_ClassMethod_SimpleAwait
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_ClassMethod_SimpleAwait_B30F7BCA.FunctionObject_ClassConstructor_83149DA3_Calculator
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x231b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Async_ClassMethod_SimpleAwait_B30F7BCA.FunctionObject_ClassConstructor_83149DA3_Calculator::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_83149DA3_Calculator::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x232a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_83149DA3_Calculator::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x232d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_83149DA3_Calculator::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2330
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_83149DA3_Calculator::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x233c
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_83149DA3_Calculator::ConstructCore
-
-} // end of class FunctionObjects.Async_ClassMethod_SimpleAwait_B30F7BCA.FunctionObject_ClassConstructor_83149DA3_Calculator
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_ClassMethod_SimpleAwait_B30F7BCA.FunctionObject_ClassMethod_4CA51A8F_Calculator_add
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2348
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_4CA51A8F_Calculator_add::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2350
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_4CA51A8F_Calculator_add::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2353
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_4CA51A8F_Calculator_add::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2356
-		// Header size: 1
-		// Code size: 26 (0x1a)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Async_ClassMethod_SimpleAwait/Calculator
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call instance object Modules.Async_ClassMethod_SimpleAwait/Calculator::'add'(object[], object, object, object)
-		IL_0019: ret
-	} // end of method FunctionObject_ClassMethod_4CA51A8F_Calculator_add::CallCore
-
-} // end of class FunctionObjects.Async_ClassMethod_SimpleAwait_B30F7BCA.FunctionObject_ClassMethod_4CA51A8F_Calculator_add
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_WithThis.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ClassMethod_WithThis.verified.txt
@@ -204,6 +204,149 @@
 
 		} // end of class Scope_getCount
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_9194BF49_Counter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x230b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Async_ClassMethod_WithThis/Counter/FunctionObject_ClassConstructor_9194BF49_Counter::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_9194BF49_Counter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x231a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_9194BF49_Counter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x231d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_9194BF49_Counter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2320
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_9194BF49_Counter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x232c
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_9194BF49_Counter::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_9194BF49_Counter
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_00DEF71B_Counter_getCount
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2338
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_00DEF71B_Counter_getCount::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2340
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_00DEF71B_Counter_getCount::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2343
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_00DEF71B_Counter_getCount::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2346
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Async_ClassMethod_WithThis/Counter
+				IL_0006: call instance object Modules.Async_ClassMethod_WithThis/Counter::getCount(object[], object)
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_00DEF71B_Counter_getCount::CallCore
+
+		} // end of class FunctionObject_ClassMethod_00DEF71B_Counter_getCount
+
 
 		// Fields
 		.field public float64 count
@@ -529,149 +672,6 @@
 	} // end of method Async_ClassMethod_WithThis::__js_module_init__
 
 } // end of class Modules.Async_ClassMethod_WithThis
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_ClassMethod_WithThis_2F0D8946.FunctionObject_ClassConstructor_9194BF49_Counter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x230b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Async_ClassMethod_WithThis_2F0D8946.FunctionObject_ClassConstructor_9194BF49_Counter::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_9194BF49_Counter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x231a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_9194BF49_Counter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x231d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_9194BF49_Counter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2320
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_9194BF49_Counter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x232c
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_9194BF49_Counter::ConstructCore
-
-} // end of class FunctionObjects.Async_ClassMethod_WithThis_2F0D8946.FunctionObject_ClassConstructor_9194BF49_Counter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_ClassMethod_WithThis_2F0D8946.FunctionObject_ClassMethod_00DEF71B_Counter_getCount
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2338
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_00DEF71B_Counter_getCount::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2340
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_00DEF71B_Counter_getCount::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2343
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_00DEF71B_Counter_getCount::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2346
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Async_ClassMethod_WithThis/Counter
-		IL_0006: call instance object Modules.Async_ClassMethod_WithThis/Counter::getCount(object[], object)
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_00DEF71B_Counter_getCount::CallCore
-
-} // end of class FunctionObjects.Async_ClassMethod_WithThis_2F0D8946.FunctionObject_ClassMethod_00DEF71B_Counter_getCount
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_Array.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_Array.verified.txt
@@ -83,6 +83,94 @@
 
 		} // end of class Scope_ForOf_L7C15
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_65EB96EF_test
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x250b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Async_ForAwaitOf_Array/test/FunctionObject_FunctionDeclaration_65EB96EF_test::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_65EB96EF_test::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x251a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_65EB96EF_test::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x251d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_65EB96EF_test::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2520
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_ForAwaitOf_Array/test/FunctionObject_FunctionDeclaration_65EB96EF_test::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Async_ForAwaitOf_Array/test::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_65EB96EF_test::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2532
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_ForAwaitOf_Array/test/FunctionObject_FunctionDeclaration_65EB96EF_test::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Async_ForAwaitOf_Array/test::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_65EB96EF_test::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_65EB96EF_test
+
 
 		// Methods
 		.method public hidebysig static 
@@ -750,94 +838,6 @@
 	} // end of method Async_ForAwaitOf_Array::__js_module_init__
 
 } // end of class Modules.Async_ForAwaitOf_Array
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_ForAwaitOf_Array_54719D44.FunctionObject_FunctionDeclaration_65EB96EF_test
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x250b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Async_ForAwaitOf_Array_54719D44.FunctionObject_FunctionDeclaration_65EB96EF_test::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_65EB96EF_test::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x251a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_65EB96EF_test::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x251d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_65EB96EF_test::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2520
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_ForAwaitOf_Array_54719D44.FunctionObject_FunctionDeclaration_65EB96EF_test::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Async_ForAwaitOf_Array/test::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_65EB96EF_test::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2532
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_ForAwaitOf_Array_54719D44.FunctionObject_FunctionDeclaration_65EB96EF_test::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Async_ForAwaitOf_Array/test::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_65EB96EF_test::ConstructBodyCore
-
-} // end of class FunctionObjects.Async_ForAwaitOf_Array_54719D44.FunctionObject_FunctionDeclaration_65EB96EF_test
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_AsyncIterator_BreakCloses.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_AsyncIterator_BreakCloses.verified.txt
@@ -355,6 +355,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_79857E5C_L5C27
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope _environment0_Async_ForAwaitOf_AsyncIterator_BreakCloses
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x26f7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_79857E5C_L5C27::_environment0_Async_ForAwaitOf_AsyncIterator_BreakCloses
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_79857E5C_L5C27::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2706
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_79857E5C_L5C27::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2709
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_79857E5C_L5C27::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x270c
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_79857E5C_L5C27::_environment0_Async_ForAwaitOf_AsyncIterator_BreakCloses
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable::__js_call__(class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_79857E5C_L5C27::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x271e
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_79857E5C_L5C27::_environment0_Async_ForAwaitOf_AsyncIterator_BreakCloses
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable::__js_call__(class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_79857E5C_L5C27::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x272c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_79857E5C_L5C27::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_79857E5C_L5C27
+
 
 		// Methods
 		.method public hidebysig static 
@@ -557,6 +664,99 @@
 			} // end of method Scope_ForOf_L18C15::.ctor
 
 		} // end of class Scope_ForOf_L18C15
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2FA20F6D_test
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope _environment0_Async_ForAwaitOf_AsyncIterator_BreakCloses
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x279d
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/FunctionObject_FunctionDeclaration_2FA20F6D_test::_environment0_Async_ForAwaitOf_AsyncIterator_BreakCloses
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/FunctionObject_FunctionDeclaration_2FA20F6D_test::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_2FA20F6D_test::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x27b3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2FA20F6D_test::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x27b6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2FA20F6D_test::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x27b9
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/FunctionObject_FunctionDeclaration_2FA20F6D_test::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_2FA20F6D_test::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x27cb
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test/FunctionObject_FunctionDeclaration_2FA20F6D_test::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_2FA20F6D_test::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_2FA20F6D_test
 
 
 		// Methods
@@ -1239,206 +1439,6 @@
 	} // end of method Async_ForAwaitOf_AsyncIterator_BreakCloses::__js_module_init__
 
 } // end of class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_ForAwaitOf_AsyncIterator_BreakCloses_459037CE.FunctionObject_FunctionExpression_79857E5C_L5C27
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope _environment0_Async_ForAwaitOf_AsyncIterator_BreakCloses
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x26f7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope FunctionObjects.Async_ForAwaitOf_AsyncIterator_BreakCloses_459037CE.FunctionObject_FunctionExpression_79857E5C_L5C27::_environment0_Async_ForAwaitOf_AsyncIterator_BreakCloses
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_79857E5C_L5C27::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2706
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_79857E5C_L5C27::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2709
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_79857E5C_L5C27::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x270c
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope FunctionObjects.Async_ForAwaitOf_AsyncIterator_BreakCloses_459037CE.FunctionObject_FunctionExpression_79857E5C_L5C27::_environment0_Async_ForAwaitOf_AsyncIterator_BreakCloses
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable::__js_call__(class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_79857E5C_L5C27::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x271e
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope FunctionObjects.Async_ForAwaitOf_AsyncIterator_BreakCloses_459037CE.FunctionObject_FunctionExpression_79857E5C_L5C27::_environment0_Async_ForAwaitOf_AsyncIterator_BreakCloses
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/FunctionExpression_iterable::__js_call__(class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_79857E5C_L5C27::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x272c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_79857E5C_L5C27::ConstructCore
-
-} // end of class FunctionObjects.Async_ForAwaitOf_AsyncIterator_BreakCloses_459037CE.FunctionObject_FunctionExpression_79857E5C_L5C27
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_ForAwaitOf_AsyncIterator_BreakCloses_459037CE.FunctionObject_FunctionDeclaration_2FA20F6D_test
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope _environment0_Async_ForAwaitOf_AsyncIterator_BreakCloses
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x279d
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/Scope FunctionObjects.Async_ForAwaitOf_AsyncIterator_BreakCloses_459037CE.FunctionObject_FunctionDeclaration_2FA20F6D_test::_environment0_Async_ForAwaitOf_AsyncIterator_BreakCloses
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Async_ForAwaitOf_AsyncIterator_BreakCloses_459037CE.FunctionObject_FunctionDeclaration_2FA20F6D_test::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_2FA20F6D_test::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x27b3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2FA20F6D_test::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x27b6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2FA20F6D_test::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x27b9
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_ForAwaitOf_AsyncIterator_BreakCloses_459037CE.FunctionObject_FunctionDeclaration_2FA20F6D_test::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_2FA20F6D_test::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27cb
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_ForAwaitOf_AsyncIterator_BreakCloses_459037CE.FunctionObject_FunctionDeclaration_2FA20F6D_test::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Async_ForAwaitOf_AsyncIterator_BreakCloses/test::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_2FA20F6D_test::ConstructBodyCore
-
-} // end of class FunctionObjects.Async_ForAwaitOf_AsyncIterator_BreakCloses_459037CE.FunctionObject_FunctionDeclaration_2FA20F6D_test
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses.verified.txt
@@ -349,6 +349,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_61E3F591_L6C22
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope _environment0_Async_ForAwaitOf_SyncIteratorFallback_BreakCloses
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x26d0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_61E3F591_L6C22::_environment0_Async_ForAwaitOf_SyncIteratorFallback_BreakCloses
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_61E3F591_L6C22::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x26df
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_61E3F591_L6C22::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x26e2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_61E3F591_L6C22::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x26e5
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_61E3F591_L6C22::_environment0_Async_ForAwaitOf_SyncIteratorFallback_BreakCloses
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable::__js_call__(class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_61E3F591_L6C22::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26f7
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable/FunctionObject_FunctionExpression_61E3F591_L6C22::_environment0_Async_ForAwaitOf_SyncIteratorFallback_BreakCloses
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable::__js_call__(class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_61E3F591_L6C22::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2705
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_61E3F591_L6C22::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_61E3F591_L6C22
+
 
 		// Methods
 		.method public hidebysig static 
@@ -551,6 +658,99 @@
 			} // end of method Scope_ForOf_L19C15::.ctor
 
 		} // end of class Scope_ForOf_L19C15
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A889D3B4_test
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope _environment0_Async_ForAwaitOf_SyncIteratorFallback_BreakCloses
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x2776
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/FunctionObject_FunctionDeclaration_A889D3B4_test::_environment0_Async_ForAwaitOf_SyncIteratorFallback_BreakCloses
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/FunctionObject_FunctionDeclaration_A889D3B4_test::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_A889D3B4_test::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x278c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A889D3B4_test::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x278f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A889D3B4_test::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2792
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/FunctionObject_FunctionDeclaration_A889D3B4_test::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_A889D3B4_test::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x27a4
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test/FunctionObject_FunctionDeclaration_A889D3B4_test::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_A889D3B4_test::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_A889D3B4_test
 
 
 		// Methods
@@ -1233,206 +1433,6 @@
 	} // end of method Async_ForAwaitOf_SyncIteratorFallback_BreakCloses::__js_module_init__
 
 } // end of class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses_99729E0D.FunctionObject_FunctionExpression_61E3F591_L6C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope _environment0_Async_ForAwaitOf_SyncIteratorFallback_BreakCloses
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x26d0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope FunctionObjects.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses_99729E0D.FunctionObject_FunctionExpression_61E3F591_L6C22::_environment0_Async_ForAwaitOf_SyncIteratorFallback_BreakCloses
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_61E3F591_L6C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x26df
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_61E3F591_L6C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x26e2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_61E3F591_L6C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x26e5
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope FunctionObjects.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses_99729E0D.FunctionObject_FunctionExpression_61E3F591_L6C22::_environment0_Async_ForAwaitOf_SyncIteratorFallback_BreakCloses
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable::__js_call__(class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_61E3F591_L6C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26f7
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope FunctionObjects.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses_99729E0D.FunctionObject_FunctionExpression_61E3F591_L6C22::_environment0_Async_ForAwaitOf_SyncIteratorFallback_BreakCloses
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/FunctionExpression_iterable::__js_call__(class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_61E3F591_L6C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2705
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_61E3F591_L6C22::ConstructCore
-
-} // end of class FunctionObjects.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses_99729E0D.FunctionObject_FunctionExpression_61E3F591_L6C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses_99729E0D.FunctionObject_FunctionDeclaration_A889D3B4_test
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope _environment0_Async_ForAwaitOf_SyncIteratorFallback_BreakCloses
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x2776
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/Scope FunctionObjects.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses_99729E0D.FunctionObject_FunctionDeclaration_A889D3B4_test::_environment0_Async_ForAwaitOf_SyncIteratorFallback_BreakCloses
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses_99729E0D.FunctionObject_FunctionDeclaration_A889D3B4_test::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_A889D3B4_test::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x278c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A889D3B4_test::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x278f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A889D3B4_test::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2792
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses_99729E0D.FunctionObject_FunctionDeclaration_A889D3B4_test::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_A889D3B4_test::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27a4
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses_99729E0D.FunctionObject_FunctionDeclaration_A889D3B4_test::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses/test::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_A889D3B4_test::ConstructBodyCore
-
-} // end of class FunctionObjects.Async_ForAwaitOf_SyncIteratorFallback_BreakCloses_99729E0D.FunctionObject_FunctionDeclaration_A889D3B4_test
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForOf_AwaitInBody.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ForOf_AwaitInBody.verified.txt
@@ -88,6 +88,115 @@
 
 		} // end of class Scope_ForOf_L3C9
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BBEFEBAA_sum
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x257c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Async_ForOf_AwaitInBody/sum/FunctionObject_FunctionDeclaration_BBEFEBAA_sum::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BBEFEBAA_sum::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x258b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BBEFEBAA_sum::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x258e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BBEFEBAA_sum::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2591
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_BBEFEBAA_sum::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2599
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_ForOf_AwaitInBody/sum/FunctionObject_FunctionDeclaration_BBEFEBAA_sum::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Async_ForOf_AwaitInBody/sum::__js_call__(object[], object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_BBEFEBAA_sum::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25b2
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_ForOf_AwaitInBody/sum/FunctionObject_FunctionDeclaration_BBEFEBAA_sum::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Async_ForOf_AwaitInBody/sum::__js_call__(object[], object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_BBEFEBAA_sum::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_BBEFEBAA_sum
+
 
 		// Methods
 		.method public hidebysig static 
@@ -753,115 +862,6 @@
 	} // end of method Async_ForOf_AwaitInBody::__js_module_async_body__
 
 } // end of class Modules.Async_ForOf_AwaitInBody
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_ForOf_AwaitInBody_D18CFB48.FunctionObject_FunctionDeclaration_BBEFEBAA_sum
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x257c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Async_ForOf_AwaitInBody_D18CFB48.FunctionObject_FunctionDeclaration_BBEFEBAA_sum::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BBEFEBAA_sum::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x258b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BBEFEBAA_sum::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x258e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BBEFEBAA_sum::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2591
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_BBEFEBAA_sum::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2599
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_ForOf_AwaitInBody_D18CFB48.FunctionObject_FunctionDeclaration_BBEFEBAA_sum::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Async_ForOf_AwaitInBody/sum::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_BBEFEBAA_sum::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25b2
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_ForOf_AwaitInBody_D18CFB48.FunctionObject_FunctionDeclaration_BBEFEBAA_sum::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Async_ForOf_AwaitInBody/sum::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_BBEFEBAA_sum::ConstructBodyCore
-
-} // end of class FunctionObjects.Async_ForOf_AwaitInBody_D18CFB48.FunctionObject_FunctionDeclaration_BBEFEBAA_sum
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_FunctionExpression_SimpleAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_FunctionExpression_SimpleAwait.verified.txt
@@ -41,6 +41,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A1C89431_L4C19
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2291
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Async_FunctionExpression_SimpleAwait/FunctionExpression_asyncFunc/FunctionObject_FunctionExpression_A1C89431_L4C19::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_A1C89431_L4C19::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22a0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A1C89431_L4C19::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22a3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A1C89431_L4C19::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22a6
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_FunctionExpression_SimpleAwait/FunctionExpression_asyncFunc/FunctionObject_FunctionExpression_A1C89431_L4C19::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Async_FunctionExpression_SimpleAwait/FunctionExpression_asyncFunc::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_A1C89431_L4C19::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22b8
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_FunctionExpression_SimpleAwait/FunctionExpression_asyncFunc/FunctionObject_FunctionExpression_A1C89431_L4C19::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Async_FunctionExpression_SimpleAwait/FunctionExpression_asyncFunc::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_A1C89431_L4C19::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionExpression_A1C89431_L4C19
+
 
 		// Methods
 		.method public hidebysig static 
@@ -427,94 +515,6 @@
 	} // end of method Async_FunctionExpression_SimpleAwait::__js_module_init__
 
 } // end of class Modules.Async_FunctionExpression_SimpleAwait
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_FunctionExpression_SimpleAwait_7BBDB06D.FunctionObject_FunctionExpression_A1C89431_L4C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2291
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Async_FunctionExpression_SimpleAwait_7BBDB06D.FunctionObject_FunctionExpression_A1C89431_L4C19::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A1C89431_L4C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22a0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A1C89431_L4C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22a3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A1C89431_L4C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22a6
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_FunctionExpression_SimpleAwait_7BBDB06D.FunctionObject_FunctionExpression_A1C89431_L4C19::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Async_FunctionExpression_SimpleAwait/FunctionExpression_asyncFunc::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_A1C89431_L4C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22b8
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_FunctionExpression_SimpleAwait_7BBDB06D.FunctionObject_FunctionExpression_A1C89431_L4C19::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Async_FunctionExpression_SimpleAwait/FunctionExpression_asyncFunc::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_A1C89431_L4C19::ConstructBodyCore
-
-} // end of class FunctionObjects.Async_FunctionExpression_SimpleAwait_7BBDB06D.FunctionObject_FunctionExpression_A1C89431_L4C19
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_HelloWorld.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_HelloWorld.verified.txt
@@ -31,6 +31,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_08C655B7_helloWorld
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2124
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Async_HelloWorld/helloWorld/FunctionObject_FunctionDeclaration_08C655B7_helloWorld::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_08C655B7_helloWorld::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2133
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_08C655B7_helloWorld::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2136
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_08C655B7_helloWorld::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2139
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_HelloWorld/helloWorld/FunctionObject_FunctionDeclaration_08C655B7_helloWorld::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Async_HelloWorld/helloWorld::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_08C655B7_helloWorld::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x214b
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_HelloWorld/helloWorld/FunctionObject_FunctionDeclaration_08C655B7_helloWorld::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Async_HelloWorld/helloWorld::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_08C655B7_helloWorld::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_08C655B7_helloWorld
+
 
 		// Methods
 		.method public hidebysig static 
@@ -161,94 +249,6 @@
 	} // end of method Async_HelloWorld::__js_module_init__
 
 } // end of class Modules.Async_HelloWorld
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_HelloWorld_B66025DC.FunctionObject_FunctionDeclaration_08C655B7_helloWorld
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2124
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Async_HelloWorld_B66025DC.FunctionObject_FunctionDeclaration_08C655B7_helloWorld::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_08C655B7_helloWorld::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2133
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_08C655B7_helloWorld::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2136
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_08C655B7_helloWorld::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2139
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_HelloWorld_B66025DC.FunctionObject_FunctionDeclaration_08C655B7_helloWorld::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Async_HelloWorld/helloWorld::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_08C655B7_helloWorld::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x214b
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_HelloWorld_B66025DC.FunctionObject_FunctionDeclaration_08C655B7_helloWorld::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Async_HelloWorld/helloWorld::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_08C655B7_helloWorld::ConstructBodyCore
-
-} // end of class FunctionObjects.Async_HelloWorld_B66025DC.FunctionObject_FunctionDeclaration_08C655B7_helloWorld
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_Inheritance_SuperAsyncMethod.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_Inheritance_SuperAsyncMethod.verified.txt
@@ -184,6 +184,152 @@
 
 		} // end of class Scope_inc
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_398688B9_Base
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x251d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Async_Inheritance_SuperAsyncMethod/Base/FunctionObject_ClassConstructor_398688B9_Base::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_398688B9_Base::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x252c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_398688B9_Base::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x252f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_398688B9_Base::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2532
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_398688B9_Base::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x253e
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_398688B9_Base::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_398688B9_Base
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_F1077DEC_Base_inc
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x254a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_F1077DEC_Base_inc::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2552
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_F1077DEC_Base_inc::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2555
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_F1077DEC_Base_inc::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2558
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Async_Inheritance_SuperAsyncMethod/Base
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.Async_Inheritance_SuperAsyncMethod/Base::inc(object[], object, object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassMethod_F1077DEC_Base_inc::CallCore
+
+		} // end of class FunctionObject_ClassMethod_F1077DEC_Base_inc
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -395,6 +541,149 @@
 			} // end of method Scope_run::.ctor
 
 		} // end of class Scope_run
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_468B227D_Derived
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x256c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Async_Inheritance_SuperAsyncMethod/Derived/FunctionObject_ClassConstructor_468B227D_Derived::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_468B227D_Derived::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x257b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_468B227D_Derived::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x257e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_468B227D_Derived::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2581
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_468B227D_Derived::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x258d
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_468B227D_Derived::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_468B227D_Derived
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_B6E78F2B_Derived_run
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2599
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_B6E78F2B_Derived_run::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x25a1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_B6E78F2B_Derived_run::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x25a4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_B6E78F2B_Derived_run::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x25a7
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Async_Inheritance_SuperAsyncMethod/Derived
+				IL_0006: call instance object Modules.Async_Inheritance_SuperAsyncMethod/Derived::run(object[], object)
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_B6E78F2B_Derived_run::CallCore
+
+		} // end of class FunctionObject_ClassMethod_B6E78F2B_Derived_run
 
 
 		// Methods
@@ -817,295 +1106,6 @@
 	} // end of method Async_Inheritance_SuperAsyncMethod::__js_module_init__
 
 } // end of class Modules.Async_Inheritance_SuperAsyncMethod
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_Inheritance_SuperAsyncMethod_C61D2885.FunctionObject_ClassConstructor_398688B9_Base
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x251d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Async_Inheritance_SuperAsyncMethod_C61D2885.FunctionObject_ClassConstructor_398688B9_Base::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_398688B9_Base::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x252c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_398688B9_Base::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x252f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_398688B9_Base::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2532
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_398688B9_Base::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x253e
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_398688B9_Base::ConstructCore
-
-} // end of class FunctionObjects.Async_Inheritance_SuperAsyncMethod_C61D2885.FunctionObject_ClassConstructor_398688B9_Base
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_Inheritance_SuperAsyncMethod_C61D2885.FunctionObject_ClassMethod_F1077DEC_Base_inc
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x254a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_F1077DEC_Base_inc::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2552
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_F1077DEC_Base_inc::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2555
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_F1077DEC_Base_inc::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2558
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Async_Inheritance_SuperAsyncMethod/Base
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.Async_Inheritance_SuperAsyncMethod/Base::inc(object[], object, object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassMethod_F1077DEC_Base_inc::CallCore
-
-} // end of class FunctionObjects.Async_Inheritance_SuperAsyncMethod_C61D2885.FunctionObject_ClassMethod_F1077DEC_Base_inc
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_Inheritance_SuperAsyncMethod_C61D2885.FunctionObject_ClassConstructor_468B227D_Derived
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x256c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Async_Inheritance_SuperAsyncMethod_C61D2885.FunctionObject_ClassConstructor_468B227D_Derived::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_468B227D_Derived::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x257b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_468B227D_Derived::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x257e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_468B227D_Derived::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2581
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_468B227D_Derived::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x258d
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_468B227D_Derived::ConstructCore
-
-} // end of class FunctionObjects.Async_Inheritance_SuperAsyncMethod_C61D2885.FunctionObject_ClassConstructor_468B227D_Derived
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_Inheritance_SuperAsyncMethod_C61D2885.FunctionObject_ClassMethod_B6E78F2B_Derived_run
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2599
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_B6E78F2B_Derived_run::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x25a1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_B6E78F2B_Derived_run::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x25a4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_B6E78F2B_Derived_run::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x25a7
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Async_Inheritance_SuperAsyncMethod/Derived
-		IL_0006: call instance object Modules.Async_Inheritance_SuperAsyncMethod/Derived::run(object[], object)
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_B6E78F2B_Derived_run::CallCore
-
-} // end of class FunctionObjects.Async_Inheritance_SuperAsyncMethod_C61D2885.FunctionObject_ClassMethod_B6E78F2B_Derived_run
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_PendingPromiseAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_PendingPromiseAwait.verified.txt
@@ -381,6 +381,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E417C379_test
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x23db
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Async_PendingPromiseAwait/test/FunctionObject_FunctionDeclaration_E417C379_test::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E417C379_test::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x23ea
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E417C379_test::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x23ed
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E417C379_test::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x23f0
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_PendingPromiseAwait/test/FunctionObject_FunctionDeclaration_E417C379_test::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Async_PendingPromiseAwait/test::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_E417C379_test::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2402
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_PendingPromiseAwait/test/FunctionObject_FunctionDeclaration_E417C379_test::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Async_PendingPromiseAwait/test::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_E417C379_test::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E417C379_test
+
 
 		// Methods
 		.method public hidebysig static 
@@ -829,94 +917,6 @@
 	} // end of method Async_PendingPromiseAwait::__js_module_init__
 
 } // end of class Modules.Async_PendingPromiseAwait
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_PendingPromiseAwait_73D38592.FunctionObject_FunctionDeclaration_E417C379_test
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x23db
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Async_PendingPromiseAwait_73D38592.FunctionObject_FunctionDeclaration_E417C379_test::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E417C379_test::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23ea
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E417C379_test::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23ed
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E417C379_test::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23f0
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_PendingPromiseAwait_73D38592.FunctionObject_FunctionDeclaration_E417C379_test::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Async_PendingPromiseAwait/test::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_E417C379_test::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2402
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_PendingPromiseAwait_73D38592.FunctionObject_FunctionDeclaration_E417C379_test::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Async_PendingPromiseAwait/test::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_E417C379_test::ConstructBodyCore
-
-} // end of class FunctionObjects.Async_PendingPromiseAwait_73D38592.FunctionObject_FunctionDeclaration_E417C379_test
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_RealSuspension_SetTimeout.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_RealSuspension_SetTimeout.verified.txt
@@ -477,6 +477,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1C358AD9_run
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Async_RealSuspension_SetTimeout/Scope _environment0_Async_RealSuspension_SetTimeout
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Async_RealSuspension_SetTimeout/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x22fc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Async_RealSuspension_SetTimeout/Scope Modules.Async_RealSuspension_SetTimeout/run/FunctionObject_FunctionDeclaration_1C358AD9_run::_environment0_Async_RealSuspension_SetTimeout
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_1C358AD9_run::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x230b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1C358AD9_run::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x230e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1C358AD9_run::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2311
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Async_RealSuspension_SetTimeout/Scope Modules.Async_RealSuspension_SetTimeout/run/FunctionObject_FunctionDeclaration_1C358AD9_run::_environment0_Async_RealSuspension_SetTimeout
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Async_RealSuspension_SetTimeout/run::__js_call__(class Modules.Async_RealSuspension_SetTimeout/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_1C358AD9_run::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2323
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Async_RealSuspension_SetTimeout/Scope Modules.Async_RealSuspension_SetTimeout/run/FunctionObject_FunctionDeclaration_1C358AD9_run::_environment0_Async_RealSuspension_SetTimeout
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Async_RealSuspension_SetTimeout/run::__js_call__(class Modules.Async_RealSuspension_SetTimeout/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_1C358AD9_run::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2331
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_1C358AD9_run::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_1C358AD9_run
+
 
 		// Methods
 		.method public hidebysig static 
@@ -735,7 +842,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_RealSuspension_SetTimeout/Scope,
-			[1] class FunctionObjects.Async_RealSuspension_SetTimeout_28E73FD9.FunctionObject_FunctionDeclaration_1C358AD9_run,
+			[1] class Modules.Async_RealSuspension_SetTimeout/run/FunctionObject_FunctionDeclaration_1C358AD9_run,
 			[2] object[],
 			[3] object,
 			[4] class Modules.Async_RealSuspension_SetTimeout/ArrowFunction_L18C12/FunctionObject
@@ -754,13 +861,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Async_RealSuspension_SetTimeout/Scope
-		IL_0019: newobj instance void FunctionObjects.Async_RealSuspension_SetTimeout_28E73FD9.FunctionObject_FunctionDeclaration_1C358AD9_run::.ctor(class Modules.Async_RealSuspension_SetTimeout/Scope)
+		IL_0019: newobj instance void Modules.Async_RealSuspension_SetTimeout/run/FunctionObject_FunctionDeclaration_1C358AD9_run::.ctor(class Modules.Async_RealSuspension_SetTimeout/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "run"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Async_RealSuspension_SetTimeout_28E73FD9.FunctionObject_FunctionDeclaration_1C358AD9_run>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_RealSuspension_SetTimeout/run/FunctionObject_FunctionDeclaration_1C358AD9_run>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldstr "console"
@@ -803,113 +910,6 @@
 	} // end of method Async_RealSuspension_SetTimeout::__js_module_init__
 
 } // end of class Modules.Async_RealSuspension_SetTimeout
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_RealSuspension_SetTimeout_28E73FD9.FunctionObject_FunctionDeclaration_1C358AD9_run
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Async_RealSuspension_SetTimeout/Scope _environment0_Async_RealSuspension_SetTimeout
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Async_RealSuspension_SetTimeout/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x22fc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Async_RealSuspension_SetTimeout/Scope FunctionObjects.Async_RealSuspension_SetTimeout_28E73FD9.FunctionObject_FunctionDeclaration_1C358AD9_run::_environment0_Async_RealSuspension_SetTimeout
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_1C358AD9_run::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x230b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1C358AD9_run::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x230e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1C358AD9_run::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2311
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Async_RealSuspension_SetTimeout/Scope FunctionObjects.Async_RealSuspension_SetTimeout_28E73FD9.FunctionObject_FunctionDeclaration_1C358AD9_run::_environment0_Async_RealSuspension_SetTimeout
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Async_RealSuspension_SetTimeout/run::__js_call__(class Modules.Async_RealSuspension_SetTimeout/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_1C358AD9_run::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2323
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Async_RealSuspension_SetTimeout/Scope FunctionObjects.Async_RealSuspension_SetTimeout_28E73FD9.FunctionObject_FunctionDeclaration_1C358AD9_run::_environment0_Async_RealSuspension_SetTimeout
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Async_RealSuspension_SetTimeout/run::__js_call__(class Modules.Async_RealSuspension_SetTimeout/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_1C358AD9_run::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2331
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_1C358AD9_run::ConstructCore
-
-} // end of class FunctionObjects.Async_RealSuspension_SetTimeout_28E73FD9.FunctionObject_FunctionDeclaration_1C358AD9_run
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ReturnValue.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_ReturnValue.verified.txt
@@ -31,6 +31,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BA1FCA97_getValue
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2129
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Async_ReturnValue/getValue/FunctionObject_FunctionDeclaration_BA1FCA97_getValue::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BA1FCA97_getValue::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2138
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BA1FCA97_getValue::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x213b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BA1FCA97_getValue::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x213e
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_ReturnValue/getValue/FunctionObject_FunctionDeclaration_BA1FCA97_getValue::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Async_ReturnValue/getValue::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_BA1FCA97_getValue::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2150
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_ReturnValue/getValue/FunctionObject_FunctionDeclaration_BA1FCA97_getValue::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Async_ReturnValue/getValue::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_BA1FCA97_getValue::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_BA1FCA97_getValue
+
 
 		// Methods
 		.method public hidebysig static 
@@ -282,94 +370,6 @@
 	} // end of method Async_ReturnValue::__js_module_init__
 
 } // end of class Modules.Async_ReturnValue
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_ReturnValue_30933137.FunctionObject_FunctionDeclaration_BA1FCA97_getValue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2129
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Async_ReturnValue_30933137.FunctionObject_FunctionDeclaration_BA1FCA97_getValue::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BA1FCA97_getValue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2138
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BA1FCA97_getValue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x213b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BA1FCA97_getValue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x213e
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_ReturnValue_30933137.FunctionObject_FunctionDeclaration_BA1FCA97_getValue::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Async_ReturnValue/getValue::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_BA1FCA97_getValue::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2150
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_ReturnValue_30933137.FunctionObject_FunctionDeclaration_BA1FCA97_getValue::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Async_ReturnValue/getValue::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_BA1FCA97_getValue::ConstructBodyCore
-
-} // end of class FunctionObjects.Async_ReturnValue_30933137.FunctionObject_FunctionDeclaration_BA1FCA97_getValue
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_SchedulerLocalAcrossAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_SchedulerLocalAcrossAwait.verified.txt
@@ -41,6 +41,100 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E9DF5E10_test
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2217
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Async_SchedulerLocalAcrossAwait/test/FunctionObject_FunctionDeclaration_E9DF5E10_test::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E9DF5E10_test::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2226
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E9DF5E10_test::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2229
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E9DF5E10_test::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x222c
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_SchedulerLocalAcrossAwait/test/FunctionObject_FunctionDeclaration_E9DF5E10_test::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Async_SchedulerLocalAcrossAwait/test::__js_call__(object[], object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_E9DF5E10_test::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2245
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_SchedulerLocalAcrossAwait/test/FunctionObject_FunctionDeclaration_E9DF5E10_test::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Async_SchedulerLocalAcrossAwait/test::__js_call__(object[], object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_E9DF5E10_test::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E9DF5E10_test
+
 
 		// Methods
 		.method public hidebysig static 
@@ -295,100 +389,6 @@
 	} // end of method Async_SchedulerLocalAcrossAwait::__js_module_init__
 
 } // end of class Modules.Async_SchedulerLocalAcrossAwait
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_SchedulerLocalAcrossAwait_34C80B01.FunctionObject_FunctionDeclaration_E9DF5E10_test
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2217
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Async_SchedulerLocalAcrossAwait_34C80B01.FunctionObject_FunctionDeclaration_E9DF5E10_test::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E9DF5E10_test::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2226
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E9DF5E10_test::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2229
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E9DF5E10_test::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x222c
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_SchedulerLocalAcrossAwait_34C80B01.FunctionObject_FunctionDeclaration_E9DF5E10_test::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Async_SchedulerLocalAcrossAwait/test::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_E9DF5E10_test::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2245
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_SchedulerLocalAcrossAwait_34C80B01.FunctionObject_FunctionDeclaration_E9DF5E10_test::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Async_SchedulerLocalAcrossAwait/test::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_E9DF5E10_test::ConstructBodyCore
-
-} // end of class FunctionObjects.Async_SchedulerLocalAcrossAwait_34C80B01.FunctionObject_FunctionDeclaration_E9DF5E10_test
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_SimpleAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_SimpleAwait.verified.txt
@@ -41,6 +41,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2021CCC7_test
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2242
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Async_SimpleAwait/test/FunctionObject_FunctionDeclaration_2021CCC7_test::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_2021CCC7_test::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2251
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2021CCC7_test::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2254
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2021CCC7_test::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2257
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_SimpleAwait/test/FunctionObject_FunctionDeclaration_2021CCC7_test::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Async_SimpleAwait/test::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_2021CCC7_test::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2269
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_SimpleAwait/test/FunctionObject_FunctionDeclaration_2021CCC7_test::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Async_SimpleAwait/test::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_2021CCC7_test::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_2021CCC7_test
+
 
 		// Methods
 		.method public hidebysig static 
@@ -412,94 +500,6 @@
 	} // end of method Async_SimpleAwait::__js_module_init__
 
 } // end of class Modules.Async_SimpleAwait
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_SimpleAwait_45362B6C.FunctionObject_FunctionDeclaration_2021CCC7_test
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2242
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Async_SimpleAwait_45362B6C.FunctionObject_FunctionDeclaration_2021CCC7_test::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_2021CCC7_test::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2251
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2021CCC7_test::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2254
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2021CCC7_test::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2257
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_SimpleAwait_45362B6C.FunctionObject_FunctionDeclaration_2021CCC7_test::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Async_SimpleAwait/test::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_2021CCC7_test::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2269
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_SimpleAwait_45362B6C.FunctionObject_FunctionDeclaration_2021CCC7_test::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Async_SimpleAwait/test::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_2021CCC7_test::ConstructBodyCore
-
-} // end of class FunctionObjects.Async_SimpleAwait_45362B6C.FunctionObject_FunctionDeclaration_2021CCC7_test
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_StaticMethod_SimpleAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_StaticMethod_SimpleAwait.verified.txt
@@ -194,6 +194,147 @@
 
 		} // end of class Scope_getData
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_0CEBEFB8_Fetcher
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x22d3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Async_StaticMethod_SimpleAwait/Fetcher/FunctionObject_ClassConstructor_0CEBEFB8_Fetcher::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_0CEBEFB8_Fetcher::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22e2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_0CEBEFB8_Fetcher::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22e5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_0CEBEFB8_Fetcher::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22e8
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_0CEBEFB8_Fetcher::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22f4
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_0CEBEFB8_Fetcher::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_0CEBEFB8_Fetcher
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassStaticMethod_A234F6EB_Fetcher_getData
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2300
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassStaticMethod_A234F6EB_Fetcher_getData::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2308
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassStaticMethod_A234F6EB_Fetcher_getData::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x230b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassStaticMethod_A234F6EB_Fetcher_getData::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x230e
+				// Header size: 1
+				// Code size: 6 (0x6)
+				.maxstack 8
+
+				IL_0000: call object Modules.Async_StaticMethod_SimpleAwait/Fetcher::getData(object[], object)
+				IL_0005: ret
+			} // end of method FunctionObject_ClassStaticMethod_A234F6EB_Fetcher_getData::CallCore
+
+		} // end of class FunctionObject_ClassStaticMethod_A234F6EB_Fetcher_getData
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -497,147 +638,6 @@
 	} // end of method Async_StaticMethod_SimpleAwait::__js_module_init__
 
 } // end of class Modules.Async_StaticMethod_SimpleAwait
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_StaticMethod_SimpleAwait_CB2197F8.FunctionObject_ClassConstructor_0CEBEFB8_Fetcher
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x22d3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Async_StaticMethod_SimpleAwait_CB2197F8.FunctionObject_ClassConstructor_0CEBEFB8_Fetcher::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_0CEBEFB8_Fetcher::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22e2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_0CEBEFB8_Fetcher::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22e5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_0CEBEFB8_Fetcher::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22e8
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_0CEBEFB8_Fetcher::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22f4
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_0CEBEFB8_Fetcher::ConstructCore
-
-} // end of class FunctionObjects.Async_StaticMethod_SimpleAwait_CB2197F8.FunctionObject_ClassConstructor_0CEBEFB8_Fetcher
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_StaticMethod_SimpleAwait_CB2197F8.FunctionObject_ClassStaticMethod_A234F6EB_Fetcher_getData
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2300
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassStaticMethod_A234F6EB_Fetcher_getData::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2308
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassStaticMethod_A234F6EB_Fetcher_getData::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x230b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassStaticMethod_A234F6EB_Fetcher_getData::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x230e
-		// Header size: 1
-		// Code size: 6 (0x6)
-		.maxstack 8
-
-		IL_0000: call object Modules.Async_StaticMethod_SimpleAwait/Fetcher::getData(object[], object)
-		IL_0005: ret
-	} // end of method FunctionObject_ClassStaticMethod_A234F6EB_Fetcher_getData::CallCore
-
-} // end of class FunctionObjects.Async_StaticMethod_SimpleAwait_CB2197F8.FunctionObject_ClassStaticMethod_A234F6EB_Fetcher_getData
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_DefaultDestructuringFunctionExport.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_DefaultDestructuringFunctionExport.verified.txt
@@ -60,6 +60,122 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_60AADF78_pick
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x22cc
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_60AADF78_pick::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22d4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_60AADF78_pick::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22d7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_60AADF78_pick::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x22da
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_60AADF78_pick::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22e2
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Async_TopLevelAwait_DefaultDestructuringFunctionExport/pick::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_60AADF78_pick::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22f5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Async_TopLevelAwait_DefaultDestructuringFunctionExport/pick::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_60AADF78_pick::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2304
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_60AADF78_pick::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_60AADF78_pick
+
 
 		// Methods
 		.method public hidebysig static 
@@ -200,7 +316,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TopLevelAwait_DefaultDestructuringFunctionExport/Scope,
-			[1] class FunctionObjects.Async_TopLevelAwait_DefaultDestructuringFunctionExport_0050DA96.FunctionObject_FunctionDeclaration_60AADF78_pick,
+			[1] class Modules.Async_TopLevelAwait_DefaultDestructuringFunctionExport/pick/FunctionObject_FunctionDeclaration_60AADF78_pick,
 			[2] object[],
 			[3] object,
 			[4] object,
@@ -273,7 +389,7 @@
 		IL_0082: dup
 		IL_0083: ldc.i4.0
 		IL_0084: ldelem.ref
-		IL_0085: castclass FunctionObjects.Async_TopLevelAwait_DefaultDestructuringFunctionExport_0050DA96.FunctionObject_FunctionDeclaration_60AADF78_pick
+		IL_0085: castclass Modules.Async_TopLevelAwait_DefaultDestructuringFunctionExport/pick/FunctionObject_FunctionDeclaration_60AADF78_pick
 		IL_008a: stloc.1
 		IL_008b: dup
 		IL_008c: ldc.i4.1
@@ -306,13 +422,13 @@
 		IL_00c3: ldloc.0
 		IL_00c4: stelem.ref
 		IL_00c5: stloc.2
-		IL_00c6: newobj instance void FunctionObjects.Async_TopLevelAwait_DefaultDestructuringFunctionExport_0050DA96.FunctionObject_FunctionDeclaration_60AADF78_pick::.ctor()
+		IL_00c6: newobj instance void Modules.Async_TopLevelAwait_DefaultDestructuringFunctionExport/pick/FunctionObject_FunctionDeclaration_60AADF78_pick::.ctor()
 		IL_00cb: ldc.i4.0
 		IL_00cc: conv.r8
 		IL_00cd: ldstr "pick"
 		IL_00d2: ldc.i4.0
 		IL_00d3: ldc.i4.0
-		IL_00d4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Async_TopLevelAwait_DefaultDestructuringFunctionExport_0050DA96.FunctionObject_FunctionDeclaration_60AADF78_pick>(!!0, float64, string, bool, bool)
+		IL_00d4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_DefaultDestructuringFunctionExport/pick/FunctionObject_FunctionDeclaration_60AADF78_pick>(!!0, float64, string, bool, bool)
 		IL_00d9: stloc.1
 		IL_00da: nop
 		IL_00db: ldstr "Promise"
@@ -420,122 +536,6 @@
 	} // end of method Async_TopLevelAwait_DefaultDestructuringFunctionExport::__js_module_async_body__
 
 } // end of class Modules.Async_TopLevelAwait_DefaultDestructuringFunctionExport
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_TopLevelAwait_DefaultDestructuringFunctionExport_0050DA96.FunctionObject_FunctionDeclaration_60AADF78_pick
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x22cc
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_60AADF78_pick::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22d4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_60AADF78_pick::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22d7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_60AADF78_pick::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x22da
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_60AADF78_pick::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22e2
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Async_TopLevelAwait_DefaultDestructuringFunctionExport/pick::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_60AADF78_pick::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22f5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Async_TopLevelAwait_DefaultDestructuringFunctionExport/pick::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_60AADF78_pick::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2304
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_60AADF78_pick::ConstructCore
-
-} // end of class FunctionObjects.Async_TopLevelAwait_DefaultDestructuringFunctionExport_0050DA96.FunctionObject_FunctionDeclaration_60AADF78_pick
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_ImportedNamedFunction.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_ImportedNamedFunction.verified.txt
@@ -53,6 +53,128 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3610
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::_environment0_Async_TopLevelAwait_ImportedNamedFunction
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x361f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3622
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x3625
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x362d
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::_environment0_Async_TopLevelAwait_ImportedNamedFunction
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x363f
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::_environment0_Async_TopLevelAwait_ImportedNamedFunction
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x364d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark
+
 
 		// Methods
 		.method public hidebysig static 
@@ -159,6 +281,122 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x365c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3664
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3667
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x366a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3672
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_default::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3685
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_default::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3694
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default
+
 
 		// Methods
 		.method public hidebysig static 
@@ -262,6 +500,130 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x36a3
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x36ab
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x36ae
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x36b1
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x36b9
+				// Header size: 1
+				// Code size: 30 (0x1e)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0018: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_get::__js_call__(object, object, string)
+				IL_001d: ret
+			} // end of method FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x36d8
+				// Header size: 1
+				// Code size: 26 (0x1a)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0014: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_get::__js_call__(object, object, string)
+				IL_0019: ret
+			} // end of method FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x36f3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get
+
 
 		// Methods
 		.method public hidebysig static 
@@ -320,6 +682,138 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3D7422AC_L34C87
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction
+				.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope capture0,
+						class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x375c
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_3D7422AC_L34C87::_environment0_Async_TopLevelAwait_ImportedNamedFunction
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_3D7422AC_L34C87::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_3D7422AC_L34C87::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_3D7422AC_L34C87::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3779
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_3D7422AC_L34C87::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x377c
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_3D7422AC_L34C87::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object ResolveThisArgumentCore (
+						object thisArgument
+					) cil managed 
+				{
+					// Method begins at RVA 0x377f
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_3D7422AC_L34C87::ResolveThisArgumentCore
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x3787
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_3D7422AC_L34C87::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_3D7422AC_L34C87::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3799
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_3D7422AC_L34C87::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_3D7422AC_L34C87::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x37a7
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_3D7422AC_L34C87::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_3D7422AC_L34C87
+
 
 			// Methods
 			.method public hidebysig static 
@@ -369,6 +863,138 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7D62214D_L35C94
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction
+				.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope capture0,
+						class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x37b6
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_7D62214D_L35C94::_environment0_Async_TopLevelAwait_ImportedNamedFunction
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_7D62214D_L35C94::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_7D62214D_L35C94::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_7D62214D_L35C94::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x37d3
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_7D62214D_L35C94::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x37d6
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_7D62214D_L35C94::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object ResolveThisArgumentCore (
+						object thisArgument
+					) cil managed 
+				{
+					// Method begins at RVA 0x37d9
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_7D62214D_L35C94::ResolveThisArgumentCore
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x37e1
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_7D62214D_L35C94::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_7D62214D_L35C94::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x37f3
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_7D62214D_L35C94::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_7D62214D_L35C94::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3801
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_7D62214D_L35C94::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_7D62214D_L35C94
 
 
 			// Methods
@@ -423,6 +1049,143 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A05F0817_L45C87
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction
+					.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+					.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/Scope _environment2_FunctionExpression_L44C9
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope capture0,
+							class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope capture1,
+							class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x3878
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_A05F0817_L45C87::_environment0_Async_TopLevelAwait_ImportedNamedFunction
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_A05F0817_L45C87::_environment1___jroc_esm_namespace
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_A05F0817_L45C87::_environment2_FunctionExpression_L44C9
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_A05F0817_L45C87::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_A05F0817_L45C87::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x389d
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_A05F0817_L45C87::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x38a0
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_A05F0817_L45C87::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object ResolveThisArgumentCore (
+							object thisArgument
+						) cil managed 
+					{
+						// Method begins at RVA 0x38a3
+						// Header size: 1
+						// Code size: 7 (0x7)
+						.maxstack 8
+
+						IL_0000: ldarg.1
+						IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+						IL_0006: ret
+					} // end of method FunctionObject_FunctionExpression_A05F0817_L45C87::ResolveThisArgumentCore
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x38ab
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_A05F0817_L45C87::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_A05F0817_L45C87::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x38bd
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_A05F0817_L45C87::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_A05F0817_L45C87::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x38cb
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_A05F0817_L45C87::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_A05F0817_L45C87
 
 
 				// Methods
@@ -489,6 +1252,144 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1AF19204_L44C10
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction
+				.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope capture0,
+						class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3810
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_1AF19204_L44C10::_environment0_Async_TopLevelAwait_ImportedNamedFunction
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_1AF19204_L44C10::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_1AF19204_L44C10::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_1AF19204_L44C10::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x382d
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_1AF19204_L44C10::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3830
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_1AF19204_L44C10::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object ResolveThisArgumentCore (
+						object thisArgument
+					) cil managed 
+				{
+					// Method begins at RVA 0x3833
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_1AF19204_L44C10::ResolveThisArgumentCore
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x383b
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_1AF19204_L44C10::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_1AF19204_L44C10::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3854
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_1AF19204_L44C10::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_1AF19204_L44C10::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3869
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_1AF19204_L44C10::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_1AF19204_L44C10
+
 
 			// Methods
 			.method public hidebysig static 
@@ -510,7 +1411,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_A05F0817_L45C87,
+					[4] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_A05F0817_L45C87,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -560,13 +1461,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_A05F0817_L45C87::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_A05F0817_L45C87::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.0
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_A05F0817_L45C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_A05F0817_L45C87>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -785,6 +1686,134 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3702
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::_environment0_Async_TopLevelAwait_ImportedNamedFunction
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3711
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3714
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x3717
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x371f
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::_environment0_Async_TopLevelAwait_ImportedNamedFunction
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3738
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::_environment0_Async_TopLevelAwait_ImportedNamedFunction
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x374d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace
+
 
 		// Methods
 		.method public hidebysig static 
@@ -824,12 +1853,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_3D7422AC_L34C87,
-				[21] class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_7D62214D_L35C94,
+				[20] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_3D7422AC_L34C87,
+				[21] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_7D62214D_L35C94,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_1AF19204_L44C10
+				[25] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_1AF19204_L44C10
 			)
 
 			IL_0000: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope::.ctor()
@@ -1035,13 +2064,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_3D7422AC_L34C87::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_3D7422AC_L34C87::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.0
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_3D7422AC_L34C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_3D7422AC_L34C87>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -1085,13 +2114,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_7D62214D_L35C94::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_7D62214D_L35C94::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.0
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_7D62214D_L35C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_7D62214D_L35C94>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -1261,13 +2290,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_1AF19204_L44C10::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_1AF19204_L44C10::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.0
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_1AF19204_L44C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_1AF19204_L44C10>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldc.i4.1
 				IL_0487: newarr [System.Runtime]System.Object
@@ -1385,6 +2414,140 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x38da
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export/FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::_environment0_Async_TopLevelAwait_ImportedNamedFunction
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x38e9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x38ec
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x38ef
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x38f7
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export/FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::_environment0_Async_TopLevelAwait_ImportedNamedFunction
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3917
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export/FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::_environment0_Async_TopLevelAwait_ImportedNamedFunction
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3933
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export
 
 
 		// Methods
@@ -1527,13 +2690,13 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope,
-			[1] class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default,
-			[2] class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get,
-			[3] class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace,
-			[4] class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export,
+			[1] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_default/FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default,
+			[2] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_get/FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get,
+			[3] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace,
+			[4] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export/FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export,
 			[5] object,
 			[6] object[],
-			[7] class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark,
+			[7] class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark,
 			[8] object,
 			[9] object,
 			[10] object[]
@@ -1608,22 +2771,22 @@
 		IL_008a: dup
 		IL_008b: ldc.i4.0
 		IL_008c: ldelem.ref
-		IL_008d: castclass FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default
+		IL_008d: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_default/FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default
 		IL_0092: stloc.1
 		IL_0093: dup
 		IL_0094: ldc.i4.1
 		IL_0095: ldelem.ref
-		IL_0096: castclass FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get
+		IL_0096: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_get/FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get
 		IL_009b: stloc.2
 		IL_009c: dup
 		IL_009d: ldc.i4.2
 		IL_009e: ldelem.ref
-		IL_009f: castclass FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace
+		IL_009f: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace
 		IL_00a4: stloc.3
 		IL_00a5: dup
 		IL_00a6: ldc.i4.3
 		IL_00a7: ldelem.ref
-		IL_00a8: castclass FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export
+		IL_00a8: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export/FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export
 		IL_00ad: stloc.s 4
 		IL_00af: dup
 		IL_00b0: ldc.i4.4
@@ -1637,7 +2800,7 @@
 		IL_00be: dup
 		IL_00bf: ldc.i4.6
 		IL_00c0: ldelem.ref
-		IL_00c1: castclass FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark
+		IL_00c1: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark
 		IL_00c6: stloc.s 7
 		IL_00c8: dup
 		IL_00c9: ldc.i4.7
@@ -1669,13 +2832,13 @@
 		IL_00ff: ldc.i4.0
 		IL_0100: ldelem.ref
 		IL_0101: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope
-		IL_0106: newobj instance void FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope)
+		IL_0106: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope)
 		IL_010b: ldc.i4.0
 		IL_010c: conv.r8
 		IL_010d: ldstr "__jroc_esm_mark"
 		IL_0112: ldc.i4.0
 		IL_0113: ldc.i4.0
-		IL_0114: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0114: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark>(!!0, float64, string, bool, bool)
 		IL_0119: stloc.s 7
 		IL_011b: ldloc.0
 		IL_011c: ldloc.s 7
@@ -1687,13 +2850,13 @@
 		IL_012b: ldloc.0
 		IL_012c: stelem.ref
 		IL_012d: stloc.s 6
-		IL_012f: newobj instance void FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default::.ctor()
+		IL_012f: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_default/FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default::.ctor()
 		IL_0134: ldc.i4.1
 		IL_0135: conv.r8
 		IL_0136: ldstr "__jroc_esm_default"
 		IL_013b: ldc.i4.0
 		IL_013c: ldc.i4.0
-		IL_013d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_013d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_default/FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default>(!!0, float64, string, bool, bool)
 		IL_0142: stloc.1
 		IL_0143: ldc.i4.1
 		IL_0144: newarr [System.Runtime]System.Object
@@ -1702,13 +2865,13 @@
 		IL_014b: ldloc.0
 		IL_014c: stelem.ref
 		IL_014d: stloc.s 6
-		IL_014f: newobj instance void FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get::.ctor()
+		IL_014f: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_get/FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get::.ctor()
 		IL_0154: ldc.i4.2
 		IL_0155: conv.r8
 		IL_0156: ldstr "__jroc_esm_get"
 		IL_015b: ldc.i4.0
 		IL_015c: ldc.i4.0
-		IL_015d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_015d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_get/FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get>(!!0, float64, string, bool, bool)
 		IL_0162: stloc.2
 		IL_0163: ldc.i4.1
 		IL_0164: newarr [System.Runtime]System.Object
@@ -1721,13 +2884,13 @@
 		IL_0171: ldc.i4.0
 		IL_0172: ldelem.ref
 		IL_0173: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope
-		IL_0178: newobj instance void FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope)
+		IL_0178: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope)
 		IL_017d: ldc.i4.1
 		IL_017e: conv.r8
 		IL_017f: ldstr "__jroc_esm_namespace"
 		IL_0184: ldc.i4.0
 		IL_0185: ldc.i4.0
-		IL_0186: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_0186: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace>(!!0, float64, string, bool, bool)
 		IL_018b: stloc.3
 		IL_018c: ldc.i4.1
 		IL_018d: newarr [System.Runtime]System.Object
@@ -1740,13 +2903,13 @@
 		IL_019a: ldc.i4.0
 		IL_019b: ldelem.ref
 		IL_019c: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope
-		IL_01a1: newobj instance void FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope)
+		IL_01a1: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export/FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope)
 		IL_01a6: ldc.i4.2
 		IL_01a7: conv.r8
 		IL_01a8: ldstr "__jroc_esm_export"
 		IL_01ad: ldc.i4.0
 		IL_01ae: ldc.i4.0
-		IL_01af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_01af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export/FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export>(!!0, float64, string, bool, bool)
 		IL_01b4: stloc.s 4
 		IL_01b6: ldc.i4.1
 		IL_01b7: newarr [System.Runtime]System.Object
@@ -1901,6 +3064,128 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_787D0E6A_L3C26
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3942
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/FunctionExpression_L3C25/FunctionObject_FunctionExpression_787D0E6A_L3C26::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_787D0E6A_L3C26::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3951
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_787D0E6A_L3C26::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3954
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_787D0E6A_L3C26::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x3957
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_787D0E6A_L3C26::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x395f
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/FunctionExpression_L3C25/FunctionObject_FunctionExpression_787D0E6A_L3C26::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/FunctionExpression_L3C25::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_787D0E6A_L3C26::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3971
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/FunctionExpression_L3C25/FunctionObject_FunctionExpression_787D0E6A_L3C26::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/FunctionExpression_L3C25::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_787D0E6A_L3C26::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x397f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_787D0E6A_L3C26::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_787D0E6A_L3C26
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1949,6 +3234,109 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_219C8DFB_run
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x398e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/run/FunctionObject_FunctionDeclaration_219C8DFB_run::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_219C8DFB_run::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x399d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_219C8DFB_run::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x39a0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_219C8DFB_run::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x39a3
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_219C8DFB_run::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x39ab
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/run/FunctionObject_FunctionDeclaration_219C8DFB_run::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/run::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_219C8DFB_run::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x39bd
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/run/FunctionObject_FunctionDeclaration_219C8DFB_run::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/run::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_219C8DFB_run::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_219C8DFB_run
 
 
 		// Methods
@@ -2018,6 +3406,128 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x39cb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark/FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x39da
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x39dd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x39e0
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x39e8
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark/FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x39fa
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark/FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a08
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark
 
 
 		// Methods
@@ -2125,6 +3635,122 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3a17
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3a1f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3a22
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a25
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a2d
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_default::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a40
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_default::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a4f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2228,6 +3854,128 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3a5e
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3a66
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3a69
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a6c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a74
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a8e
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3aa4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2286,6 +4034,138 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_91DBC25E_L34C87
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+				.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope capture0,
+						class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3b0d
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_91DBC25E_L34C87::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_91DBC25E_L34C87::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_91DBC25E_L34C87::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_91DBC25E_L34C87::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3b2a
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_91DBC25E_L34C87::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3b2d
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_91DBC25E_L34C87::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object ResolveThisArgumentCore (
+						object thisArgument
+					) cil managed 
+				{
+					// Method begins at RVA 0x3b30
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_91DBC25E_L34C87::ResolveThisArgumentCore
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x3b38
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_91DBC25E_L34C87::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_91DBC25E_L34C87::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3b4a
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_91DBC25E_L34C87::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_91DBC25E_L34C87::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3b58
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_91DBC25E_L34C87::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_91DBC25E_L34C87
+
 
 			// Methods
 			.method public hidebysig static 
@@ -2335,6 +4215,138 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A5C595DB_L35C94
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+				.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope capture0,
+						class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3b67
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_A5C595DB_L35C94::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_A5C595DB_L35C94::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_A5C595DB_L35C94::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_A5C595DB_L35C94::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3b84
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_A5C595DB_L35C94::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3b87
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_A5C595DB_L35C94::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object ResolveThisArgumentCore (
+						object thisArgument
+					) cil managed 
+				{
+					// Method begins at RVA 0x3b8a
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_A5C595DB_L35C94::ResolveThisArgumentCore
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x3b92
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_A5C595DB_L35C94::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_A5C595DB_L35C94::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3ba4
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_A5C595DB_L35C94::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_A5C595DB_L35C94::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3bb2
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_A5C595DB_L35C94::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_A5C595DB_L35C94
 
 
 			// Methods
@@ -2389,6 +4401,143 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_21758CF9_L45C87
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+					.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+					.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/Scope _environment2_FunctionExpression_L44C9
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope capture0,
+							class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope capture1,
+							class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x3c29
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_21758CF9_L45C87::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_21758CF9_L45C87::_environment1___jroc_esm_namespace
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_21758CF9_L45C87::_environment2_FunctionExpression_L44C9
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_21758CF9_L45C87::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_21758CF9_L45C87::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x3c4e
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_21758CF9_L45C87::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x3c51
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_21758CF9_L45C87::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object ResolveThisArgumentCore (
+							object thisArgument
+						) cil managed 
+					{
+						// Method begins at RVA 0x3c54
+						// Header size: 1
+						// Code size: 7 (0x7)
+						.maxstack 8
+
+						IL_0000: ldarg.1
+						IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+						IL_0006: ret
+					} // end of method FunctionObject_FunctionExpression_21758CF9_L45C87::ResolveThisArgumentCore
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x3c5c
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_21758CF9_L45C87::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_21758CF9_L45C87::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x3c6e
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_21758CF9_L45C87::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_21758CF9_L45C87::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x3c7c
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_21758CF9_L45C87::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_21758CF9_L45C87
 
 
 				// Methods
@@ -2455,6 +4604,144 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6A22A512_L44C10
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+				.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope capture0,
+						class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3bc1
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_6A22A512_L44C10::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_6A22A512_L44C10::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_6A22A512_L44C10::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_6A22A512_L44C10::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3bde
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_6A22A512_L44C10::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3be1
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_6A22A512_L44C10::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object ResolveThisArgumentCore (
+						object thisArgument
+					) cil managed 
+				{
+					// Method begins at RVA 0x3be4
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_6A22A512_L44C10::ResolveThisArgumentCore
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x3bec
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_6A22A512_L44C10::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_6A22A512_L44C10::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3c05
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_6A22A512_L44C10::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_6A22A512_L44C10::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3c1a
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_6A22A512_L44C10::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_6A22A512_L44C10
+
 
 			// Methods
 			.method public hidebysig static 
@@ -2476,7 +4763,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_21758CF9_L45C87,
+					[4] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_21758CF9_L45C87,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -2526,13 +4813,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_21758CF9_L45C87::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_21758CF9_L45C87::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.0
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_21758CF9_L45C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86/FunctionObject_FunctionExpression_21758CF9_L45C87>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -2751,6 +5038,134 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ab3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3ac2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3ac5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ac8
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ad0
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ae9
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3afe
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2790,12 +5205,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_91DBC25E_L34C87,
-				[21] class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_A5C595DB_L35C94,
+				[20] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_91DBC25E_L34C87,
+				[21] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_A5C595DB_L35C94,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_6A22A512_L44C10
+				[25] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_6A22A512_L44C10
 			)
 
 			IL_0000: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope::.ctor()
@@ -3001,13 +5416,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_91DBC25E_L34C87::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_91DBC25E_L34C87::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.0
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_91DBC25E_L34C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86/FunctionObject_FunctionExpression_91DBC25E_L34C87>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -3051,13 +5466,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_A5C595DB_L35C94::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_A5C595DB_L35C94::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.0
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_A5C595DB_L35C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93/FunctionObject_FunctionExpression_A5C595DB_L35C94>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -3227,13 +5642,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_6A22A512_L44C10::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_6A22A512_L44C10::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.0
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_6A22A512_L44C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionObject_FunctionExpression_6A22A512_L44C10>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldc.i4.1
 				IL_0487: newarr [System.Runtime]System.Object
@@ -3352,6 +5767,142 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3c8b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export/FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3c9a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3c9d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ca0
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ca8
+				// Header size: 1
+				// Code size: 36 (0x24)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export/FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0017: ldarg.2
+				IL_0018: ldc.i4.1
+				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001e: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object, string, object)
+				IL_0023: ret
+			} // end of method FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ccd
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export/FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.1
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object, string, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3cee
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export
+
 
 		// Methods
 		.method public hidebysig static 
@@ -3460,14 +6011,14 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope,
-			[1] class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default,
-			[2] class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get,
-			[3] class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace,
-			[4] class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export,
+			[1] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_default/FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default,
+			[2] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_get/FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get,
+			[3] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace,
+			[4] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export/FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export,
 			[5] object[],
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
-			[7] class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark,
-			[8] class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_787D0E6A_L3C26
+			[7] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark/FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark,
+			[8] class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/FunctionExpression_L3C25/FunctionObject_FunctionExpression_787D0E6A_L3C26
 		)
 
 		IL_0000: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope::.ctor()
@@ -3507,13 +6058,13 @@
 		IL_0051: ldc.i4.0
 		IL_0052: ldelem.ref
 		IL_0053: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope
-		IL_0058: newobj instance void FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope)
+		IL_0058: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark/FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope)
 		IL_005d: ldc.i4.0
 		IL_005e: conv.r8
 		IL_005f: ldstr "__jroc_esm_mark"
 		IL_0064: ldc.i4.0
 		IL_0065: ldc.i4.0
-		IL_0066: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0066: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark/FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark>(!!0, float64, string, bool, bool)
 		IL_006b: stloc.s 7
 		IL_006d: ldloc.0
 		IL_006e: ldloc.s 7
@@ -3525,13 +6076,13 @@
 		IL_007d: ldloc.0
 		IL_007e: stelem.ref
 		IL_007f: stloc.s 5
-		IL_0081: newobj instance void FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default::.ctor()
+		IL_0081: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_default/FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default::.ctor()
 		IL_0086: ldc.i4.1
 		IL_0087: conv.r8
 		IL_0088: ldstr "__jroc_esm_default"
 		IL_008d: ldc.i4.0
 		IL_008e: ldc.i4.0
-		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_default/FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default>(!!0, float64, string, bool, bool)
 		IL_0094: stloc.1
 		IL_0095: ldc.i4.1
 		IL_0096: newarr [System.Runtime]System.Object
@@ -3540,13 +6091,13 @@
 		IL_009d: ldloc.0
 		IL_009e: stelem.ref
 		IL_009f: stloc.s 5
-		IL_00a1: newobj instance void FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get::.ctor()
+		IL_00a1: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_get/FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get::.ctor()
 		IL_00a6: ldc.i4.2
 		IL_00a7: conv.r8
 		IL_00a8: ldstr "__jroc_esm_get"
 		IL_00ad: ldc.i4.0
 		IL_00ae: ldc.i4.0
-		IL_00af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_00af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_get/FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get>(!!0, float64, string, bool, bool)
 		IL_00b4: stloc.2
 		IL_00b5: ldc.i4.1
 		IL_00b6: newarr [System.Runtime]System.Object
@@ -3559,13 +6110,13 @@
 		IL_00c3: ldc.i4.0
 		IL_00c4: ldelem.ref
 		IL_00c5: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope
-		IL_00ca: newobj instance void FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope)
+		IL_00ca: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope)
 		IL_00cf: ldc.i4.1
 		IL_00d0: conv.r8
 		IL_00d1: ldstr "__jroc_esm_namespace"
 		IL_00d6: ldc.i4.0
 		IL_00d7: ldc.i4.0
-		IL_00d8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00d8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace>(!!0, float64, string, bool, bool)
 		IL_00dd: stloc.3
 		IL_00de: ldc.i4.1
 		IL_00df: newarr [System.Runtime]System.Object
@@ -3578,13 +6129,13 @@
 		IL_00ec: ldc.i4.0
 		IL_00ed: ldelem.ref
 		IL_00ee: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope
-		IL_00f3: newobj instance void FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope)
+		IL_00f3: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export/FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope)
 		IL_00f8: ldc.i4.2
 		IL_00f9: conv.r8
 		IL_00fa: ldstr "__jroc_esm_export"
 		IL_00ff: ldc.i4.0
 		IL_0100: ldc.i4.0
-		IL_0101: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_0101: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export/FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export>(!!0, float64, string, bool, bool)
 		IL_0106: stloc.s 4
 		IL_0108: ldloc.0
 		IL_0109: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope
@@ -3602,13 +6153,13 @@
 		IL_0123: ldc.i4.0
 		IL_0124: ldelem.ref
 		IL_0125: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope
-		IL_012a: newobj instance void FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_787D0E6A_L3C26::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope)
+		IL_012a: newobj instance void Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/FunctionExpression_L3C25/FunctionObject_FunctionExpression_787D0E6A_L3C26::.ctor(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope)
 		IL_012f: ldc.i4.0
 		IL_0130: conv.r8
 		IL_0131: ldstr ""
 		IL_0136: ldc.i4.0
 		IL_0137: ldc.i4.0
-		IL_0138: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_787D0E6A_L3C26>(!!0, float64, string, bool, bool)
+		IL_0138: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/FunctionExpression_L3C25/FunctionObject_FunctionExpression_787D0E6A_L3C26>(!!0, float64, string, bool, bool)
 		IL_013d: stloc.s 8
 		IL_013f: ldloc.0
 		IL_0140: castclass Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope
@@ -3621,2557 +6172,6 @@
 	} // end of method Async_TopLevelAwait_ImportedNamedFunction_Dependency::__js_module_init__
 
 } // end of class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3610
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::_environment0_Async_TopLevelAwait_ImportedNamedFunction
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x361f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3622
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x3625
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x362d
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::_environment0_Async_TopLevelAwait_ImportedNamedFunction
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x363f
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::_environment0_Async_TopLevelAwait_ImportedNamedFunction
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_mark::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x364d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark::ConstructCore
-
-} // end of class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_8BD72C24___jroc_esm_mark
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x365c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3664
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3667
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x366a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3672
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_default::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3685
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_default::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3694
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default::ConstructCore
-
-} // end of class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_7877AAE2___jroc_esm_default
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x36a3
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x36ab
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x36ae
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x36b1
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x36b9
-		// Header size: 1
-		// Code size: 30 (0x1e)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0018: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_get::__js_call__(object, object, string)
-		IL_001d: ret
-	} // end of method FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x36d8
-		// Header size: 1
-		// Code size: 26 (0x1a)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0014: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_get::__js_call__(object, object, string)
-		IL_0019: ret
-	} // end of method FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x36f3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get::ConstructCore
-
-} // end of class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_88F59063___jroc_esm_get
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3702
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::_environment0_Async_TopLevelAwait_ImportedNamedFunction
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3711
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3714
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x3717
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x371f
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::_environment0_Async_TopLevelAwait_ImportedNamedFunction
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3738
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::_environment0_Async_TopLevelAwait_ImportedNamedFunction
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x374d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace::ConstructCore
-
-} // end of class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_99125D64___jroc_esm_namespace
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_3D7422AC_L34C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction
-	.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope capture0,
-			class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x375c
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_3D7422AC_L34C87::_environment0_Async_TopLevelAwait_ImportedNamedFunction
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_3D7422AC_L34C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_3D7422AC_L34C87::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_3D7422AC_L34C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3779
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3D7422AC_L34C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x377c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3D7422AC_L34C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x377f
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_3D7422AC_L34C87::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3787
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_3D7422AC_L34C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_3D7422AC_L34C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3799
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_3D7422AC_L34C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L34C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_3D7422AC_L34C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x37a7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3D7422AC_L34C87::ConstructCore
-
-} // end of class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_3D7422AC_L34C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_7D62214D_L35C94
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction
-	.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope capture0,
-			class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x37b6
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_7D62214D_L35C94::_environment0_Async_TopLevelAwait_ImportedNamedFunction
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_7D62214D_L35C94::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_7D62214D_L35C94::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_7D62214D_L35C94::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x37d3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7D62214D_L35C94::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x37d6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7D62214D_L35C94::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x37d9
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_7D62214D_L35C94::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x37e1
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_7D62214D_L35C94::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_7D62214D_L35C94::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x37f3
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_7D62214D_L35C94::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L35C93::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_7D62214D_L35C94::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3801
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7D62214D_L35C94::ConstructCore
-
-} // end of class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_7D62214D_L35C94
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_1AF19204_L44C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction
-	.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope capture0,
-			class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3810
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_1AF19204_L44C10::_environment0_Async_TopLevelAwait_ImportedNamedFunction
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_1AF19204_L44C10::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_1AF19204_L44C10::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_1AF19204_L44C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x382d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1AF19204_L44C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3830
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1AF19204_L44C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x3833
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_1AF19204_L44C10::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x383b
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_1AF19204_L44C10::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_1AF19204_L44C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3854
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_1AF19204_L44C10::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_1AF19204_L44C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3869
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1AF19204_L44C10::ConstructCore
-
-} // end of class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_1AF19204_L44C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_A05F0817_L45C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction
-	.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/Scope _environment2_FunctionExpression_L44C9
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope capture0,
-			class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope capture1,
-			class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x3878
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_A05F0817_L45C87::_environment0_Async_TopLevelAwait_ImportedNamedFunction
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_A05F0817_L45C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_A05F0817_L45C87::_environment2_FunctionExpression_L44C9
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_A05F0817_L45C87::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_A05F0817_L45C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x389d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A05F0817_L45C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x38a0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A05F0817_L45C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x38a3
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_A05F0817_L45C87::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x38ab
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_A05F0817_L45C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_A05F0817_L45C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x38bd
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_A05F0817_L45C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_A05F0817_L45C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x38cb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A05F0817_L45C87::ConstructCore
-
-} // end of class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionExpression_A05F0817_L45C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x38da
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::_environment0_Async_TopLevelAwait_ImportedNamedFunction
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x38e9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x38ec
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x38ef
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x38f7
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::_environment0_Async_TopLevelAwait_ImportedNamedFunction
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3917
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::_environment0_Async_TopLevelAwait_ImportedNamedFunction
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Async_TopLevelAwait_ImportedNamedFunction/__jroc_esm_export::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3933
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export::ConstructCore
-
-} // end of class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_15385C29.FunctionObject_FunctionDeclaration_9690DE87___jroc_esm_export
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_787D0E6A_L3C26
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3942
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_787D0E6A_L3C26::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_787D0E6A_L3C26::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3951
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_787D0E6A_L3C26::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3954
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_787D0E6A_L3C26::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x3957
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_787D0E6A_L3C26::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x395f
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_787D0E6A_L3C26::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/FunctionExpression_L3C25::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_787D0E6A_L3C26::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3971
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_787D0E6A_L3C26::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/FunctionExpression_L3C25::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_787D0E6A_L3C26::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x397f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_787D0E6A_L3C26::ConstructCore
-
-} // end of class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_787D0E6A_L3C26
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_219C8DFB_run
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x398e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_219C8DFB_run::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_219C8DFB_run::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x399d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_219C8DFB_run::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x39a0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_219C8DFB_run::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x39a3
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_219C8DFB_run::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x39ab
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_219C8DFB_run::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/run::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_219C8DFB_run::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x39bd
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_219C8DFB_run::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/run::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_219C8DFB_run::ConstructBodyCore
-
-} // end of class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_219C8DFB_run
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x39cb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x39da
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x39dd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x39e0
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x39e8
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x39fa
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_mark::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a08
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark::ConstructCore
-
-} // end of class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_43F83872___jroc_esm_mark
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3a17
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3a1f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3a22
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a25
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a2d
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_default::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a40
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_default::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a4f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default::ConstructCore
-
-} // end of class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_CA5B05D0___jroc_esm_default
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3a5e
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3a66
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3a69
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a6c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a74
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a8e
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3aa4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get::ConstructCore
-
-} // end of class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_D3648E51___jroc_esm_get
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ab3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3ac2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3ac5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ac8
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ad0
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ae9
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3afe
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace::ConstructCore
-
-} // end of class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_C475DC7A___jroc_esm_namespace
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_91DBC25E_L34C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
-	.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope capture0,
-			class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b0d
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_91DBC25E_L34C87::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_91DBC25E_L34C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_91DBC25E_L34C87::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_91DBC25E_L34C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3b2a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_91DBC25E_L34C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3b2d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_91DBC25E_L34C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b30
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_91DBC25E_L34C87::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b38
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_91DBC25E_L34C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_91DBC25E_L34C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b4a
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_91DBC25E_L34C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L34C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_91DBC25E_L34C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b58
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_91DBC25E_L34C87::ConstructCore
-
-} // end of class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_91DBC25E_L34C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_A5C595DB_L35C94
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
-	.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope capture0,
-			class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b67
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_A5C595DB_L35C94::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_A5C595DB_L35C94::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_A5C595DB_L35C94::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_A5C595DB_L35C94::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3b84
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A5C595DB_L35C94::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3b87
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A5C595DB_L35C94::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b8a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_A5C595DB_L35C94::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b92
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_A5C595DB_L35C94::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_A5C595DB_L35C94::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ba4
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_A5C595DB_L35C94::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L35C93::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_A5C595DB_L35C94::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3bb2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A5C595DB_L35C94::ConstructCore
-
-} // end of class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_A5C595DB_L35C94
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_6A22A512_L44C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
-	.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope capture0,
-			class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3bc1
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_6A22A512_L44C10::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_6A22A512_L44C10::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_6A22A512_L44C10::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_6A22A512_L44C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3bde
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6A22A512_L44C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3be1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6A22A512_L44C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x3be4
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_6A22A512_L44C10::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3bec
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_6A22A512_L44C10::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_6A22A512_L44C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c05
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_6A22A512_L44C10::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_6A22A512_L44C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c1a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_6A22A512_L44C10::ConstructCore
-
-} // end of class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_6A22A512_L44C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_21758CF9_L45C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
-	.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/Scope _environment2_FunctionExpression_L44C9
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope capture0,
-			class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope capture1,
-			class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c29
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_21758CF9_L45C87::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_21758CF9_L45C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_21758CF9_L45C87::_environment2_FunctionExpression_L44C9
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_21758CF9_L45C87::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_21758CF9_L45C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3c4e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_21758CF9_L45C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3c51
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_21758CF9_L45C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c54
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_21758CF9_L45C87::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c5c
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_21758CF9_L45C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_21758CF9_L45C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c6e
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_21758CF9_L45C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_namespace/FunctionExpression_L44C9/FunctionExpression_L45C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_21758CF9_L45C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c7c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_21758CF9_L45C87::ConstructCore
-
-} // end of class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionExpression_21758CF9_L45C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope _environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c8b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3c9a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3c9d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ca0
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ca8
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0017: ldarg.2
-		IL_0018: ldc.i4.1
-		IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001e: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object, string, object)
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ccd
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::_environment0_Async_TopLevelAwait_ImportedNamedFunction_Dependency
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.1
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/__jroc_esm_export::__js_call__(class Modules.Async_TopLevelAwait_ImportedNamedFunction_Dependency/Scope, object, string, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3cee
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export::ConstructCore
-
-} // end of class FunctionObjects.Async_TopLevelAwait_ImportedNamedFunction_Dependency_60BD0B57.FunctionObject_FunctionDeclaration_3AE313B5___jroc_esm_export
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_PendingPromise.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TopLevelAwait_PendingPromise.verified.txt
@@ -389,6 +389,134 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E45DA0E2_delay
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Async_TopLevelAwait_PendingPromise/Scope _environment0_Async_TopLevelAwait_PendingPromise
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Async_TopLevelAwait_PendingPromise/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2392
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Async_TopLevelAwait_PendingPromise/Scope Modules.Async_TopLevelAwait_PendingPromise/delay/FunctionObject_FunctionDeclaration_E45DA0E2_delay::_environment0_Async_TopLevelAwait_PendingPromise
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E45DA0E2_delay::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x23a1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E45DA0E2_delay::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x23a4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E45DA0E2_delay::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x23a7
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_E45DA0E2_delay::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x23af
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_PendingPromise/Scope Modules.Async_TopLevelAwait_PendingPromise/delay/FunctionObject_FunctionDeclaration_E45DA0E2_delay::_environment0_Async_TopLevelAwait_PendingPromise
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Async_TopLevelAwait_PendingPromise/delay::__js_call__(class Modules.Async_TopLevelAwait_PendingPromise/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_E45DA0E2_delay::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23c8
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Async_TopLevelAwait_PendingPromise/Scope Modules.Async_TopLevelAwait_PendingPromise/delay/FunctionObject_FunctionDeclaration_E45DA0E2_delay::_environment0_Async_TopLevelAwait_PendingPromise
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Async_TopLevelAwait_PendingPromise/delay::__js_call__(class Modules.Async_TopLevelAwait_PendingPromise/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_E45DA0E2_delay::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23dd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E45DA0E2_delay::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E45DA0E2_delay
+
 
 		// Methods
 		.method public hidebysig static 
@@ -532,7 +660,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Async_TopLevelAwait_PendingPromise/Scope,
-			[1] class FunctionObjects.Async_TopLevelAwait_PendingPromise_4797480C.FunctionObject_FunctionDeclaration_E45DA0E2_delay,
+			[1] class Modules.Async_TopLevelAwait_PendingPromise/delay/FunctionObject_FunctionDeclaration_E45DA0E2_delay,
 			[2] object,
 			[3] object[],
 			[4] object
@@ -604,7 +732,7 @@
 		IL_0082: dup
 		IL_0083: ldc.i4.0
 		IL_0084: ldelem.ref
-		IL_0085: castclass FunctionObjects.Async_TopLevelAwait_PendingPromise_4797480C.FunctionObject_FunctionDeclaration_E45DA0E2_delay
+		IL_0085: castclass Modules.Async_TopLevelAwait_PendingPromise/delay/FunctionObject_FunctionDeclaration_E45DA0E2_delay
 		IL_008a: stloc.1
 		IL_008b: dup
 		IL_008c: ldc.i4.1
@@ -636,13 +764,13 @@
 		IL_00bd: ldc.i4.0
 		IL_00be: ldelem.ref
 		IL_00bf: castclass Modules.Async_TopLevelAwait_PendingPromise/Scope
-		IL_00c4: newobj instance void FunctionObjects.Async_TopLevelAwait_PendingPromise_4797480C.FunctionObject_FunctionDeclaration_E45DA0E2_delay::.ctor(class Modules.Async_TopLevelAwait_PendingPromise/Scope)
+		IL_00c4: newobj instance void Modules.Async_TopLevelAwait_PendingPromise/delay/FunctionObject_FunctionDeclaration_E45DA0E2_delay::.ctor(class Modules.Async_TopLevelAwait_PendingPromise/Scope)
 		IL_00c9: ldc.i4.1
 		IL_00ca: conv.r8
 		IL_00cb: ldstr "delay"
 		IL_00d0: ldc.i4.0
 		IL_00d1: ldc.i4.0
-		IL_00d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Async_TopLevelAwait_PendingPromise_4797480C.FunctionObject_FunctionDeclaration_E45DA0E2_delay>(!!0, float64, string, bool, bool)
+		IL_00d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Async_TopLevelAwait_PendingPromise/delay/FunctionObject_FunctionDeclaration_E45DA0E2_delay>(!!0, float64, string, bool, bool)
 		IL_00d7: stloc.1
 		IL_00d8: nop
 		IL_00d9: ldstr "console"
@@ -749,134 +877,6 @@
 	} // end of method Async_TopLevelAwait_PendingPromise::__js_module_async_body__
 
 } // end of class Modules.Async_TopLevelAwait_PendingPromise
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_TopLevelAwait_PendingPromise_4797480C.FunctionObject_FunctionDeclaration_E45DA0E2_delay
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Async_TopLevelAwait_PendingPromise/Scope _environment0_Async_TopLevelAwait_PendingPromise
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Async_TopLevelAwait_PendingPromise/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2392
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Async_TopLevelAwait_PendingPromise/Scope FunctionObjects.Async_TopLevelAwait_PendingPromise_4797480C.FunctionObject_FunctionDeclaration_E45DA0E2_delay::_environment0_Async_TopLevelAwait_PendingPromise
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E45DA0E2_delay::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23a1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E45DA0E2_delay::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23a4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E45DA0E2_delay::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x23a7
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_E45DA0E2_delay::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23af
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Async_TopLevelAwait_PendingPromise/Scope FunctionObjects.Async_TopLevelAwait_PendingPromise_4797480C.FunctionObject_FunctionDeclaration_E45DA0E2_delay::_environment0_Async_TopLevelAwait_PendingPromise
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Async_TopLevelAwait_PendingPromise/delay::__js_call__(class Modules.Async_TopLevelAwait_PendingPromise/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_E45DA0E2_delay::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23c8
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Async_TopLevelAwait_PendingPromise/Scope FunctionObjects.Async_TopLevelAwait_PendingPromise_4797480C.FunctionObject_FunctionDeclaration_E45DA0E2_delay::_environment0_Async_TopLevelAwait_PendingPromise
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Async_TopLevelAwait_PendingPromise/delay::__js_call__(class Modules.Async_TopLevelAwait_PendingPromise/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_E45DA0E2_delay::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23dd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E45DA0E2_delay::ConstructCore
-
-} // end of class FunctionObjects.Async_TopLevelAwait_PendingPromise_4797480C.FunctionObject_FunctionDeclaration_E45DA0E2_delay
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryCatchFinally_AwaitInFinally_OnReject.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryCatchFinally_AwaitInFinally_OnReject.verified.txt
@@ -118,6 +118,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BA033FBE_test
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x24ef
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test/FunctionObject_FunctionDeclaration_BA033FBE_test::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BA033FBE_test::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24fe
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BA033FBE_test::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2501
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BA033FBE_test::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2504
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test/FunctionObject_FunctionDeclaration_BA033FBE_test::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_BA033FBE_test::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2516
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test/FunctionObject_FunctionDeclaration_BA033FBE_test::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_BA033FBE_test::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_BA033FBE_test
+
 
 		// Methods
 		.method public hidebysig static 
@@ -718,94 +806,6 @@
 	} // end of method Async_TryCatchFinally_AwaitInFinally_OnReject::__js_module_init__
 
 } // end of class Modules.Async_TryCatchFinally_AwaitInFinally_OnReject
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_TryCatchFinally_AwaitInFinally_OnReject_06BAD4A3.FunctionObject_FunctionDeclaration_BA033FBE_test
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x24ef
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Async_TryCatchFinally_AwaitInFinally_OnReject_06BAD4A3.FunctionObject_FunctionDeclaration_BA033FBE_test::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BA033FBE_test::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24fe
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BA033FBE_test::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2501
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BA033FBE_test::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2504
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TryCatchFinally_AwaitInFinally_OnReject_06BAD4A3.FunctionObject_FunctionDeclaration_BA033FBE_test::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_BA033FBE_test::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2516
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TryCatchFinally_AwaitInFinally_OnReject_06BAD4A3.FunctionObject_FunctionDeclaration_BA033FBE_test::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Async_TryCatchFinally_AwaitInFinally_OnReject/test::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_BA033FBE_test::ConstructBodyCore
-
-} // end of class FunctionObjects.Async_TryCatchFinally_AwaitInFinally_OnReject_06BAD4A3.FunctionObject_FunctionDeclaration_BA033FBE_test
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryCatch_AwaitReject.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryCatch_AwaitReject.verified.txt
@@ -88,6 +88,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x232f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Async_TryCatch_AwaitReject/testTryCatch/FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x233e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2341
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2344
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_TryCatch_AwaitReject/testTryCatch/FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Async_TryCatch_AwaitReject/testTryCatch::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2356
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_TryCatch_AwaitReject/testTryCatch/FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Async_TryCatch_AwaitReject/testTryCatch::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch
+
 
 		// Methods
 		.method public hidebysig static 
@@ -522,94 +610,6 @@
 	} // end of method Async_TryCatch_AwaitReject::__js_module_init__
 
 } // end of class Modules.Async_TryCatch_AwaitReject
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_TryCatch_AwaitReject_B2EA5FA6.FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x232f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Async_TryCatch_AwaitReject_B2EA5FA6.FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x233e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2341
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2344
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TryCatch_AwaitReject_B2EA5FA6.FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Async_TryCatch_AwaitReject/testTryCatch::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2356
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TryCatch_AwaitReject_B2EA5FA6.FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Async_TryCatch_AwaitReject/testTryCatch::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch::ConstructBodyCore
-
-} // end of class FunctionObjects.Async_TryCatch_AwaitReject_B2EA5FA6.FunctionObject_FunctionDeclaration_ABE4FA51_testTryCatch
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_AwaitInFinally_Normal.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_AwaitInFinally_Normal.verified.txt
@@ -98,6 +98,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1C2E403C_test
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x24a5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Async_TryFinally_AwaitInFinally_Normal/test/FunctionObject_FunctionDeclaration_1C2E403C_test::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_1C2E403C_test::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24b4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1C2E403C_test::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24b7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1C2E403C_test::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24ba
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_TryFinally_AwaitInFinally_Normal/test/FunctionObject_FunctionDeclaration_1C2E403C_test::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Async_TryFinally_AwaitInFinally_Normal/test::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_1C2E403C_test::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24cc
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_TryFinally_AwaitInFinally_Normal/test/FunctionObject_FunctionDeclaration_1C2E403C_test::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Async_TryFinally_AwaitInFinally_Normal/test::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_1C2E403C_test::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_1C2E403C_test
+
 
 		// Methods
 		.method public hidebysig static 
@@ -674,94 +762,6 @@
 	} // end of method Async_TryFinally_AwaitInFinally_Normal::__js_module_init__
 
 } // end of class Modules.Async_TryFinally_AwaitInFinally_Normal
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_TryFinally_AwaitInFinally_Normal_58C07325.FunctionObject_FunctionDeclaration_1C2E403C_test
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x24a5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Async_TryFinally_AwaitInFinally_Normal_58C07325.FunctionObject_FunctionDeclaration_1C2E403C_test::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_1C2E403C_test::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24b4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1C2E403C_test::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24b7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1C2E403C_test::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24ba
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TryFinally_AwaitInFinally_Normal_58C07325.FunctionObject_FunctionDeclaration_1C2E403C_test::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Async_TryFinally_AwaitInFinally_Normal/test::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_1C2E403C_test::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24cc
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TryFinally_AwaitInFinally_Normal_58C07325.FunctionObject_FunctionDeclaration_1C2E403C_test::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Async_TryFinally_AwaitInFinally_Normal/test::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_1C2E403C_test::ConstructBodyCore
-
-} // end of class FunctionObjects.Async_TryFinally_AwaitInFinally_Normal_58C07325.FunctionObject_FunctionDeclaration_1C2E403C_test
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_FinallyThrowOverridesOriginal.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_FinallyThrowOverridesOriginal.verified.txt
@@ -140,6 +140,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_19E56F41_test
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x244c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test/FunctionObject_FunctionDeclaration_19E56F41_test::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_19E56F41_test::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x245b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_19E56F41_test::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x245e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_19E56F41_test::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2461
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test/FunctionObject_FunctionDeclaration_19E56F41_test::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_19E56F41_test::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2473
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test/FunctionObject_FunctionDeclaration_19E56F41_test::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_19E56F41_test::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_19E56F41_test
+
 
 		// Methods
 		.method public hidebysig static 
@@ -676,94 +764,6 @@
 	} // end of method Async_TryFinally_FinallyThrowOverridesOriginal::__js_module_init__
 
 } // end of class Modules.Async_TryFinally_FinallyThrowOverridesOriginal
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_TryFinally_FinallyThrowOverridesOriginal_E873120A.FunctionObject_FunctionDeclaration_19E56F41_test
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x244c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Async_TryFinally_FinallyThrowOverridesOriginal_E873120A.FunctionObject_FunctionDeclaration_19E56F41_test::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_19E56F41_test::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x245b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_19E56F41_test::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x245e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_19E56F41_test::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2461
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TryFinally_FinallyThrowOverridesOriginal_E873120A.FunctionObject_FunctionDeclaration_19E56F41_test::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_19E56F41_test::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2473
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TryFinally_FinallyThrowOverridesOriginal_E873120A.FunctionObject_FunctionDeclaration_19E56F41_test::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Async_TryFinally_FinallyThrowOverridesOriginal/test::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_19E56F41_test::ConstructBodyCore
-
-} // end of class FunctionObjects.Async_TryFinally_FinallyThrowOverridesOriginal_E873120A.FunctionObject_FunctionDeclaration_19E56F41_test
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_PreservesExceptionThroughAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_PreservesExceptionThroughAwait.verified.txt
@@ -148,6 +148,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E25B5249_test
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x24d8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Async_TryFinally_PreservesExceptionThroughAwait/test/FunctionObject_FunctionDeclaration_E25B5249_test::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E25B5249_test::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24e7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E25B5249_test::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24ea
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E25B5249_test::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24ed
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_TryFinally_PreservesExceptionThroughAwait/test/FunctionObject_FunctionDeclaration_E25B5249_test::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Async_TryFinally_PreservesExceptionThroughAwait/test::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_E25B5249_test::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24ff
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_TryFinally_PreservesExceptionThroughAwait/test/FunctionObject_FunctionDeclaration_E25B5249_test::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Async_TryFinally_PreservesExceptionThroughAwait/test::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_E25B5249_test::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E25B5249_test
+
 
 		// Methods
 		.method public hidebysig static 
@@ -733,94 +821,6 @@
 	} // end of method Async_TryFinally_PreservesExceptionThroughAwait::__js_module_init__
 
 } // end of class Modules.Async_TryFinally_PreservesExceptionThroughAwait
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_TryFinally_PreservesExceptionThroughAwait_CD294C42.FunctionObject_FunctionDeclaration_E25B5249_test
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x24d8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Async_TryFinally_PreservesExceptionThroughAwait_CD294C42.FunctionObject_FunctionDeclaration_E25B5249_test::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E25B5249_test::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24e7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E25B5249_test::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24ea
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E25B5249_test::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24ed
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TryFinally_PreservesExceptionThroughAwait_CD294C42.FunctionObject_FunctionDeclaration_E25B5249_test::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Async_TryFinally_PreservesExceptionThroughAwait/test::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_E25B5249_test::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24ff
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TryFinally_PreservesExceptionThroughAwait_CD294C42.FunctionObject_FunctionDeclaration_E25B5249_test::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Async_TryFinally_PreservesExceptionThroughAwait/test::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_E25B5249_test::ConstructBodyCore
-
-} // end of class FunctionObjects.Async_TryFinally_PreservesExceptionThroughAwait_CD294C42.FunctionObject_FunctionDeclaration_E25B5249_test
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_ReturnPreservedThroughAwait.verified.txt
+++ b/tests/Jroc.Tests/Async/Snapshots/GeneratorTests.Async_TryFinally_ReturnPreservedThroughAwait.verified.txt
@@ -88,6 +88,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CCB1BF9B_test
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x23df
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Async_TryFinally_ReturnPreservedThroughAwait/test/FunctionObject_FunctionDeclaration_CCB1BF9B_test::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_CCB1BF9B_test::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x23ee
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CCB1BF9B_test::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x23f1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CCB1BF9B_test::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x23f4
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_TryFinally_ReturnPreservedThroughAwait/test/FunctionObject_FunctionDeclaration_CCB1BF9B_test::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Async_TryFinally_ReturnPreservedThroughAwait/test::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_CCB1BF9B_test::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2406
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Async_TryFinally_ReturnPreservedThroughAwait/test/FunctionObject_FunctionDeclaration_CCB1BF9B_test::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Async_TryFinally_ReturnPreservedThroughAwait/test::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_CCB1BF9B_test::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_CCB1BF9B_test
+
 
 		// Methods
 		.method public hidebysig static 
@@ -607,94 +695,6 @@
 	} // end of method Async_TryFinally_ReturnPreservedThroughAwait::__js_module_init__
 
 } // end of class Modules.Async_TryFinally_ReturnPreservedThroughAwait
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Async_TryFinally_ReturnPreservedThroughAwait_04DD0AD8.FunctionObject_FunctionDeclaration_CCB1BF9B_test
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x23df
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Async_TryFinally_ReturnPreservedThroughAwait_04DD0AD8.FunctionObject_FunctionDeclaration_CCB1BF9B_test::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_CCB1BF9B_test::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23ee
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CCB1BF9B_test::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23f1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CCB1BF9B_test::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23f4
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TryFinally_ReturnPreservedThroughAwait_04DD0AD8.FunctionObject_FunctionDeclaration_CCB1BF9B_test::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Async_TryFinally_ReturnPreservedThroughAwait/test::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_CCB1BF9B_test::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2406
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Async_TryFinally_ReturnPreservedThroughAwait_04DD0AD8.FunctionObject_FunctionDeclaration_CCB1BF9B_test::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Async_TryFinally_ReturnPreservedThroughAwait/test::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_CCB1BF9B_test::ConstructBodyCore
-
-} // end of class FunctionObjects.Async_TryFinally_ReturnPreservedThroughAwait_04DD0AD8.FunctionObject_FunctionDeclaration_CCB1BF9B_test
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_BasicNext.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_BasicNext.verified.txt
@@ -46,6 +46,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F18BC1F4_g
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x271d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.AsyncGenerator_BasicNext/g/FunctionObject_FunctionDeclaration_F18BC1F4_g::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F18BC1F4_g::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x272c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F18BC1F4_g::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x272f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F18BC1F4_g::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2732
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.AsyncGenerator_BasicNext/g/FunctionObject_FunctionDeclaration_F18BC1F4_g::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.AsyncGenerator_BasicNext/g::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_F18BC1F4_g::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2744
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.AsyncGenerator_BasicNext/g/FunctionObject_FunctionDeclaration_F18BC1F4_g::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.AsyncGenerator_BasicNext/g::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_F18BC1F4_g::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_F18BC1F4_g
+
 
 		// Methods
 		.method public hidebysig static 
@@ -959,94 +1047,6 @@
 	} // end of method AsyncGenerator_BasicNext::__js_module_init__
 
 } // end of class Modules.AsyncGenerator_BasicNext
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.AsyncGenerator_BasicNext_06A84DE4.FunctionObject_FunctionDeclaration_F18BC1F4_g
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x271d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.AsyncGenerator_BasicNext_06A84DE4.FunctionObject_FunctionDeclaration_F18BC1F4_g::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F18BC1F4_g::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x272c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F18BC1F4_g::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x272f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F18BC1F4_g::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2732
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.AsyncGenerator_BasicNext_06A84DE4.FunctionObject_FunctionDeclaration_F18BC1F4_g::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.AsyncGenerator_BasicNext/g::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_F18BC1F4_g::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2744
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.AsyncGenerator_BasicNext_06A84DE4.FunctionObject_FunctionDeclaration_F18BC1F4_g::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.AsyncGenerator_BasicNext/g::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_F18BC1F4_g::ConstructBodyCore
-
-} // end of class FunctionObjects.AsyncGenerator_BasicNext_06A84DE4.FunctionObject_FunctionDeclaration_F18BC1F4_g
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_ForAwaitOf.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_ForAwaitOf.verified.txt
@@ -31,6 +31,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CEF26CCF_g
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x278f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.AsyncGenerator_ForAwaitOf/g/FunctionObject_FunctionDeclaration_CEF26CCF_g::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_CEF26CCF_g::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x279e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CEF26CCF_g::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x27a1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CEF26CCF_g::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x27a4
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.AsyncGenerator_ForAwaitOf/g/FunctionObject_FunctionDeclaration_CEF26CCF_g::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.AsyncGenerator_ForAwaitOf/g::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_CEF26CCF_g::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x27b6
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.AsyncGenerator_ForAwaitOf/g/FunctionObject_FunctionDeclaration_CEF26CCF_g::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.AsyncGenerator_ForAwaitOf/g::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_CEF26CCF_g::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_CEF26CCF_g
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1036,94 +1124,6 @@
 	} // end of method AsyncGenerator_ForAwaitOf::__js_module_init__
 
 } // end of class Modules.AsyncGenerator_ForAwaitOf
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.AsyncGenerator_ForAwaitOf_8317DFDF.FunctionObject_FunctionDeclaration_CEF26CCF_g
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x278f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.AsyncGenerator_ForAwaitOf_8317DFDF.FunctionObject_FunctionDeclaration_CEF26CCF_g::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_CEF26CCF_g::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x279e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CEF26CCF_g::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x27a1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CEF26CCF_g::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x27a4
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.AsyncGenerator_ForAwaitOf_8317DFDF.FunctionObject_FunctionDeclaration_CEF26CCF_g::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.AsyncGenerator_ForAwaitOf/g::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_CEF26CCF_g::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27b6
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.AsyncGenerator_ForAwaitOf_8317DFDF.FunctionObject_FunctionDeclaration_CEF26CCF_g::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.AsyncGenerator_ForAwaitOf/g::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_CEF26CCF_g::ConstructBodyCore
-
-} // end of class FunctionObjects.AsyncGenerator_ForAwaitOf_8317DFDF.FunctionObject_FunctionDeclaration_CEF26CCF_g
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_Return.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_Return.verified.txt
@@ -73,6 +73,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_AC260B63_g
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x288d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.AsyncGenerator_Return/g/FunctionObject_FunctionDeclaration_AC260B63_g::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_AC260B63_g::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x289c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_AC260B63_g::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x289f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_AC260B63_g::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x28a2
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.AsyncGenerator_Return/g/FunctionObject_FunctionDeclaration_AC260B63_g::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.AsyncGenerator_Return/g::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_AC260B63_g::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x28b4
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.AsyncGenerator_Return/g/FunctionObject_FunctionDeclaration_AC260B63_g::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.AsyncGenerator_Return/g::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_AC260B63_g::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_AC260B63_g
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1125,94 +1213,6 @@
 	} // end of method AsyncGenerator_Return::__js_module_init__
 
 } // end of class Modules.AsyncGenerator_Return
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.AsyncGenerator_Return_7863BB03.FunctionObject_FunctionDeclaration_AC260B63_g
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x288d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.AsyncGenerator_Return_7863BB03.FunctionObject_FunctionDeclaration_AC260B63_g::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_AC260B63_g::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x289c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_AC260B63_g::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x289f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_AC260B63_g::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x28a2
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.AsyncGenerator_Return_7863BB03.FunctionObject_FunctionDeclaration_AC260B63_g::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.AsyncGenerator_Return/g::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_AC260B63_g::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28b4
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.AsyncGenerator_Return_7863BB03.FunctionObject_FunctionDeclaration_AC260B63_g::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.AsyncGenerator_Return/g::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_AC260B63_g::ConstructBodyCore
-
-} // end of class FunctionObjects.AsyncGenerator_Return_7863BB03.FunctionObject_FunctionDeclaration_AC260B63_g
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_Throw.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_Throw.verified.txt
@@ -93,6 +93,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_31CD1283_g
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x28d1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.AsyncGenerator_Throw/g/FunctionObject_FunctionDeclaration_31CD1283_g::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_31CD1283_g::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x28e0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_31CD1283_g::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x28e3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_31CD1283_g::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x28e6
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.AsyncGenerator_Throw/g/FunctionObject_FunctionDeclaration_31CD1283_g::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.AsyncGenerator_Throw/g::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_31CD1283_g::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x28f8
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.AsyncGenerator_Throw/g/FunctionObject_FunctionDeclaration_31CD1283_g::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.AsyncGenerator_Throw/g::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_31CD1283_g::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_31CD1283_g
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1164,94 +1252,6 @@
 	} // end of method AsyncGenerator_Throw::__js_module_init__
 
 } // end of class Modules.AsyncGenerator_Throw
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.AsyncGenerator_Throw_7E7B0CA3.FunctionObject_FunctionDeclaration_31CD1283_g
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x28d1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.AsyncGenerator_Throw_7E7B0CA3.FunctionObject_FunctionDeclaration_31CD1283_g::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_31CD1283_g::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x28e0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_31CD1283_g::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x28e3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_31CD1283_g::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x28e6
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.AsyncGenerator_Throw_7E7B0CA3.FunctionObject_FunctionDeclaration_31CD1283_g::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.AsyncGenerator_Throw/g::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_31CD1283_g::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28f8
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.AsyncGenerator_Throw_7E7B0CA3.FunctionObject_FunctionDeclaration_31CD1283_g::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.AsyncGenerator_Throw/g::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_31CD1283_g::ConstructBodyCore
-
-} // end of class FunctionObjects.AsyncGenerator_Throw_7E7B0CA3.FunctionObject_FunctionDeclaration_31CD1283_g
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_TryCatchFinally.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_TryCatchFinally.verified.txt
@@ -118,6 +118,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6BD12A88_g
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2aec
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.AsyncGenerator_TryCatchFinally/g/FunctionObject_FunctionDeclaration_6BD12A88_g::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6BD12A88_g::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2afb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6BD12A88_g::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2afe
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6BD12A88_g::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b01
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.AsyncGenerator_TryCatchFinally/g/FunctionObject_FunctionDeclaration_6BD12A88_g::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.AsyncGenerator_TryCatchFinally/g::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_6BD12A88_g::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b13
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.AsyncGenerator_TryCatchFinally/g/FunctionObject_FunctionDeclaration_6BD12A88_g::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.AsyncGenerator_TryCatchFinally/g::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_6BD12A88_g::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_6BD12A88_g
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1424,94 +1512,6 @@
 	} // end of method AsyncGenerator_TryCatchFinally::__js_module_init__
 
 } // end of class Modules.AsyncGenerator_TryCatchFinally
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.AsyncGenerator_TryCatchFinally_A76846C8.FunctionObject_FunctionDeclaration_6BD12A88_g
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2aec
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.AsyncGenerator_TryCatchFinally_A76846C8.FunctionObject_FunctionDeclaration_6BD12A88_g::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6BD12A88_g::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2afb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6BD12A88_g::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2afe
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6BD12A88_g::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b01
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.AsyncGenerator_TryCatchFinally_A76846C8.FunctionObject_FunctionDeclaration_6BD12A88_g::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.AsyncGenerator_TryCatchFinally/g::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_6BD12A88_g::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b13
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.AsyncGenerator_TryCatchFinally_A76846C8.FunctionObject_FunctionDeclaration_6BD12A88_g::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.AsyncGenerator_TryCatchFinally/g::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_6BD12A88_g::ConstructBodyCore
-
-} // end of class FunctionObjects.AsyncGenerator_TryCatchFinally_A76846C8.FunctionObject_FunctionDeclaration_6BD12A88_g
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_YieldAwait.verified.txt
+++ b/tests/Jroc.Tests/AsyncGenerator/Snapshots/GeneratorTests.AsyncGenerator_YieldAwait.verified.txt
@@ -43,6 +43,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_30E5A464_g
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a0c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.AsyncGenerator_YieldAwait/g/FunctionObject_FunctionDeclaration_30E5A464_g::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_30E5A464_g::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2a1b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_30E5A464_g::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2a1e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_30E5A464_g::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a21
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.AsyncGenerator_YieldAwait/g/FunctionObject_FunctionDeclaration_30E5A464_g::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.AsyncGenerator_YieldAwait/g::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_30E5A464_g::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a33
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.AsyncGenerator_YieldAwait/g/FunctionObject_FunctionDeclaration_30E5A464_g::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.AsyncGenerator_YieldAwait/g::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_30E5A464_g::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_30E5A464_g
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1290,94 +1378,6 @@
 	} // end of method AsyncGenerator_YieldAwait::__js_module_init__
 
 } // end of class Modules.AsyncGenerator_YieldAwait
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.AsyncGenerator_YieldAwait_7DE58974.FunctionObject_FunctionDeclaration_30E5A464_g
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a0c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.AsyncGenerator_YieldAwait_7DE58974.FunctionObject_FunctionDeclaration_30E5A464_g::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_30E5A464_g::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a1b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_30E5A464_g::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a1e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_30E5A464_g::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a21
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.AsyncGenerator_YieldAwait_7DE58974.FunctionObject_FunctionDeclaration_30E5A464_g::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.AsyncGenerator_YieldAwait/g::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_30E5A464_g::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a33
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.AsyncGenerator_YieldAwait_7DE58974.FunctionObject_FunctionDeclaration_30E5A464_g::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.AsyncGenerator_YieldAwait/g::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_30E5A464_g::ConstructBodyCore
-
-} // end of class FunctionObjects.AsyncGenerator_YieldAwait_7DE58974.FunctionObject_FunctionDeclaration_30E5A464_g
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_AddDynamicThenToNumber_StringPreserved.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_AddDynamicThenToNumber_StringPreserved.verified.txt
@@ -51,6 +51,153 @@
 
 		} // end of class Scope_addAndCoerce
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_7DCA0CAF_Accumulator
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2185
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.BinaryOperator_AddDynamicThenToNumber_StringPreserved/Accumulator/FunctionObject_ClassConstructor_7DCA0CAF_Accumulator::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_7DCA0CAF_Accumulator::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2194
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_7DCA0CAF_Accumulator::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2197
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_7DCA0CAF_Accumulator::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x219a
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_7DCA0CAF_Accumulator::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21a6
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_7DCA0CAF_Accumulator::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_7DCA0CAF_Accumulator
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_C83C048F_Accumulator_addAndCoerce
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21b2
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_C83C048F_Accumulator_addAndCoerce::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21ba
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_C83C048F_Accumulator_addAndCoerce::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21bd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_C83C048F_Accumulator_addAndCoerce::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21c0
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.BinaryOperator_AddDynamicThenToNumber_StringPreserved/Accumulator
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance float64 Modules.BinaryOperator_AddDynamicThenToNumber_StringPreserved/Accumulator::addAndCoerce(object)
+				IL_0012: box [System.Runtime]System.Double
+				IL_0017: ret
+			} // end of method FunctionObject_ClassMethod_C83C048F_Accumulator_addAndCoerce::CallCore
+
+		} // end of class FunctionObject_ClassMethod_C83C048F_Accumulator_addAndCoerce
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -217,153 +364,6 @@
 	} // end of method BinaryOperator_AddDynamicThenToNumber_StringPreserved::__js_module_init__
 
 } // end of class Modules.BinaryOperator_AddDynamicThenToNumber_StringPreserved
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_AddDynamicThenToNumber_StringPreserved_7E87DF7E.FunctionObject_ClassConstructor_7DCA0CAF_Accumulator
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2185
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.BinaryOperator_AddDynamicThenToNumber_StringPreserved_7E87DF7E.FunctionObject_ClassConstructor_7DCA0CAF_Accumulator::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_7DCA0CAF_Accumulator::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2194
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_7DCA0CAF_Accumulator::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2197
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_7DCA0CAF_Accumulator::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x219a
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_7DCA0CAF_Accumulator::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21a6
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_7DCA0CAF_Accumulator::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_AddDynamicThenToNumber_StringPreserved_7E87DF7E.FunctionObject_ClassConstructor_7DCA0CAF_Accumulator
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_AddDynamicThenToNumber_StringPreserved_7E87DF7E.FunctionObject_ClassMethod_C83C048F_Accumulator_addAndCoerce
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21b2
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_C83C048F_Accumulator_addAndCoerce::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21ba
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_C83C048F_Accumulator_addAndCoerce::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21bd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_C83C048F_Accumulator_addAndCoerce::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21c0
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.BinaryOperator_AddDynamicThenToNumber_StringPreserved/Accumulator
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance float64 Modules.BinaryOperator_AddDynamicThenToNumber_StringPreserved/Accumulator::addAndCoerce(object)
-		IL_0012: box [System.Runtime]System.Double
-		IL_0017: ret
-	} // end of method FunctionObject_ClassMethod_C83C048F_Accumulator_addAndCoerce::CallCore
-
-} // end of class FunctionObjects.BinaryOperator_AddDynamicThenToNumber_StringPreserved_7E87DF7E.FunctionObject_ClassMethod_C83C048F_Accumulator_addAndCoerce
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_AddObjectObject.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_AddObjectObject.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BE09096E_add
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x212c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_BE09096E_add::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2134
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BE09096E_add::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2137
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BE09096E_add::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x213a
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.BinaryOperator_AddObjectObject/'add'::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_BE09096E_add::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2154
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.BinaryOperator_AddObjectObject/'add'::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_BE09096E_add::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x216a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BE09096E_add::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_BE09096E_add
+
 
 		// Methods
 		.method public hidebysig static 
@@ -105,7 +212,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_AddObjectObject/Scope,
-			[1] class FunctionObjects.BinaryOperator_AddObjectObject_F6859CC4.FunctionObject_FunctionDeclaration_BE09096E_add,
+			[1] class Modules.BinaryOperator_AddObjectObject/'add'/FunctionObject_FunctionDeclaration_BE09096E_add,
 			[2] object[],
 			[3] object,
 			[4] object
@@ -120,13 +227,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.BinaryOperator_AddObjectObject_F6859CC4.FunctionObject_FunctionDeclaration_BE09096E_add::.ctor()
+		IL_0011: newobj instance void Modules.BinaryOperator_AddObjectObject/'add'/FunctionObject_FunctionDeclaration_BE09096E_add::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "add"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_AddObjectObject_F6859CC4.FunctionObject_FunctionDeclaration_BE09096E_add>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_AddObjectObject/'add'/FunctionObject_FunctionDeclaration_BE09096E_add>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -170,113 +277,6 @@
 	} // end of method BinaryOperator_AddObjectObject::__js_module_init__
 
 } // end of class Modules.BinaryOperator_AddObjectObject
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_AddObjectObject_F6859CC4.FunctionObject_FunctionDeclaration_BE09096E_add
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x212c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_BE09096E_add::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2134
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BE09096E_add::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2137
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BE09096E_add::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x213a
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.BinaryOperator_AddObjectObject/'add'::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_BE09096E_add::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2154
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.BinaryOperator_AddObjectObject/'add'::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_BE09096E_add::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x216a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BE09096E_add::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_AddObjectObject_F6859CC4.FunctionObject_FunctionDeclaration_BE09096E_add
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_EqualMethodReturn.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_EqualMethodReturn.verified.txt
@@ -51,6 +51,150 @@
 
 		} // end of class Scope_getValue
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_013FD243_TestClass
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21d4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.BinaryOperator_EqualMethodReturn/TestClass/FunctionObject_ClassConstructor_013FD243_TestClass::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_013FD243_TestClass::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21e3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_013FD243_TestClass::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21e6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_013FD243_TestClass::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21e9
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_013FD243_TestClass::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f5
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_013FD243_TestClass::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_013FD243_TestClass
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_5E9218E3_TestClass_getValue
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2201
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_5E9218E3_TestClass_getValue::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2209
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_5E9218E3_TestClass_getValue::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x220c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_5E9218E3_TestClass_getValue::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x220f
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.BinaryOperator_EqualMethodReturn/TestClass
+				IL_0006: call instance float64 Modules.BinaryOperator_EqualMethodReturn/TestClass::getValue()
+				IL_000b: box [System.Runtime]System.Double
+				IL_0010: ret
+			} // end of method FunctionObject_ClassMethod_5E9218E3_TestClass_getValue::CallCore
+
+		} // end of class FunctionObject_ClassMethod_5E9218E3_TestClass_getValue
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -246,150 +390,6 @@
 	} // end of method BinaryOperator_EqualMethodReturn::__js_module_init__
 
 } // end of class Modules.BinaryOperator_EqualMethodReturn
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_EqualMethodReturn_7C2E835C.FunctionObject_ClassConstructor_013FD243_TestClass
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21d4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.BinaryOperator_EqualMethodReturn_7C2E835C.FunctionObject_ClassConstructor_013FD243_TestClass::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_013FD243_TestClass::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21e3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_013FD243_TestClass::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21e6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_013FD243_TestClass::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21e9
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_013FD243_TestClass::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f5
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_013FD243_TestClass::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_EqualMethodReturn_7C2E835C.FunctionObject_ClassConstructor_013FD243_TestClass
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_EqualMethodReturn_7C2E835C.FunctionObject_ClassMethod_5E9218E3_TestClass_getValue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2201
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_5E9218E3_TestClass_getValue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2209
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_5E9218E3_TestClass_getValue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x220c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_5E9218E3_TestClass_getValue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x220f
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.BinaryOperator_EqualMethodReturn/TestClass
-		IL_0006: call instance float64 Modules.BinaryOperator_EqualMethodReturn/TestClass::getValue()
-		IL_000b: box [System.Runtime]System.Double
-		IL_0010: ret
-	} // end of method FunctionObject_ClassMethod_5E9218E3_TestClass_getValue::CallCore
-
-} // end of class FunctionObjects.BinaryOperator_EqualMethodReturn_7C2E835C.FunctionObject_ClassMethod_5E9218E3_TestClass_getValue
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_EqualObjectPropertyVsMethodReturn.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_EqualObjectPropertyVsMethodReturn.verified.txt
@@ -93,6 +93,150 @@
 
 		} // end of class Scope_For_L9C7
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_024EE388_Counter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2223
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.BinaryOperator_EqualObjectPropertyVsMethodReturn/Counter/FunctionObject_ClassConstructor_024EE388_Counter::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_024EE388_Counter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2232
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_024EE388_Counter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2235
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_024EE388_Counter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2238
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_024EE388_Counter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2244
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_024EE388_Counter::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_024EE388_Counter
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_1ACE45B8_Counter_count
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2250
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_1ACE45B8_Counter_count::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2258
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_1ACE45B8_Counter_count::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x225b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_1ACE45B8_Counter_count::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x225e
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.BinaryOperator_EqualObjectPropertyVsMethodReturn/Counter
+				IL_0006: call instance float64 Modules.BinaryOperator_EqualObjectPropertyVsMethodReturn/Counter::count()
+				IL_000b: box [System.Runtime]System.Double
+				IL_0010: ret
+			} // end of method FunctionObject_ClassMethod_1ACE45B8_Counter_count::CallCore
+
+		} // end of class FunctionObject_ClassMethod_1ACE45B8_Counter_count
+
 
 		// Fields
 		.field private object[] _scopes
@@ -312,150 +456,6 @@
 	} // end of method BinaryOperator_EqualObjectPropertyVsMethodReturn::__js_module_init__
 
 } // end of class Modules.BinaryOperator_EqualObjectPropertyVsMethodReturn
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_EqualObjectPropertyVsMethodReturn_8EDE5C2D.FunctionObject_ClassConstructor_024EE388_Counter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2223
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.BinaryOperator_EqualObjectPropertyVsMethodReturn_8EDE5C2D.FunctionObject_ClassConstructor_024EE388_Counter::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_024EE388_Counter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2232
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_024EE388_Counter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2235
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_024EE388_Counter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2238
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_024EE388_Counter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2244
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_024EE388_Counter::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_EqualObjectPropertyVsMethodReturn_8EDE5C2D.FunctionObject_ClassConstructor_024EE388_Counter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_EqualObjectPropertyVsMethodReturn_8EDE5C2D.FunctionObject_ClassMethod_1ACE45B8_Counter_count
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2250
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_1ACE45B8_Counter_count::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2258
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_1ACE45B8_Counter_count::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x225b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_1ACE45B8_Counter_count::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x225e
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.BinaryOperator_EqualObjectPropertyVsMethodReturn/Counter
-		IL_0006: call instance float64 Modules.BinaryOperator_EqualObjectPropertyVsMethodReturn/Counter::count()
-		IL_000b: box [System.Runtime]System.Double
-		IL_0010: ret
-	} // end of method FunctionObject_ClassMethod_1ACE45B8_Counter_count::CallCore
-
-} // end of class FunctionObjects.BinaryOperator_EqualObjectPropertyVsMethodReturn_8EDE5C2D.FunctionObject_ClassMethod_1ACE45B8_Counter_count
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_EqualParameter.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_EqualParameter.verified.txt
@@ -31,6 +31,109 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_05C891FE_testParam
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21b9
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_05C891FE_testParam::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21c1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_05C891FE_testParam::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21c4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_05C891FE_testParam::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21c7
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: call object Modules.BinaryOperator_EqualParameter/testParam::__js_call__(object, float64)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_05C891FE_testParam::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21df
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: call object Modules.BinaryOperator_EqualParameter/testParam::__js_call__(object, float64)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_05C891FE_testParam::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_05C891FE_testParam::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_05C891FE_testParam
+
 
 		// Methods
 		.method public hidebysig static 
@@ -157,7 +260,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_EqualParameter/Scope,
-			[1] class FunctionObjects.BinaryOperator_EqualParameter_D4FF91AA.FunctionObject_FunctionDeclaration_05C891FE_testParam,
+			[1] class Modules.BinaryOperator_EqualParameter/testParam/FunctionObject_FunctionDeclaration_05C891FE_testParam,
 			[2] object[]
 		)
 
@@ -170,13 +273,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.BinaryOperator_EqualParameter_D4FF91AA.FunctionObject_FunctionDeclaration_05C891FE_testParam::.ctor()
+		IL_0011: newobj instance void Modules.BinaryOperator_EqualParameter/testParam/FunctionObject_FunctionDeclaration_05C891FE_testParam::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "testParam"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_EqualParameter_D4FF91AA.FunctionObject_FunctionDeclaration_05C891FE_testParam>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_EqualParameter/testParam/FunctionObject_FunctionDeclaration_05C891FE_testParam>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -208,109 +311,6 @@
 	} // end of method BinaryOperator_EqualParameter::__js_module_init__
 
 } // end of class Modules.BinaryOperator_EqualParameter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_EqualParameter_D4FF91AA.FunctionObject_FunctionDeclaration_05C891FE_testParam
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21b9
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_05C891FE_testParam::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21c1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_05C891FE_testParam::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21c4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_05C891FE_testParam::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21c7
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: call object Modules.BinaryOperator_EqualParameter/testParam::__js_call__(object, float64)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_05C891FE_testParam::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21df
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: call object Modules.BinaryOperator_EqualParameter/testParam::__js_call__(object, float64)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_05C891FE_testParam::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_05C891FE_testParam::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_EqualParameter_D4FF91AA.FunctionObject_FunctionDeclaration_05C891FE_testParam
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_InstanceOf_Basic.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_InstanceOf_Basic.verified.txt
@@ -31,6 +31,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0B57AE94_A
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2277
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_0B57AE94_A::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x227f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0B57AE94_A::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2282
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0B57AE94_A::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2285
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.BinaryOperator_InstanceOf_Basic/A::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_0B57AE94_A::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2291
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.BinaryOperator_InstanceOf_Basic/A::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_0B57AE94_A::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2299
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0B57AE94_A::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_0B57AE94_A
+
 
 		// Methods
 		.method public hidebysig static 
@@ -76,6 +171,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0E57B34D_B
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x22a8
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_0E57B34D_B::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22b0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0E57B34D_B::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22b3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0E57B34D_B::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22b6
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.BinaryOperator_InstanceOf_Basic/B::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_0E57B34D_B::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22c2
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.BinaryOperator_InstanceOf_Basic/B::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_0E57B34D_B::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22ca
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0E57B34D_B::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_0E57B34D_B
+
 
 		// Methods
 		.method public hidebysig static 
@@ -120,6 +310,101 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_AA105045_Node
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x22d9
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_AA105045_Node::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22e1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_AA105045_Node::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22e4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_AA105045_Node::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22e7
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.BinaryOperator_InstanceOf_Basic/Node::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_AA105045_Node::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22f3
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.BinaryOperator_InstanceOf_Basic/Node::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_AA105045_Node::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22fb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_AA105045_Node::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_AA105045_Node
 
 
 		// Methods
@@ -189,9 +474,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_InstanceOf_Basic/Scope,
-			[1] class FunctionObjects.BinaryOperator_InstanceOf_Basic_091A173E.FunctionObject_FunctionDeclaration_0B57AE94_A,
-			[2] class FunctionObjects.BinaryOperator_InstanceOf_Basic_091A173E.FunctionObject_FunctionDeclaration_0E57B34D_B,
-			[3] class FunctionObjects.BinaryOperator_InstanceOf_Basic_091A173E.FunctionObject_FunctionDeclaration_AA105045_Node,
+			[1] class Modules.BinaryOperator_InstanceOf_Basic/A/FunctionObject_FunctionDeclaration_0B57AE94_A,
+			[2] class Modules.BinaryOperator_InstanceOf_Basic/B/FunctionObject_FunctionDeclaration_0E57B34D_B,
+			[3] class Modules.BinaryOperator_InstanceOf_Basic/Node/FunctionObject_FunctionDeclaration_AA105045_Node,
 			[4] object,
 			[5] object,
 			[6] object[],
@@ -211,13 +496,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 6
-		IL_0012: newobj instance void FunctionObjects.BinaryOperator_InstanceOf_Basic_091A173E.FunctionObject_FunctionDeclaration_0B57AE94_A::.ctor()
+		IL_0012: newobj instance void Modules.BinaryOperator_InstanceOf_Basic/A/FunctionObject_FunctionDeclaration_0B57AE94_A::.ctor()
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "A"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_InstanceOf_Basic_091A173E.FunctionObject_FunctionDeclaration_0B57AE94_A>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_InstanceOf_Basic/A/FunctionObject_FunctionDeclaration_0B57AE94_A>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -226,13 +511,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 6
-		IL_0032: newobj instance void FunctionObjects.BinaryOperator_InstanceOf_Basic_091A173E.FunctionObject_FunctionDeclaration_0E57B34D_B::.ctor()
+		IL_0032: newobj instance void Modules.BinaryOperator_InstanceOf_Basic/B/FunctionObject_FunctionDeclaration_0E57B34D_B::.ctor()
 		IL_0037: ldc.i4.0
 		IL_0038: conv.r8
 		IL_0039: ldstr "B"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_InstanceOf_Basic_091A173E.FunctionObject_FunctionDeclaration_0E57B34D_B>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_InstanceOf_Basic/B/FunctionObject_FunctionDeclaration_0E57B34D_B>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -241,13 +526,13 @@
 		IL_004e: ldloc.0
 		IL_004f: stelem.ref
 		IL_0050: stloc.s 6
-		IL_0052: newobj instance void FunctionObjects.BinaryOperator_InstanceOf_Basic_091A173E.FunctionObject_FunctionDeclaration_AA105045_Node::.ctor()
+		IL_0052: newobj instance void Modules.BinaryOperator_InstanceOf_Basic/Node/FunctionObject_FunctionDeclaration_AA105045_Node::.ctor()
 		IL_0057: ldc.i4.0
 		IL_0058: conv.r8
 		IL_0059: ldstr "Node"
 		IL_005e: ldc.i4.0
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_InstanceOf_Basic_091A173E.FunctionObject_FunctionDeclaration_AA105045_Node>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_InstanceOf_Basic/Node/FunctionObject_FunctionDeclaration_AA105045_Node>(!!0, float64, string, bool, bool)
 		IL_0065: stloc.3
 		IL_0066: nop
 		IL_0067: nop
@@ -383,291 +668,6 @@
 	} // end of method BinaryOperator_InstanceOf_Basic::__js_module_init__
 
 } // end of class Modules.BinaryOperator_InstanceOf_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_InstanceOf_Basic_091A173E.FunctionObject_FunctionDeclaration_0B57AE94_A
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2277
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_0B57AE94_A::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x227f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0B57AE94_A::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2282
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0B57AE94_A::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2285
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.BinaryOperator_InstanceOf_Basic/A::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_0B57AE94_A::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2291
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.BinaryOperator_InstanceOf_Basic/A::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_0B57AE94_A::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2299
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0B57AE94_A::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_InstanceOf_Basic_091A173E.FunctionObject_FunctionDeclaration_0B57AE94_A
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_InstanceOf_Basic_091A173E.FunctionObject_FunctionDeclaration_0E57B34D_B
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x22a8
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_0E57B34D_B::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22b0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0E57B34D_B::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22b3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0E57B34D_B::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22b6
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.BinaryOperator_InstanceOf_Basic/B::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_0E57B34D_B::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22c2
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.BinaryOperator_InstanceOf_Basic/B::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_0E57B34D_B::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22ca
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0E57B34D_B::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_InstanceOf_Basic_091A173E.FunctionObject_FunctionDeclaration_0E57B34D_B
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_InstanceOf_Basic_091A173E.FunctionObject_FunctionDeclaration_AA105045_Node
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x22d9
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_AA105045_Node::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22e1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_AA105045_Node::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22e4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_AA105045_Node::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22e7
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.BinaryOperator_InstanceOf_Basic/Node::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_AA105045_Node::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22f3
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.BinaryOperator_InstanceOf_Basic/Node::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_AA105045_Node::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22fb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_AA105045_Node::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_InstanceOf_Basic_091A173E.FunctionObject_FunctionDeclaration_AA105045_Node
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalAnd_ShortCircuit.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalAnd_ShortCircuit.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5E9AB76A_inc
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope _environment0_BinaryOperator_LogicalAnd_ShortCircuit
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2143
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope Modules.BinaryOperator_LogicalAnd_ShortCircuit/inc/FunctionObject_FunctionDeclaration_5E9AB76A_inc::_environment0_BinaryOperator_LogicalAnd_ShortCircuit
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E9AB76A_inc::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2152
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E9AB76A_inc::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2155
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E9AB76A_inc::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2158
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope Modules.BinaryOperator_LogicalAnd_ShortCircuit/inc/FunctionObject_FunctionDeclaration_5E9AB76A_inc::_environment0_BinaryOperator_LogicalAnd_ShortCircuit
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.BinaryOperator_LogicalAnd_ShortCircuit/inc::__js_call__(class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E9AB76A_inc::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x216a
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope Modules.BinaryOperator_LogicalAnd_ShortCircuit/inc/FunctionObject_FunctionDeclaration_5E9AB76A_inc::_environment0_BinaryOperator_LogicalAnd_ShortCircuit
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.BinaryOperator_LogicalAnd_ShortCircuit/inc::__js_call__(class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E9AB76A_inc::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2178
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E9AB76A_inc::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_5E9AB76A_inc
+
 
 		// Methods
 		.method public hidebysig static 
@@ -115,7 +222,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope,
-			[1] class FunctionObjects.BinaryOperator_LogicalAnd_ShortCircuit_B4DD41AF.FunctionObject_FunctionDeclaration_5E9AB76A_inc,
+			[1] class Modules.BinaryOperator_LogicalAnd_ShortCircuit/inc/FunctionObject_FunctionDeclaration_5E9AB76A_inc,
 			[2] object,
 			[3] object[],
 			[4] bool,
@@ -138,13 +245,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope
-		IL_0019: newobj instance void FunctionObjects.BinaryOperator_LogicalAnd_ShortCircuit_B4DD41AF.FunctionObject_FunctionDeclaration_5E9AB76A_inc::.ctor(class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope)
+		IL_0019: newobj instance void Modules.BinaryOperator_LogicalAnd_ShortCircuit/inc/FunctionObject_FunctionDeclaration_5E9AB76A_inc::.ctor(class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "inc"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_LogicalAnd_ShortCircuit_B4DD41AF.FunctionObject_FunctionDeclaration_5E9AB76A_inc>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_LogicalAnd_ShortCircuit/inc/FunctionObject_FunctionDeclaration_5E9AB76A_inc>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldloc.0
@@ -189,113 +296,6 @@
 	} // end of method BinaryOperator_LogicalAnd_ShortCircuit::__js_module_init__
 
 } // end of class Modules.BinaryOperator_LogicalAnd_ShortCircuit
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_LogicalAnd_ShortCircuit_B4DD41AF.FunctionObject_FunctionDeclaration_5E9AB76A_inc
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope _environment0_BinaryOperator_LogicalAnd_ShortCircuit
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2143
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope FunctionObjects.BinaryOperator_LogicalAnd_ShortCircuit_B4DD41AF.FunctionObject_FunctionDeclaration_5E9AB76A_inc::_environment0_BinaryOperator_LogicalAnd_ShortCircuit
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E9AB76A_inc::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2152
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E9AB76A_inc::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2155
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E9AB76A_inc::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2158
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope FunctionObjects.BinaryOperator_LogicalAnd_ShortCircuit_B4DD41AF.FunctionObject_FunctionDeclaration_5E9AB76A_inc::_environment0_BinaryOperator_LogicalAnd_ShortCircuit
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.BinaryOperator_LogicalAnd_ShortCircuit/inc::__js_call__(class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E9AB76A_inc::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x216a
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope FunctionObjects.BinaryOperator_LogicalAnd_ShortCircuit_B4DD41AF.FunctionObject_FunctionDeclaration_5E9AB76A_inc::_environment0_BinaryOperator_LogicalAnd_ShortCircuit
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.BinaryOperator_LogicalAnd_ShortCircuit/inc::__js_call__(class Modules.BinaryOperator_LogicalAnd_ShortCircuit/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E9AB76A_inc::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2178
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E9AB76A_inc::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_LogicalAnd_ShortCircuit_B4DD41AF.FunctionObject_FunctionDeclaration_5E9AB76A_inc
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalOr_ArrayHasData.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalOr_ArrayHasData.verified.txt
@@ -53,6 +53,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C867B623_arrayHasData
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21d9
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_C867B623_arrayHasData::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21e1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C867B623_arrayHasData::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21e4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C867B623_arrayHasData::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21e7
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.BinaryOperator_LogicalOr_ArrayHasData/arrayHasData::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_C867B623_arrayHasData::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21fa
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.BinaryOperator_LogicalOr_ArrayHasData/arrayHasData::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C867B623_arrayHasData::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2209
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C867B623_arrayHasData::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C867B623_arrayHasData
+
 
 		// Methods
 		.method public hidebysig static 
@@ -172,7 +273,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_LogicalOr_ArrayHasData/Scope,
-			[1] class FunctionObjects.BinaryOperator_LogicalOr_ArrayHasData_657AB59D.FunctionObject_FunctionDeclaration_C867B623_arrayHasData,
+			[1] class Modules.BinaryOperator_LogicalOr_ArrayHasData/arrayHasData/FunctionObject_FunctionDeclaration_C867B623_arrayHasData,
 			[2] object[],
 			[3] object,
 			[4] object,
@@ -188,13 +289,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.BinaryOperator_LogicalOr_ArrayHasData_657AB59D.FunctionObject_FunctionDeclaration_C867B623_arrayHasData::.ctor()
+		IL_0011: newobj instance void Modules.BinaryOperator_LogicalOr_ArrayHasData/arrayHasData/FunctionObject_FunctionDeclaration_C867B623_arrayHasData::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "arrayHasData"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_LogicalOr_ArrayHasData_657AB59D.FunctionObject_FunctionDeclaration_C867B623_arrayHasData>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_LogicalOr_ArrayHasData/arrayHasData/FunctionObject_FunctionDeclaration_C867B623_arrayHasData>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -265,107 +366,6 @@
 	} // end of method BinaryOperator_LogicalOr_ArrayHasData::__js_module_init__
 
 } // end of class Modules.BinaryOperator_LogicalOr_ArrayHasData
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_LogicalOr_ArrayHasData_657AB59D.FunctionObject_FunctionDeclaration_C867B623_arrayHasData
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21d9
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_C867B623_arrayHasData::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21e1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C867B623_arrayHasData::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21e4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C867B623_arrayHasData::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21e7
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.BinaryOperator_LogicalOr_ArrayHasData/arrayHasData::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_C867B623_arrayHasData::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21fa
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.BinaryOperator_LogicalOr_ArrayHasData/arrayHasData::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C867B623_arrayHasData::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2209
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C867B623_arrayHasData::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_LogicalOr_ArrayHasData_657AB59D.FunctionObject_FunctionDeclaration_C867B623_arrayHasData
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalOr_ShortCircuit.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_LogicalOr_ShortCircuit.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7403C23E_inc
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope _environment0_BinaryOperator_LogicalOr_ShortCircuit
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2143
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope Modules.BinaryOperator_LogicalOr_ShortCircuit/inc/FunctionObject_FunctionDeclaration_7403C23E_inc::_environment0_BinaryOperator_LogicalOr_ShortCircuit
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_7403C23E_inc::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2152
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7403C23E_inc::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2155
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7403C23E_inc::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2158
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope Modules.BinaryOperator_LogicalOr_ShortCircuit/inc/FunctionObject_FunctionDeclaration_7403C23E_inc::_environment0_BinaryOperator_LogicalOr_ShortCircuit
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.BinaryOperator_LogicalOr_ShortCircuit/inc::__js_call__(class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_7403C23E_inc::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x216a
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope Modules.BinaryOperator_LogicalOr_ShortCircuit/inc/FunctionObject_FunctionDeclaration_7403C23E_inc::_environment0_BinaryOperator_LogicalOr_ShortCircuit
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.BinaryOperator_LogicalOr_ShortCircuit/inc::__js_call__(class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_7403C23E_inc::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2178
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_7403C23E_inc::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_7403C23E_inc
+
 
 		// Methods
 		.method public hidebysig static 
@@ -115,7 +222,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope,
-			[1] class FunctionObjects.BinaryOperator_LogicalOr_ShortCircuit_445C5633.FunctionObject_FunctionDeclaration_7403C23E_inc,
+			[1] class Modules.BinaryOperator_LogicalOr_ShortCircuit/inc/FunctionObject_FunctionDeclaration_7403C23E_inc,
 			[2] object,
 			[3] object[],
 			[4] bool,
@@ -138,13 +245,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope
-		IL_0019: newobj instance void FunctionObjects.BinaryOperator_LogicalOr_ShortCircuit_445C5633.FunctionObject_FunctionDeclaration_7403C23E_inc::.ctor(class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope)
+		IL_0019: newobj instance void Modules.BinaryOperator_LogicalOr_ShortCircuit/inc/FunctionObject_FunctionDeclaration_7403C23E_inc::.ctor(class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "inc"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_LogicalOr_ShortCircuit_445C5633.FunctionObject_FunctionDeclaration_7403C23E_inc>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_LogicalOr_ShortCircuit/inc/FunctionObject_FunctionDeclaration_7403C23E_inc>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldloc.0
@@ -189,113 +296,6 @@
 	} // end of method BinaryOperator_LogicalOr_ShortCircuit::__js_module_init__
 
 } // end of class Modules.BinaryOperator_LogicalOr_ShortCircuit
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_LogicalOr_ShortCircuit_445C5633.FunctionObject_FunctionDeclaration_7403C23E_inc
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope _environment0_BinaryOperator_LogicalOr_ShortCircuit
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2143
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope FunctionObjects.BinaryOperator_LogicalOr_ShortCircuit_445C5633.FunctionObject_FunctionDeclaration_7403C23E_inc::_environment0_BinaryOperator_LogicalOr_ShortCircuit
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_7403C23E_inc::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2152
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7403C23E_inc::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2155
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7403C23E_inc::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2158
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope FunctionObjects.BinaryOperator_LogicalOr_ShortCircuit_445C5633.FunctionObject_FunctionDeclaration_7403C23E_inc::_environment0_BinaryOperator_LogicalOr_ShortCircuit
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.BinaryOperator_LogicalOr_ShortCircuit/inc::__js_call__(class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_7403C23E_inc::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x216a
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope FunctionObjects.BinaryOperator_LogicalOr_ShortCircuit_445C5633.FunctionObject_FunctionDeclaration_7403C23E_inc::_environment0_BinaryOperator_LogicalOr_ShortCircuit
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.BinaryOperator_LogicalOr_ShortCircuit/inc::__js_call__(class Modules.BinaryOperator_LogicalOr_ShortCircuit/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_7403C23E_inc::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2178
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_7403C23E_inc::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_LogicalOr_ShortCircuit_445C5633.FunctionObject_FunctionDeclaration_7403C23E_inc
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_MulObjectObject.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_MulObjectObject.verified.txt
@@ -31,6 +31,117 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2F2D5C92_mul
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2132
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_2F2D5C92_mul::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x213a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2F2D5C92_mul::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x213d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2F2D5C92_mul::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2140
+				// Header size: 1
+				// Code size: 35 (0x23)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001d: call object Modules.BinaryOperator_MulObjectObject/'mul'::__js_call__(object, float64, float64)
+				IL_0022: ret
+			} // end of method FunctionObject_FunctionDeclaration_2F2D5C92_mul::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2164
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0019: call object Modules.BinaryOperator_MulObjectObject/'mul'::__js_call__(object, float64, float64)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_2F2D5C92_mul::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2184
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_2F2D5C92_mul::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_2F2D5C92_mul
+
 
 		// Methods
 		.method public hidebysig static 
@@ -101,7 +212,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_MulObjectObject/Scope,
-			[1] class FunctionObjects.BinaryOperator_MulObjectObject_04730BC1.FunctionObject_FunctionDeclaration_2F2D5C92_mul,
+			[1] class Modules.BinaryOperator_MulObjectObject/'mul'/FunctionObject_FunctionDeclaration_2F2D5C92_mul,
 			[2] object[],
 			[3] object,
 			[4] object
@@ -116,13 +227,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.BinaryOperator_MulObjectObject_04730BC1.FunctionObject_FunctionDeclaration_2F2D5C92_mul::.ctor()
+		IL_0011: newobj instance void Modules.BinaryOperator_MulObjectObject/'mul'/FunctionObject_FunctionDeclaration_2F2D5C92_mul::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "mul"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_MulObjectObject_04730BC1.FunctionObject_FunctionDeclaration_2F2D5C92_mul>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_MulObjectObject/'mul'/FunctionObject_FunctionDeclaration_2F2D5C92_mul>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -168,117 +279,6 @@
 	} // end of method BinaryOperator_MulObjectObject::__js_module_init__
 
 } // end of class Modules.BinaryOperator_MulObjectObject
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_MulObjectObject_04730BC1.FunctionObject_FunctionDeclaration_2F2D5C92_mul
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2132
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_2F2D5C92_mul::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x213a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2F2D5C92_mul::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x213d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2F2D5C92_mul::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2140
-		// Header size: 1
-		// Code size: 35 (0x23)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001d: call object Modules.BinaryOperator_MulObjectObject/'mul'::__js_call__(object, float64, float64)
-		IL_0022: ret
-	} // end of method FunctionObject_FunctionDeclaration_2F2D5C92_mul::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2164
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0019: call object Modules.BinaryOperator_MulObjectObject/'mul'::__js_call__(object, float64, float64)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_2F2D5C92_mul::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2184
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_2F2D5C92_mul::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_MulObjectObject_04730BC1.FunctionObject_FunctionDeclaration_2F2D5C92_mul
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_NumericRefinement_ExplicitNumberAssignment.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_NumericRefinement_ExplicitNumberAssignment.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2183
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x218b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x218e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2191
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment/numberAssignmentRefinement::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21a4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment/numberAssignmentRefinement::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21b3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement
+
 
 		// Methods
 		.method public hidebysig static 
@@ -132,7 +233,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment/Scope,
-			[1] class FunctionObjects.BinaryOperator_NumericRefinement_ExplicitNumberAssignment_6C9AB4FA.FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement,
+			[1] class Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment/numberAssignmentRefinement/FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement,
 			[2] object[],
 			[3] object,
 			[4] object
@@ -147,13 +248,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.BinaryOperator_NumericRefinement_ExplicitNumberAssignment_6C9AB4FA.FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement::.ctor()
+		IL_0011: newobj instance void Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment/numberAssignmentRefinement/FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "numberAssignmentRefinement"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_NumericRefinement_ExplicitNumberAssignment_6C9AB4FA.FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment/numberAssignmentRefinement/FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -211,107 +312,6 @@
 	} // end of method BinaryOperator_NumericRefinement_ExplicitNumberAssignment::__js_module_init__
 
 } // end of class Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_NumericRefinement_ExplicitNumberAssignment_6C9AB4FA.FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2183
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x218b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x218e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2191
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment/numberAssignmentRefinement::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21a4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.BinaryOperator_NumericRefinement_ExplicitNumberAssignment/numberAssignmentRefinement::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21b3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_NumericRefinement_ExplicitNumberAssignment_6C9AB4FA.FunctionObject_FunctionDeclaration_469F51B4_numberAssignmentRefinement
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_NumericRefinement_ParameterReuseCSE.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_NumericRefinement_ParameterReuseCSE.verified.txt
@@ -31,6 +31,109 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x217e
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2186
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2189
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x218c
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: call object Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE/bitwiseParamTwice::__js_call__(object, float64)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21a4
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: call object Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE/bitwiseParamTwice::__js_call__(object, float64)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21b8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice
+
 
 		// Methods
 		.method public hidebysig static 
@@ -120,7 +223,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE/Scope,
-			[1] class FunctionObjects.BinaryOperator_NumericRefinement_ParameterReuseCSE_B20488C8.FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice,
+			[1] class Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE/bitwiseParamTwice/FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice,
 			[2] object[],
 			[3] object,
 			[4] object
@@ -135,13 +238,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.BinaryOperator_NumericRefinement_ParameterReuseCSE_B20488C8.FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice::.ctor()
+		IL_0011: newobj instance void Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE/bitwiseParamTwice/FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "bitwiseParamTwice"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_NumericRefinement_ParameterReuseCSE_B20488C8.FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE/bitwiseParamTwice/FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -200,109 +303,6 @@
 	} // end of method BinaryOperator_NumericRefinement_ParameterReuseCSE::__js_module_init__
 
 } // end of class Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_NumericRefinement_ParameterReuseCSE_B20488C8.FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x217e
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2186
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2189
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x218c
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: call object Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE/bitwiseParamTwice::__js_call__(object, float64)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21a4
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: call object Modules.BinaryOperator_NumericRefinement_ParameterReuseCSE/bitwiseParamTwice::__js_call__(object, float64)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21b8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_NumericRefinement_ParameterReuseCSE_B20488C8.FunctionObject_FunctionDeclaration_01740225_bitwiseParamTwice
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D44246D3_key
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope _environment0_BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2168
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/key/FunctionObject_FunctionDeclaration_D44246D3_key::_environment0_BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D44246D3_key::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2177
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D44246D3_key::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x217a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D44246D3_key::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x217d
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/key/FunctionObject_FunctionDeclaration_D44246D3_key::_environment0_BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/key::__js_call__(class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_D44246D3_key::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x218f
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/key/FunctionObject_FunctionDeclaration_D44246D3_key::_environment0_BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/key::__js_call__(class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_D44246D3_key::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x219d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D44246D3_key::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_D44246D3_key
+
 
 		// Methods
 		.method public hidebysig static 
@@ -117,7 +224,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope,
-			[1] class FunctionObjects.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit_6CBEF3E1.FunctionObject_FunctionDeclaration_D44246D3_key,
+			[1] class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/key/FunctionObject_FunctionDeclaration_D44246D3_key,
 			[2] object,
 			[3] object[],
 			[4] object,
@@ -137,13 +244,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope
-		IL_0019: newobj instance void FunctionObjects.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit_6CBEF3E1.FunctionObject_FunctionDeclaration_D44246D3_key::.ctor(class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope)
+		IL_0019: newobj instance void Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/key/FunctionObject_FunctionDeclaration_D44246D3_key::.ctor(class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "key"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit_6CBEF3E1.FunctionObject_FunctionDeclaration_D44246D3_key>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/key/FunctionObject_FunctionDeclaration_D44246D3_key>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldloc.0
@@ -199,113 +306,6 @@
 	} // end of method BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit::__js_module_init__
 
 } // end of class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit_6CBEF3E1.FunctionObject_FunctionDeclaration_D44246D3_key
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope _environment0_BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2168
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope FunctionObjects.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit_6CBEF3E1.FunctionObject_FunctionDeclaration_D44246D3_key::_environment0_BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D44246D3_key::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2177
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D44246D3_key::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x217a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D44246D3_key::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x217d
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope FunctionObjects.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit_6CBEF3E1.FunctionObject_FunctionDeclaration_D44246D3_key::_environment0_BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/key::__js_call__(class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_D44246D3_key::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x218f
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope FunctionObjects.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit_6CBEF3E1.FunctionObject_FunctionDeclaration_D44246D3_key::_environment0_BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/key::__js_call__(class Modules.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_D44246D3_key::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x219d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D44246D3_key::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_OptionalChaining_ComputedKey_ShortCircuit_6CBEF3E1.FunctionObject_FunctionDeclaration_D44246D3_key
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_StrictEqualCapturedVariable.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_StrictEqualCapturedVariable.verified.txt
@@ -73,6 +73,119 @@
 
 		} // end of class Scope_For_L9C9
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3E7EB29A_process
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope _environment0_BinaryOperator_StrictEqualCapturedVariable
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21fa
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope Modules.BinaryOperator_StrictEqualCapturedVariable/process/FunctionObject_FunctionDeclaration_3E7EB29A_process::_environment0_BinaryOperator_StrictEqualCapturedVariable
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3E7EB29A_process::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2209
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3E7EB29A_process::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x220c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3E7EB29A_process::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x220f
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope Modules.BinaryOperator_StrictEqualCapturedVariable/process/FunctionObject_FunctionDeclaration_3E7EB29A_process::_environment0_BinaryOperator_StrictEqualCapturedVariable
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.BinaryOperator_StrictEqualCapturedVariable/process::__js_call__(class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_3E7EB29A_process::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2228
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope Modules.BinaryOperator_StrictEqualCapturedVariable/process/FunctionObject_FunctionDeclaration_3E7EB29A_process::_environment0_BinaryOperator_StrictEqualCapturedVariable
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.BinaryOperator_StrictEqualCapturedVariable/process::__js_call__(class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_3E7EB29A_process::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x223d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3E7EB29A_process::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_3E7EB29A_process
+
 
 		// Methods
 		.method public hidebysig static 
@@ -368,7 +481,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope,
-			[1] class FunctionObjects.BinaryOperator_StrictEqualCapturedVariable_AA17CA36.FunctionObject_FunctionDeclaration_3E7EB29A_process,
+			[1] class Modules.BinaryOperator_StrictEqualCapturedVariable/process/FunctionObject_FunctionDeclaration_3E7EB29A_process,
 			[2] object[],
 			[3] object[],
 			[4] class Modules.BinaryOperator_StrictEqualCapturedVariable/ArrowFunction_L14C9/FunctionObject
@@ -387,13 +500,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.BinaryOperator_StrictEqualCapturedVariable/Scope
-		IL_0019: newobj instance void FunctionObjects.BinaryOperator_StrictEqualCapturedVariable_AA17CA36.FunctionObject_FunctionDeclaration_3E7EB29A_process::.ctor(class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope)
+		IL_0019: newobj instance void Modules.BinaryOperator_StrictEqualCapturedVariable/process/FunctionObject_FunctionDeclaration_3E7EB29A_process::.ctor(class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope)
 		IL_001e: ldc.i4.1
 		IL_001f: conv.r8
 		IL_0020: ldstr "process"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_StrictEqualCapturedVariable_AA17CA36.FunctionObject_FunctionDeclaration_3E7EB29A_process>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_StrictEqualCapturedVariable/process/FunctionObject_FunctionDeclaration_3E7EB29A_process>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
@@ -431,119 +544,6 @@
 	} // end of method BinaryOperator_StrictEqualCapturedVariable::__js_module_init__
 
 } // end of class Modules.BinaryOperator_StrictEqualCapturedVariable
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_StrictEqualCapturedVariable_AA17CA36.FunctionObject_FunctionDeclaration_3E7EB29A_process
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope _environment0_BinaryOperator_StrictEqualCapturedVariable
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21fa
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope FunctionObjects.BinaryOperator_StrictEqualCapturedVariable_AA17CA36.FunctionObject_FunctionDeclaration_3E7EB29A_process::_environment0_BinaryOperator_StrictEqualCapturedVariable
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3E7EB29A_process::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2209
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3E7EB29A_process::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x220c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3E7EB29A_process::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x220f
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope FunctionObjects.BinaryOperator_StrictEqualCapturedVariable_AA17CA36.FunctionObject_FunctionDeclaration_3E7EB29A_process::_environment0_BinaryOperator_StrictEqualCapturedVariable
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.BinaryOperator_StrictEqualCapturedVariable/process::__js_call__(class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_3E7EB29A_process::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2228
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope FunctionObjects.BinaryOperator_StrictEqualCapturedVariable_AA17CA36.FunctionObject_FunctionDeclaration_3E7EB29A_process::_environment0_BinaryOperator_StrictEqualCapturedVariable
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.BinaryOperator_StrictEqualCapturedVariable/process::__js_call__(class Modules.BinaryOperator_StrictEqualCapturedVariable/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_3E7EB29A_process::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x223d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3E7EB29A_process::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_StrictEqualCapturedVariable_AA17CA36.FunctionObject_FunctionDeclaration_3E7EB29A_process
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypedComparisonScheduler.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypedComparisonScheduler.verified.txt
@@ -31,6 +31,109 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A7653F68_neg
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2759
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_A7653F68_neg::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2761
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A7653F68_neg::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2764
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A7653F68_neg::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2767
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: call object Modules.BinaryOperator_TypedComparisonScheduler/'neg'::__js_call__(object, float64)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_A7653F68_neg::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x277f
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: call object Modules.BinaryOperator_TypedComparisonScheduler/'neg'::__js_call__(object, float64)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_A7653F68_neg::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2793
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A7653F68_neg::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_A7653F68_neg
+
 
 		// Methods
 		.method public hidebysig static 
@@ -78,6 +181,109 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F688842E_bitNot
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x27a2
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_F688842E_bitNot::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x27aa
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F688842E_bitNot::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x27ad
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F688842E_bitNot::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x27b0
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: call object Modules.BinaryOperator_TypedComparisonScheduler/bitNot::__js_call__(object, float64)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_F688842E_bitNot::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x27c8
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: call object Modules.BinaryOperator_TypedComparisonScheduler/bitNot::__js_call__(object, float64)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_F688842E_bitNot::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x27dc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F688842E_bitNot::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_F688842E_bitNot
 
 
 		// Methods
@@ -132,6 +338,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7AC4C157_less
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x27eb
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_7AC4C157_less::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x27f3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7AC4C157_less::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x27f6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7AC4C157_less::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x27f9
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.BinaryOperator_TypedComparisonScheduler/less::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_7AC4C157_less::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2813
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.BinaryOperator_TypedComparisonScheduler/less::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_7AC4C157_less::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2829
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_7AC4C157_less::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_7AC4C157_less
+
 
 		// Methods
 		.method public hidebysig static 
@@ -183,6 +496,125 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1286DABE_compareExpr
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2838
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_1286DABE_compareExpr::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2840
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1286DABE_compareExpr::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2843
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1286DABE_compareExpr::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2846
+				// Header size: 1
+				// Code size: 47 (0x2f)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001d: ldarg.2
+				IL_001e: ldc.i4.2
+				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0029: call object Modules.BinaryOperator_TypedComparisonScheduler/compareExpr::__js_call__(object, float64, float64, float64)
+				IL_002e: ret
+			} // end of method FunctionObject_FunctionDeclaration_1286DABE_compareExpr::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2876
+				// Header size: 1
+				// Code size: 43 (0x2b)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0025: call object Modules.BinaryOperator_TypedComparisonScheduler/compareExpr::__js_call__(object, float64, float64, float64)
+				IL_002a: ret
+			} // end of method FunctionObject_FunctionDeclaration_1286DABE_compareExpr::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x28a2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_1286DABE_compareExpr::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_1286DABE_compareExpr
 
 
 		// Methods
@@ -265,6 +697,117 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6373975E_branch
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x28b1
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_6373975E_branch::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x28b9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6373975E_branch::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x28bc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6373975E_branch::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x28bf
+				// Header size: 1
+				// Code size: 35 (0x23)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001d: call object Modules.BinaryOperator_TypedComparisonScheduler/branch::__js_call__(object, float64, float64)
+				IL_0022: ret
+			} // end of method FunctionObject_FunctionDeclaration_6373975E_branch::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x28e3
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0019: call object Modules.BinaryOperator_TypedComparisonScheduler/branch::__js_call__(object, float64, float64)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_6373975E_branch::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2903
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6373975E_branch::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_6373975E_branch
+
 
 		// Methods
 		.method public hidebysig static 
@@ -325,6 +868,117 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F885F27C_boolEq
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2912
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_F885F27C_boolEq::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x291a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F885F27C_boolEq::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x291d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F885F27C_boolEq::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2920
+				// Header size: 1
+				// Code size: 35 (0x23)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_001d: call object Modules.BinaryOperator_TypedComparisonScheduler/boolEq::__js_call__(object, float64, string)
+				IL_0022: ret
+			} // end of method FunctionObject_FunctionDeclaration_F885F27C_boolEq::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2944
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0019: call object Modules.BinaryOperator_TypedComparisonScheduler/boolEq::__js_call__(object, float64, string)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_F885F27C_boolEq::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2964
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F885F27C_boolEq::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_F885F27C_boolEq
 
 
 		// Methods
@@ -398,6 +1052,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_75F894DB_left
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.BinaryOperator_TypedComparisonScheduler/Scope _environment0_BinaryOperator_TypedComparisonScheduler
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.BinaryOperator_TypedComparisonScheduler/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2973
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.BinaryOperator_TypedComparisonScheduler/Scope Modules.BinaryOperator_TypedComparisonScheduler/left/FunctionObject_FunctionDeclaration_75F894DB_left::_environment0_BinaryOperator_TypedComparisonScheduler
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_75F894DB_left::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2982
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_75F894DB_left::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2985
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_75F894DB_left::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2988
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.BinaryOperator_TypedComparisonScheduler/Scope Modules.BinaryOperator_TypedComparisonScheduler/left/FunctionObject_FunctionDeclaration_75F894DB_left::_environment0_BinaryOperator_TypedComparisonScheduler
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.BinaryOperator_TypedComparisonScheduler/left::__js_call__(class Modules.BinaryOperator_TypedComparisonScheduler/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_75F894DB_left::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x299a
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.BinaryOperator_TypedComparisonScheduler/Scope Modules.BinaryOperator_TypedComparisonScheduler/left/FunctionObject_FunctionDeclaration_75F894DB_left::_environment0_BinaryOperator_TypedComparisonScheduler
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.BinaryOperator_TypedComparisonScheduler/left::__js_call__(class Modules.BinaryOperator_TypedComparisonScheduler/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_75F894DB_left::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x29a8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_75F894DB_left::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_75F894DB_left
+
 
 		// Methods
 		.method public hidebysig static 
@@ -460,6 +1221,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2A86C924_right
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.BinaryOperator_TypedComparisonScheduler/Scope _environment0_BinaryOperator_TypedComparisonScheduler
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.BinaryOperator_TypedComparisonScheduler/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x29b7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.BinaryOperator_TypedComparisonScheduler/Scope Modules.BinaryOperator_TypedComparisonScheduler/right/FunctionObject_FunctionDeclaration_2A86C924_right::_environment0_BinaryOperator_TypedComparisonScheduler
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_2A86C924_right::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x29c6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2A86C924_right::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x29c9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2A86C924_right::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x29cc
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.BinaryOperator_TypedComparisonScheduler/Scope Modules.BinaryOperator_TypedComparisonScheduler/right/FunctionObject_FunctionDeclaration_2A86C924_right::_environment0_BinaryOperator_TypedComparisonScheduler
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.BinaryOperator_TypedComparisonScheduler/right::__js_call__(class Modules.BinaryOperator_TypedComparisonScheduler/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_2A86C924_right::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x29de
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.BinaryOperator_TypedComparisonScheduler/Scope Modules.BinaryOperator_TypedComparisonScheduler/right/FunctionObject_FunctionDeclaration_2A86C924_right::_environment0_BinaryOperator_TypedComparisonScheduler
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.BinaryOperator_TypedComparisonScheduler/right::__js_call__(class Modules.BinaryOperator_TypedComparisonScheduler/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_2A86C924_right::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x29ec
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_2A86C924_right::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_2A86C924_right
 
 
 		// Methods
@@ -601,14 +1469,14 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_TypedComparisonScheduler/Scope,
-			[1] class FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_A7653F68_neg,
-			[2] class FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_F688842E_bitNot,
-			[3] class FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_7AC4C157_less,
-			[4] class FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_1286DABE_compareExpr,
-			[5] class FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_6373975E_branch,
-			[6] class FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_F885F27C_boolEq,
-			[7] class FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_75F894DB_left,
-			[8] class FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_2A86C924_right,
+			[1] class Modules.BinaryOperator_TypedComparisonScheduler/'neg'/FunctionObject_FunctionDeclaration_A7653F68_neg,
+			[2] class Modules.BinaryOperator_TypedComparisonScheduler/bitNot/FunctionObject_FunctionDeclaration_F688842E_bitNot,
+			[3] class Modules.BinaryOperator_TypedComparisonScheduler/less/FunctionObject_FunctionDeclaration_7AC4C157_less,
+			[4] class Modules.BinaryOperator_TypedComparisonScheduler/compareExpr/FunctionObject_FunctionDeclaration_1286DABE_compareExpr,
+			[5] class Modules.BinaryOperator_TypedComparisonScheduler/branch/FunctionObject_FunctionDeclaration_6373975E_branch,
+			[6] class Modules.BinaryOperator_TypedComparisonScheduler/boolEq/FunctionObject_FunctionDeclaration_F885F27C_boolEq,
+			[7] class Modules.BinaryOperator_TypedComparisonScheduler/left/FunctionObject_FunctionDeclaration_75F894DB_left,
+			[8] class Modules.BinaryOperator_TypedComparisonScheduler/right/FunctionObject_FunctionDeclaration_2A86C924_right,
 			[9] class [System.Runtime]System.Exception,
 			[10] object,
 			[11] object,
@@ -635,13 +1503,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 14
-		IL_0012: newobj instance void FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_A7653F68_neg::.ctor()
+		IL_0012: newobj instance void Modules.BinaryOperator_TypedComparisonScheduler/'neg'/FunctionObject_FunctionDeclaration_A7653F68_neg::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "neg"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_A7653F68_neg>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedComparisonScheduler/'neg'/FunctionObject_FunctionDeclaration_A7653F68_neg>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -650,13 +1518,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 14
-		IL_0032: newobj instance void FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_F688842E_bitNot::.ctor()
+		IL_0032: newobj instance void Modules.BinaryOperator_TypedComparisonScheduler/bitNot/FunctionObject_FunctionDeclaration_F688842E_bitNot::.ctor()
 		IL_0037: ldc.i4.1
 		IL_0038: conv.r8
 		IL_0039: ldstr "bitNot"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_F688842E_bitNot>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedComparisonScheduler/bitNot/FunctionObject_FunctionDeclaration_F688842E_bitNot>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -665,13 +1533,13 @@
 		IL_004e: ldloc.0
 		IL_004f: stelem.ref
 		IL_0050: stloc.s 14
-		IL_0052: newobj instance void FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_7AC4C157_less::.ctor()
+		IL_0052: newobj instance void Modules.BinaryOperator_TypedComparisonScheduler/less/FunctionObject_FunctionDeclaration_7AC4C157_less::.ctor()
 		IL_0057: ldc.i4.2
 		IL_0058: conv.r8
 		IL_0059: ldstr "less"
 		IL_005e: ldc.i4.0
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_7AC4C157_less>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedComparisonScheduler/less/FunctionObject_FunctionDeclaration_7AC4C157_less>(!!0, float64, string, bool, bool)
 		IL_0065: stloc.3
 		IL_0066: ldc.i4.1
 		IL_0067: newarr [System.Runtime]System.Object
@@ -680,13 +1548,13 @@
 		IL_006e: ldloc.0
 		IL_006f: stelem.ref
 		IL_0070: stloc.s 14
-		IL_0072: newobj instance void FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_1286DABE_compareExpr::.ctor()
+		IL_0072: newobj instance void Modules.BinaryOperator_TypedComparisonScheduler/compareExpr/FunctionObject_FunctionDeclaration_1286DABE_compareExpr::.ctor()
 		IL_0077: ldc.i4.3
 		IL_0078: conv.r8
 		IL_0079: ldstr "compareExpr"
 		IL_007e: ldc.i4.0
 		IL_007f: ldc.i4.1
-		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_1286DABE_compareExpr>(!!0, float64, string, bool, bool)
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedComparisonScheduler/compareExpr/FunctionObject_FunctionDeclaration_1286DABE_compareExpr>(!!0, float64, string, bool, bool)
 		IL_0085: stloc.s 4
 		IL_0087: ldc.i4.1
 		IL_0088: newarr [System.Runtime]System.Object
@@ -695,13 +1563,13 @@
 		IL_008f: ldloc.0
 		IL_0090: stelem.ref
 		IL_0091: stloc.s 14
-		IL_0093: newobj instance void FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_6373975E_branch::.ctor()
+		IL_0093: newobj instance void Modules.BinaryOperator_TypedComparisonScheduler/branch/FunctionObject_FunctionDeclaration_6373975E_branch::.ctor()
 		IL_0098: ldc.i4.2
 		IL_0099: conv.r8
 		IL_009a: ldstr "branch"
 		IL_009f: ldc.i4.0
 		IL_00a0: ldc.i4.1
-		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_6373975E_branch>(!!0, float64, string, bool, bool)
+		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedComparisonScheduler/branch/FunctionObject_FunctionDeclaration_6373975E_branch>(!!0, float64, string, bool, bool)
 		IL_00a6: stloc.s 5
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -710,13 +1578,13 @@
 		IL_00b0: ldloc.0
 		IL_00b1: stelem.ref
 		IL_00b2: stloc.s 14
-		IL_00b4: newobj instance void FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_F885F27C_boolEq::.ctor()
+		IL_00b4: newobj instance void Modules.BinaryOperator_TypedComparisonScheduler/boolEq/FunctionObject_FunctionDeclaration_F885F27C_boolEq::.ctor()
 		IL_00b9: ldc.i4.2
 		IL_00ba: conv.r8
 		IL_00bb: ldstr "boolEq"
 		IL_00c0: ldc.i4.0
 		IL_00c1: ldc.i4.1
-		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_F885F27C_boolEq>(!!0, float64, string, bool, bool)
+		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedComparisonScheduler/boolEq/FunctionObject_FunctionDeclaration_F885F27C_boolEq>(!!0, float64, string, bool, bool)
 		IL_00c7: stloc.s 6
 		IL_00c9: ldc.i4.1
 		IL_00ca: newarr [System.Runtime]System.Object
@@ -729,13 +1597,13 @@
 		IL_00d7: ldc.i4.0
 		IL_00d8: ldelem.ref
 		IL_00d9: castclass Modules.BinaryOperator_TypedComparisonScheduler/Scope
-		IL_00de: newobj instance void FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_75F894DB_left::.ctor(class Modules.BinaryOperator_TypedComparisonScheduler/Scope)
+		IL_00de: newobj instance void Modules.BinaryOperator_TypedComparisonScheduler/left/FunctionObject_FunctionDeclaration_75F894DB_left::.ctor(class Modules.BinaryOperator_TypedComparisonScheduler/Scope)
 		IL_00e3: ldc.i4.0
 		IL_00e4: conv.r8
 		IL_00e5: ldstr "left"
 		IL_00ea: ldc.i4.0
 		IL_00eb: ldc.i4.1
-		IL_00ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_75F894DB_left>(!!0, float64, string, bool, bool)
+		IL_00ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedComparisonScheduler/left/FunctionObject_FunctionDeclaration_75F894DB_left>(!!0, float64, string, bool, bool)
 		IL_00f1: stloc.s 7
 		IL_00f3: ldc.i4.1
 		IL_00f4: newarr [System.Runtime]System.Object
@@ -748,13 +1616,13 @@
 		IL_0101: ldc.i4.0
 		IL_0102: ldelem.ref
 		IL_0103: castclass Modules.BinaryOperator_TypedComparisonScheduler/Scope
-		IL_0108: newobj instance void FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_2A86C924_right::.ctor(class Modules.BinaryOperator_TypedComparisonScheduler/Scope)
+		IL_0108: newobj instance void Modules.BinaryOperator_TypedComparisonScheduler/right/FunctionObject_FunctionDeclaration_2A86C924_right::.ctor(class Modules.BinaryOperator_TypedComparisonScheduler/Scope)
 		IL_010d: ldc.i4.0
 		IL_010e: conv.r8
 		IL_010f: ldstr "right"
 		IL_0114: ldc.i4.0
 		IL_0115: ldc.i4.1
-		IL_0116: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_2A86C924_right>(!!0, float64, string, bool, bool)
+		IL_0116: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedComparisonScheduler/right/FunctionObject_FunctionDeclaration_2A86C924_right>(!!0, float64, string, bool, bool)
 		IL_011b: stloc.s 8
 		IL_011d: nop
 		IL_011e: nop
@@ -1074,874 +1942,6 @@
 	} // end of method BinaryOperator_TypedComparisonScheduler::__js_module_init__
 
 } // end of class Modules.BinaryOperator_TypedComparisonScheduler
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_A7653F68_neg
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2759
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_A7653F68_neg::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2761
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A7653F68_neg::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2764
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A7653F68_neg::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2767
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: call object Modules.BinaryOperator_TypedComparisonScheduler/'neg'::__js_call__(object, float64)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_A7653F68_neg::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x277f
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: call object Modules.BinaryOperator_TypedComparisonScheduler/'neg'::__js_call__(object, float64)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_A7653F68_neg::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2793
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A7653F68_neg::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_A7653F68_neg
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_F688842E_bitNot
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x27a2
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_F688842E_bitNot::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x27aa
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F688842E_bitNot::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x27ad
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F688842E_bitNot::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x27b0
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: call object Modules.BinaryOperator_TypedComparisonScheduler/bitNot::__js_call__(object, float64)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_F688842E_bitNot::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27c8
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: call object Modules.BinaryOperator_TypedComparisonScheduler/bitNot::__js_call__(object, float64)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_F688842E_bitNot::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27dc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F688842E_bitNot::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_F688842E_bitNot
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_7AC4C157_less
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x27eb
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_7AC4C157_less::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x27f3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7AC4C157_less::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x27f6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7AC4C157_less::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x27f9
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.BinaryOperator_TypedComparisonScheduler/less::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_7AC4C157_less::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2813
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.BinaryOperator_TypedComparisonScheduler/less::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_7AC4C157_less::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2829
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_7AC4C157_less::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_7AC4C157_less
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_1286DABE_compareExpr
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2838
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_1286DABE_compareExpr::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2840
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1286DABE_compareExpr::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2843
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1286DABE_compareExpr::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2846
-		// Header size: 1
-		// Code size: 47 (0x2f)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001d: ldarg.2
-		IL_001e: ldc.i4.2
-		IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0029: call object Modules.BinaryOperator_TypedComparisonScheduler/compareExpr::__js_call__(object, float64, float64, float64)
-		IL_002e: ret
-	} // end of method FunctionObject_FunctionDeclaration_1286DABE_compareExpr::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2876
-		// Header size: 1
-		// Code size: 43 (0x2b)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0025: call object Modules.BinaryOperator_TypedComparisonScheduler/compareExpr::__js_call__(object, float64, float64, float64)
-		IL_002a: ret
-	} // end of method FunctionObject_FunctionDeclaration_1286DABE_compareExpr::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28a2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_1286DABE_compareExpr::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_1286DABE_compareExpr
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_6373975E_branch
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x28b1
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_6373975E_branch::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x28b9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6373975E_branch::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x28bc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6373975E_branch::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x28bf
-		// Header size: 1
-		// Code size: 35 (0x23)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001d: call object Modules.BinaryOperator_TypedComparisonScheduler/branch::__js_call__(object, float64, float64)
-		IL_0022: ret
-	} // end of method FunctionObject_FunctionDeclaration_6373975E_branch::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28e3
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0019: call object Modules.BinaryOperator_TypedComparisonScheduler/branch::__js_call__(object, float64, float64)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_6373975E_branch::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2903
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6373975E_branch::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_6373975E_branch
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_F885F27C_boolEq
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2912
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_F885F27C_boolEq::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x291a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F885F27C_boolEq::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x291d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F885F27C_boolEq::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2920
-		// Header size: 1
-		// Code size: 35 (0x23)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_001d: call object Modules.BinaryOperator_TypedComparisonScheduler/boolEq::__js_call__(object, float64, string)
-		IL_0022: ret
-	} // end of method FunctionObject_FunctionDeclaration_F885F27C_boolEq::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2944
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0019: call object Modules.BinaryOperator_TypedComparisonScheduler/boolEq::__js_call__(object, float64, string)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_F885F27C_boolEq::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2964
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F885F27C_boolEq::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_F885F27C_boolEq
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_75F894DB_left
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.BinaryOperator_TypedComparisonScheduler/Scope _environment0_BinaryOperator_TypedComparisonScheduler
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.BinaryOperator_TypedComparisonScheduler/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2973
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.BinaryOperator_TypedComparisonScheduler/Scope FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_75F894DB_left::_environment0_BinaryOperator_TypedComparisonScheduler
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_75F894DB_left::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2982
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_75F894DB_left::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2985
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_75F894DB_left::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2988
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.BinaryOperator_TypedComparisonScheduler/Scope FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_75F894DB_left::_environment0_BinaryOperator_TypedComparisonScheduler
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.BinaryOperator_TypedComparisonScheduler/left::__js_call__(class Modules.BinaryOperator_TypedComparisonScheduler/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_75F894DB_left::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x299a
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.BinaryOperator_TypedComparisonScheduler/Scope FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_75F894DB_left::_environment0_BinaryOperator_TypedComparisonScheduler
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.BinaryOperator_TypedComparisonScheduler/left::__js_call__(class Modules.BinaryOperator_TypedComparisonScheduler/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_75F894DB_left::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29a8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_75F894DB_left::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_75F894DB_left
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_2A86C924_right
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.BinaryOperator_TypedComparisonScheduler/Scope _environment0_BinaryOperator_TypedComparisonScheduler
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.BinaryOperator_TypedComparisonScheduler/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x29b7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.BinaryOperator_TypedComparisonScheduler/Scope FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_2A86C924_right::_environment0_BinaryOperator_TypedComparisonScheduler
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_2A86C924_right::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x29c6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2A86C924_right::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x29c9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2A86C924_right::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x29cc
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.BinaryOperator_TypedComparisonScheduler/Scope FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_2A86C924_right::_environment0_BinaryOperator_TypedComparisonScheduler
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.BinaryOperator_TypedComparisonScheduler/right::__js_call__(class Modules.BinaryOperator_TypedComparisonScheduler/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_2A86C924_right::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29de
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.BinaryOperator_TypedComparisonScheduler/Scope FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_2A86C924_right::_environment0_BinaryOperator_TypedComparisonScheduler
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.BinaryOperator_TypedComparisonScheduler/right::__js_call__(class Modules.BinaryOperator_TypedComparisonScheduler/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_2A86C924_right::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29ec
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_2A86C924_right::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_TypedComparisonScheduler_2DA5262B.FunctionObject_FunctionDeclaration_2A86C924_right
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypedNumericScheduler.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypedNumericScheduler.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2751
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2759
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x275c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x275f
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.BinaryOperator_TypedNumericScheduler/mulAdd::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2772
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.BinaryOperator_TypedNumericScheduler/mulAdd::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2781
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd
+
 
 		// Methods
 		.method public hidebysig static 
@@ -82,6 +183,133 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F48743DA_addChain
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2790
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_F48743DA_addChain::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2798
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F48743DA_addChain::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x279b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F48743DA_addChain::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x279e
+				// Header size: 1
+				// Code size: 59 (0x3b)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001d: ldarg.2
+				IL_001e: ldc.i4.2
+				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0029: ldarg.2
+				IL_002a: ldc.i4.3
+				IL_002b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0035: call object Modules.BinaryOperator_TypedNumericScheduler/addChain::__js_call__(object, float64, float64, float64, float64)
+				IL_003a: ret
+			} // end of method FunctionObject_FunctionDeclaration_F48743DA_addChain::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x27da
+				// Header size: 1
+				// Code size: 55 (0x37)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0025: ldarg.2
+				IL_0026: ldc.i4.3
+				IL_0027: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_002c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0031: call object Modules.BinaryOperator_TypedNumericScheduler/addChain::__js_call__(object, float64, float64, float64, float64)
+				IL_0036: ret
+			} // end of method FunctionObject_FunctionDeclaration_F48743DA_addChain::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2812
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F48743DA_addChain::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_F48743DA_addChain
 
 
 		// Methods
@@ -139,6 +367,133 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A433882E_tree
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2821
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_A433882E_tree::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2829
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A433882E_tree::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x282c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A433882E_tree::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x282f
+				// Header size: 1
+				// Code size: 59 (0x3b)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001d: ldarg.2
+				IL_001e: ldc.i4.2
+				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0029: ldarg.2
+				IL_002a: ldc.i4.3
+				IL_002b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0035: call object Modules.BinaryOperator_TypedNumericScheduler/tree::__js_call__(object, float64, float64, float64, float64)
+				IL_003a: ret
+			} // end of method FunctionObject_FunctionDeclaration_A433882E_tree::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x286b
+				// Header size: 1
+				// Code size: 55 (0x37)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0025: ldarg.2
+				IL_0026: ldc.i4.3
+				IL_0027: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_002c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0031: call object Modules.BinaryOperator_TypedNumericScheduler/tree::__js_call__(object, float64, float64, float64, float64)
+				IL_0036: ret
+			} // end of method FunctionObject_FunctionDeclaration_A433882E_tree::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x28a3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A433882E_tree::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_A433882E_tree
+
 
 		// Methods
 		.method public hidebysig static 
@@ -195,6 +550,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_73DC7159_subChain
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x28b2
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_73DC7159_subChain::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x28ba
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_73DC7159_subChain::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x28bd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_73DC7159_subChain::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x28c0
+				// Header size: 1
+				// Code size: 47 (0x2f)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001d: ldarg.2
+				IL_001e: ldc.i4.2
+				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0029: call object Modules.BinaryOperator_TypedNumericScheduler/subChain::__js_call__(object, float64, float64, float64)
+				IL_002e: ret
+			} // end of method FunctionObject_FunctionDeclaration_73DC7159_subChain::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x28f0
+				// Header size: 1
+				// Code size: 43 (0x2b)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0025: call object Modules.BinaryOperator_TypedNumericScheduler/subChain::__js_call__(object, float64, float64, float64)
+				IL_002a: ret
+			} // end of method FunctionObject_FunctionDeclaration_73DC7159_subChain::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x291c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_73DC7159_subChain::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_73DC7159_subChain
+
 
 		// Methods
 		.method public hidebysig static 
@@ -247,6 +721,125 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_14EF6D03_divMod
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x292b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_14EF6D03_divMod::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2933
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_14EF6D03_divMod::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2936
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_14EF6D03_divMod::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2939
+				// Header size: 1
+				// Code size: 47 (0x2f)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001d: ldarg.2
+				IL_001e: ldc.i4.2
+				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0029: call object Modules.BinaryOperator_TypedNumericScheduler/divMod::__js_call__(object, float64, float64, float64)
+				IL_002e: ret
+			} // end of method FunctionObject_FunctionDeclaration_14EF6D03_divMod::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2969
+				// Header size: 1
+				// Code size: 43 (0x2b)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0025: call object Modules.BinaryOperator_TypedNumericScheduler/divMod::__js_call__(object, float64, float64, float64)
+				IL_002a: ret
+			} // end of method FunctionObject_FunctionDeclaration_14EF6D03_divMod::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2995
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_14EF6D03_divMod::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_14EF6D03_divMod
 
 
 		// Methods
@@ -301,6 +894,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_03A3A6D4_expAdd
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x29a4
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_03A3A6D4_expAdd::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x29ac
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_03A3A6D4_expAdd::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x29af
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_03A3A6D4_expAdd::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x29b2
+				// Header size: 1
+				// Code size: 47 (0x2f)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001d: ldarg.2
+				IL_001e: ldc.i4.2
+				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0029: call object Modules.BinaryOperator_TypedNumericScheduler/expAdd::__js_call__(object, float64, float64, float64)
+				IL_002e: ret
+			} // end of method FunctionObject_FunctionDeclaration_03A3A6D4_expAdd::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x29e2
+				// Header size: 1
+				// Code size: 43 (0x2b)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0025: call object Modules.BinaryOperator_TypedNumericScheduler/expAdd::__js_call__(object, float64, float64, float64)
+				IL_002a: ret
+			} // end of method FunctionObject_FunctionDeclaration_03A3A6D4_expAdd::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a0e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_03A3A6D4_expAdd::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_03A3A6D4_expAdd
+
 
 		// Methods
 		.method public hidebysig static 
@@ -353,6 +1065,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4AA8841F_left
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.BinaryOperator_TypedNumericScheduler/Scope _environment0_BinaryOperator_TypedNumericScheduler
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.BinaryOperator_TypedNumericScheduler/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a1d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.BinaryOperator_TypedNumericScheduler/Scope Modules.BinaryOperator_TypedNumericScheduler/left/FunctionObject_FunctionDeclaration_4AA8841F_left::_environment0_BinaryOperator_TypedNumericScheduler
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4AA8841F_left::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2a2c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4AA8841F_left::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2a2f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4AA8841F_left::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a32
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.BinaryOperator_TypedNumericScheduler/Scope Modules.BinaryOperator_TypedNumericScheduler/left/FunctionObject_FunctionDeclaration_4AA8841F_left::_environment0_BinaryOperator_TypedNumericScheduler
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.BinaryOperator_TypedNumericScheduler/left::__js_call__(class Modules.BinaryOperator_TypedNumericScheduler/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_4AA8841F_left::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a44
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.BinaryOperator_TypedNumericScheduler/Scope Modules.BinaryOperator_TypedNumericScheduler/left/FunctionObject_FunctionDeclaration_4AA8841F_left::_environment0_BinaryOperator_TypedNumericScheduler
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.BinaryOperator_TypedNumericScheduler/left::__js_call__(class Modules.BinaryOperator_TypedNumericScheduler/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_4AA8841F_left::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a52
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4AA8841F_left::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_4AA8841F_left
 
 
 		// Methods
@@ -417,6 +1236,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BF4CE850_right
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.BinaryOperator_TypedNumericScheduler/Scope _environment0_BinaryOperator_TypedNumericScheduler
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.BinaryOperator_TypedNumericScheduler/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a61
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.BinaryOperator_TypedNumericScheduler/Scope Modules.BinaryOperator_TypedNumericScheduler/right/FunctionObject_FunctionDeclaration_BF4CE850_right::_environment0_BinaryOperator_TypedNumericScheduler
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BF4CE850_right::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2a70
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BF4CE850_right::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2a73
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BF4CE850_right::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a76
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.BinaryOperator_TypedNumericScheduler/Scope Modules.BinaryOperator_TypedNumericScheduler/right/FunctionObject_FunctionDeclaration_BF4CE850_right::_environment0_BinaryOperator_TypedNumericScheduler
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.BinaryOperator_TypedNumericScheduler/right::__js_call__(class Modules.BinaryOperator_TypedNumericScheduler/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_BF4CE850_right::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a88
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.BinaryOperator_TypedNumericScheduler/Scope Modules.BinaryOperator_TypedNumericScheduler/right/FunctionObject_FunctionDeclaration_BF4CE850_right::_environment0_BinaryOperator_TypedNumericScheduler
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.BinaryOperator_TypedNumericScheduler/right::__js_call__(class Modules.BinaryOperator_TypedNumericScheduler/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_BF4CE850_right::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a96
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BF4CE850_right::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_BF4CE850_right
+
 
 		// Methods
 		.method public hidebysig static 
@@ -479,6 +1405,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D8F5465F_calls
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.BinaryOperator_TypedNumericScheduler/Scope _environment0_BinaryOperator_TypedNumericScheduler
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.BinaryOperator_TypedNumericScheduler/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2aa5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.BinaryOperator_TypedNumericScheduler/Scope Modules.BinaryOperator_TypedNumericScheduler/calls/FunctionObject_FunctionDeclaration_D8F5465F_calls::_environment0_BinaryOperator_TypedNumericScheduler
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D8F5465F_calls::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2ab4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D8F5465F_calls::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2ab7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D8F5465F_calls::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2aba
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.BinaryOperator_TypedNumericScheduler/Scope Modules.BinaryOperator_TypedNumericScheduler/calls/FunctionObject_FunctionDeclaration_D8F5465F_calls::_environment0_BinaryOperator_TypedNumericScheduler
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.BinaryOperator_TypedNumericScheduler/calls::__js_call__(class Modules.BinaryOperator_TypedNumericScheduler/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_D8F5465F_calls::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2acc
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.BinaryOperator_TypedNumericScheduler/Scope Modules.BinaryOperator_TypedNumericScheduler/calls/FunctionObject_FunctionDeclaration_D8F5465F_calls::_environment0_BinaryOperator_TypedNumericScheduler
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.BinaryOperator_TypedNumericScheduler/calls::__js_call__(class Modules.BinaryOperator_TypedNumericScheduler/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_D8F5465F_calls::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ada
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D8F5465F_calls::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_D8F5465F_calls
 
 
 		// Methods
@@ -556,6 +1589,109 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B3DBBF8F_postfix
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2ae9
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_B3DBBF8F_postfix::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2af1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B3DBBF8F_postfix::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2af4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B3DBBF8F_postfix::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2af7
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.BinaryOperator_TypedNumericScheduler/postfix::__js_call__(object, float64)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_B3DBBF8F_postfix::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b0f
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.BinaryOperator_TypedNumericScheduler/postfix::__js_call__(object, float64)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_B3DBBF8F_postfix::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b23
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B3DBBF8F_postfix::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_B3DBBF8F_postfix
 
 
 		// Methods
@@ -664,17 +1800,17 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_TypedNumericScheduler/Scope,
-			[1] class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd,
-			[2] class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_F48743DA_addChain,
-			[3] class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_A433882E_tree,
-			[4] class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_73DC7159_subChain,
-			[5] class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_14EF6D03_divMod,
-			[6] class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_03A3A6D4_expAdd,
-			[7] class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_D8F5465F_calls,
-			[8] class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_B3DBBF8F_postfix,
+			[1] class Modules.BinaryOperator_TypedNumericScheduler/mulAdd/FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd,
+			[2] class Modules.BinaryOperator_TypedNumericScheduler/addChain/FunctionObject_FunctionDeclaration_F48743DA_addChain,
+			[3] class Modules.BinaryOperator_TypedNumericScheduler/tree/FunctionObject_FunctionDeclaration_A433882E_tree,
+			[4] class Modules.BinaryOperator_TypedNumericScheduler/subChain/FunctionObject_FunctionDeclaration_73DC7159_subChain,
+			[5] class Modules.BinaryOperator_TypedNumericScheduler/divMod/FunctionObject_FunctionDeclaration_14EF6D03_divMod,
+			[6] class Modules.BinaryOperator_TypedNumericScheduler/expAdd/FunctionObject_FunctionDeclaration_03A3A6D4_expAdd,
+			[7] class Modules.BinaryOperator_TypedNumericScheduler/calls/FunctionObject_FunctionDeclaration_D8F5465F_calls,
+			[8] class Modules.BinaryOperator_TypedNumericScheduler/postfix/FunctionObject_FunctionDeclaration_B3DBBF8F_postfix,
 			[9] object[],
-			[10] class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_4AA8841F_left,
-			[11] class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_BF4CE850_right,
+			[10] class Modules.BinaryOperator_TypedNumericScheduler/left/FunctionObject_FunctionDeclaration_4AA8841F_left,
+			[11] class Modules.BinaryOperator_TypedNumericScheduler/right/FunctionObject_FunctionDeclaration_BF4CE850_right,
 			[12] object,
 			[13] object,
 			[14] object,
@@ -692,13 +1828,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 9
-		IL_0012: newobj instance void FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd::.ctor()
+		IL_0012: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/mulAdd/FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "mulAdd"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/mulAdd/FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -707,13 +1843,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 9
-		IL_0032: newobj instance void FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_F48743DA_addChain::.ctor()
+		IL_0032: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/addChain/FunctionObject_FunctionDeclaration_F48743DA_addChain::.ctor()
 		IL_0037: ldc.i4.4
 		IL_0038: conv.r8
 		IL_0039: ldstr "addChain"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_F48743DA_addChain>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/addChain/FunctionObject_FunctionDeclaration_F48743DA_addChain>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -722,13 +1858,13 @@
 		IL_004e: ldloc.0
 		IL_004f: stelem.ref
 		IL_0050: stloc.s 9
-		IL_0052: newobj instance void FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_A433882E_tree::.ctor()
+		IL_0052: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/tree/FunctionObject_FunctionDeclaration_A433882E_tree::.ctor()
 		IL_0057: ldc.i4.4
 		IL_0058: conv.r8
 		IL_0059: ldstr "tree"
 		IL_005e: ldc.i4.0
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_A433882E_tree>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/tree/FunctionObject_FunctionDeclaration_A433882E_tree>(!!0, float64, string, bool, bool)
 		IL_0065: stloc.3
 		IL_0066: ldc.i4.1
 		IL_0067: newarr [System.Runtime]System.Object
@@ -737,13 +1873,13 @@
 		IL_006e: ldloc.0
 		IL_006f: stelem.ref
 		IL_0070: stloc.s 9
-		IL_0072: newobj instance void FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_73DC7159_subChain::.ctor()
+		IL_0072: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/subChain/FunctionObject_FunctionDeclaration_73DC7159_subChain::.ctor()
 		IL_0077: ldc.i4.3
 		IL_0078: conv.r8
 		IL_0079: ldstr "subChain"
 		IL_007e: ldc.i4.0
 		IL_007f: ldc.i4.1
-		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_73DC7159_subChain>(!!0, float64, string, bool, bool)
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/subChain/FunctionObject_FunctionDeclaration_73DC7159_subChain>(!!0, float64, string, bool, bool)
 		IL_0085: stloc.s 4
 		IL_0087: ldc.i4.1
 		IL_0088: newarr [System.Runtime]System.Object
@@ -752,13 +1888,13 @@
 		IL_008f: ldloc.0
 		IL_0090: stelem.ref
 		IL_0091: stloc.s 9
-		IL_0093: newobj instance void FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_14EF6D03_divMod::.ctor()
+		IL_0093: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/divMod/FunctionObject_FunctionDeclaration_14EF6D03_divMod::.ctor()
 		IL_0098: ldc.i4.3
 		IL_0099: conv.r8
 		IL_009a: ldstr "divMod"
 		IL_009f: ldc.i4.0
 		IL_00a0: ldc.i4.1
-		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_14EF6D03_divMod>(!!0, float64, string, bool, bool)
+		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/divMod/FunctionObject_FunctionDeclaration_14EF6D03_divMod>(!!0, float64, string, bool, bool)
 		IL_00a6: stloc.s 5
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -767,13 +1903,13 @@
 		IL_00b0: ldloc.0
 		IL_00b1: stelem.ref
 		IL_00b2: stloc.s 9
-		IL_00b4: newobj instance void FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_03A3A6D4_expAdd::.ctor()
+		IL_00b4: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/expAdd/FunctionObject_FunctionDeclaration_03A3A6D4_expAdd::.ctor()
 		IL_00b9: ldc.i4.3
 		IL_00ba: conv.r8
 		IL_00bb: ldstr "expAdd"
 		IL_00c0: ldc.i4.0
 		IL_00c1: ldc.i4.1
-		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_03A3A6D4_expAdd>(!!0, float64, string, bool, bool)
+		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/expAdd/FunctionObject_FunctionDeclaration_03A3A6D4_expAdd>(!!0, float64, string, bool, bool)
 		IL_00c7: stloc.s 6
 		IL_00c9: ldc.i4.1
 		IL_00ca: newarr [System.Runtime]System.Object
@@ -786,13 +1922,13 @@
 		IL_00d7: ldc.i4.0
 		IL_00d8: ldelem.ref
 		IL_00d9: castclass Modules.BinaryOperator_TypedNumericScheduler/Scope
-		IL_00de: newobj instance void FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_4AA8841F_left::.ctor(class Modules.BinaryOperator_TypedNumericScheduler/Scope)
+		IL_00de: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/left/FunctionObject_FunctionDeclaration_4AA8841F_left::.ctor(class Modules.BinaryOperator_TypedNumericScheduler/Scope)
 		IL_00e3: ldc.i4.0
 		IL_00e4: conv.r8
 		IL_00e5: ldstr "left"
 		IL_00ea: ldc.i4.0
 		IL_00eb: ldc.i4.1
-		IL_00ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_4AA8841F_left>(!!0, float64, string, bool, bool)
+		IL_00ec: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/left/FunctionObject_FunctionDeclaration_4AA8841F_left>(!!0, float64, string, bool, bool)
 		IL_00f1: stloc.s 10
 		IL_00f3: ldloc.0
 		IL_00f4: ldloc.s 10
@@ -808,13 +1944,13 @@
 		IL_0109: ldc.i4.0
 		IL_010a: ldelem.ref
 		IL_010b: castclass Modules.BinaryOperator_TypedNumericScheduler/Scope
-		IL_0110: newobj instance void FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_BF4CE850_right::.ctor(class Modules.BinaryOperator_TypedNumericScheduler/Scope)
+		IL_0110: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/right/FunctionObject_FunctionDeclaration_BF4CE850_right::.ctor(class Modules.BinaryOperator_TypedNumericScheduler/Scope)
 		IL_0115: ldc.i4.0
 		IL_0116: conv.r8
 		IL_0117: ldstr "right"
 		IL_011c: ldc.i4.0
 		IL_011d: ldc.i4.1
-		IL_011e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_BF4CE850_right>(!!0, float64, string, bool, bool)
+		IL_011e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/right/FunctionObject_FunctionDeclaration_BF4CE850_right>(!!0, float64, string, bool, bool)
 		IL_0123: stloc.s 11
 		IL_0125: ldloc.0
 		IL_0126: ldloc.s 11
@@ -830,13 +1966,13 @@
 		IL_013b: ldc.i4.0
 		IL_013c: ldelem.ref
 		IL_013d: castclass Modules.BinaryOperator_TypedNumericScheduler/Scope
-		IL_0142: newobj instance void FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_D8F5465F_calls::.ctor(class Modules.BinaryOperator_TypedNumericScheduler/Scope)
+		IL_0142: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/calls/FunctionObject_FunctionDeclaration_D8F5465F_calls::.ctor(class Modules.BinaryOperator_TypedNumericScheduler/Scope)
 		IL_0147: ldc.i4.0
 		IL_0148: conv.r8
 		IL_0149: ldstr "calls"
 		IL_014e: ldc.i4.0
 		IL_014f: ldc.i4.1
-		IL_0150: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_D8F5465F_calls>(!!0, float64, string, bool, bool)
+		IL_0150: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/calls/FunctionObject_FunctionDeclaration_D8F5465F_calls>(!!0, float64, string, bool, bool)
 		IL_0155: stloc.s 7
 		IL_0157: ldc.i4.1
 		IL_0158: newarr [System.Runtime]System.Object
@@ -845,13 +1981,13 @@
 		IL_015f: ldloc.0
 		IL_0160: stelem.ref
 		IL_0161: stloc.s 9
-		IL_0163: newobj instance void FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_B3DBBF8F_postfix::.ctor()
+		IL_0163: newobj instance void Modules.BinaryOperator_TypedNumericScheduler/postfix/FunctionObject_FunctionDeclaration_B3DBBF8F_postfix::.ctor()
 		IL_0168: ldc.i4.1
 		IL_0169: conv.r8
 		IL_016a: ldstr "postfix"
 		IL_016f: ldc.i4.0
 		IL_0170: ldc.i4.1
-		IL_0171: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_B3DBBF8F_postfix>(!!0, float64, string, bool, bool)
+		IL_0171: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypedNumericScheduler/postfix/FunctionObject_FunctionDeclaration_B3DBBF8F_postfix>(!!0, float64, string, bool, bool)
 		IL_0176: stloc.s 8
 		IL_0178: nop
 		IL_0179: nop
@@ -1123,1142 +2259,6 @@
 	} // end of method BinaryOperator_TypedNumericScheduler::__js_module_init__
 
 } // end of class Modules.BinaryOperator_TypedNumericScheduler
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2751
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2759
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x275c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x275f
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.BinaryOperator_TypedNumericScheduler/mulAdd::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2772
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.BinaryOperator_TypedNumericScheduler/mulAdd::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2781
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_ECDDA9F7_mulAdd
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_F48743DA_addChain
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2790
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_F48743DA_addChain::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2798
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F48743DA_addChain::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x279b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F48743DA_addChain::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x279e
-		// Header size: 1
-		// Code size: 59 (0x3b)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001d: ldarg.2
-		IL_001e: ldc.i4.2
-		IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0029: ldarg.2
-		IL_002a: ldc.i4.3
-		IL_002b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0035: call object Modules.BinaryOperator_TypedNumericScheduler/addChain::__js_call__(object, float64, float64, float64, float64)
-		IL_003a: ret
-	} // end of method FunctionObject_FunctionDeclaration_F48743DA_addChain::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27da
-		// Header size: 1
-		// Code size: 55 (0x37)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0025: ldarg.2
-		IL_0026: ldc.i4.3
-		IL_0027: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_002c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0031: call object Modules.BinaryOperator_TypedNumericScheduler/addChain::__js_call__(object, float64, float64, float64, float64)
-		IL_0036: ret
-	} // end of method FunctionObject_FunctionDeclaration_F48743DA_addChain::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2812
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F48743DA_addChain::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_F48743DA_addChain
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_A433882E_tree
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2821
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_A433882E_tree::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2829
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A433882E_tree::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x282c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A433882E_tree::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x282f
-		// Header size: 1
-		// Code size: 59 (0x3b)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001d: ldarg.2
-		IL_001e: ldc.i4.2
-		IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0029: ldarg.2
-		IL_002a: ldc.i4.3
-		IL_002b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0035: call object Modules.BinaryOperator_TypedNumericScheduler/tree::__js_call__(object, float64, float64, float64, float64)
-		IL_003a: ret
-	} // end of method FunctionObject_FunctionDeclaration_A433882E_tree::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x286b
-		// Header size: 1
-		// Code size: 55 (0x37)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0025: ldarg.2
-		IL_0026: ldc.i4.3
-		IL_0027: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_002c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0031: call object Modules.BinaryOperator_TypedNumericScheduler/tree::__js_call__(object, float64, float64, float64, float64)
-		IL_0036: ret
-	} // end of method FunctionObject_FunctionDeclaration_A433882E_tree::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28a3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A433882E_tree::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_A433882E_tree
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_73DC7159_subChain
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x28b2
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_73DC7159_subChain::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x28ba
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_73DC7159_subChain::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x28bd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_73DC7159_subChain::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x28c0
-		// Header size: 1
-		// Code size: 47 (0x2f)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001d: ldarg.2
-		IL_001e: ldc.i4.2
-		IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0029: call object Modules.BinaryOperator_TypedNumericScheduler/subChain::__js_call__(object, float64, float64, float64)
-		IL_002e: ret
-	} // end of method FunctionObject_FunctionDeclaration_73DC7159_subChain::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28f0
-		// Header size: 1
-		// Code size: 43 (0x2b)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0025: call object Modules.BinaryOperator_TypedNumericScheduler/subChain::__js_call__(object, float64, float64, float64)
-		IL_002a: ret
-	} // end of method FunctionObject_FunctionDeclaration_73DC7159_subChain::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x291c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_73DC7159_subChain::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_73DC7159_subChain
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_14EF6D03_divMod
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x292b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_14EF6D03_divMod::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2933
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_14EF6D03_divMod::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2936
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_14EF6D03_divMod::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2939
-		// Header size: 1
-		// Code size: 47 (0x2f)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001d: ldarg.2
-		IL_001e: ldc.i4.2
-		IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0029: call object Modules.BinaryOperator_TypedNumericScheduler/divMod::__js_call__(object, float64, float64, float64)
-		IL_002e: ret
-	} // end of method FunctionObject_FunctionDeclaration_14EF6D03_divMod::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2969
-		// Header size: 1
-		// Code size: 43 (0x2b)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0025: call object Modules.BinaryOperator_TypedNumericScheduler/divMod::__js_call__(object, float64, float64, float64)
-		IL_002a: ret
-	} // end of method FunctionObject_FunctionDeclaration_14EF6D03_divMod::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2995
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_14EF6D03_divMod::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_14EF6D03_divMod
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_03A3A6D4_expAdd
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x29a4
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_03A3A6D4_expAdd::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x29ac
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_03A3A6D4_expAdd::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x29af
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_03A3A6D4_expAdd::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x29b2
-		// Header size: 1
-		// Code size: 47 (0x2f)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001d: ldarg.2
-		IL_001e: ldc.i4.2
-		IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0029: call object Modules.BinaryOperator_TypedNumericScheduler/expAdd::__js_call__(object, float64, float64, float64)
-		IL_002e: ret
-	} // end of method FunctionObject_FunctionDeclaration_03A3A6D4_expAdd::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29e2
-		// Header size: 1
-		// Code size: 43 (0x2b)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0025: call object Modules.BinaryOperator_TypedNumericScheduler/expAdd::__js_call__(object, float64, float64, float64)
-		IL_002a: ret
-	} // end of method FunctionObject_FunctionDeclaration_03A3A6D4_expAdd::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a0e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_03A3A6D4_expAdd::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_03A3A6D4_expAdd
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_4AA8841F_left
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.BinaryOperator_TypedNumericScheduler/Scope _environment0_BinaryOperator_TypedNumericScheduler
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.BinaryOperator_TypedNumericScheduler/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a1d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.BinaryOperator_TypedNumericScheduler/Scope FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_4AA8841F_left::_environment0_BinaryOperator_TypedNumericScheduler
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4AA8841F_left::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a2c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4AA8841F_left::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a2f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4AA8841F_left::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a32
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.BinaryOperator_TypedNumericScheduler/Scope FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_4AA8841F_left::_environment0_BinaryOperator_TypedNumericScheduler
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.BinaryOperator_TypedNumericScheduler/left::__js_call__(class Modules.BinaryOperator_TypedNumericScheduler/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_4AA8841F_left::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a44
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.BinaryOperator_TypedNumericScheduler/Scope FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_4AA8841F_left::_environment0_BinaryOperator_TypedNumericScheduler
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.BinaryOperator_TypedNumericScheduler/left::__js_call__(class Modules.BinaryOperator_TypedNumericScheduler/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_4AA8841F_left::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a52
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4AA8841F_left::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_4AA8841F_left
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_BF4CE850_right
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.BinaryOperator_TypedNumericScheduler/Scope _environment0_BinaryOperator_TypedNumericScheduler
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.BinaryOperator_TypedNumericScheduler/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a61
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.BinaryOperator_TypedNumericScheduler/Scope FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_BF4CE850_right::_environment0_BinaryOperator_TypedNumericScheduler
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BF4CE850_right::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a70
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BF4CE850_right::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a73
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BF4CE850_right::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a76
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.BinaryOperator_TypedNumericScheduler/Scope FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_BF4CE850_right::_environment0_BinaryOperator_TypedNumericScheduler
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.BinaryOperator_TypedNumericScheduler/right::__js_call__(class Modules.BinaryOperator_TypedNumericScheduler/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_BF4CE850_right::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a88
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.BinaryOperator_TypedNumericScheduler/Scope FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_BF4CE850_right::_environment0_BinaryOperator_TypedNumericScheduler
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.BinaryOperator_TypedNumericScheduler/right::__js_call__(class Modules.BinaryOperator_TypedNumericScheduler/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_BF4CE850_right::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a96
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BF4CE850_right::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_BF4CE850_right
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_D8F5465F_calls
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.BinaryOperator_TypedNumericScheduler/Scope _environment0_BinaryOperator_TypedNumericScheduler
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.BinaryOperator_TypedNumericScheduler/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2aa5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.BinaryOperator_TypedNumericScheduler/Scope FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_D8F5465F_calls::_environment0_BinaryOperator_TypedNumericScheduler
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D8F5465F_calls::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2ab4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D8F5465F_calls::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2ab7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D8F5465F_calls::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2aba
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.BinaryOperator_TypedNumericScheduler/Scope FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_D8F5465F_calls::_environment0_BinaryOperator_TypedNumericScheduler
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.BinaryOperator_TypedNumericScheduler/calls::__js_call__(class Modules.BinaryOperator_TypedNumericScheduler/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_D8F5465F_calls::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2acc
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.BinaryOperator_TypedNumericScheduler/Scope FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_D8F5465F_calls::_environment0_BinaryOperator_TypedNumericScheduler
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.BinaryOperator_TypedNumericScheduler/calls::__js_call__(class Modules.BinaryOperator_TypedNumericScheduler/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_D8F5465F_calls::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ada
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D8F5465F_calls::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_D8F5465F_calls
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_B3DBBF8F_postfix
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2ae9
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_B3DBBF8F_postfix::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2af1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B3DBBF8F_postfix::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2af4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B3DBBF8F_postfix::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2af7
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.BinaryOperator_TypedNumericScheduler/postfix::__js_call__(object, float64)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_B3DBBF8F_postfix::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b0f
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.BinaryOperator_TypedNumericScheduler/postfix::__js_call__(object, float64)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_B3DBBF8F_postfix::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b23
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B3DBBF8F_postfix::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_TypedNumericScheduler_15BB9EDF.FunctionObject_FunctionDeclaration_B3DBBF8F_postfix
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypedNumericScheduler_DuplicateOperandSlotReuse.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypedNumericScheduler_DuplicateOperandSlotReuse.verified.txt
@@ -71,6 +71,152 @@
 
 		} // end of class Scope_calc
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_19052360_K
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2212
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.BinaryOperator_TypedNumericScheduler_DuplicateOperandSlotReuse/K/FunctionObject_ClassConstructor_19052360_K::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_19052360_K::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2221
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_19052360_K::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2224
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_19052360_K::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2227
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_19052360_K::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2233
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_19052360_K::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_19052360_K
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_49281A06_K_calc
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x223f
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_49281A06_K_calc::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2247
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_49281A06_K_calc::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x224a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_49281A06_K_calc::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x224d
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.BinaryOperator_TypedNumericScheduler_DuplicateOperandSlotReuse/K
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.BinaryOperator_TypedNumericScheduler_DuplicateOperandSlotReuse/K::calc(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassMethod_49281A06_K_calc::CallCore
+
+		} // end of class FunctionObject_ClassMethod_49281A06_K_calc
+
 
 		// Fields
 		.field public float64 x
@@ -292,152 +438,6 @@
 	} // end of method BinaryOperator_TypedNumericScheduler_DuplicateOperandSlotReuse::__js_module_init__
 
 } // end of class Modules.BinaryOperator_TypedNumericScheduler_DuplicateOperandSlotReuse
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_TypedNumericScheduler_DuplicateOperandSlotReuse_5BC1689A.FunctionObject_ClassConstructor_19052360_K
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2212
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.BinaryOperator_TypedNumericScheduler_DuplicateOperandSlotReuse_5BC1689A.FunctionObject_ClassConstructor_19052360_K::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_19052360_K::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2221
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_19052360_K::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2224
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_19052360_K::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2227
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_19052360_K::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2233
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_19052360_K::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_TypedNumericScheduler_DuplicateOperandSlotReuse_5BC1689A.FunctionObject_ClassConstructor_19052360_K
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_TypedNumericScheduler_DuplicateOperandSlotReuse_5BC1689A.FunctionObject_ClassMethod_49281A06_K_calc
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x223f
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_49281A06_K_calc::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2247
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_49281A06_K_calc::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x224a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_49281A06_K_calc::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x224d
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.BinaryOperator_TypedNumericScheduler_DuplicateOperandSlotReuse/K
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.BinaryOperator_TypedNumericScheduler_DuplicateOperandSlotReuse/K::calc(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassMethod_49281A06_K_calc::CallCore
-
-} // end of class FunctionObjects.BinaryOperator_TypedNumericScheduler_DuplicateOperandSlotReuse_5BC1689A.FunctionObject_ClassMethod_49281A06_K_calc
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes.verified.txt
+++ b/tests/Jroc.Tests/BinaryOperator/Snapshots/GeneratorTests.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_AB9C36BC_add
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2214
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_AB9C36BC_add::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x221c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_AB9C36BC_add::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x221f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_AB9C36BC_add::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2222
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes/'add'::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_AB9C36BC_add::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x223c
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes/'add'::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_AB9C36BC_add::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2252
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_AB9C36BC_add::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_AB9C36BC_add
+
 
 		// Methods
 		.method public hidebysig static 
@@ -187,7 +294,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes/Scope,
-			[1] class FunctionObjects.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes_5C1E3A3E.FunctionObject_FunctionDeclaration_AB9C36BC_add,
+			[1] class Modules.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes/'add'/FunctionObject_FunctionDeclaration_AB9C36BC_add,
 			[2] object,
 			[3] object[],
 			[4] string,
@@ -204,13 +311,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes_5C1E3A3E.FunctionObject_FunctionDeclaration_AB9C36BC_add::.ctor()
+		IL_0011: newobj instance void Modules.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes/'add'/FunctionObject_FunctionDeclaration_AB9C36BC_add::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "add"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes_5C1E3A3E.FunctionObject_FunctionDeclaration_AB9C36BC_add>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes/'add'/FunctionObject_FunctionDeclaration_AB9C36BC_add>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -311,113 +418,6 @@
 	} // end of method BinaryOperator_TypeofFunctionStrictEqual_CallableShapes::__js_module_init__
 
 } // end of class Modules.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes_5C1E3A3E.FunctionObject_FunctionDeclaration_AB9C36BC_add
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2214
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_AB9C36BC_add::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x221c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_AB9C36BC_add::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x221f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_AB9C36BC_add::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2222
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes/'add'::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_AB9C36BC_add::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x223c
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes/'add'::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_AB9C36BC_add::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2252
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_AB9C36BC_add::ConstructCore
-
-} // end of class FunctionObjects.BinaryOperator_TypeofFunctionStrictEqual_CallableShapes_5C1E3A3E.FunctionObject_FunctionDeclaration_AB9C36BC_add
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_AccessorMethods_InstanceAndStatic.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_AccessorMethods_InstanceAndStatic.verified.txt
@@ -121,6 +121,391 @@
 
 		} // end of class Scope_get_total
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_F76E5D0D_Counter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x26db
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_AccessorMethods_InstanceAndStatic/Counter/FunctionObject_ClassConstructor_F76E5D0D_Counter::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_F76E5D0D_Counter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x26ea
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_F76E5D0D_Counter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x26ed
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_F76E5D0D_Counter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x26f0
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_F76E5D0D_Counter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26fc
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_F76E5D0D_Counter::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_F76E5D0D_Counter
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassGetter_9E713C73_Counter_get_count
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2708
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassGetter_9E713C73_Counter_get_count::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2710
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassGetter_9E713C73_Counter_get_count::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2713
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassGetter_9E713C73_Counter_get_count::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2716
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
+				IL_0006: call instance object Modules.Classes_AccessorMethods_InstanceAndStatic/Counter::get_count()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassGetter_9E713C73_Counter_get_count::CallCore
+
+		} // end of class FunctionObject_ClassGetter_9E713C73_Counter_get_count
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassSetter_B7DCDE33_Counter_set_count
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2723
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassSetter_B7DCDE33_Counter_set_count::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x272b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassSetter_B7DCDE33_Counter_set_count::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x272e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassSetter_B7DCDE33_Counter_set_count::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2731
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.Classes_AccessorMethods_InstanceAndStatic/Counter::set_count(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassSetter_B7DCDE33_Counter_set_count::CallCore
+
+		} // end of class FunctionObject_ClassSetter_B7DCDE33_Counter_set_count
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassGetter_F992ED3A_Counter_get_label
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2745
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassGetter_F992ED3A_Counter_get_label::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x274d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassGetter_F992ED3A_Counter_get_label::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2750
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassGetter_F992ED3A_Counter_get_label::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2753
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
+				IL_0006: call instance object Modules.Classes_AccessorMethods_InstanceAndStatic/Counter::get_label()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassGetter_F992ED3A_Counter_get_label::CallCore
+
+		} // end of class FunctionObject_ClassGetter_F992ED3A_Counter_get_label
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2760
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2768
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x276b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x276e
+				// Header size: 1
+				// Code size: 6 (0x6)
+				.maxstack 8
+
+				IL_0000: call object Modules.Classes_AccessorMethods_InstanceAndStatic/Counter::get_total(object[], object)
+				IL_0005: ret
+			} // end of method FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total::CallCore
+
+		} // end of class FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassStaticSetter_3B870468_Counter_set_total
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2775
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassStaticSetter_3B870468_Counter_set_total::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x277d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassStaticSetter_3B870468_Counter_set_total::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2780
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassStaticSetter_3B870468_Counter_set_total::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2783
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.2
+				IL_0001: ldc.i4.0
+				IL_0002: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0007: call object Modules.Classes_AccessorMethods_InstanceAndStatic/Counter::set_total(object[], object, object)
+				IL_000c: ret
+			} // end of method FunctionObject_ClassStaticSetter_3B870468_Counter_set_total::CallCore
+
+		} // end of class FunctionObject_ClassStaticSetter_3B870468_Counter_set_total
+
 
 		// Fields
 		.field public static object _total
@@ -885,391 +1270,6 @@
 	} // end of method Classes_AccessorMethods_InstanceAndStatic::__js_module_init__
 
 } // end of class Modules.Classes_AccessorMethods_InstanceAndStatic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_AccessorMethods_InstanceAndStatic_DF5376FA.FunctionObject_ClassConstructor_F76E5D0D_Counter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x26db
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_AccessorMethods_InstanceAndStatic_DF5376FA.FunctionObject_ClassConstructor_F76E5D0D_Counter::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_F76E5D0D_Counter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x26ea
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_F76E5D0D_Counter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x26ed
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_F76E5D0D_Counter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x26f0
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_F76E5D0D_Counter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26fc
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_F76E5D0D_Counter::ConstructCore
-
-} // end of class FunctionObjects.Classes_AccessorMethods_InstanceAndStatic_DF5376FA.FunctionObject_ClassConstructor_F76E5D0D_Counter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_AccessorMethods_InstanceAndStatic_DF5376FA.FunctionObject_ClassGetter_9E713C73_Counter_get_count
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2708
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassGetter_9E713C73_Counter_get_count::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2710
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassGetter_9E713C73_Counter_get_count::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2713
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassGetter_9E713C73_Counter_get_count::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2716
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_0006: call instance object Modules.Classes_AccessorMethods_InstanceAndStatic/Counter::get_count()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassGetter_9E713C73_Counter_get_count::CallCore
-
-} // end of class FunctionObjects.Classes_AccessorMethods_InstanceAndStatic_DF5376FA.FunctionObject_ClassGetter_9E713C73_Counter_get_count
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_AccessorMethods_InstanceAndStatic_DF5376FA.FunctionObject_ClassSetter_B7DCDE33_Counter_set_count
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2723
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassSetter_B7DCDE33_Counter_set_count::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x272b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassSetter_B7DCDE33_Counter_set_count::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x272e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassSetter_B7DCDE33_Counter_set_count::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2731
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.Classes_AccessorMethods_InstanceAndStatic/Counter::set_count(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassSetter_B7DCDE33_Counter_set_count::CallCore
-
-} // end of class FunctionObjects.Classes_AccessorMethods_InstanceAndStatic_DF5376FA.FunctionObject_ClassSetter_B7DCDE33_Counter_set_count
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_AccessorMethods_InstanceAndStatic_DF5376FA.FunctionObject_ClassGetter_F992ED3A_Counter_get_label
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2745
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassGetter_F992ED3A_Counter_get_label::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x274d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassGetter_F992ED3A_Counter_get_label::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2750
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassGetter_F992ED3A_Counter_get_label::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2753
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_AccessorMethods_InstanceAndStatic/Counter
-		IL_0006: call instance object Modules.Classes_AccessorMethods_InstanceAndStatic/Counter::get_label()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassGetter_F992ED3A_Counter_get_label::CallCore
-
-} // end of class FunctionObjects.Classes_AccessorMethods_InstanceAndStatic_DF5376FA.FunctionObject_ClassGetter_F992ED3A_Counter_get_label
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_AccessorMethods_InstanceAndStatic_DF5376FA.FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2760
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2768
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x276b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x276e
-		// Header size: 1
-		// Code size: 6 (0x6)
-		.maxstack 8
-
-		IL_0000: call object Modules.Classes_AccessorMethods_InstanceAndStatic/Counter::get_total(object[], object)
-		IL_0005: ret
-	} // end of method FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total::CallCore
-
-} // end of class FunctionObjects.Classes_AccessorMethods_InstanceAndStatic_DF5376FA.FunctionObject_ClassStaticGetter_B76C5B68_Counter_get_total
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_AccessorMethods_InstanceAndStatic_DF5376FA.FunctionObject_ClassStaticSetter_3B870468_Counter_set_total
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2775
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassStaticSetter_3B870468_Counter_set_total::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x277d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassStaticSetter_3B870468_Counter_set_total::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2780
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassStaticSetter_3B870468_Counter_set_total::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2783
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.2
-		IL_0001: ldc.i4.0
-		IL_0002: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0007: call object Modules.Classes_AccessorMethods_InstanceAndStatic/Counter::set_total(object[], object, object)
-		IL_000c: ret
-	} // end of method FunctionObject_ClassStaticSetter_3B870468_Counter_set_total::CallCore
-
-} // end of class FunctionObjects.Classes_AccessorMethods_InstanceAndStatic_DF5376FA.FunctionObject_ClassStaticSetter_3B870468_Counter_set_total
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_BitShiftInCtor_Int32Array.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_BitShiftInCtor_Int32Array.verified.txt
@@ -91,6 +91,216 @@
 
 		} // end of class Scope_test
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_1DD5642E_BitBag
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x224b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_BitShiftInCtor_Int32Array/BitBag/FunctionObject_ClassConstructor_1DD5642E_BitBag::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_1DD5642E_BitBag::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x225a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_1DD5642E_BitBag::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x225d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_1DD5642E_BitBag::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2260
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_1DD5642E_BitBag::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x226c
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_1DD5642E_BitBag::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_1DD5642E_BitBag
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_B2E3F181_BitBag_set
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2278
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_B2E3F181_BitBag_set::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2280
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_B2E3F181_BitBag_set::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2283
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_B2E3F181_BitBag_set::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2286
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_BitShiftInCtor_Int32Array/BitBag
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.Classes_BitShiftInCtor_Int32Array/BitBag::set(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassMethod_B2E3F181_BitBag_set::CallCore
+
+		} // end of class FunctionObject_ClassMethod_B2E3F181_BitBag_set
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_79A57BD7_BitBag_test
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x229a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_79A57BD7_BitBag_test::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22a2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_79A57BD7_BitBag_test::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22a5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_79A57BD7_BitBag_test::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22a8
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_BitShiftInCtor_Int32Array/BitBag
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance float64 Modules.Classes_BitShiftInCtor_Int32Array/BitBag::test(object)
+				IL_0012: box [System.Runtime]System.Double
+				IL_0017: ret
+			} // end of method FunctionObject_ClassMethod_79A57BD7_BitBag_test::CallCore
+
+		} // end of class FunctionObject_ClassMethod_79A57BD7_BitBag_test
+
 
 		// Fields
 		.field public class [JavaScriptRuntime]JavaScriptRuntime.Int32Array buf
@@ -358,216 +568,6 @@
 	} // end of method Classes_BitShiftInCtor_Int32Array::__js_module_init__
 
 } // end of class Modules.Classes_BitShiftInCtor_Int32Array
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_BitShiftInCtor_Int32Array_1FE89808.FunctionObject_ClassConstructor_1DD5642E_BitBag
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x224b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_BitShiftInCtor_Int32Array_1FE89808.FunctionObject_ClassConstructor_1DD5642E_BitBag::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_1DD5642E_BitBag::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x225a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_1DD5642E_BitBag::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x225d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_1DD5642E_BitBag::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2260
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_1DD5642E_BitBag::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x226c
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_1DD5642E_BitBag::ConstructCore
-
-} // end of class FunctionObjects.Classes_BitShiftInCtor_Int32Array_1FE89808.FunctionObject_ClassConstructor_1DD5642E_BitBag
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_BitShiftInCtor_Int32Array_1FE89808.FunctionObject_ClassMethod_B2E3F181_BitBag_set
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2278
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_B2E3F181_BitBag_set::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2280
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_B2E3F181_BitBag_set::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2283
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_B2E3F181_BitBag_set::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2286
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_BitShiftInCtor_Int32Array/BitBag
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.Classes_BitShiftInCtor_Int32Array/BitBag::set(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassMethod_B2E3F181_BitBag_set::CallCore
-
-} // end of class FunctionObjects.Classes_BitShiftInCtor_Int32Array_1FE89808.FunctionObject_ClassMethod_B2E3F181_BitBag_set
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_BitShiftInCtor_Int32Array_1FE89808.FunctionObject_ClassMethod_79A57BD7_BitBag_test
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x229a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_79A57BD7_BitBag_test::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22a2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_79A57BD7_BitBag_test::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22a5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_79A57BD7_BitBag_test::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22a8
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_BitShiftInCtor_Int32Array/BitBag
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance float64 Modules.Classes_BitShiftInCtor_Int32Array/BitBag::test(object)
-		IL_0012: box [System.Runtime]System.Double
-		IL_0017: ret
-	} // end of method FunctionObject_ClassMethod_79A57BD7_BitBag_test::CallCore
-
-} // end of class FunctionObjects.Classes_BitShiftInCtor_Int32Array_1FE89808.FunctionObject_ClassMethod_79A57BD7_BitBag_test
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassComputedFieldAndMethod_DeclarationOrder.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassComputedFieldAndMethod_DeclarationOrder.verified.txt
@@ -51,6 +51,149 @@
 
 		} // end of class Scope_Method_L5C2
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_6BFCC015_Example
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2229
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example/FunctionObject_ClassConstructor_6BFCC015_Example::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_6BFCC015_Example::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2238
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_6BFCC015_Example::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x223b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_6BFCC015_Example::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x223e
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_6BFCC015_Example::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x224a
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_6BFCC015_Example::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_6BFCC015_Example
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_A6279509_Example_method
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2256
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_A6279509_Example_method::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x225e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_A6279509_Example_method::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2261
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_A6279509_Example_method::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2264
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example
+				IL_0006: call instance object Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example::'method'()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_A6279509_Example_method::CallCore
+
+		} // end of class FunctionObject_ClassMethod_A6279509_Example_method
+
 
 		// Fields
 		.field private object[] _scopes
@@ -294,149 +437,6 @@
 	} // end of method Classes_ClassComputedFieldAndMethod_DeclarationOrder::__js_module_init__
 
 } // end of class Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassComputedFieldAndMethod_DeclarationOrder_658E2B5C.FunctionObject_ClassConstructor_6BFCC015_Example
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2229
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassComputedFieldAndMethod_DeclarationOrder_658E2B5C.FunctionObject_ClassConstructor_6BFCC015_Example::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_6BFCC015_Example::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2238
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_6BFCC015_Example::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x223b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_6BFCC015_Example::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x223e
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_6BFCC015_Example::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x224a
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_6BFCC015_Example::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassComputedFieldAndMethod_DeclarationOrder_658E2B5C.FunctionObject_ClassConstructor_6BFCC015_Example
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassComputedFieldAndMethod_DeclarationOrder_658E2B5C.FunctionObject_ClassMethod_A6279509_Example_method
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2256
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_A6279509_Example_method::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x225e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_A6279509_Example_method::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2261
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_A6279509_Example_method::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2264
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example
-		IL_0006: call instance object Modules.Classes_ClassComputedFieldAndMethod_DeclarationOrder/Example::'method'()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_A6279509_Example_method::CallCore
-
-} // end of class FunctionObjects.Classes_ClassComputedFieldAndMethod_DeclarationOrder_658E2B5C.FunctionObject_ClassMethod_A6279509_Example_method
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassComputedFieldAndMethod_DynamicKey_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassComputedFieldAndMethod_DynamicKey_Log.verified.txt
@@ -10,6 +10,115 @@
 	.class nested public auto ansi abstract sealed beforefieldinit methodKey
 		extends [System.Runtime]System.Object
 	{
+		// Nested Types
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DCE75730_L9C14
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope _environment0_Classes_ClassComputedFieldAndMethod_DynamicKey_Log
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x22c6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey/FunctionObject_FunctionExpression_DCE75730_L9C14::_environment0_Classes_ClassComputedFieldAndMethod_DynamicKey_Log
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_DCE75730_L9C14::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22d5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_DCE75730_L9C14::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22d8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_DCE75730_L9C14::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22db
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey/FunctionObject_FunctionExpression_DCE75730_L9C14::_environment0_Classes_ClassComputedFieldAndMethod_DynamicKey_Log
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey::__js_call__(class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_DCE75730_L9C14::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22ed
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey/FunctionObject_FunctionExpression_DCE75730_L9C14::_environment0_Classes_ClassComputedFieldAndMethod_DynamicKey_Log
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey::__js_call__(class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_DCE75730_L9C14::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22fb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_DCE75730_L9C14::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_DCE75730_L9C14
+
+
 		// Methods
 		.method public hidebysig static 
 			object __js_call__ (
@@ -89,6 +198,89 @@
 			} // end of method Scope_methodKey::.ctor
 
 		} // end of class Scope_methodKey
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_901BD596_Example
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2299
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example/FunctionObject_ClassConstructor_901BD596_Example::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_901BD596_Example::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22a8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_901BD596_Example::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22ab
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_901BD596_Example::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22ae
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_901BD596_Example::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22ba
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_901BD596_Example::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_901BD596_Example
 
 
 		// Fields
@@ -171,7 +363,7 @@
 			[3] class [System.Runtime]System.Type,
 			[4] object,
 			[5] object[],
-			[6] class FunctionObjects.Classes_ClassComputedFieldAndMethod_DynamicKey_Log_B3DCC751.FunctionObject_FunctionExpression_DCE75730_L9C14,
+			[6] class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey/FunctionObject_FunctionExpression_DCE75730_L9C14,
 			[7] object,
 			[8] class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Example,
 			[9] bool,
@@ -201,13 +393,13 @@
 		IL_0037: ldc.i4.0
 		IL_0038: ldelem.ref
 		IL_0039: castclass Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope
-		IL_003e: newobj instance void FunctionObjects.Classes_ClassComputedFieldAndMethod_DynamicKey_Log_B3DCC751.FunctionObject_FunctionExpression_DCE75730_L9C14::.ctor(class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope)
+		IL_003e: newobj instance void Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey/FunctionObject_FunctionExpression_DCE75730_L9C14::.ctor(class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope)
 		IL_0043: ldc.i4.0
 		IL_0044: conv.r8
 		IL_0045: ldstr ""
 		IL_004a: ldc.i4.1
 		IL_004b: ldc.i4.1
-		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Classes_ClassComputedFieldAndMethod_DynamicKey_Log_B3DCC751.FunctionObject_FunctionExpression_DCE75730_L9C14>(!!0, float64, string, bool, bool)
+		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey/FunctionObject_FunctionExpression_DCE75730_L9C14>(!!0, float64, string, bool, bool)
 		IL_0051: stloc.s 6
 		IL_0053: ldloc.s 4
 		IL_0055: ldstr "bump"
@@ -324,196 +516,6 @@
 	} // end of method Classes_ClassComputedFieldAndMethod_DynamicKey_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassComputedFieldAndMethod_DynamicKey_Log_B3DCC751.FunctionObject_ClassConstructor_901BD596_Example
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2299
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassComputedFieldAndMethod_DynamicKey_Log_B3DCC751.FunctionObject_ClassConstructor_901BD596_Example::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_901BD596_Example::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22a8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_901BD596_Example::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22ab
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_901BD596_Example::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22ae
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_901BD596_Example::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22ba
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_901BD596_Example::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassComputedFieldAndMethod_DynamicKey_Log_B3DCC751.FunctionObject_ClassConstructor_901BD596_Example
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassComputedFieldAndMethod_DynamicKey_Log_B3DCC751.FunctionObject_FunctionExpression_DCE75730_L9C14
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope _environment0_Classes_ClassComputedFieldAndMethod_DynamicKey_Log
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x22c6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope FunctionObjects.Classes_ClassComputedFieldAndMethod_DynamicKey_Log_B3DCC751.FunctionObject_FunctionExpression_DCE75730_L9C14::_environment0_Classes_ClassComputedFieldAndMethod_DynamicKey_Log
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DCE75730_L9C14::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22d5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DCE75730_L9C14::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22d8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DCE75730_L9C14::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22db
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope FunctionObjects.Classes_ClassComputedFieldAndMethod_DynamicKey_Log_B3DCC751.FunctionObject_FunctionExpression_DCE75730_L9C14::_environment0_Classes_ClassComputedFieldAndMethod_DynamicKey_Log
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey::__js_call__(class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_DCE75730_L9C14::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22ed
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope FunctionObjects.Classes_ClassComputedFieldAndMethod_DynamicKey_Log_B3DCC751.FunctionObject_FunctionExpression_DCE75730_L9C14::_environment0_Classes_ClassComputedFieldAndMethod_DynamicKey_Log
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/methodKey::__js_call__(class Modules.Classes_ClassComputedFieldAndMethod_DynamicKey_Log/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_DCE75730_L9C14::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22fb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DCE75730_L9C14::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassComputedFieldAndMethod_DynamicKey_Log_B3DCC751.FunctionObject_FunctionExpression_DCE75730_L9C14
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log.verified.txt
@@ -55,6 +55,94 @@
 
 			} // end of class Scope_ctor
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_B79F2CB3_MyClass
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope _environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x2215
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/MyClass/FunctionObject_ClassConstructor_B79F2CB3_MyClass::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/MyClass/FunctionObject_ClassConstructor_B79F2CB3_MyClass::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_ClassConstructor_B79F2CB3_MyClass::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x222b
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_ClassConstructor_B79F2CB3_MyClass::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x222e
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_ClassConstructor_B79F2CB3_MyClass::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2231
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+					IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+					IL_000a: throw
+				} // end of method FunctionObject_ClassConstructor_B79F2CB3_MyClass::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x223d
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+					IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+					IL_000a: throw
+				} // end of method FunctionObject_ClassConstructor_B79F2CB3_MyClass::ConstructCore
+
+			} // end of class FunctionObject_ClassConstructor_B79F2CB3_MyClass
+
 
 			// Fields
 			.field private object[] _scopes
@@ -139,6 +227,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CC92D50C_testFunction
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope _environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21d1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/FunctionObject_FunctionDeclaration_CC92D50C_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_CC92D50C_testFunction::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21e0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CC92D50C_testFunction::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21e3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CC92D50C_testFunction::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21e6
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/FunctionObject_FunctionDeclaration_CC92D50C_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_CC92D50C_testFunction::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f8
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/FunctionObject_FunctionDeclaration_CC92D50C_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_CC92D50C_testFunction::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2206
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_CC92D50C_testFunction::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_CC92D50C_testFunction
 
 
 		// Methods
@@ -266,7 +461,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope,
-			[1] class FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log_68491FDD.FunctionObject_FunctionDeclaration_CC92D50C_testFunction,
+			[1] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/FunctionObject_FunctionDeclaration_CC92D50C_testFunction,
 			[2] object[]
 		)
 
@@ -283,13 +478,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope
-		IL_0019: newobj instance void FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log_68491FDD.FunctionObject_FunctionDeclaration_CC92D50C_testFunction::.ctor(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope)
+		IL_0019: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/FunctionObject_FunctionDeclaration_CC92D50C_testFunction::.ctor(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "testFunction"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log_68491FDD.FunctionObject_FunctionDeclaration_CC92D50C_testFunction>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction/FunctionObject_FunctionDeclaration_CC92D50C_testFunction>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldloc.0
@@ -304,201 +499,6 @@
 	} // end of method Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log_68491FDD.FunctionObject_FunctionDeclaration_CC92D50C_testFunction
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope _environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21d1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log_68491FDD.FunctionObject_FunctionDeclaration_CC92D50C_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_CC92D50C_testFunction::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21e0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CC92D50C_testFunction::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21e3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CC92D50C_testFunction::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21e6
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log_68491FDD.FunctionObject_FunctionDeclaration_CC92D50C_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_CC92D50C_testFunction::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f8
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log_68491FDD.FunctionObject_FunctionDeclaration_CC92D50C_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_CC92D50C_testFunction::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2206
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_CC92D50C_testFunction::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log_68491FDD.FunctionObject_FunctionDeclaration_CC92D50C_testFunction
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log_68491FDD.FunctionObject_ClassConstructor_B79F2CB3_MyClass
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope _environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x2215
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log/Scope FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log_68491FDD.FunctionObject_ClassConstructor_B79F2CB3_MyClass::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log_68491FDD.FunctionObject_ClassConstructor_B79F2CB3_MyClass::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_ClassConstructor_B79F2CB3_MyClass::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x222b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_B79F2CB3_MyClass::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x222e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_B79F2CB3_MyClass::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2231
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_B79F2CB3_MyClass::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x223d
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_B79F2CB3_MyClass::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariableAndParameterValue_Log_68491FDD.FunctionObject_ClassConstructor_B79F2CB3_MyClass
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -55,6 +55,94 @@
 
 			} // end of class Scope_ctor
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_30E4CCE8_MyClass
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope _environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x21ee
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass/FunctionObject_ClassConstructor_30E4CCE8_MyClass::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass/FunctionObject_ClassConstructor_30E4CCE8_MyClass::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_ClassConstructor_30E4CCE8_MyClass::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2204
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_ClassConstructor_30E4CCE8_MyClass::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2207
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_ClassConstructor_30E4CCE8_MyClass::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x220a
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+					IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+					IL_000a: throw
+				} // end of method FunctionObject_ClassConstructor_30E4CCE8_MyClass::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2216
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+					IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+					IL_000a: throw
+				} // end of method FunctionObject_ClassConstructor_30E4CCE8_MyClass::ConstructCore
+
+			} // end of class FunctionObject_ClassConstructor_30E4CCE8_MyClass
+
 
 			// Fields
 			.field private object[] _scopes
@@ -131,6 +219,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9DB40405_testFunction
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope _environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21aa
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject_FunctionDeclaration_9DB40405_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9DB40405_testFunction::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21b9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9DB40405_testFunction::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21bc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9DB40405_testFunction::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21bf
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject_FunctionDeclaration_9DB40405_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_9DB40405_testFunction::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21d1
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject_FunctionDeclaration_9DB40405_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_9DB40405_testFunction::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21df
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9DB40405_testFunction::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9DB40405_testFunction
 
 
 		// Methods
@@ -253,7 +448,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope,
-			[1] class FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log_422D31AA.FunctionObject_FunctionDeclaration_9DB40405_testFunction,
+			[1] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject_FunctionDeclaration_9DB40405_testFunction,
 			[2] object[]
 		)
 
@@ -270,13 +465,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope
-		IL_0019: newobj instance void FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log_422D31AA.FunctionObject_FunctionDeclaration_9DB40405_testFunction::.ctor(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope)
+		IL_0019: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject_FunctionDeclaration_9DB40405_testFunction::.ctor(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "testFunction"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log_422D31AA.FunctionObject_FunctionDeclaration_9DB40405_testFunction>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject_FunctionDeclaration_9DB40405_testFunction>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldloc.0
@@ -291,201 +486,6 @@
 	} // end of method Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log_422D31AA.FunctionObject_FunctionDeclaration_9DB40405_testFunction
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope _environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21aa
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log_422D31AA.FunctionObject_FunctionDeclaration_9DB40405_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9DB40405_testFunction::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21b9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9DB40405_testFunction::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21bc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9DB40405_testFunction::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21bf
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log_422D31AA.FunctionObject_FunctionDeclaration_9DB40405_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_9DB40405_testFunction::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21d1
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log_422D31AA.FunctionObject_FunctionDeclaration_9DB40405_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_9DB40405_testFunction::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21df
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9DB40405_testFunction::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log_422D31AA.FunctionObject_FunctionDeclaration_9DB40405_testFunction
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log_422D31AA.FunctionObject_ClassConstructor_30E4CCE8_MyClass
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope _environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ee
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log/Scope FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log_422D31AA.FunctionObject_ClassConstructor_30E4CCE8_MyClass::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log_422D31AA.FunctionObject_ClassConstructor_30E4CCE8_MyClass::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_ClassConstructor_30E4CCE8_MyClass::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2204
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_30E4CCE8_MyClass::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2207
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_30E4CCE8_MyClass::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x220a
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_30E4CCE8_MyClass::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2216
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_30E4CCE8_MyClass::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndGlobalVariable_Log_422D31AA.FunctionObject_ClassConstructor_30E4CCE8_MyClass
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log.verified.txt
@@ -55,6 +55,89 @@
 
 			} // end of class Scope_ctor
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_69520357_MyClass
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Method begins at RVA 0x21de
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/MyClass/FunctionObject_ClassConstructor_69520357_MyClass::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject_ClassConstructor_69520357_MyClass::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x21ed
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_ClassConstructor_69520357_MyClass::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x21f0
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_ClassConstructor_69520357_MyClass::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x21f3
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+					IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+					IL_000a: throw
+				} // end of method FunctionObject_ClassConstructor_69520357_MyClass::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x21ff
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+					IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+					IL_000a: throw
+				} // end of method FunctionObject_ClassConstructor_69520357_MyClass::ConstructCore
+
+			} // end of class FunctionObject_ClassConstructor_69520357_MyClass
+
 
 			// Fields
 			.field private object[] _scopes
@@ -122,6 +205,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_EFCEA678_testFunction
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope _environment0_Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x219a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/FunctionObject_FunctionDeclaration_EFCEA678_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_EFCEA678_testFunction::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21a9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_EFCEA678_testFunction::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21ac
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_EFCEA678_testFunction::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21af
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/FunctionObject_FunctionDeclaration_EFCEA678_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_EFCEA678_testFunction::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21c1
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/FunctionObject_FunctionDeclaration_EFCEA678_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_EFCEA678_testFunction::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21cf
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_EFCEA678_testFunction::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_EFCEA678_testFunction
 
 
 		// Methods
@@ -246,7 +436,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope,
-			[1] class FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log_1F676641.FunctionObject_FunctionDeclaration_EFCEA678_testFunction,
+			[1] class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/FunctionObject_FunctionDeclaration_EFCEA678_testFunction,
 			[2] object[]
 		)
 
@@ -263,13 +453,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope
-		IL_0019: newobj instance void FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log_1F676641.FunctionObject_FunctionDeclaration_EFCEA678_testFunction::.ctor(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope)
+		IL_0019: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/FunctionObject_FunctionDeclaration_EFCEA678_testFunction::.ctor(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "testFunction"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log_1F676641.FunctionObject_FunctionDeclaration_EFCEA678_testFunction>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction/FunctionObject_FunctionDeclaration_EFCEA678_testFunction>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
@@ -281,196 +471,6 @@
 	} // end of method Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log_1F676641.FunctionObject_FunctionDeclaration_EFCEA678_testFunction
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope _environment0_Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x219a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log_1F676641.FunctionObject_FunctionDeclaration_EFCEA678_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_EFCEA678_testFunction::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21a9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_EFCEA678_testFunction::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21ac
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_EFCEA678_testFunction::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21af
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log_1F676641.FunctionObject_FunctionDeclaration_EFCEA678_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_EFCEA678_testFunction::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21c1
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log_1F676641.FunctionObject_FunctionDeclaration_EFCEA678_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_EFCEA678_testFunction::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21cf
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_EFCEA678_testFunction::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log_1F676641.FunctionObject_FunctionDeclaration_EFCEA678_testFunction
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log_1F676641.FunctionObject_ClassConstructor_69520357_MyClass
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21de
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log_1F676641.FunctionObject_ClassConstructor_69520357_MyClass::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_69520357_MyClass::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21ed
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_69520357_MyClass::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21f0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_69520357_MyClass::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f3
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_69520357_MyClass::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ff
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_69520357_MyClass::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_AccessFunctionVariableAndParameterValue_Log_1F676641.FunctionObject_ClassConstructor_69520357_MyClass
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessFunctionVariable_Log.verified.txt
@@ -55,6 +55,89 @@
 
 			} // end of class Scope_ctor
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_016F80B4_MyClass
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Method begins at RVA 0x21b7
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/MyClass/FunctionObject_ClassConstructor_016F80B4_MyClass::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject_ClassConstructor_016F80B4_MyClass::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x21c6
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_ClassConstructor_016F80B4_MyClass::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x21c9
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_ClassConstructor_016F80B4_MyClass::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x21cc
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+					IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+					IL_000a: throw
+				} // end of method FunctionObject_ClassConstructor_016F80B4_MyClass::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x21d8
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+					IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+					IL_000a: throw
+				} // end of method FunctionObject_ClassConstructor_016F80B4_MyClass::ConstructCore
+
+			} // end of class FunctionObject_ClassConstructor_016F80B4_MyClass
+
 
 			// Fields
 			.field private object[] _scopes
@@ -114,6 +197,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9F3BA909_testFunction
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope _environment0_Classes_ClassConstructor_AccessFunctionVariable_Log
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2173
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/FunctionObject_FunctionDeclaration_9F3BA909_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariable_Log
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9F3BA909_testFunction::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2182
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9F3BA909_testFunction::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2185
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9F3BA909_testFunction::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2188
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/FunctionObject_FunctionDeclaration_9F3BA909_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariable_Log
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_9F3BA909_testFunction::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x219a
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/FunctionObject_FunctionDeclaration_9F3BA909_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariable_Log
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_9F3BA909_testFunction::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21a8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9F3BA909_testFunction::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9F3BA909_testFunction
 
 
 		// Methods
@@ -233,7 +423,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope,
-			[1] class FunctionObjects.Classes_ClassConstructor_AccessFunctionVariable_Log_26B19CD6.FunctionObject_FunctionDeclaration_9F3BA909_testFunction,
+			[1] class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/FunctionObject_FunctionDeclaration_9F3BA909_testFunction,
 			[2] object[]
 		)
 
@@ -250,13 +440,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope
-		IL_0019: newobj instance void FunctionObjects.Classes_ClassConstructor_AccessFunctionVariable_Log_26B19CD6.FunctionObject_FunctionDeclaration_9F3BA909_testFunction::.ctor(class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope)
+		IL_0019: newobj instance void Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/FunctionObject_FunctionDeclaration_9F3BA909_testFunction::.ctor(class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "testFunction"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Classes_ClassConstructor_AccessFunctionVariable_Log_26B19CD6.FunctionObject_FunctionDeclaration_9F3BA909_testFunction>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction/FunctionObject_FunctionDeclaration_9F3BA909_testFunction>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
@@ -268,196 +458,6 @@
 	} // end of method Classes_ClassConstructor_AccessFunctionVariable_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_AccessFunctionVariable_Log_26B19CD6.FunctionObject_FunctionDeclaration_9F3BA909_testFunction
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope _environment0_Classes_ClassConstructor_AccessFunctionVariable_Log
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2173
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope FunctionObjects.Classes_ClassConstructor_AccessFunctionVariable_Log_26B19CD6.FunctionObject_FunctionDeclaration_9F3BA909_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariable_Log
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9F3BA909_testFunction::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2182
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9F3BA909_testFunction::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2185
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9F3BA909_testFunction::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2188
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope FunctionObjects.Classes_ClassConstructor_AccessFunctionVariable_Log_26B19CD6.FunctionObject_FunctionDeclaration_9F3BA909_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariable_Log
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_9F3BA909_testFunction::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x219a
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope FunctionObjects.Classes_ClassConstructor_AccessFunctionVariable_Log_26B19CD6.FunctionObject_FunctionDeclaration_9F3BA909_testFunction::_environment0_Classes_ClassConstructor_AccessFunctionVariable_Log
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassConstructor_AccessFunctionVariable_Log/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_9F3BA909_testFunction::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21a8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9F3BA909_testFunction::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_AccessFunctionVariable_Log_26B19CD6.FunctionObject_FunctionDeclaration_9F3BA909_testFunction
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_AccessFunctionVariable_Log_26B19CD6.FunctionObject_ClassConstructor_016F80B4_MyClass
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21b7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassConstructor_AccessFunctionVariable_Log_26B19CD6.FunctionObject_ClassConstructor_016F80B4_MyClass::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_016F80B4_MyClass::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21c6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_016F80B4_MyClass::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21c9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_016F80B4_MyClass::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21cc
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_016F80B4_MyClass::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21d8
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_016F80B4_MyClass::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_AccessFunctionVariable_Log_26B19CD6.FunctionObject_ClassConstructor_016F80B4_MyClass
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log.verified.txt
@@ -51,6 +51,89 @@
 
 		} // end of class Scope_ctor
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_9F35C9DD_MyClass
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2141
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log/MyClass/FunctionObject_ClassConstructor_9F35C9DD_MyClass::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_9F35C9DD_MyClass::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2150
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_9F35C9DD_MyClass::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2153
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_9F35C9DD_MyClass::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2156
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_9F35C9DD_MyClass::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2162
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_9F35C9DD_MyClass::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_9F35C9DD_MyClass
+
 
 		// Fields
 		.field private object[] _scopes
@@ -186,89 +269,6 @@
 	} // end of method Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log_295F79B8.FunctionObject_ClassConstructor_9F35C9DD_MyClass
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2141
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log_295F79B8.FunctionObject_ClassConstructor_9F35C9DD_MyClass::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_9F35C9DD_MyClass::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2150
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_9F35C9DD_MyClass::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2153
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_9F35C9DD_MyClass::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2156
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_9F35C9DD_MyClass::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2162
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_9F35C9DD_MyClass::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_AccessGlobalVariableAndParameterValue_Log_295F79B8.FunctionObject_ClassConstructor_9F35C9DD_MyClass
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_AccessGlobalVariable_Log.verified.txt
@@ -51,6 +51,89 @@
 
 		} // end of class Scope_ctor
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_7A43705E_MyClass
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x211a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassConstructor_AccessGlobalVariable_Log/MyClass/FunctionObject_ClassConstructor_7A43705E_MyClass::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_7A43705E_MyClass::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2129
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_7A43705E_MyClass::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x212c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_7A43705E_MyClass::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x212f
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_7A43705E_MyClass::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x213b
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_7A43705E_MyClass::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_7A43705E_MyClass
+
 
 		// Fields
 		.field private object[] _scopes
@@ -173,89 +256,6 @@
 	} // end of method Classes_ClassConstructor_AccessGlobalVariable_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_AccessGlobalVariable_Log
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_AccessGlobalVariable_Log_6C208845.FunctionObject_ClassConstructor_7A43705E_MyClass
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x211a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassConstructor_AccessGlobalVariable_Log_6C208845.FunctionObject_ClassConstructor_7A43705E_MyClass::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_7A43705E_MyClass::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2129
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_7A43705E_MyClass::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x212c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_7A43705E_MyClass::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x212f
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_7A43705E_MyClass::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x213b
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_7A43705E_MyClass::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_AccessGlobalVariable_Log_6C208845.FunctionObject_ClassConstructor_7A43705E_MyClass
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_NewClassReferencingGlobal.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_NewClassReferencingGlobal.verified.txt
@@ -51,6 +51,94 @@
 
 		} // end of class Scope_ctor
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_53291FE3_Inner
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope _environment0_Classes_ClassConstructor_NewClassReferencingGlobal
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x21dc
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner/FunctionObject_ClassConstructor_53291FE3_Inner::_environment0_Classes_ClassConstructor_NewClassReferencingGlobal
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Inner/FunctionObject_ClassConstructor_53291FE3_Inner::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_ClassConstructor_53291FE3_Inner::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21f2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_53291FE3_Inner::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21f5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_53291FE3_Inner::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f8
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_53291FE3_Inner::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2204
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_53291FE3_Inner::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_53291FE3_Inner
+
 
 		// Fields
 		.field private object[] _scopes
@@ -131,6 +219,94 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_4CBD5D48_Outer
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope _environment0_Classes_ClassConstructor_NewClassReferencingGlobal
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x2210
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer/FunctionObject_ClassConstructor_4CBD5D48_Outer::_environment0_Classes_ClassConstructor_NewClassReferencingGlobal
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Outer/FunctionObject_ClassConstructor_4CBD5D48_Outer::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_ClassConstructor_4CBD5D48_Outer::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2226
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_4CBD5D48_Outer::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2229
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_4CBD5D48_Outer::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x222c
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_4CBD5D48_Outer::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2238
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_4CBD5D48_Outer::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_4CBD5D48_Outer
 
 
 		// Fields
@@ -310,182 +486,6 @@
 	} // end of method Classes_ClassConstructor_NewClassReferencingGlobal::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_NewClassReferencingGlobal
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_NewClassReferencingGlobal_0059E6AC.FunctionObject_ClassConstructor_53291FE3_Inner
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope _environment0_Classes_ClassConstructor_NewClassReferencingGlobal
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x21dc
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope FunctionObjects.Classes_ClassConstructor_NewClassReferencingGlobal_0059E6AC.FunctionObject_ClassConstructor_53291FE3_Inner::_environment0_Classes_ClassConstructor_NewClassReferencingGlobal
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Classes_ClassConstructor_NewClassReferencingGlobal_0059E6AC.FunctionObject_ClassConstructor_53291FE3_Inner::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_ClassConstructor_53291FE3_Inner::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21f2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_53291FE3_Inner::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21f5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_53291FE3_Inner::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f8
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_53291FE3_Inner::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2204
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_53291FE3_Inner::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_NewClassReferencingGlobal_0059E6AC.FunctionObject_ClassConstructor_53291FE3_Inner
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_NewClassReferencingGlobal_0059E6AC.FunctionObject_ClassConstructor_4CBD5D48_Outer
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope _environment0_Classes_ClassConstructor_NewClassReferencingGlobal
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x2210
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Classes_ClassConstructor_NewClassReferencingGlobal/Scope FunctionObjects.Classes_ClassConstructor_NewClassReferencingGlobal_0059E6AC.FunctionObject_ClassConstructor_4CBD5D48_Outer::_environment0_Classes_ClassConstructor_NewClassReferencingGlobal
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Classes_ClassConstructor_NewClassReferencingGlobal_0059E6AC.FunctionObject_ClassConstructor_4CBD5D48_Outer::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_ClassConstructor_4CBD5D48_Outer::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2226
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_4CBD5D48_Outer::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2229
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_4CBD5D48_Outer::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x222c
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_4CBD5D48_Outer::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2238
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_4CBD5D48_Outer::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_NewClassReferencingGlobal_0059E6AC.FunctionObject_ClassConstructor_4CBD5D48_Outer
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_New_In_ArrowFunction.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_New_In_ArrowFunction.verified.txt
@@ -189,6 +189,89 @@
 
 		} // end of class Scope_ctor
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_096DDC25_PrimeSieve
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21a7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassConstructor_New_In_ArrowFunction/PrimeSieve/FunctionObject_ClassConstructor_096DDC25_PrimeSieve::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_096DDC25_PrimeSieve::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21b6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_096DDC25_PrimeSieve::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21b9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_096DDC25_PrimeSieve::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21bc
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_096DDC25_PrimeSieve::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21c8
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_096DDC25_PrimeSieve::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_096DDC25_PrimeSieve
+
 
 		// Fields
 		.field public float64 n
@@ -341,89 +424,6 @@
 	} // end of method Classes_ClassConstructor_New_In_ArrowFunction::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_New_In_ArrowFunction
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_New_In_ArrowFunction_821CE88F.FunctionObject_ClassConstructor_096DDC25_PrimeSieve
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21a7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassConstructor_New_In_ArrowFunction_821CE88F.FunctionObject_ClassConstructor_096DDC25_PrimeSieve::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_096DDC25_PrimeSieve::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21b6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_096DDC25_PrimeSieve::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21b9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_096DDC25_PrimeSieve::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21bc
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_096DDC25_PrimeSieve::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21c8
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_096DDC25_PrimeSieve::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_New_In_ArrowFunction_821CE88F.FunctionObject_ClassConstructor_096DDC25_PrimeSieve
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_Param_Field_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_Param_Field_Log.verified.txt
@@ -71,6 +71,149 @@
 
 		} // end of class Scope_sayName
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_A5FD9DE9_Greeter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2128
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassConstructor_Param_Field_Log/Greeter/FunctionObject_ClassConstructor_A5FD9DE9_Greeter::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_A5FD9DE9_Greeter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2137
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_A5FD9DE9_Greeter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x213a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_A5FD9DE9_Greeter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x213d
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_A5FD9DE9_Greeter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2149
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_A5FD9DE9_Greeter::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_A5FD9DE9_Greeter
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_3AF307DC_Greeter_sayName
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2155
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_3AF307DC_Greeter_sayName::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x215d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_3AF307DC_Greeter_sayName::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2160
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_3AF307DC_Greeter_sayName::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2163
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassConstructor_Param_Field_Log/Greeter
+				IL_0006: call instance object Modules.Classes_ClassConstructor_Param_Field_Log/Greeter::sayName()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_3AF307DC_Greeter_sayName::CallCore
+
+		} // end of class FunctionObject_ClassMethod_3AF307DC_Greeter_sayName
+
 
 		// Fields
 		.field public string name
@@ -208,149 +351,6 @@
 	} // end of method Classes_ClassConstructor_Param_Field_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_Param_Field_Log
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_Param_Field_Log_F409ECAC.FunctionObject_ClassConstructor_A5FD9DE9_Greeter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2128
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassConstructor_Param_Field_Log_F409ECAC.FunctionObject_ClassConstructor_A5FD9DE9_Greeter::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_A5FD9DE9_Greeter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2137
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_A5FD9DE9_Greeter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x213a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_A5FD9DE9_Greeter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x213d
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_A5FD9DE9_Greeter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2149
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_A5FD9DE9_Greeter::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_Param_Field_Log_F409ECAC.FunctionObject_ClassConstructor_A5FD9DE9_Greeter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_Param_Field_Log_F409ECAC.FunctionObject_ClassMethod_3AF307DC_Greeter_sayName
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2155
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_3AF307DC_Greeter_sayName::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x215d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_3AF307DC_Greeter_sayName::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2160
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_3AF307DC_Greeter_sayName::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2163
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassConstructor_Param_Field_Log/Greeter
-		IL_0006: call instance object Modules.Classes_ClassConstructor_Param_Field_Log/Greeter::sayName()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_3AF307DC_Greeter_sayName::CallCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_Param_Field_Log_F409ECAC.FunctionObject_ClassMethod_3AF307DC_Greeter_sayName
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_ParameterDestructuring.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_ParameterDestructuring.verified.txt
@@ -79,6 +79,149 @@
 
 		} // end of class Scope_display
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_6F38F35C_Point
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x27b4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassConstructor_ParameterDestructuring/Point/FunctionObject_ClassConstructor_6F38F35C_Point::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_6F38F35C_Point::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x27c3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_6F38F35C_Point::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x27c6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_6F38F35C_Point::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x27c9
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_6F38F35C_Point::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x27d5
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_6F38F35C_Point::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_6F38F35C_Point
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_0A30C2A1_Point_display
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x27e1
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_0A30C2A1_Point_display::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x27e9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_0A30C2A1_Point_display::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x27ec
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_0A30C2A1_Point_display::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x27ef
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassConstructor_ParameterDestructuring/Point
+				IL_0006: call instance object Modules.Classes_ClassConstructor_ParameterDestructuring/Point::display()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_0A30C2A1_Point_display::CallCore
+
+		} // end of class FunctionObject_ClassMethod_0A30C2A1_Point_display
+
 
 		// Fields
 		.field public object x
@@ -255,6 +398,149 @@
 			} // end of method Scope_greet::.ctor
 
 		} // end of class Scope_greet
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_CF97FAD7_Person
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x27fc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassConstructor_ParameterDestructuring/Person/FunctionObject_ClassConstructor_CF97FAD7_Person::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_CF97FAD7_Person::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x280b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_CF97FAD7_Person::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x280e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_CF97FAD7_Person::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2811
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_CF97FAD7_Person::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x281d
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_CF97FAD7_Person::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_CF97FAD7_Person
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_8CCBBF9B_Person_greet
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2829
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_8CCBBF9B_Person_greet::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2831
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_8CCBBF9B_Person_greet::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2834
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_8CCBBF9B_Person_greet::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2837
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassConstructor_ParameterDestructuring/Person
+				IL_0006: call instance object Modules.Classes_ClassConstructor_ParameterDestructuring/Person::greet()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_8CCBBF9B_Person_greet::CallCore
+
+		} // end of class FunctionObject_ClassMethod_8CCBBF9B_Person_greet
 
 
 		// Fields
@@ -464,6 +750,149 @@
 			} // end of method Scope_display::.ctor
 
 		} // end of class Scope_display
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_7646F544_Config
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2844
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassConstructor_ParameterDestructuring/Config/FunctionObject_ClassConstructor_7646F544_Config::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_7646F544_Config::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2853
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_7646F544_Config::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2856
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_7646F544_Config::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2859
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_7646F544_Config::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2865
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_7646F544_Config::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_7646F544_Config
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_C1E38EFF_Config_display
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2871
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_C1E38EFF_Config_display::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2879
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_C1E38EFF_Config_display::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x287c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_C1E38EFF_Config_display::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x287f
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassConstructor_ParameterDestructuring/Config
+				IL_0006: call instance object Modules.Classes_ClassConstructor_ParameterDestructuring/Config::display()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_C1E38EFF_Config_display::CallCore
+
+		} // end of class FunctionObject_ClassMethod_C1E38EFF_Config_display
 
 
 		// Fields
@@ -1006,435 +1435,6 @@
 	} // end of method Classes_ClassConstructor_ParameterDestructuring::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_ParameterDestructuring
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_ParameterDestructuring_73DE1457.FunctionObject_ClassConstructor_6F38F35C_Point
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x27b4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassConstructor_ParameterDestructuring_73DE1457.FunctionObject_ClassConstructor_6F38F35C_Point::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_6F38F35C_Point::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x27c3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_6F38F35C_Point::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x27c6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_6F38F35C_Point::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x27c9
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_6F38F35C_Point::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27d5
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_6F38F35C_Point::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_ParameterDestructuring_73DE1457.FunctionObject_ClassConstructor_6F38F35C_Point
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_ParameterDestructuring_73DE1457.FunctionObject_ClassMethod_0A30C2A1_Point_display
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x27e1
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_0A30C2A1_Point_display::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x27e9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_0A30C2A1_Point_display::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x27ec
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_0A30C2A1_Point_display::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x27ef
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassConstructor_ParameterDestructuring/Point
-		IL_0006: call instance object Modules.Classes_ClassConstructor_ParameterDestructuring/Point::display()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_0A30C2A1_Point_display::CallCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_ParameterDestructuring_73DE1457.FunctionObject_ClassMethod_0A30C2A1_Point_display
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_ParameterDestructuring_73DE1457.FunctionObject_ClassConstructor_CF97FAD7_Person
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x27fc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassConstructor_ParameterDestructuring_73DE1457.FunctionObject_ClassConstructor_CF97FAD7_Person::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_CF97FAD7_Person::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x280b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_CF97FAD7_Person::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x280e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_CF97FAD7_Person::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2811
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_CF97FAD7_Person::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x281d
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_CF97FAD7_Person::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_ParameterDestructuring_73DE1457.FunctionObject_ClassConstructor_CF97FAD7_Person
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_ParameterDestructuring_73DE1457.FunctionObject_ClassMethod_8CCBBF9B_Person_greet
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2829
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_8CCBBF9B_Person_greet::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2831
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_8CCBBF9B_Person_greet::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2834
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_8CCBBF9B_Person_greet::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2837
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassConstructor_ParameterDestructuring/Person
-		IL_0006: call instance object Modules.Classes_ClassConstructor_ParameterDestructuring/Person::greet()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_8CCBBF9B_Person_greet::CallCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_ParameterDestructuring_73DE1457.FunctionObject_ClassMethod_8CCBBF9B_Person_greet
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_ParameterDestructuring_73DE1457.FunctionObject_ClassConstructor_7646F544_Config
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2844
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassConstructor_ParameterDestructuring_73DE1457.FunctionObject_ClassConstructor_7646F544_Config::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_7646F544_Config::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2853
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_7646F544_Config::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2856
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_7646F544_Config::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2859
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_7646F544_Config::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2865
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_7646F544_Config::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_ParameterDestructuring_73DE1457.FunctionObject_ClassConstructor_7646F544_Config
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_ParameterDestructuring_73DE1457.FunctionObject_ClassMethod_C1E38EFF_Config_display
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2871
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_C1E38EFF_Config_display::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2879
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_C1E38EFF_Config_display::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x287c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_C1E38EFF_Config_display::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x287f
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassConstructor_ParameterDestructuring/Config
-		IL_0006: call instance object Modules.Classes_ClassConstructor_ParameterDestructuring/Config::display()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_C1E38EFF_Config_display::CallCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_ParameterDestructuring_73DE1457.FunctionObject_ClassMethod_C1E38EFF_Config_display
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_TwoParams_AddMethod.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_TwoParams_AddMethod.verified.txt
@@ -71,6 +71,149 @@
 
 		} // end of class Scope_add
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_3E5F8A45_Adder
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x221c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassConstructor_TwoParams_AddMethod/Adder/FunctionObject_ClassConstructor_3E5F8A45_Adder::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_3E5F8A45_Adder::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x222b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_3E5F8A45_Adder::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x222e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_3E5F8A45_Adder::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2231
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_3E5F8A45_Adder::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x223d
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_3E5F8A45_Adder::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_3E5F8A45_Adder
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_BBF2F92B_Adder_add
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2249
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_BBF2F92B_Adder_add::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2251
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_BBF2F92B_Adder_add::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2254
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_BBF2F92B_Adder_add::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2257
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassConstructor_TwoParams_AddMethod/Adder
+				IL_0006: call instance object Modules.Classes_ClassConstructor_TwoParams_AddMethod/Adder::'add'()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_BBF2F92B_Adder_add::CallCore
+
+		} // end of class FunctionObject_ClassMethod_BBF2F92B_Adder_add
+
 
 		// Fields
 		.field public object a
@@ -284,149 +427,6 @@
 	} // end of method Classes_ClassConstructor_TwoParams_AddMethod::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_TwoParams_AddMethod
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_TwoParams_AddMethod_8EDEE1A6.FunctionObject_ClassConstructor_3E5F8A45_Adder
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x221c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassConstructor_TwoParams_AddMethod_8EDEE1A6.FunctionObject_ClassConstructor_3E5F8A45_Adder::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_3E5F8A45_Adder::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x222b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_3E5F8A45_Adder::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x222e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_3E5F8A45_Adder::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2231
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_3E5F8A45_Adder::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x223d
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_3E5F8A45_Adder::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_TwoParams_AddMethod_8EDEE1A6.FunctionObject_ClassConstructor_3E5F8A45_Adder
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_TwoParams_AddMethod_8EDEE1A6.FunctionObject_ClassMethod_BBF2F92B_Adder_add
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2249
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_BBF2F92B_Adder_add::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2251
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_BBF2F92B_Adder_add::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2254
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_BBF2F92B_Adder_add::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2257
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassConstructor_TwoParams_AddMethod/Adder
-		IL_0006: call instance object Modules.Classes_ClassConstructor_TwoParams_AddMethod/Adder::'add'()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_BBF2F92B_Adder_add::CallCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_TwoParams_AddMethod_8EDEE1A6.FunctionObject_ClassMethod_BBF2F92B_Adder_add
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_TwoParams_SubtractMethod.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_TwoParams_SubtractMethod.verified.txt
@@ -71,6 +71,149 @@
 
 		} // end of class Scope_sub
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_DC85BC97_Subber
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2219
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassConstructor_TwoParams_SubtractMethod/Subber/FunctionObject_ClassConstructor_DC85BC97_Subber::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_DC85BC97_Subber::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2228
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_DC85BC97_Subber::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x222b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_DC85BC97_Subber::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x222e
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_DC85BC97_Subber::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x223a
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_DC85BC97_Subber::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_DC85BC97_Subber
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_6E1B7D68_Subber_sub
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2246
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_6E1B7D68_Subber_sub::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x224e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_6E1B7D68_Subber_sub::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2251
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_6E1B7D68_Subber_sub::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2254
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassConstructor_TwoParams_SubtractMethod/Subber
+				IL_0006: call instance object Modules.Classes_ClassConstructor_TwoParams_SubtractMethod/Subber::'sub'()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_6E1B7D68_Subber_sub::CallCore
+
+		} // end of class FunctionObject_ClassMethod_6E1B7D68_Subber_sub
+
 
 		// Fields
 		.field public object a
@@ -282,149 +425,6 @@
 	} // end of method Classes_ClassConstructor_TwoParams_SubtractMethod::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_TwoParams_SubtractMethod
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_TwoParams_SubtractMethod_B6D54959.FunctionObject_ClassConstructor_DC85BC97_Subber
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2219
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassConstructor_TwoParams_SubtractMethod_B6D54959.FunctionObject_ClassConstructor_DC85BC97_Subber::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_DC85BC97_Subber::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2228
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_DC85BC97_Subber::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x222b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_DC85BC97_Subber::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x222e
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_DC85BC97_Subber::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x223a
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_DC85BC97_Subber::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_TwoParams_SubtractMethod_B6D54959.FunctionObject_ClassConstructor_DC85BC97_Subber
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_TwoParams_SubtractMethod_B6D54959.FunctionObject_ClassMethod_6E1B7D68_Subber_sub
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2246
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_6E1B7D68_Subber_sub::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x224e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_6E1B7D68_Subber_sub::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2251
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_6E1B7D68_Subber_sub::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2254
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassConstructor_TwoParams_SubtractMethod/Subber
-		IL_0006: call instance object Modules.Classes_ClassConstructor_TwoParams_SubtractMethod/Subber::'sub'()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_6E1B7D68_Subber_sub::CallCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_TwoParams_SubtractMethod_B6D54959.FunctionObject_ClassMethod_6E1B7D68_Subber_sub
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_TypedNestedNew_FieldStore.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_TypedNestedNew_FieldStore.verified.txt
@@ -51,6 +51,89 @@
 
 		} // end of class Scope_ctor
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_B4BBA70C_Bar
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2254
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Bar/FunctionObject_ClassConstructor_B4BBA70C_Bar::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_B4BBA70C_Bar::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2263
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_B4BBA70C_Bar::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2266
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_B4BBA70C_Bar::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2269
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_B4BBA70C_Bar::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2275
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_B4BBA70C_Bar::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_B4BBA70C_Bar
+
 
 		// Fields
 		.field public float64 n
@@ -122,6 +205,94 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_7E70C62D_Foo
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Scope _environment0_Classes_ClassConstructor_TypedNestedNew_FieldStore
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x2281
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Scope Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Foo/FunctionObject_ClassConstructor_7E70C62D_Foo::_environment0_Classes_ClassConstructor_TypedNestedNew_FieldStore
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Foo/FunctionObject_ClassConstructor_7E70C62D_Foo::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_ClassConstructor_7E70C62D_Foo::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2297
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_7E70C62D_Foo::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x229a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_7E70C62D_Foo::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x229d
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_7E70C62D_Foo::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22a9
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_7E70C62D_Foo::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_7E70C62D_Foo
 
 
 		// Fields
@@ -330,177 +501,6 @@
 	} // end of method Classes_ClassConstructor_TypedNestedNew_FieldStore::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_TypedNestedNew_FieldStore_8F6968F2.FunctionObject_ClassConstructor_B4BBA70C_Bar
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2254
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassConstructor_TypedNestedNew_FieldStore_8F6968F2.FunctionObject_ClassConstructor_B4BBA70C_Bar::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_B4BBA70C_Bar::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2263
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_B4BBA70C_Bar::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2266
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_B4BBA70C_Bar::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2269
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_B4BBA70C_Bar::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2275
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_B4BBA70C_Bar::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_TypedNestedNew_FieldStore_8F6968F2.FunctionObject_ClassConstructor_B4BBA70C_Bar
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_TypedNestedNew_FieldStore_8F6968F2.FunctionObject_ClassConstructor_7E70C62D_Foo
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Scope _environment0_Classes_ClassConstructor_TypedNestedNew_FieldStore
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x2281
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Classes_ClassConstructor_TypedNestedNew_FieldStore/Scope FunctionObjects.Classes_ClassConstructor_TypedNestedNew_FieldStore_8F6968F2.FunctionObject_ClassConstructor_7E70C62D_Foo::_environment0_Classes_ClassConstructor_TypedNestedNew_FieldStore
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Classes_ClassConstructor_TypedNestedNew_FieldStore_8F6968F2.FunctionObject_ClassConstructor_7E70C62D_Foo::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_ClassConstructor_7E70C62D_Foo::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2297
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_7E70C62D_Foo::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x229a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_7E70C62D_Foo::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x229d
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_7E70C62D_Foo::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22a9
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_7E70C62D_Foo::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_TypedNestedNew_FieldStore_8F6968F2.FunctionObject_ClassConstructor_7E70C62D_Foo
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_WithMultipleParameters.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassConstructor_WithMultipleParameters.verified.txt
@@ -51,6 +51,89 @@
 
 		} // end of class Scope_ctor
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_757F8F94_C1
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x26ed
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassConstructor_WithMultipleParameters/C1/FunctionObject_ClassConstructor_757F8F94_C1::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_757F8F94_C1::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x26fc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_757F8F94_C1::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x26ff
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_757F8F94_C1::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2702
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_757F8F94_C1::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x270e
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_757F8F94_C1::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_757F8F94_C1
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -125,6 +208,89 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_787F944D_C2
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x271a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassConstructor_WithMultipleParameters/C2/FunctionObject_ClassConstructor_787F944D_C2::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_787F944D_C2::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2729
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_787F944D_C2::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x272c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_787F944D_C2::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x272f
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_787F944D_C2::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x273b
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_787F944D_C2::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_787F944D_C2
 
 
 		// Methods
@@ -203,6 +369,89 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_777F92BA_C3
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2747
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassConstructor_WithMultipleParameters/C3/FunctionObject_ClassConstructor_777F92BA_C3::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_777F92BA_C3::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2756
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_777F92BA_C3::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2759
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_777F92BA_C3::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x275c
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_777F92BA_C3::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2768
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_777F92BA_C3::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_777F92BA_C3
 
 
 		// Methods
@@ -298,6 +547,89 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_727F8ADB_C4
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2774
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassConstructor_WithMultipleParameters/C4/FunctionObject_ClassConstructor_727F8ADB_C4::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_727F8ADB_C4::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2783
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_727F8ADB_C4::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2786
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_727F8ADB_C4::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2789
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_727F8ADB_C4::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2795
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_727F8ADB_C4::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_727F8ADB_C4
 
 
 		// Methods
@@ -399,6 +731,89 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_717F8948_C5
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x27a1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassConstructor_WithMultipleParameters/C5/FunctionObject_ClassConstructor_717F8948_C5::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_717F8948_C5::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x27b0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_717F8948_C5::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x27b3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_717F8948_C5::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x27b6
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_717F8948_C5::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x27c2
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_717F8948_C5::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_717F8948_C5
 
 
 		// Methods
@@ -506,6 +921,89 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_747F8E01_C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x27ce
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassConstructor_WithMultipleParameters/C6/FunctionObject_ClassConstructor_747F8E01_C6::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_747F8E01_C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x27dd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_747F8E01_C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x27e0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_747F8E01_C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x27e4
+				// Header size: 12
+				// Code size: 11 (0xb)
+				.maxstack 9
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_747F8E01_C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x27fb
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_747F8E01_C6::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_747F8E01_C6
 
 
 		// Methods
@@ -906,504 +1404,6 @@
 	} // end of method Classes_ClassConstructor_WithMultipleParameters::__js_module_init__
 
 } // end of class Modules.Classes_ClassConstructor_WithMultipleParameters
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_WithMultipleParameters_CAA83595.FunctionObject_ClassConstructor_757F8F94_C1
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x26ed
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassConstructor_WithMultipleParameters_CAA83595.FunctionObject_ClassConstructor_757F8F94_C1::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_757F8F94_C1::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x26fc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_757F8F94_C1::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x26ff
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_757F8F94_C1::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2702
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_757F8F94_C1::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x270e
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_757F8F94_C1::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_WithMultipleParameters_CAA83595.FunctionObject_ClassConstructor_757F8F94_C1
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_WithMultipleParameters_CAA83595.FunctionObject_ClassConstructor_787F944D_C2
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x271a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassConstructor_WithMultipleParameters_CAA83595.FunctionObject_ClassConstructor_787F944D_C2::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_787F944D_C2::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2729
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_787F944D_C2::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x272c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_787F944D_C2::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x272f
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_787F944D_C2::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x273b
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_787F944D_C2::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_WithMultipleParameters_CAA83595.FunctionObject_ClassConstructor_787F944D_C2
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_WithMultipleParameters_CAA83595.FunctionObject_ClassConstructor_777F92BA_C3
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2747
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassConstructor_WithMultipleParameters_CAA83595.FunctionObject_ClassConstructor_777F92BA_C3::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_777F92BA_C3::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2756
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_777F92BA_C3::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2759
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_777F92BA_C3::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x275c
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_777F92BA_C3::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2768
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_777F92BA_C3::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_WithMultipleParameters_CAA83595.FunctionObject_ClassConstructor_777F92BA_C3
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_WithMultipleParameters_CAA83595.FunctionObject_ClassConstructor_727F8ADB_C4
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2774
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassConstructor_WithMultipleParameters_CAA83595.FunctionObject_ClassConstructor_727F8ADB_C4::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_727F8ADB_C4::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2783
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_727F8ADB_C4::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2786
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_727F8ADB_C4::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2789
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_727F8ADB_C4::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2795
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_727F8ADB_C4::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_WithMultipleParameters_CAA83595.FunctionObject_ClassConstructor_727F8ADB_C4
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_WithMultipleParameters_CAA83595.FunctionObject_ClassConstructor_717F8948_C5
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x27a1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassConstructor_WithMultipleParameters_CAA83595.FunctionObject_ClassConstructor_717F8948_C5::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_717F8948_C5::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x27b0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_717F8948_C5::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x27b3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_717F8948_C5::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x27b6
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_717F8948_C5::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27c2
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_717F8948_C5::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_WithMultipleParameters_CAA83595.FunctionObject_ClassConstructor_717F8948_C5
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassConstructor_WithMultipleParameters_CAA83595.FunctionObject_ClassConstructor_747F8E01_C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x27ce
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassConstructor_WithMultipleParameters_CAA83595.FunctionObject_ClassConstructor_747F8E01_C6::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_747F8E01_C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x27dd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_747F8E01_C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x27e0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_747F8E01_C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x27e4
-		// Header size: 12
-		// Code size: 11 (0xb)
-		.maxstack 9
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_747F8E01_C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27fb
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_747F8E01_C6::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassConstructor_WithMultipleParameters_CAA83595.FunctionObject_ClassConstructor_747F8E01_C6
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassExpression_LazyPrototypeMetadata.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassExpression_LazyPrototypeMetadata.verified.txt
@@ -51,6 +51,149 @@
 
 		} // end of class Scope_greet
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_FB181732_ClassExpression_L1C17
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x22eb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17/FunctionObject_ClassConstructor_FB181732_ClassExpression_L1C17::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_FB181732_ClassExpression_L1C17::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22fa
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_FB181732_ClassExpression_L1C17::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22fd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_FB181732_ClassExpression_L1C17::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2300
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_FB181732_ClassExpression_L1C17::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x230c
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_FB181732_ClassExpression_L1C17::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_FB181732_ClassExpression_L1C17
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2318
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2320
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2323
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2326
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17
+				IL_0006: call instance object Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17::greet()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet::CallCore
+
+		} // end of class FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -346,149 +489,6 @@
 	} // end of method Classes_ClassExpression_LazyPrototypeMetadata::__js_module_init__
 
 } // end of class Modules.Classes_ClassExpression_LazyPrototypeMetadata
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassExpression_LazyPrototypeMetadata_2740CF7C.FunctionObject_ClassConstructor_FB181732_ClassExpression_L1C17
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x22eb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassExpression_LazyPrototypeMetadata_2740CF7C.FunctionObject_ClassConstructor_FB181732_ClassExpression_L1C17::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_FB181732_ClassExpression_L1C17::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22fa
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_FB181732_ClassExpression_L1C17::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22fd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_FB181732_ClassExpression_L1C17::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2300
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_FB181732_ClassExpression_L1C17::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x230c
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_FB181732_ClassExpression_L1C17::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassExpression_LazyPrototypeMetadata_2740CF7C.FunctionObject_ClassConstructor_FB181732_ClassExpression_L1C17
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassExpression_LazyPrototypeMetadata_2740CF7C.FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2318
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2320
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2323
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2326
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17
-		IL_0006: call instance object Modules.Classes_ClassExpression_LazyPrototypeMetadata/ClassExpression_L1C17::greet()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet::CallCore
-
-} // end of class FunctionObjects.Classes_ClassExpression_LazyPrototypeMetadata_2740CF7C.FunctionObject_ClassMethod_3B133C66_ClassExpression_L1C17_greet
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassFieldTypeInference_Primitives.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassFieldTypeInference_Primitives.verified.txt
@@ -71,6 +71,149 @@
 
 		} // end of class Scope_increment
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_E57E053D_Counter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x225a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassFieldTypeInference_Primitives/Counter/FunctionObject_ClassConstructor_E57E053D_Counter::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_E57E053D_Counter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2269
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_E57E053D_Counter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x226c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_E57E053D_Counter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x226f
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_E57E053D_Counter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x227b
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_E57E053D_Counter::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_E57E053D_Counter
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_8D75F331_Counter_increment
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2287
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_8D75F331_Counter_increment::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x228f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_8D75F331_Counter_increment::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2292
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_8D75F331_Counter_increment::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2295
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassFieldTypeInference_Primitives/Counter
+				IL_0006: call instance object Modules.Classes_ClassFieldTypeInference_Primitives/Counter::increment()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_8D75F331_Counter_increment::CallCore
+
+		} // end of class FunctionObject_ClassMethod_8D75F331_Counter_increment
+
 
 		// Fields
 		.field public float64 'value'
@@ -323,149 +466,6 @@
 	} // end of method Classes_ClassFieldTypeInference_Primitives::__js_module_init__
 
 } // end of class Modules.Classes_ClassFieldTypeInference_Primitives
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassFieldTypeInference_Primitives_A66D3DCA.FunctionObject_ClassConstructor_E57E053D_Counter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x225a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassFieldTypeInference_Primitives_A66D3DCA.FunctionObject_ClassConstructor_E57E053D_Counter::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_E57E053D_Counter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2269
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_E57E053D_Counter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x226c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_E57E053D_Counter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x226f
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_E57E053D_Counter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x227b
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_E57E053D_Counter::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassFieldTypeInference_Primitives_A66D3DCA.FunctionObject_ClassConstructor_E57E053D_Counter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassFieldTypeInference_Primitives_A66D3DCA.FunctionObject_ClassMethod_8D75F331_Counter_increment
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2287
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_8D75F331_Counter_increment::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x228f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_8D75F331_Counter_increment::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2292
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_8D75F331_Counter_increment::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2295
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassFieldTypeInference_Primitives/Counter
-		IL_0006: call instance object Modules.Classes_ClassFieldTypeInference_Primitives/Counter::increment()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_8D75F331_Counter_increment::CallCore
-
-} // end of class FunctionObjects.Classes_ClassFieldTypeInference_Primitives_A66D3DCA.FunctionObject_ClassMethod_8D75F331_Counter_increment
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassLocal_ReassignedClass_FallsBack.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassLocal_ReassignedClass_FallsBack.verified.txt
@@ -73,6 +73,128 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B0C5CE34_test
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope _environment0_Classes_ClassLocal_ReassignedClass_FallsBack
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2296
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test/FunctionObject_FunctionDeclaration_B0C5CE34_test::_environment0_Classes_ClassLocal_ReassignedClass_FallsBack
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B0C5CE34_test::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22a5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B0C5CE34_test::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22a8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B0C5CE34_test::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x22ab
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_B0C5CE34_test::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22b3
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test/FunctionObject_FunctionDeclaration_B0C5CE34_test::_environment0_Classes_ClassLocal_ReassignedClass_FallsBack
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test::__js_call__(class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_B0C5CE34_test::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22c5
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test/FunctionObject_FunctionDeclaration_B0C5CE34_test::_environment0_Classes_ClassLocal_ReassignedClass_FallsBack
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test::__js_call__(class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_B0C5CE34_test::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22d3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B0C5CE34_test::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_B0C5CE34_test
+
 
 		// Methods
 		.method public hidebysig static 
@@ -206,6 +328,150 @@
 
 		} // end of class Scope_read
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_BF595FDD_Box
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2249
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box/FunctionObject_ClassConstructor_BF595FDD_Box::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_BF595FDD_Box::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2258
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_BF595FDD_Box::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x225b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_BF595FDD_Box::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x225e
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_BF595FDD_Box::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x226a
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_BF595FDD_Box::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_BF595FDD_Box
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_F961BB76_Box_read
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2276
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_F961BB76_Box_read::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x227e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_F961BB76_Box_read::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2281
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_F961BB76_Box_read::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2284
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box
+				IL_0006: call instance float64 Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box::read()
+				IL_000b: box [System.Runtime]System.Double
+				IL_0010: ret
+			} // end of method FunctionObject_ClassMethod_F961BB76_Box_read::CallCore
+
+		} // end of class FunctionObject_ClassMethod_F961BB76_Box_read
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -286,7 +552,7 @@
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope,
-			[1] class FunctionObjects.Classes_ClassLocal_ReassignedClass_FallsBack_2333798D.FunctionObject_FunctionDeclaration_B0C5CE34_test,
+			[1] class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test/FunctionObject_FunctionDeclaration_B0C5CE34_test,
 			[2] object[],
 			[3] class [System.Runtime]System.Type,
 			[4] object
@@ -305,13 +571,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope
-		IL_0019: newobj instance void FunctionObjects.Classes_ClassLocal_ReassignedClass_FallsBack_2333798D.FunctionObject_FunctionDeclaration_B0C5CE34_test::.ctor(class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope)
+		IL_0019: newobj instance void Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test/FunctionObject_FunctionDeclaration_B0C5CE34_test::.ctor(class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "test"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.0
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Classes_ClassLocal_ReassignedClass_FallsBack_2333798D.FunctionObject_FunctionDeclaration_B0C5CE34_test>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test/FunctionObject_FunctionDeclaration_B0C5CE34_test>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: ldtoken Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box
 		IL_0032: call void [System.Runtime]System.Runtime.CompilerServices.RuntimeHelpers::RunClassConstructor(valuetype [System.Runtime]System.RuntimeTypeHandle)
@@ -400,272 +666,6 @@
 	} // end of method Classes_ClassLocal_ReassignedClass_FallsBack::__js_module_init__
 
 } // end of class Modules.Classes_ClassLocal_ReassignedClass_FallsBack
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassLocal_ReassignedClass_FallsBack_2333798D.FunctionObject_ClassConstructor_BF595FDD_Box
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2249
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassLocal_ReassignedClass_FallsBack_2333798D.FunctionObject_ClassConstructor_BF595FDD_Box::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_BF595FDD_Box::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2258
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_BF595FDD_Box::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x225b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_BF595FDD_Box::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x225e
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_BF595FDD_Box::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x226a
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_BF595FDD_Box::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassLocal_ReassignedClass_FallsBack_2333798D.FunctionObject_ClassConstructor_BF595FDD_Box
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassLocal_ReassignedClass_FallsBack_2333798D.FunctionObject_ClassMethod_F961BB76_Box_read
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2276
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_F961BB76_Box_read::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x227e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_F961BB76_Box_read::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2281
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_F961BB76_Box_read::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2284
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box
-		IL_0006: call instance float64 Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Box::read()
-		IL_000b: box [System.Runtime]System.Double
-		IL_0010: ret
-	} // end of method FunctionObject_ClassMethod_F961BB76_Box_read::CallCore
-
-} // end of class FunctionObjects.Classes_ClassLocal_ReassignedClass_FallsBack_2333798D.FunctionObject_ClassMethod_F961BB76_Box_read
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassLocal_ReassignedClass_FallsBack_2333798D.FunctionObject_FunctionDeclaration_B0C5CE34_test
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope _environment0_Classes_ClassLocal_ReassignedClass_FallsBack
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2296
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope FunctionObjects.Classes_ClassLocal_ReassignedClass_FallsBack_2333798D.FunctionObject_FunctionDeclaration_B0C5CE34_test::_environment0_Classes_ClassLocal_ReassignedClass_FallsBack
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B0C5CE34_test::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22a5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B0C5CE34_test::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22a8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B0C5CE34_test::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x22ab
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_B0C5CE34_test::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22b3
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope FunctionObjects.Classes_ClassLocal_ReassignedClass_FallsBack_2333798D.FunctionObject_FunctionDeclaration_B0C5CE34_test::_environment0_Classes_ClassLocal_ReassignedClass_FallsBack
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test::__js_call__(class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_B0C5CE34_test::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22c5
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope FunctionObjects.Classes_ClassLocal_ReassignedClass_FallsBack_2333798D.FunctionObject_FunctionDeclaration_B0C5CE34_test::_environment0_Classes_ClassLocal_ReassignedClass_FallsBack
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Classes_ClassLocal_ReassignedClass_FallsBack/test::__js_call__(class Modules.Classes_ClassLocal_ReassignedClass_FallsBack/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_B0C5CE34_test::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22d3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B0C5CE34_test::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassLocal_ReassignedClass_FallsBack_2333798D.FunctionObject_FunctionDeclaration_B0C5CE34_test
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -55,6 +55,149 @@
 
 			} // end of class Scope_logValues
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_15D265B3_MyClass
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Method begins at RVA 0x21e7
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass/FunctionObject_ClassConstructor_15D265B3_MyClass::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject_ClassConstructor_15D265B3_MyClass::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x21f6
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_ClassConstructor_15D265B3_MyClass::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x21f9
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_ClassConstructor_15D265B3_MyClass::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x21fc
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+					IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+					IL_000a: throw
+				} // end of method FunctionObject_ClassConstructor_15D265B3_MyClass::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2208
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+					IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+					IL_000a: throw
+				} // end of method FunctionObject_ClassConstructor_15D265B3_MyClass::ConstructCore
+
+			} // end of class FunctionObject_ClassConstructor_15D265B3_MyClass
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_ED6ADFBA_MyClass_logValues
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2214
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_ClassMethod_ED6ADFBA_MyClass_logValues::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x221c
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_ClassMethod_ED6ADFBA_MyClass_logValues::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x221f
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_ClassMethod_ED6ADFBA_MyClass_logValues::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2222
+					// Header size: 1
+					// Code size: 12 (0xc)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass
+					IL_0006: call instance object Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass::logValues()
+					IL_000b: ret
+				} // end of method FunctionObject_ClassMethod_ED6ADFBA_MyClass_logValues::CallCore
+
+			} // end of class FunctionObject_ClassMethod_ED6ADFBA_MyClass_logValues
+
 
 			// Fields
 			.field private object[] _scopes
@@ -364,149 +507,6 @@
 	} // end of method Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log_5E314B3C.FunctionObject_ClassConstructor_15D265B3_MyClass
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21e7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log_5E314B3C.FunctionObject_ClassConstructor_15D265B3_MyClass::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_15D265B3_MyClass::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21f6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_15D265B3_MyClass::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21f9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_15D265B3_MyClass::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21fc
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_15D265B3_MyClass::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2208
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_15D265B3_MyClass::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log_5E314B3C.FunctionObject_ClassConstructor_15D265B3_MyClass
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log_5E314B3C.FunctionObject_ClassMethod_ED6ADFBA_MyClass_logValues
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2214
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_ED6ADFBA_MyClass_logValues::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x221c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_ED6ADFBA_MyClass_logValues::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x221f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_ED6ADFBA_MyClass_logValues::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2222
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass
-		IL_0006: call instance object Modules.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log/ArrowFunction_L5C27/MyClass::logValues()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_ED6ADFBA_MyClass_logValues::CallCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_AccessArrowFunctionVariableAndGlobalVariable_Log_5E314B3C.FunctionObject_ClassMethod_ED6ADFBA_MyClass_logValues
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessArrowFunctionVariable_Log.verified.txt
@@ -55,6 +55,149 @@
 
 			} // end of class Scope_logValue
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_D311ADDD_MyClass
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Method begins at RVA 0x21bd
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass/FunctionObject_ClassConstructor_D311ADDD_MyClass::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject_ClassConstructor_D311ADDD_MyClass::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x21cc
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_ClassConstructor_D311ADDD_MyClass::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x21cf
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_ClassConstructor_D311ADDD_MyClass::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x21d2
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+					IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+					IL_000a: throw
+				} // end of method FunctionObject_ClassConstructor_D311ADDD_MyClass::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x21de
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+					IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+					IL_000a: throw
+				} // end of method FunctionObject_ClassConstructor_D311ADDD_MyClass::ConstructCore
+
+			} // end of class FunctionObject_ClassConstructor_D311ADDD_MyClass
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_B4D5C393_MyClass_logValue
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x21ea
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_ClassMethod_B4D5C393_MyClass_logValue::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x21f2
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_ClassMethod_B4D5C393_MyClass_logValue::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x21f5
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_ClassMethod_B4D5C393_MyClass_logValue::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x21f8
+					// Header size: 1
+					// Code size: 12 (0xc)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass
+					IL_0006: call instance object Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass::logValue()
+					IL_000b: ret
+				} // end of method FunctionObject_ClassMethod_B4D5C393_MyClass_logValue::CallCore
+
+			} // end of class FunctionObject_ClassMethod_B4D5C393_MyClass_logValue
+
 
 			// Fields
 			.field private object[] _scopes
@@ -357,149 +500,6 @@
 	} // end of method Classes_ClassMethod_AccessArrowFunctionVariable_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_AccessArrowFunctionVariable_Log_19ACBDA8.FunctionObject_ClassConstructor_D311ADDD_MyClass
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21bd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassMethod_AccessArrowFunctionVariable_Log_19ACBDA8.FunctionObject_ClassConstructor_D311ADDD_MyClass::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_D311ADDD_MyClass::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21cc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_D311ADDD_MyClass::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21cf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_D311ADDD_MyClass::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21d2
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_D311ADDD_MyClass::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21de
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_D311ADDD_MyClass::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_AccessArrowFunctionVariable_Log_19ACBDA8.FunctionObject_ClassConstructor_D311ADDD_MyClass
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_AccessArrowFunctionVariable_Log_19ACBDA8.FunctionObject_ClassMethod_B4D5C393_MyClass_logValue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21ea
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_B4D5C393_MyClass_logValue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21f2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_B4D5C393_MyClass_logValue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21f5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_B4D5C393_MyClass_logValue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f8
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass
-		IL_0006: call instance object Modules.Classes_ClassMethod_AccessArrowFunctionVariable_Log/ArrowFunction_L3C27/MyClass::logValue()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_B4D5C393_MyClass_logValue::CallCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_AccessArrowFunctionVariable_Log_19ACBDA8.FunctionObject_ClassMethod_B4D5C393_MyClass_logValue
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log.verified.txt
@@ -55,6 +55,149 @@
 
 			} // end of class Scope_logValues
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_D442CEB1_MyClass
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Method begins at RVA 0x2211
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass/FunctionObject_ClassConstructor_D442CEB1_MyClass::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject_ClassConstructor_D442CEB1_MyClass::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2220
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_ClassConstructor_D442CEB1_MyClass::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2223
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_ClassConstructor_D442CEB1_MyClass::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2226
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+					IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+					IL_000a: throw
+				} // end of method FunctionObject_ClassConstructor_D442CEB1_MyClass::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2232
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+					IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+					IL_000a: throw
+				} // end of method FunctionObject_ClassConstructor_D442CEB1_MyClass::ConstructCore
+
+			} // end of class FunctionObject_ClassConstructor_D442CEB1_MyClass
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_C6CDAD84_MyClass_logValues
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x223e
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_ClassMethod_C6CDAD84_MyClass_logValues::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2246
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_ClassMethod_C6CDAD84_MyClass_logValues::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2249
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_ClassMethod_C6CDAD84_MyClass_logValues::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x224c
+					// Header size: 1
+					// Code size: 12 (0xc)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: castclass Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass
+					IL_0006: call instance object Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass::logValues()
+					IL_000b: ret
+				} // end of method FunctionObject_ClassMethod_C6CDAD84_MyClass_logValues::CallCore
+
+			} // end of class FunctionObject_ClassMethod_C6CDAD84_MyClass_logValues
+
 
 			// Fields
 			.field private object[] _scopes
@@ -149,6 +292,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope _environment0_Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21cd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::_environment0_Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21dc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21df
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21e2
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::_environment0_Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f4
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::_environment0_Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2202
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction
 
 
 		// Methods
@@ -278,7 +528,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope,
-			[1] class FunctionObjects.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log_D9BE2747.FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction,
+			[1] class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction,
 			[2] object[]
 		)
 
@@ -295,13 +545,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope
-		IL_0019: newobj instance void FunctionObjects.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log_D9BE2747.FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::.ctor(class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope)
+		IL_0019: newobj instance void Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::.ctor(class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "testFunction"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log_D9BE2747.FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldloc.0
@@ -316,256 +566,6 @@
 	} // end of method Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log_D9BE2747.FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope _environment0_Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21cd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope FunctionObjects.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log_D9BE2747.FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::_environment0_Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21dc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21df
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21e2
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope FunctionObjects.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log_D9BE2747.FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::_environment0_Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f4
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope FunctionObjects.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log_D9BE2747.FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::_environment0_Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2202
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log_D9BE2747.FunctionObject_FunctionDeclaration_2BA7CB7E_testFunction
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log_D9BE2747.FunctionObject_ClassConstructor_D442CEB1_MyClass
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2211
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log_D9BE2747.FunctionObject_ClassConstructor_D442CEB1_MyClass::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_D442CEB1_MyClass::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2220
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_D442CEB1_MyClass::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2223
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_D442CEB1_MyClass::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2226
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_D442CEB1_MyClass::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2232
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_D442CEB1_MyClass::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log_D9BE2747.FunctionObject_ClassConstructor_D442CEB1_MyClass
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log_D9BE2747.FunctionObject_ClassMethod_C6CDAD84_MyClass_logValues
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x223e
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_C6CDAD84_MyClass_logValues::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2246
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_C6CDAD84_MyClass_logValues::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2249
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_C6CDAD84_MyClass_logValues::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x224c
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass
-		IL_0006: call instance object Modules.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log/testFunction/MyClass::logValues()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_C6CDAD84_MyClass_logValues::CallCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_AccessFunctionVariableAndGlobalVariable_Log_D9BE2747.FunctionObject_ClassMethod_C6CDAD84_MyClass_logValues
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessFunctionVariable_Log.verified.txt
@@ -55,6 +55,149 @@
 
 			} // end of class Scope_logValue
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_674B927B_MyClass
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Method begins at RVA 0x21ca
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass/FunctionObject_ClassConstructor_674B927B_MyClass::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject_ClassConstructor_674B927B_MyClass::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x21d9
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_ClassConstructor_674B927B_MyClass::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x21dc
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_ClassConstructor_674B927B_MyClass::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x21df
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+					IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+					IL_000a: throw
+				} // end of method FunctionObject_ClassConstructor_674B927B_MyClass::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x21eb
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+					IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+					IL_000a: throw
+				} // end of method FunctionObject_ClassConstructor_674B927B_MyClass::ConstructCore
+
+			} // end of class FunctionObject_ClassConstructor_674B927B_MyClass
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_C626B0F5_MyClass_logValue
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x21f7
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_ClassMethod_C626B0F5_MyClass_logValue::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x21ff
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_ClassMethod_C626B0F5_MyClass_logValue::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2202
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_ClassMethod_C626B0F5_MyClass_logValue::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2205
+					// Header size: 1
+					// Code size: 12 (0xc)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: castclass Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass
+					IL_0006: call instance object Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass::logValue()
+					IL_000b: ret
+				} // end of method FunctionObject_ClassMethod_C626B0F5_MyClass_logValue::CallCore
+
+			} // end of class FunctionObject_ClassMethod_C626B0F5_MyClass_logValue
+
 
 			// Fields
 			.field private object[] _scopes
@@ -129,6 +272,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_77788B24_testFunction
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope _environment0_Classes_ClassMethod_AccessFunctionVariable_Log
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2186
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/FunctionObject_FunctionDeclaration_77788B24_testFunction::_environment0_Classes_ClassMethod_AccessFunctionVariable_Log
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_77788B24_testFunction::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2195
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_77788B24_testFunction::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2198
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_77788B24_testFunction::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x219b
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/FunctionObject_FunctionDeclaration_77788B24_testFunction::_environment0_Classes_ClassMethod_AccessFunctionVariable_Log
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_77788B24_testFunction::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21ad
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/FunctionObject_FunctionDeclaration_77788B24_testFunction::_environment0_Classes_ClassMethod_AccessFunctionVariable_Log
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_77788B24_testFunction::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21bb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_77788B24_testFunction::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_77788B24_testFunction
 
 
 		// Methods
@@ -255,7 +505,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope,
-			[1] class FunctionObjects.Classes_ClassMethod_AccessFunctionVariable_Log_1623AE25.FunctionObject_FunctionDeclaration_77788B24_testFunction,
+			[1] class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/FunctionObject_FunctionDeclaration_77788B24_testFunction,
 			[2] object[]
 		)
 
@@ -272,13 +522,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope
-		IL_0019: newobj instance void FunctionObjects.Classes_ClassMethod_AccessFunctionVariable_Log_1623AE25.FunctionObject_FunctionDeclaration_77788B24_testFunction::.ctor(class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope)
+		IL_0019: newobj instance void Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/FunctionObject_FunctionDeclaration_77788B24_testFunction::.ctor(class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "testFunction"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Classes_ClassMethod_AccessFunctionVariable_Log_1623AE25.FunctionObject_FunctionDeclaration_77788B24_testFunction>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/FunctionObject_FunctionDeclaration_77788B24_testFunction>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
@@ -290,256 +540,6 @@
 	} // end of method Classes_ClassMethod_AccessFunctionVariable_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_AccessFunctionVariable_Log
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_AccessFunctionVariable_Log_1623AE25.FunctionObject_FunctionDeclaration_77788B24_testFunction
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope _environment0_Classes_ClassMethod_AccessFunctionVariable_Log
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2186
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope FunctionObjects.Classes_ClassMethod_AccessFunctionVariable_Log_1623AE25.FunctionObject_FunctionDeclaration_77788B24_testFunction::_environment0_Classes_ClassMethod_AccessFunctionVariable_Log
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_77788B24_testFunction::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2195
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_77788B24_testFunction::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2198
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_77788B24_testFunction::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x219b
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope FunctionObjects.Classes_ClassMethod_AccessFunctionVariable_Log_1623AE25.FunctionObject_FunctionDeclaration_77788B24_testFunction::_environment0_Classes_ClassMethod_AccessFunctionVariable_Log
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_77788B24_testFunction::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ad
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope FunctionObjects.Classes_ClassMethod_AccessFunctionVariable_Log_1623AE25.FunctionObject_FunctionDeclaration_77788B24_testFunction::_environment0_Classes_ClassMethod_AccessFunctionVariable_Log
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction::__js_call__(class Modules.Classes_ClassMethod_AccessFunctionVariable_Log/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_77788B24_testFunction::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21bb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_77788B24_testFunction::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_AccessFunctionVariable_Log_1623AE25.FunctionObject_FunctionDeclaration_77788B24_testFunction
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_AccessFunctionVariable_Log_1623AE25.FunctionObject_ClassConstructor_674B927B_MyClass
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ca
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassMethod_AccessFunctionVariable_Log_1623AE25.FunctionObject_ClassConstructor_674B927B_MyClass::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_674B927B_MyClass::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21d9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_674B927B_MyClass::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21dc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_674B927B_MyClass::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21df
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_674B927B_MyClass::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21eb
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_674B927B_MyClass::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_AccessFunctionVariable_Log_1623AE25.FunctionObject_ClassConstructor_674B927B_MyClass
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_AccessFunctionVariable_Log_1623AE25.FunctionObject_ClassMethod_C626B0F5_MyClass_logValue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21f7
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_C626B0F5_MyClass_logValue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21ff
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_C626B0F5_MyClass_logValue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2202
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_C626B0F5_MyClass_logValue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2205
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass
-		IL_0006: call instance object Modules.Classes_ClassMethod_AccessFunctionVariable_Log/testFunction/MyClass::logValue()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_C626B0F5_MyClass_logValue::CallCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_AccessFunctionVariable_Log_1623AE25.FunctionObject_ClassMethod_C626B0F5_MyClass_logValue
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessGlobalVariable_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_AccessGlobalVariable_Log.verified.txt
@@ -51,6 +51,149 @@
 
 		} // end of class Scope_logGlobal
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_6011F0C3_MyClass
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x212d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass/FunctionObject_ClassConstructor_6011F0C3_MyClass::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_6011F0C3_MyClass::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x213c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_6011F0C3_MyClass::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x213f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_6011F0C3_MyClass::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2142
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_6011F0C3_MyClass::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x214e
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_6011F0C3_MyClass::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_6011F0C3_MyClass
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_FE1F8DEB_MyClass_logGlobal
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x215a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_FE1F8DEB_MyClass_logGlobal::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2162
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_FE1F8DEB_MyClass_logGlobal::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2165
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_FE1F8DEB_MyClass_logGlobal::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2168
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass
+				IL_0006: call instance object Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass::logGlobal()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_FE1F8DEB_MyClass_logGlobal::CallCore
+
+		} // end of class FunctionObject_ClassMethod_FE1F8DEB_MyClass_logGlobal
+
 
 		// Fields
 		.field private object[] _scopes
@@ -195,149 +338,6 @@
 	} // end of method Classes_ClassMethod_AccessGlobalVariable_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_AccessGlobalVariable_Log
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_AccessGlobalVariable_Log_30662DE2.FunctionObject_ClassConstructor_6011F0C3_MyClass
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x212d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassMethod_AccessGlobalVariable_Log_30662DE2.FunctionObject_ClassConstructor_6011F0C3_MyClass::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_6011F0C3_MyClass::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x213c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_6011F0C3_MyClass::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x213f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_6011F0C3_MyClass::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2142
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_6011F0C3_MyClass::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x214e
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_6011F0C3_MyClass::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_AccessGlobalVariable_Log_30662DE2.FunctionObject_ClassConstructor_6011F0C3_MyClass
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_AccessGlobalVariable_Log_30662DE2.FunctionObject_ClassMethod_FE1F8DEB_MyClass_logGlobal
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x215a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_FE1F8DEB_MyClass_logGlobal::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2162
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_FE1F8DEB_MyClass_logGlobal::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2165
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_FE1F8DEB_MyClass_logGlobal::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2168
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass
-		IL_0006: call instance object Modules.Classes_ClassMethod_AccessGlobalVariable_Log/MyClass::logGlobal()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_FE1F8DEB_MyClass_logGlobal::CallCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_AccessGlobalVariable_Log_30662DE2.FunctionObject_ClassMethod_FE1F8DEB_MyClass_logGlobal
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_CallsAnotherMethod.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_CallsAnotherMethod.verified.txt
@@ -111,6 +111,269 @@
 
 		} // end of class Scope_logHello
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_8162E6C8_Greeter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2173
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter/FunctionObject_ClassConstructor_8162E6C8_Greeter::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_8162E6C8_Greeter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2182
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_8162E6C8_Greeter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2185
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_8162E6C8_Greeter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2188
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_8162E6C8_Greeter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2194
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_8162E6C8_Greeter::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_8162E6C8_Greeter
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_B6B72DA7_Greeter_hello
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21a0
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_B6B72DA7_Greeter_hello::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21a8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_B6B72DA7_Greeter_hello::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21ab
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_B6B72DA7_Greeter_hello::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21ae
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter
+				IL_0006: call instance object Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter::hello()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_B6B72DA7_Greeter_hello::CallCore
+
+		} // end of class FunctionObject_ClassMethod_B6B72DA7_Greeter_hello
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_D09AE85D_Greeter_prefix
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21bb
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_D09AE85D_Greeter_prefix::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21c3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_D09AE85D_Greeter_prefix::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21c6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_D09AE85D_Greeter_prefix::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21c9
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter
+				IL_0006: call instance object Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter::prefix()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_D09AE85D_Greeter_prefix::CallCore
+
+		} // end of class FunctionObject_ClassMethod_D09AE85D_Greeter_prefix
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_E52A68FB_Greeter_logHello
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21d6
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_E52A68FB_Greeter_logHello::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21de
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_E52A68FB_Greeter_logHello::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21e1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_E52A68FB_Greeter_logHello::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21e4
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter
+				IL_0006: call instance object Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter::logHello()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_E52A68FB_Greeter_logHello::CallCore
+
+		} // end of class FunctionObject_ClassMethod_E52A68FB_Greeter_logHello
+
 
 		// Fields
 		.field public string name
@@ -295,269 +558,6 @@
 	} // end of method Classes_ClassMethod_CallsAnotherMethod::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_CallsAnotherMethod
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_CallsAnotherMethod_72242A6B.FunctionObject_ClassConstructor_8162E6C8_Greeter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2173
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassMethod_CallsAnotherMethod_72242A6B.FunctionObject_ClassConstructor_8162E6C8_Greeter::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_8162E6C8_Greeter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2182
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_8162E6C8_Greeter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2185
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_8162E6C8_Greeter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2188
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_8162E6C8_Greeter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2194
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_8162E6C8_Greeter::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_CallsAnotherMethod_72242A6B.FunctionObject_ClassConstructor_8162E6C8_Greeter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_CallsAnotherMethod_72242A6B.FunctionObject_ClassMethod_B6B72DA7_Greeter_hello
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21a0
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_B6B72DA7_Greeter_hello::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21a8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_B6B72DA7_Greeter_hello::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21ab
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_B6B72DA7_Greeter_hello::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ae
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter
-		IL_0006: call instance object Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter::hello()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_B6B72DA7_Greeter_hello::CallCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_CallsAnotherMethod_72242A6B.FunctionObject_ClassMethod_B6B72DA7_Greeter_hello
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_CallsAnotherMethod_72242A6B.FunctionObject_ClassMethod_D09AE85D_Greeter_prefix
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21bb
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_D09AE85D_Greeter_prefix::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21c3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_D09AE85D_Greeter_prefix::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21c6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_D09AE85D_Greeter_prefix::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21c9
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter
-		IL_0006: call instance object Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter::prefix()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_D09AE85D_Greeter_prefix::CallCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_CallsAnotherMethod_72242A6B.FunctionObject_ClassMethod_D09AE85D_Greeter_prefix
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_CallsAnotherMethod_72242A6B.FunctionObject_ClassMethod_E52A68FB_Greeter_logHello
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21d6
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_E52A68FB_Greeter_logHello::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21de
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_E52A68FB_Greeter_logHello::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21e1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_E52A68FB_Greeter_logHello::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21e4
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter
-		IL_0006: call instance object Modules.Classes_ClassMethod_CallsAnotherMethod/Greeter::logHello()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_E52A68FB_Greeter_logHello::CallCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_CallsAnotherMethod_72242A6B.FunctionObject_ClassMethod_E52A68FB_Greeter_logHello
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_ForLoop_CallsAnotherMethod.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_ForLoop_CallsAnotherMethod.verified.txt
@@ -153,6 +153,276 @@
 
 		} // end of class Scope_log
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_85134ECE_Accumulator
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2216
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator/FunctionObject_ClassConstructor_85134ECE_Accumulator::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_85134ECE_Accumulator::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2225
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_85134ECE_Accumulator::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2228
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_85134ECE_Accumulator::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x222b
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_85134ECE_Accumulator::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2237
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_85134ECE_Accumulator::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_85134ECE_Accumulator
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_7BB25A56_Accumulator_add
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2243
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_7BB25A56_Accumulator_add::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x224b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_7BB25A56_Accumulator_add::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x224e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_7BB25A56_Accumulator_add::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2251
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0012: call instance object Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator::'add'(float64)
+				IL_0017: ret
+			} // end of method FunctionObject_ClassMethod_7BB25A56_Accumulator_add::CallCore
+
+		} // end of class FunctionObject_ClassMethod_7BB25A56_Accumulator_add
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_2F5A97A3_Accumulator_addRange
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x226a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_2F5A97A3_Accumulator_addRange::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2272
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_2F5A97A3_Accumulator_addRange::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2275
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_2F5A97A3_Accumulator_addRange::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2278
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator::addRange(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassMethod_2F5A97A3_Accumulator_addRange::CallCore
+
+		} // end of class FunctionObject_ClassMethod_2F5A97A3_Accumulator_addRange
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_E2587F73_Accumulator_log
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x228c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_E2587F73_Accumulator_log::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2294
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_E2587F73_Accumulator_log::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2297
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_E2587F73_Accumulator_log::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x229a
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator
+				IL_0006: call instance object Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator::log()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_E2587F73_Accumulator_log::CallCore
+
+		} // end of class FunctionObject_ClassMethod_E2587F73_Accumulator_log
+
 
 		// Fields
 		.field private object[] _scopes
@@ -399,276 +669,6 @@
 	} // end of method Classes_ClassMethod_ForLoop_CallsAnotherMethod::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_ForLoop_CallsAnotherMethod_93748649.FunctionObject_ClassConstructor_85134ECE_Accumulator
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2216
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassMethod_ForLoop_CallsAnotherMethod_93748649.FunctionObject_ClassConstructor_85134ECE_Accumulator::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_85134ECE_Accumulator::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2225
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_85134ECE_Accumulator::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2228
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_85134ECE_Accumulator::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x222b
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_85134ECE_Accumulator::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2237
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_85134ECE_Accumulator::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_ForLoop_CallsAnotherMethod_93748649.FunctionObject_ClassConstructor_85134ECE_Accumulator
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_ForLoop_CallsAnotherMethod_93748649.FunctionObject_ClassMethod_7BB25A56_Accumulator_add
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2243
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_7BB25A56_Accumulator_add::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x224b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_7BB25A56_Accumulator_add::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x224e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_7BB25A56_Accumulator_add::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2251
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0012: call instance object Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator::'add'(float64)
-		IL_0017: ret
-	} // end of method FunctionObject_ClassMethod_7BB25A56_Accumulator_add::CallCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_ForLoop_CallsAnotherMethod_93748649.FunctionObject_ClassMethod_7BB25A56_Accumulator_add
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_ForLoop_CallsAnotherMethod_93748649.FunctionObject_ClassMethod_2F5A97A3_Accumulator_addRange
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x226a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_2F5A97A3_Accumulator_addRange::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2272
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_2F5A97A3_Accumulator_addRange::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2275
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_2F5A97A3_Accumulator_addRange::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2278
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator::addRange(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassMethod_2F5A97A3_Accumulator_addRange::CallCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_ForLoop_CallsAnotherMethod_93748649.FunctionObject_ClassMethod_2F5A97A3_Accumulator_addRange
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_ForLoop_CallsAnotherMethod_93748649.FunctionObject_ClassMethod_E2587F73_Accumulator_log
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x228c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_E2587F73_Accumulator_log::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2294
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_E2587F73_Accumulator_log::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2297
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_E2587F73_Accumulator_log::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x229a
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator
-		IL_0006: call instance object Modules.Classes_ClassMethod_ForLoop_CallsAnotherMethod/Accumulator::log()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_E2587F73_Accumulator_log::CallCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_ForLoop_CallsAnotherMethod_93748649.FunctionObject_ClassMethod_E2587F73_Accumulator_log
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall.verified.txt
@@ -71,6 +71,150 @@
 
 		} // end of class Scope_getNext
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_AB7DA7FA_Counter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x22ea
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter/FunctionObject_ClassConstructor_AB7DA7FA_Counter::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_AB7DA7FA_Counter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22f9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_AB7DA7FA_Counter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22fc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_AB7DA7FA_Counter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22ff
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_AB7DA7FA_Counter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x230b
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_AB7DA7FA_Counter::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_AB7DA7FA_Counter
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_2BC95740_Counter_getNext
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2317
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_2BC95740_Counter_getNext::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x231f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_2BC95740_Counter_getNext::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2322
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_2BC95740_Counter_getNext::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2325
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter
+				IL_0006: call instance float64 Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter::getNext()
+				IL_000b: box [System.Runtime]System.Double
+				IL_0010: ret
+			} // end of method FunctionObject_ClassMethod_2BC95740_Counter_getNext::CallCore
+
+		} // end of class FunctionObject_ClassMethod_2BC95740_Counter_getNext
+
 
 		// Fields
 		.field public float64 'value'
@@ -187,6 +331,155 @@
 			} // end of method Scope_compute::.ctor
 
 		} // end of class Scope_compute
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_2721F182_Calculator
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Scope _environment0_Classes_ClassMethod_LocalVar_ReassignedFromMethodCall
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x2337
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Scope Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator/FunctionObject_ClassConstructor_2721F182_Calculator::_environment0_Classes_ClassMethod_LocalVar_ReassignedFromMethodCall
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator/FunctionObject_ClassConstructor_2721F182_Calculator::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_ClassConstructor_2721F182_Calculator::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x234d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_2721F182_Calculator::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2350
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_2721F182_Calculator::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2353
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_2721F182_Calculator::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x235f
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_2721F182_Calculator::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_2721F182_Calculator
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_DAB46382_Calculator_compute
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x236b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_DAB46382_Calculator_compute::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2373
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_DAB46382_Calculator_compute::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2376
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_DAB46382_Calculator_compute::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2379
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator
+				IL_0006: call instance float64 Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator::compute()
+				IL_000b: box [System.Runtime]System.Double
+				IL_0010: ret
+			} // end of method FunctionObject_ClassMethod_DAB46382_Calculator_compute::CallCore
+
+		} // end of class FunctionObject_ClassMethod_DAB46382_Calculator_compute
 
 
 		// Fields
@@ -474,299 +767,6 @@
 	} // end of method Classes_ClassMethod_LocalVar_ReassignedFromMethodCall::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall_8D2CC057.FunctionObject_ClassConstructor_AB7DA7FA_Counter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x22ea
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall_8D2CC057.FunctionObject_ClassConstructor_AB7DA7FA_Counter::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_AB7DA7FA_Counter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22f9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_AB7DA7FA_Counter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22fc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_AB7DA7FA_Counter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22ff
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_AB7DA7FA_Counter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x230b
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_AB7DA7FA_Counter::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall_8D2CC057.FunctionObject_ClassConstructor_AB7DA7FA_Counter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall_8D2CC057.FunctionObject_ClassMethod_2BC95740_Counter_getNext
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2317
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_2BC95740_Counter_getNext::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x231f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_2BC95740_Counter_getNext::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2322
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_2BC95740_Counter_getNext::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2325
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter
-		IL_0006: call instance float64 Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Counter::getNext()
-		IL_000b: box [System.Runtime]System.Double
-		IL_0010: ret
-	} // end of method FunctionObject_ClassMethod_2BC95740_Counter_getNext::CallCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall_8D2CC057.FunctionObject_ClassMethod_2BC95740_Counter_getNext
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall_8D2CC057.FunctionObject_ClassConstructor_2721F182_Calculator
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Scope _environment0_Classes_ClassMethod_LocalVar_ReassignedFromMethodCall
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x2337
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Scope FunctionObjects.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall_8D2CC057.FunctionObject_ClassConstructor_2721F182_Calculator::_environment0_Classes_ClassMethod_LocalVar_ReassignedFromMethodCall
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall_8D2CC057.FunctionObject_ClassConstructor_2721F182_Calculator::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_ClassConstructor_2721F182_Calculator::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x234d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_2721F182_Calculator::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2350
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_2721F182_Calculator::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2353
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_2721F182_Calculator::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x235f
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_2721F182_Calculator::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall_8D2CC057.FunctionObject_ClassConstructor_2721F182_Calculator
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall_8D2CC057.FunctionObject_ClassMethod_DAB46382_Calculator_compute
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x236b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_DAB46382_Calculator_compute::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2373
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_DAB46382_Calculator_compute::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2376
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_DAB46382_Calculator_compute::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2379
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator
-		IL_0006: call instance float64 Modules.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall/Calculator::compute()
-		IL_000b: box [System.Runtime]System.Double
-		IL_0010: ret
-	} // end of method FunctionObject_ClassMethod_DAB46382_Calculator_compute::CallCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_LocalVar_ReassignedFromMethodCall_8D2CC057.FunctionObject_ClassMethod_DAB46382_Calculator_compute
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_MaxParameters_32.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_MaxParameters_32.verified.txt
@@ -51,6 +51,245 @@
 
 		} // end of class Scope_m
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_85D6A1FA_C
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x22cd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassMethod_MaxParameters_32/C/FunctionObject_ClassConstructor_85D6A1FA_C::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_85D6A1FA_C::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22dc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_85D6A1FA_C::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22df
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_85D6A1FA_C::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22e2
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_85D6A1FA_C::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22ee
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_85D6A1FA_C::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_85D6A1FA_C
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_CE844044_C_m
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x22fa
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_CE844044_C_m::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2302
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_CE844044_C_m::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2305
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_CE844044_C_m::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2308
+				// Header size: 12
+				// Code size: 259 (0x103)
+				.maxstack 35
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassMethod_MaxParameters_32/C
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: ldarg.2
+				IL_0015: ldc.i4.2
+				IL_0016: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001b: ldarg.2
+				IL_001c: ldc.i4.3
+				IL_001d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0022: ldarg.2
+				IL_0023: ldc.i4.4
+				IL_0024: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0029: ldarg.2
+				IL_002a: ldc.i4.5
+				IL_002b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0030: ldarg.2
+				IL_0031: ldc.i4.6
+				IL_0032: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0037: ldarg.2
+				IL_0038: ldc.i4.7
+				IL_0039: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_003e: ldarg.2
+				IL_003f: ldc.i4.8
+				IL_0040: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0045: ldarg.2
+				IL_0046: ldc.i4.s 9
+				IL_0048: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_004d: ldarg.2
+				IL_004e: ldc.i4.s 10
+				IL_0050: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0055: ldarg.2
+				IL_0056: ldc.i4.s 11
+				IL_0058: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_005d: ldarg.2
+				IL_005e: ldc.i4.s 12
+				IL_0060: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0065: ldarg.2
+				IL_0066: ldc.i4.s 13
+				IL_0068: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_006d: ldarg.2
+				IL_006e: ldc.i4.s 14
+				IL_0070: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0075: ldarg.2
+				IL_0076: ldc.i4.s 15
+				IL_0078: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_007d: ldarg.2
+				IL_007e: ldc.i4.s 16
+				IL_0080: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0085: ldarg.2
+				IL_0086: ldc.i4.s 17
+				IL_0088: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_008d: ldarg.2
+				IL_008e: ldc.i4.s 18
+				IL_0090: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0095: ldarg.2
+				IL_0096: ldc.i4.s 19
+				IL_0098: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_009d: ldarg.2
+				IL_009e: ldc.i4.s 20
+				IL_00a0: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00a5: ldarg.2
+				IL_00a6: ldc.i4.s 21
+				IL_00a8: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00ad: ldarg.2
+				IL_00ae: ldc.i4.s 22
+				IL_00b0: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00b5: ldarg.2
+				IL_00b6: ldc.i4.s 23
+				IL_00b8: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00bd: ldarg.2
+				IL_00be: ldc.i4.s 24
+				IL_00c0: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00c5: ldarg.2
+				IL_00c6: ldc.i4.s 25
+				IL_00c8: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00cd: ldarg.2
+				IL_00ce: ldc.i4.s 26
+				IL_00d0: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00d5: ldarg.2
+				IL_00d6: ldc.i4.s 27
+				IL_00d8: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00dd: ldarg.2
+				IL_00de: ldc.i4.s 28
+				IL_00e0: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00e5: ldarg.2
+				IL_00e6: ldc.i4.s 29
+				IL_00e8: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00ed: ldarg.2
+				IL_00ee: ldc.i4.s 30
+				IL_00f0: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00f5: ldarg.2
+				IL_00f6: ldc.i4.s 31
+				IL_00f8: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00fd: call instance object Modules.Classes_ClassMethod_MaxParameters_32/C::m(object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object)
+				IL_0102: ret
+			} // end of method FunctionObject_ClassMethod_CE844044_C_m::CallCore
+
+		} // end of class FunctionObject_ClassMethod_CE844044_C_m
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -275,245 +514,6 @@
 	} // end of method Classes_ClassMethod_MaxParameters_32::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_MaxParameters_32
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_MaxParameters_32_BDF99D78.FunctionObject_ClassConstructor_85D6A1FA_C
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x22cd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassMethod_MaxParameters_32_BDF99D78.FunctionObject_ClassConstructor_85D6A1FA_C::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_85D6A1FA_C::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22dc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_85D6A1FA_C::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22df
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_85D6A1FA_C::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22e2
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_85D6A1FA_C::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22ee
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_85D6A1FA_C::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_MaxParameters_32_BDF99D78.FunctionObject_ClassConstructor_85D6A1FA_C
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_MaxParameters_32_BDF99D78.FunctionObject_ClassMethod_CE844044_C_m
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x22fa
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_CE844044_C_m::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2302
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_CE844044_C_m::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2305
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_CE844044_C_m::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2308
-		// Header size: 12
-		// Code size: 259 (0x103)
-		.maxstack 35
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassMethod_MaxParameters_32/C
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: ldarg.2
-		IL_0015: ldc.i4.2
-		IL_0016: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001b: ldarg.2
-		IL_001c: ldc.i4.3
-		IL_001d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0022: ldarg.2
-		IL_0023: ldc.i4.4
-		IL_0024: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0029: ldarg.2
-		IL_002a: ldc.i4.5
-		IL_002b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0030: ldarg.2
-		IL_0031: ldc.i4.6
-		IL_0032: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0037: ldarg.2
-		IL_0038: ldc.i4.7
-		IL_0039: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_003e: ldarg.2
-		IL_003f: ldc.i4.8
-		IL_0040: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0045: ldarg.2
-		IL_0046: ldc.i4.s 9
-		IL_0048: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_004d: ldarg.2
-		IL_004e: ldc.i4.s 10
-		IL_0050: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0055: ldarg.2
-		IL_0056: ldc.i4.s 11
-		IL_0058: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_005d: ldarg.2
-		IL_005e: ldc.i4.s 12
-		IL_0060: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0065: ldarg.2
-		IL_0066: ldc.i4.s 13
-		IL_0068: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_006d: ldarg.2
-		IL_006e: ldc.i4.s 14
-		IL_0070: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0075: ldarg.2
-		IL_0076: ldc.i4.s 15
-		IL_0078: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_007d: ldarg.2
-		IL_007e: ldc.i4.s 16
-		IL_0080: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0085: ldarg.2
-		IL_0086: ldc.i4.s 17
-		IL_0088: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_008d: ldarg.2
-		IL_008e: ldc.i4.s 18
-		IL_0090: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0095: ldarg.2
-		IL_0096: ldc.i4.s 19
-		IL_0098: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_009d: ldarg.2
-		IL_009e: ldc.i4.s 20
-		IL_00a0: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00a5: ldarg.2
-		IL_00a6: ldc.i4.s 21
-		IL_00a8: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00ad: ldarg.2
-		IL_00ae: ldc.i4.s 22
-		IL_00b0: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00b5: ldarg.2
-		IL_00b6: ldc.i4.s 23
-		IL_00b8: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00bd: ldarg.2
-		IL_00be: ldc.i4.s 24
-		IL_00c0: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00c5: ldarg.2
-		IL_00c6: ldc.i4.s 25
-		IL_00c8: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00cd: ldarg.2
-		IL_00ce: ldc.i4.s 26
-		IL_00d0: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00d5: ldarg.2
-		IL_00d6: ldc.i4.s 27
-		IL_00d8: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00dd: ldarg.2
-		IL_00de: ldc.i4.s 28
-		IL_00e0: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00e5: ldarg.2
-		IL_00e6: ldc.i4.s 29
-		IL_00e8: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00ed: ldarg.2
-		IL_00ee: ldc.i4.s 30
-		IL_00f0: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00f5: ldarg.2
-		IL_00f6: ldc.i4.s 31
-		IL_00f8: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00fd: call instance object Modules.Classes_ClassMethod_MaxParameters_32/C::m(object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object)
-		IL_0102: ret
-	} // end of method FunctionObject_ClassMethod_CE844044_C_m::CallCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_MaxParameters_32_BDF99D78.FunctionObject_ClassMethod_CE844044_C_m
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_MethodValueRequiresMetadata.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_MethodValueRequiresMetadata.verified.txt
@@ -71,6 +71,209 @@
 
 		} // end of class Scope_getGreet
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_6B77E7C6_Greeter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x222d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter/FunctionObject_ClassConstructor_6B77E7C6_Greeter::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_6B77E7C6_Greeter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x223c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_6B77E7C6_Greeter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x223f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_6B77E7C6_Greeter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2242
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_6B77E7C6_Greeter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x224e
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_6B77E7C6_Greeter::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_6B77E7C6_Greeter
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_55D3FD98_Greeter_greet
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x225a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_55D3FD98_Greeter_greet::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2262
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_55D3FD98_Greeter_greet::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2265
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_55D3FD98_Greeter_greet::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2268
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter
+				IL_0006: call instance object Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter::greet()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_55D3FD98_Greeter_greet::CallCore
+
+		} // end of class FunctionObject_ClassMethod_55D3FD98_Greeter_greet
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2275
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x227d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2280
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2283
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter
+				IL_0006: call instance object Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter::getGreet()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet::CallCore
+
+		} // end of class FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -336,209 +539,6 @@
 	} // end of method Classes_ClassMethod_MethodValueRequiresMetadata::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_MethodValueRequiresMetadata
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_MethodValueRequiresMetadata_11CEE5C5.FunctionObject_ClassConstructor_6B77E7C6_Greeter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x222d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassMethod_MethodValueRequiresMetadata_11CEE5C5.FunctionObject_ClassConstructor_6B77E7C6_Greeter::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_6B77E7C6_Greeter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x223c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_6B77E7C6_Greeter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x223f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_6B77E7C6_Greeter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2242
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_6B77E7C6_Greeter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x224e
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_6B77E7C6_Greeter::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_MethodValueRequiresMetadata_11CEE5C5.FunctionObject_ClassConstructor_6B77E7C6_Greeter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_MethodValueRequiresMetadata_11CEE5C5.FunctionObject_ClassMethod_55D3FD98_Greeter_greet
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x225a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_55D3FD98_Greeter_greet::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2262
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_55D3FD98_Greeter_greet::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2265
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_55D3FD98_Greeter_greet::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2268
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter
-		IL_0006: call instance object Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter::greet()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_55D3FD98_Greeter_greet::CallCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_MethodValueRequiresMetadata_11CEE5C5.FunctionObject_ClassMethod_55D3FD98_Greeter_greet
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_MethodValueRequiresMetadata_11CEE5C5.FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2275
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x227d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2280
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2283
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter
-		IL_0006: call instance object Modules.Classes_ClassMethod_MethodValueRequiresMetadata/Greeter::getGreet()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet::CallCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_MethodValueRequiresMetadata_11CEE5C5.FunctionObject_ClassMethod_812D6CB6_Greeter_getGreet
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_ParameterDestructuring.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_ParameterDestructuring.verified.txt
@@ -87,6 +87,215 @@
 
 		} // end of class Scope_multiply
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_22853239_Calculator
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2729
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassMethod_ParameterDestructuring/Calculator/FunctionObject_ClassConstructor_22853239_Calculator::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_22853239_Calculator::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2738
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_22853239_Calculator::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x273b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_22853239_Calculator::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x273e
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_22853239_Calculator::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x274a
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_22853239_Calculator::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_22853239_Calculator
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_B8BF3D91_Calculator_add
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2756
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_B8BF3D91_Calculator_add::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x275e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_B8BF3D91_Calculator_add::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2761
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_B8BF3D91_Calculator_add::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2764
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassMethod_ParameterDestructuring/Calculator
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.Classes_ClassMethod_ParameterDestructuring/Calculator::'add'(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassMethod_B8BF3D91_Calculator_add::CallCore
+
+		} // end of class FunctionObject_ClassMethod_B8BF3D91_Calculator_add
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_7C8E7CCA_Calculator_multiply
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2778
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_7C8E7CCA_Calculator_multiply::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2780
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_7C8E7CCA_Calculator_multiply::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2783
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_7C8E7CCA_Calculator_multiply::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2786
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassMethod_ParameterDestructuring/Calculator
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.Classes_ClassMethod_ParameterDestructuring/Calculator::multiply(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassMethod_7C8E7CCA_Calculator_multiply::CallCore
+
+		} // end of class FunctionObject_ClassMethod_7C8E7CCA_Calculator_multiply
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -290,6 +499,215 @@
 			} // end of method Scope_formatDate::.ctor
 
 		} // end of class Scope_formatDate
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_7862EBA1_Formatter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x279a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassMethod_ParameterDestructuring/Formatter/FunctionObject_ClassConstructor_7862EBA1_Formatter::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_7862EBA1_Formatter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x27a9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_7862EBA1_Formatter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x27ac
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_7862EBA1_Formatter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x27af
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_7862EBA1_Formatter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x27bb
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_7862EBA1_Formatter::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_7862EBA1_Formatter
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_76F5B1F6_Formatter_formatPerson
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x27c7
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_76F5B1F6_Formatter_formatPerson::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x27cf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_76F5B1F6_Formatter_formatPerson::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x27d2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_76F5B1F6_Formatter_formatPerson::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x27d5
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassMethod_ParameterDestructuring/Formatter
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.Classes_ClassMethod_ParameterDestructuring/Formatter::formatPerson(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassMethod_76F5B1F6_Formatter_formatPerson::CallCore
+
+		} // end of class FunctionObject_ClassMethod_76F5B1F6_Formatter_formatPerson
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_33CDD56F_Formatter_formatDate
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x27e9
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_33CDD56F_Formatter_formatDate::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x27f1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_33CDD56F_Formatter_formatDate::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x27f4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_33CDD56F_Formatter_formatDate::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x27f7
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassMethod_ParameterDestructuring/Formatter
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.Classes_ClassMethod_ParameterDestructuring/Formatter::formatDate(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassMethod_33CDD56F_Formatter_formatDate::CallCore
+
+		} // end of class FunctionObject_ClassMethod_33CDD56F_Formatter_formatDate
 
 
 		// Methods
@@ -524,6 +942,152 @@
 			} // end of method Scope_setConnection::.ctor
 
 		} // end of class Scope_setConnection
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_39E5F53B_Config
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x280b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassMethod_ParameterDestructuring/Config/FunctionObject_ClassConstructor_39E5F53B_Config::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_39E5F53B_Config::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x281a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_39E5F53B_Config::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x281d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_39E5F53B_Config::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2820
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_39E5F53B_Config::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x282c
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_39E5F53B_Config::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_39E5F53B_Config
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_BBE88488_Config_setConnection
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2838
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_BBE88488_Config_setConnection::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2840
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_BBE88488_Config_setConnection::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2843
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_BBE88488_Config_setConnection::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2846
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassMethod_ParameterDestructuring/Config
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.Classes_ClassMethod_ParameterDestructuring/Config::setConnection(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassMethod_BBE88488_Config_setConnection::CallCore
+
+		} // end of class FunctionObject_ClassMethod_BBE88488_Config_setConnection
 
 
 		// Fields
@@ -976,570 +1540,6 @@
 	} // end of method Classes_ClassMethod_ParameterDestructuring::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_ParameterDestructuring
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_ParameterDestructuring_4E358564.FunctionObject_ClassConstructor_22853239_Calculator
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2729
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassMethod_ParameterDestructuring_4E358564.FunctionObject_ClassConstructor_22853239_Calculator::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_22853239_Calculator::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2738
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_22853239_Calculator::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x273b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_22853239_Calculator::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x273e
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_22853239_Calculator::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x274a
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_22853239_Calculator::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_ParameterDestructuring_4E358564.FunctionObject_ClassConstructor_22853239_Calculator
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_ParameterDestructuring_4E358564.FunctionObject_ClassMethod_B8BF3D91_Calculator_add
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2756
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_B8BF3D91_Calculator_add::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x275e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_B8BF3D91_Calculator_add::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2761
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_B8BF3D91_Calculator_add::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2764
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassMethod_ParameterDestructuring/Calculator
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.Classes_ClassMethod_ParameterDestructuring/Calculator::'add'(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassMethod_B8BF3D91_Calculator_add::CallCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_ParameterDestructuring_4E358564.FunctionObject_ClassMethod_B8BF3D91_Calculator_add
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_ParameterDestructuring_4E358564.FunctionObject_ClassMethod_7C8E7CCA_Calculator_multiply
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2778
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_7C8E7CCA_Calculator_multiply::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2780
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_7C8E7CCA_Calculator_multiply::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2783
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_7C8E7CCA_Calculator_multiply::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2786
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassMethod_ParameterDestructuring/Calculator
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.Classes_ClassMethod_ParameterDestructuring/Calculator::multiply(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassMethod_7C8E7CCA_Calculator_multiply::CallCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_ParameterDestructuring_4E358564.FunctionObject_ClassMethod_7C8E7CCA_Calculator_multiply
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_ParameterDestructuring_4E358564.FunctionObject_ClassConstructor_7862EBA1_Formatter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x279a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassMethod_ParameterDestructuring_4E358564.FunctionObject_ClassConstructor_7862EBA1_Formatter::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_7862EBA1_Formatter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x27a9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_7862EBA1_Formatter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x27ac
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_7862EBA1_Formatter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x27af
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_7862EBA1_Formatter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27bb
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_7862EBA1_Formatter::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_ParameterDestructuring_4E358564.FunctionObject_ClassConstructor_7862EBA1_Formatter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_ParameterDestructuring_4E358564.FunctionObject_ClassMethod_76F5B1F6_Formatter_formatPerson
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x27c7
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_76F5B1F6_Formatter_formatPerson::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x27cf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_76F5B1F6_Formatter_formatPerson::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x27d2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_76F5B1F6_Formatter_formatPerson::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x27d5
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassMethod_ParameterDestructuring/Formatter
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.Classes_ClassMethod_ParameterDestructuring/Formatter::formatPerson(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassMethod_76F5B1F6_Formatter_formatPerson::CallCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_ParameterDestructuring_4E358564.FunctionObject_ClassMethod_76F5B1F6_Formatter_formatPerson
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_ParameterDestructuring_4E358564.FunctionObject_ClassMethod_33CDD56F_Formatter_formatDate
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x27e9
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_33CDD56F_Formatter_formatDate::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x27f1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_33CDD56F_Formatter_formatDate::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x27f4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_33CDD56F_Formatter_formatDate::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x27f7
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassMethod_ParameterDestructuring/Formatter
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.Classes_ClassMethod_ParameterDestructuring/Formatter::formatDate(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassMethod_33CDD56F_Formatter_formatDate::CallCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_ParameterDestructuring_4E358564.FunctionObject_ClassMethod_33CDD56F_Formatter_formatDate
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_ParameterDestructuring_4E358564.FunctionObject_ClassConstructor_39E5F53B_Config
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x280b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassMethod_ParameterDestructuring_4E358564.FunctionObject_ClassConstructor_39E5F53B_Config::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_39E5F53B_Config::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x281a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_39E5F53B_Config::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x281d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_39E5F53B_Config::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2820
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_39E5F53B_Config::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x282c
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_39E5F53B_Config::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_ParameterDestructuring_4E358564.FunctionObject_ClassConstructor_39E5F53B_Config
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_ParameterDestructuring_4E358564.FunctionObject_ClassMethod_BBE88488_Config_setConnection
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2838
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_BBE88488_Config_setConnection::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2840
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_BBE88488_Config_setConnection::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2843
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_BBE88488_Config_setConnection::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2846
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassMethod_ParameterDestructuring/Config
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.Classes_ClassMethod_ParameterDestructuring/Config::setConnection(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassMethod_BBE88488_Config_setConnection::CallCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_ParameterDestructuring_4E358564.FunctionObject_ClassMethod_BBE88488_Config_setConnection
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number.verified.txt
@@ -71,6 +71,218 @@
 
 		} // end of class Scope_add
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_3AE3B93D_Accumulator
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2195
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number/Accumulator/FunctionObject_ClassConstructor_3AE3B93D_Accumulator::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_3AE3B93D_Accumulator::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21a4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_3AE3B93D_Accumulator::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21a7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_3AE3B93D_Accumulator::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21aa
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_3AE3B93D_Accumulator::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21b6
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_3AE3B93D_Accumulator::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_3AE3B93D_Accumulator
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_0C9F7E0D_Accumulator_run
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21c2
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_0C9F7E0D_Accumulator_run::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21ca
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_0C9F7E0D_Accumulator_run::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21cd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_0C9F7E0D_Accumulator_run::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21d0
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number/Accumulator
+				IL_0006: call instance object Modules.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number/Accumulator::run()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_0C9F7E0D_Accumulator_run::CallCore
+
+		} // end of class FunctionObject_ClassMethod_0C9F7E0D_Accumulator_run
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_53BDE38B_Accumulator_add
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21dd
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_53BDE38B_Accumulator_add::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21e5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_53BDE38B_Accumulator_add::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21e8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_53BDE38B_Accumulator_add::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21eb
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number/Accumulator
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001e: call instance float64 Modules.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number/Accumulator::'add'(float64, float64)
+				IL_0023: box [System.Runtime]System.Double
+				IL_0028: ret
+			} // end of method FunctionObject_ClassMethod_53BDE38B_Accumulator_add::CallCore
+
+		} // end of class FunctionObject_ClassMethod_53BDE38B_Accumulator_add
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -248,218 +460,6 @@
 	} // end of method Classes_ClassMethod_ParameterTypeInference_DirectThis_Number::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number_D4F9C77C.FunctionObject_ClassConstructor_3AE3B93D_Accumulator
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2195
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number_D4F9C77C.FunctionObject_ClassConstructor_3AE3B93D_Accumulator::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_3AE3B93D_Accumulator::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21a4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_3AE3B93D_Accumulator::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21a7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_3AE3B93D_Accumulator::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21aa
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_3AE3B93D_Accumulator::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21b6
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_3AE3B93D_Accumulator::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number_D4F9C77C.FunctionObject_ClassConstructor_3AE3B93D_Accumulator
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number_D4F9C77C.FunctionObject_ClassMethod_0C9F7E0D_Accumulator_run
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21c2
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_0C9F7E0D_Accumulator_run::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21ca
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_0C9F7E0D_Accumulator_run::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21cd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_0C9F7E0D_Accumulator_run::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21d0
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number/Accumulator
-		IL_0006: call instance object Modules.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number/Accumulator::run()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_0C9F7E0D_Accumulator_run::CallCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number_D4F9C77C.FunctionObject_ClassMethod_0C9F7E0D_Accumulator_run
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number_D4F9C77C.FunctionObject_ClassMethod_53BDE38B_Accumulator_add
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21dd
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_53BDE38B_Accumulator_add::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21e5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_53BDE38B_Accumulator_add::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21e8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_53BDE38B_Accumulator_add::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21eb
-		// Header size: 1
-		// Code size: 41 (0x29)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number/Accumulator
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001e: call instance float64 Modules.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number/Accumulator::'add'(float64, float64)
-		IL_0023: box [System.Runtime]System.Double
-		IL_0028: ret
-	} // end of method FunctionObject_ClassMethod_53BDE38B_Accumulator_add::CallCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_ParameterTypeInference_DirectThis_Number_D4F9C77C.FunctionObject_ClassMethod_53BDE38B_Accumulator_add
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_ReturnsThis_IsSelf_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_ReturnsThis_IsSelf_Log.verified.txt
@@ -51,6 +51,149 @@
 
 		} // end of class Scope_isSelf
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_28EE6FB2_Self
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2128
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassMethod_ReturnsThis_IsSelf_Log/Self/FunctionObject_ClassConstructor_28EE6FB2_Self::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_28EE6FB2_Self::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2137
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_28EE6FB2_Self::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x213a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_28EE6FB2_Self::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x213d
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_28EE6FB2_Self::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2149
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_28EE6FB2_Self::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_28EE6FB2_Self
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_47927AE7_Self_isSelf
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2155
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_47927AE7_Self_isSelf::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x215d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_47927AE7_Self_isSelf::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2160
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_47927AE7_Self_isSelf::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2163
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassMethod_ReturnsThis_IsSelf_Log/Self
+				IL_0006: call instance class Modules.Classes_ClassMethod_ReturnsThis_IsSelf_Log/Self Modules.Classes_ClassMethod_ReturnsThis_IsSelf_Log/Self::isSelf()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_47927AE7_Self_isSelf::CallCore
+
+		} // end of class FunctionObject_ClassMethod_47927AE7_Self_isSelf
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -191,149 +334,6 @@
 	} // end of method Classes_ClassMethod_ReturnsThis_IsSelf_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_ReturnsThis_IsSelf_Log
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_ReturnsThis_IsSelf_Log_3C0C1E01.FunctionObject_ClassConstructor_28EE6FB2_Self
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2128
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassMethod_ReturnsThis_IsSelf_Log_3C0C1E01.FunctionObject_ClassConstructor_28EE6FB2_Self::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_28EE6FB2_Self::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2137
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_28EE6FB2_Self::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x213a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_28EE6FB2_Self::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x213d
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_28EE6FB2_Self::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2149
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_28EE6FB2_Self::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_ReturnsThis_IsSelf_Log_3C0C1E01.FunctionObject_ClassConstructor_28EE6FB2_Self
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_ReturnsThis_IsSelf_Log_3C0C1E01.FunctionObject_ClassMethod_47927AE7_Self_isSelf
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2155
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_47927AE7_Self_isSelf::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x215d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_47927AE7_Self_isSelf::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2160
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_47927AE7_Self_isSelf::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2163
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassMethod_ReturnsThis_IsSelf_Log/Self
-		IL_0006: call instance class Modules.Classes_ClassMethod_ReturnsThis_IsSelf_Log/Self Modules.Classes_ClassMethod_ReturnsThis_IsSelf_Log/Self::isSelf()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_47927AE7_Self_isSelf::CallCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_ReturnsThis_IsSelf_Log_3C0C1E01.FunctionObject_ClassMethod_47927AE7_Self_isSelf
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_While_Increment_Param_Postfix.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_While_Increment_Param_Postfix.verified.txt
@@ -73,6 +73,152 @@
 
 		} // end of class Scope_run
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_75B77750_Counter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2161
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassMethod_While_Increment_Param_Postfix/Counter/FunctionObject_ClassConstructor_75B77750_Counter::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_75B77750_Counter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2170
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_75B77750_Counter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2173
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_75B77750_Counter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2176
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_75B77750_Counter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2182
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_75B77750_Counter::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_75B77750_Counter
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_7AC55D46_Counter_run
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x218e
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_7AC55D46_Counter_run::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2196
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_7AC55D46_Counter_run::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2199
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_7AC55D46_Counter_run::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x219c
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassMethod_While_Increment_Param_Postfix/Counter
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.Classes_ClassMethod_While_Increment_Param_Postfix/Counter::run(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassMethod_7AC55D46_Counter_run::CallCore
+
+		} // end of class FunctionObject_ClassMethod_7AC55D46_Counter_run
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -225,152 +371,6 @@
 	} // end of method Classes_ClassMethod_While_Increment_Param_Postfix::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_While_Increment_Param_Postfix
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_While_Increment_Param_Postfix_8C904685.FunctionObject_ClassConstructor_75B77750_Counter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2161
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassMethod_While_Increment_Param_Postfix_8C904685.FunctionObject_ClassConstructor_75B77750_Counter::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_75B77750_Counter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2170
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_75B77750_Counter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2173
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_75B77750_Counter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2176
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_75B77750_Counter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2182
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_75B77750_Counter::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_While_Increment_Param_Postfix_8C904685.FunctionObject_ClassConstructor_75B77750_Counter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_While_Increment_Param_Postfix_8C904685.FunctionObject_ClassMethod_7AC55D46_Counter_run
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x218e
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_7AC55D46_Counter_run::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2196
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_7AC55D46_Counter_run::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2199
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_7AC55D46_Counter_run::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x219c
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassMethod_While_Increment_Param_Postfix/Counter
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.Classes_ClassMethod_While_Increment_Param_Postfix/Counter::run(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassMethod_7AC55D46_Counter_run::CallCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_While_Increment_Param_Postfix_8C904685.FunctionObject_ClassMethod_7AC55D46_Counter_run
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_While_Increment_Param_Prefix.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_While_Increment_Param_Prefix.verified.txt
@@ -73,6 +73,152 @@
 
 		} // end of class Scope_run
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_DBC1CA27_Counter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2161
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassMethod_While_Increment_Param_Prefix/Counter/FunctionObject_ClassConstructor_DBC1CA27_Counter::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_DBC1CA27_Counter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2170
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_DBC1CA27_Counter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2173
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_DBC1CA27_Counter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2176
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_DBC1CA27_Counter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2182
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_DBC1CA27_Counter::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_DBC1CA27_Counter
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_C04B0C77_Counter_run
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x218e
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_C04B0C77_Counter_run::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2196
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_C04B0C77_Counter_run::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2199
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_C04B0C77_Counter_run::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x219c
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassMethod_While_Increment_Param_Prefix/Counter
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.Classes_ClassMethod_While_Increment_Param_Prefix/Counter::run(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassMethod_C04B0C77_Counter_run::CallCore
+
+		} // end of class FunctionObject_ClassMethod_C04B0C77_Counter_run
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -225,152 +371,6 @@
 	} // end of method Classes_ClassMethod_While_Increment_Param_Prefix::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_While_Increment_Param_Prefix
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_While_Increment_Param_Prefix_C294FC44.FunctionObject_ClassConstructor_DBC1CA27_Counter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2161
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassMethod_While_Increment_Param_Prefix_C294FC44.FunctionObject_ClassConstructor_DBC1CA27_Counter::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_DBC1CA27_Counter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2170
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_DBC1CA27_Counter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2173
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_DBC1CA27_Counter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2176
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_DBC1CA27_Counter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2182
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_DBC1CA27_Counter::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_While_Increment_Param_Prefix_C294FC44.FunctionObject_ClassConstructor_DBC1CA27_Counter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_While_Increment_Param_Prefix_C294FC44.FunctionObject_ClassMethod_C04B0C77_Counter_run
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x218e
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_C04B0C77_Counter_run::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2196
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_C04B0C77_Counter_run::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2199
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_C04B0C77_Counter_run::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x219c
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassMethod_While_Increment_Param_Prefix/Counter
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.Classes_ClassMethod_While_Increment_Param_Prefix/Counter::run(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassMethod_C04B0C77_Counter_run::CallCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_While_Increment_Param_Prefix_C294FC44.FunctionObject_ClassMethod_C04B0C77_Counter_run
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_While_Increment_Postfix.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_While_Increment_Postfix.verified.txt
@@ -73,6 +73,152 @@
 
 		} // end of class Scope_run
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_3A0313C6_Counter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x215b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassMethod_While_Increment_Postfix/Counter/FunctionObject_ClassConstructor_3A0313C6_Counter::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_3A0313C6_Counter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x216a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_3A0313C6_Counter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x216d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_3A0313C6_Counter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2170
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_3A0313C6_Counter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x217c
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_3A0313C6_Counter::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_3A0313C6_Counter
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_05AA4598_Counter_run
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2188
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_05AA4598_Counter_run::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2190
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_05AA4598_Counter_run::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2193
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_05AA4598_Counter_run::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2196
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassMethod_While_Increment_Postfix/Counter
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.Classes_ClassMethod_While_Increment_Postfix/Counter::run(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassMethod_05AA4598_Counter_run::CallCore
+
+		} // end of class FunctionObject_ClassMethod_05AA4598_Counter_run
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -225,152 +371,6 @@
 	} // end of method Classes_ClassMethod_While_Increment_Postfix::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_While_Increment_Postfix
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_While_Increment_Postfix_F3FA7133.FunctionObject_ClassConstructor_3A0313C6_Counter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x215b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassMethod_While_Increment_Postfix_F3FA7133.FunctionObject_ClassConstructor_3A0313C6_Counter::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_3A0313C6_Counter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x216a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_3A0313C6_Counter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x216d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_3A0313C6_Counter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2170
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_3A0313C6_Counter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x217c
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_3A0313C6_Counter::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_While_Increment_Postfix_F3FA7133.FunctionObject_ClassConstructor_3A0313C6_Counter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_While_Increment_Postfix_F3FA7133.FunctionObject_ClassMethod_05AA4598_Counter_run
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2188
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_05AA4598_Counter_run::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2190
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_05AA4598_Counter_run::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2193
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_05AA4598_Counter_run::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2196
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassMethod_While_Increment_Postfix/Counter
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.Classes_ClassMethod_While_Increment_Postfix/Counter::run(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassMethod_05AA4598_Counter_run::CallCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_While_Increment_Postfix_F3FA7133.FunctionObject_ClassMethod_05AA4598_Counter_run
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_While_Increment_Prefix.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassMethod_While_Increment_Prefix.verified.txt
@@ -73,6 +73,152 @@
 
 		} // end of class Scope_run
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_7A4E996D_Counter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x215b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassMethod_While_Increment_Prefix/Counter/FunctionObject_ClassConstructor_7A4E996D_Counter::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_7A4E996D_Counter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x216a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_7A4E996D_Counter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x216d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_7A4E996D_Counter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2170
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_7A4E996D_Counter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x217c
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_7A4E996D_Counter::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_7A4E996D_Counter
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_5B0B0D19_Counter_run
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2188
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_5B0B0D19_Counter_run::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2190
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_5B0B0D19_Counter_run::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2193
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_5B0B0D19_Counter_run::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2196
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassMethod_While_Increment_Prefix/Counter
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.Classes_ClassMethod_While_Increment_Prefix/Counter::run(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassMethod_5B0B0D19_Counter_run::CallCore
+
+		} // end of class FunctionObject_ClassMethod_5B0B0D19_Counter_run
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -225,152 +371,6 @@
 	} // end of method Classes_ClassMethod_While_Increment_Prefix::__js_module_init__
 
 } // end of class Modules.Classes_ClassMethod_While_Increment_Prefix
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_While_Increment_Prefix_3044629A.FunctionObject_ClassConstructor_7A4E996D_Counter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x215b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassMethod_While_Increment_Prefix_3044629A.FunctionObject_ClassConstructor_7A4E996D_Counter::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_7A4E996D_Counter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x216a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_7A4E996D_Counter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x216d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_7A4E996D_Counter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2170
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_7A4E996D_Counter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x217c
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_7A4E996D_Counter::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_While_Increment_Prefix_3044629A.FunctionObject_ClassConstructor_7A4E996D_Counter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassMethod_While_Increment_Prefix_3044629A.FunctionObject_ClassMethod_5B0B0D19_Counter_run
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2188
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_5B0B0D19_Counter_run::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2190
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_5B0B0D19_Counter_run::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2193
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_5B0B0D19_Counter_run::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2196
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassMethod_While_Increment_Prefix/Counter
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.Classes_ClassMethod_While_Increment_Prefix/Counter::run(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassMethod_5B0B0D19_Counter_run::CallCore
-
-} // end of class FunctionObjects.Classes_ClassMethod_While_Increment_Prefix_3044629A.FunctionObject_ClassMethod_5B0B0D19_Counter_run
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateAccessor_ClassExpression_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateAccessor_ClassExpression_Log.verified.txt
@@ -71,6 +71,222 @@
 
 		} // end of class Scope_log
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_CB97B5BC_ClassExpression_L3C17
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+			.field private initonly class [System.Runtime]System.Object _privateBrand
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0,
+					class [System.Runtime]System.Object capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x22a9
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassConstructor_CB97B5BC_ClassExpression_L3C17::_transitionalScopes
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassConstructor_CB97B5BC_ClassExpression_L3C17::_privateBrand
+				IL_0014: ret
+			} // end of method FunctionObject_ClassConstructor_CB97B5BC_ClassExpression_L3C17::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22bf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_CB97B5BC_ClassExpression_L3C17::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22c2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_CB97B5BC_ClassExpression_L3C17::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22c5
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_CB97B5BC_ClassExpression_L3C17::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22d1
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_CB97B5BC_ClassExpression_L3C17::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_CB97B5BC_ClassExpression_L3C17
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class [System.Runtime]System.Object _privateBrand
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class [System.Runtime]System.Object capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x22dd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17/FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value::_privateBrand
+				IL_000d: ret
+			} // end of method FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22ec
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22ef
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22f2
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17
+				IL_0006: call instance float64 Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17::__jroc_priv_get_value()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value::CallCore
+
+		} // end of class FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x22ff
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2307
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x230a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x230d
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17
+				IL_0006: call instance object Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17::log()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log::CallCore
+
+		} // end of class FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -379,222 +595,6 @@
 	} // end of method Classes_ClassPrivateAccessor_ClassExpression_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassPrivateAccessor_ClassExpression_Log
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassPrivateAccessor_ClassExpression_Log_92514F40.FunctionObject_ClassConstructor_CB97B5BC_ClassExpression_L3C17
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-	.field private initonly class [System.Runtime]System.Object _privateBrand
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0,
-			class [System.Runtime]System.Object capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x22a9
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassPrivateAccessor_ClassExpression_Log_92514F40.FunctionObject_ClassConstructor_CB97B5BC_ClassExpression_L3C17::_transitionalScopes
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class [System.Runtime]System.Object FunctionObjects.Classes_ClassPrivateAccessor_ClassExpression_Log_92514F40.FunctionObject_ClassConstructor_CB97B5BC_ClassExpression_L3C17::_privateBrand
-		IL_0014: ret
-	} // end of method FunctionObject_ClassConstructor_CB97B5BC_ClassExpression_L3C17::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22bf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_CB97B5BC_ClassExpression_L3C17::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22c2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_CB97B5BC_ClassExpression_L3C17::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22c5
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_CB97B5BC_ClassExpression_L3C17::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22d1
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_CB97B5BC_ClassExpression_L3C17::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassPrivateAccessor_ClassExpression_Log_92514F40.FunctionObject_ClassConstructor_CB97B5BC_ClassExpression_L3C17
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassPrivateAccessor_ClassExpression_Log_92514F40.FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class [System.Runtime]System.Object _privateBrand
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class [System.Runtime]System.Object capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x22dd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class [System.Runtime]System.Object FunctionObjects.Classes_ClassPrivateAccessor_ClassExpression_Log_92514F40.FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value::_privateBrand
-		IL_000d: ret
-	} // end of method FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22ec
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22ef
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22f2
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17
-		IL_0006: call instance float64 Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17::__jroc_priv_get_value()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value::CallCore
-
-} // end of class FunctionObjects.Classes_ClassPrivateAccessor_ClassExpression_Log_92514F40.FunctionObject_ClassGetter_CEFB85D4_ClassExpression_L3C17_get___jroc_priv_get_value
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassPrivateAccessor_ClassExpression_Log_92514F40.FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x22ff
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2307
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x230a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x230d
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17
-		IL_0006: call instance object Modules.Classes_ClassPrivateAccessor_ClassExpression_Log/ClassExpression_L3C17::log()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log::CallCore
-
-} // end of class FunctionObjects.Classes_ClassPrivateAccessor_ClassExpression_Log_92514F40.FunctionObject_ClassMethod_8DACF767_ClassExpression_L3C17_log
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateAccessor_EdgeCases_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateAccessor_EdgeCases_Log.verified.txt
@@ -133,6 +133,293 @@
 
 		} // end of class Scope_log
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_C167C688_AccessorEdges
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+			.field private initonly class [System.Runtime]System.Object _privateBrand
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0,
+					class [System.Runtime]System.Object capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x249d
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassConstructor_C167C688_AccessorEdges::_transitionalScopes
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassConstructor_C167C688_AccessorEdges::_privateBrand
+				IL_0014: ret
+			} // end of method FunctionObject_ClassConstructor_C167C688_AccessorEdges::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24b3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_C167C688_AccessorEdges::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24b6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_C167C688_AccessorEdges::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24b9
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_C167C688_AccessorEdges::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24c5
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_C167C688_AccessorEdges::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_C167C688_AccessorEdges
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class [System.Runtime]System.Object _privateBrand
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class [System.Runtime]System.Object capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x24d1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly::_privateBrand
+				IL_000d: ret
+			} // end of method FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24e0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24e3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24e6
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
+				IL_0006: call instance float64 Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::__jroc_priv_get_readOnly()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly::CallCore
+
+		} // end of class FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class [System.Runtime]System.Object _privateBrand
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class [System.Runtime]System.Object capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x24f3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges/FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly::_privateBrand
+				IL_000d: ret
+			} // end of method FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2502
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2505
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2508
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::__jroc_priv_set_writeOnly(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly::CallCore
+
+		} // end of class FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_0783223B_AccessorEdges_log
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x251c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_0783223B_AccessorEdges_log::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2524
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_0783223B_AccessorEdges_log::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2527
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_0783223B_AccessorEdges_log::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x252a
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
+				IL_0006: call instance object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::log()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_0783223B_AccessorEdges_log::CallCore
+
+		} // end of class FunctionObject_ClassMethod_0783223B_AccessorEdges_log
+
 
 		// Fields
 		.field public object saved
@@ -644,293 +931,6 @@
 	} // end of method Classes_ClassPrivateAccessor_EdgeCases_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassPrivateAccessor_EdgeCases_Log
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassPrivateAccessor_EdgeCases_Log_EEDF6BC8.FunctionObject_ClassConstructor_C167C688_AccessorEdges
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-	.field private initonly class [System.Runtime]System.Object _privateBrand
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0,
-			class [System.Runtime]System.Object capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x249d
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassPrivateAccessor_EdgeCases_Log_EEDF6BC8.FunctionObject_ClassConstructor_C167C688_AccessorEdges::_transitionalScopes
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class [System.Runtime]System.Object FunctionObjects.Classes_ClassPrivateAccessor_EdgeCases_Log_EEDF6BC8.FunctionObject_ClassConstructor_C167C688_AccessorEdges::_privateBrand
-		IL_0014: ret
-	} // end of method FunctionObject_ClassConstructor_C167C688_AccessorEdges::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24b3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_C167C688_AccessorEdges::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24b6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_C167C688_AccessorEdges::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24b9
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_C167C688_AccessorEdges::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24c5
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_C167C688_AccessorEdges::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassPrivateAccessor_EdgeCases_Log_EEDF6BC8.FunctionObject_ClassConstructor_C167C688_AccessorEdges
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassPrivateAccessor_EdgeCases_Log_EEDF6BC8.FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class [System.Runtime]System.Object _privateBrand
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class [System.Runtime]System.Object capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x24d1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class [System.Runtime]System.Object FunctionObjects.Classes_ClassPrivateAccessor_EdgeCases_Log_EEDF6BC8.FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly::_privateBrand
-		IL_000d: ret
-	} // end of method FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24e0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24e3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24e6
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
-		IL_0006: call instance float64 Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::__jroc_priv_get_readOnly()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly::CallCore
-
-} // end of class FunctionObjects.Classes_ClassPrivateAccessor_EdgeCases_Log_EEDF6BC8.FunctionObject_ClassGetter_FF682151_AccessorEdges_get___jroc_priv_get_readOnly
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassPrivateAccessor_EdgeCases_Log_EEDF6BC8.FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class [System.Runtime]System.Object _privateBrand
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class [System.Runtime]System.Object capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x24f3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class [System.Runtime]System.Object FunctionObjects.Classes_ClassPrivateAccessor_EdgeCases_Log_EEDF6BC8.FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly::_privateBrand
-		IL_000d: ret
-	} // end of method FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2502
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2505
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2508
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::__jroc_priv_set_writeOnly(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly::CallCore
-
-} // end of class FunctionObjects.Classes_ClassPrivateAccessor_EdgeCases_Log_EEDF6BC8.FunctionObject_ClassSetter_A58BBBBC_AccessorEdges_set___jroc_priv_set_writeOnly
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassPrivateAccessor_EdgeCases_Log_EEDF6BC8.FunctionObject_ClassMethod_0783223B_AccessorEdges_log
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x251c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_0783223B_AccessorEdges_log::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2524
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_0783223B_AccessorEdges_log::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2527
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_0783223B_AccessorEdges_log::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x252a
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges
-		IL_0006: call instance object Modules.Classes_ClassPrivateAccessor_EdgeCases_Log/AccessorEdges::log()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_0783223B_AccessorEdges_log::CallCore
-
-} // end of class FunctionObjects.Classes_ClassPrivateAccessor_EdgeCases_Log_EEDF6BC8.FunctionObject_ClassMethod_0783223B_AccessorEdges_log
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateField_HelperMethod_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateField_HelperMethod_Log.verified.txt
@@ -51,6 +51,154 @@
 
 		} // end of class Scope_logSecret
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_B2B50D0B_Greeter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+			.field private initonly class [System.Runtime]System.Object _privateBrand
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0,
+					class [System.Runtime]System.Object capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x21c5
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassConstructor_B2B50D0B_Greeter::_transitionalScopes
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter/FunctionObject_ClassConstructor_B2B50D0B_Greeter::_privateBrand
+				IL_0014: ret
+			} // end of method FunctionObject_ClassConstructor_B2B50D0B_Greeter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21db
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_B2B50D0B_Greeter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21de
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_B2B50D0B_Greeter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21e1
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_B2B50D0B_Greeter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21ed
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_B2B50D0B_Greeter::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_B2B50D0B_Greeter
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_96735848_Greeter_logSecret
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21f9
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_96735848_Greeter_logSecret::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2201
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_96735848_Greeter_logSecret::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2204
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_96735848_Greeter_logSecret::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2207
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter
+				IL_0006: call instance object Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter::logSecret()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_96735848_Greeter_logSecret::CallCore
+
+		} // end of class FunctionObject_ClassMethod_96735848_Greeter_logSecret
+
 
 		// Fields
 		.field private string __jroc_priv_secret
@@ -265,154 +413,6 @@
 	} // end of method Classes_ClassPrivateField_HelperMethod_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassPrivateField_HelperMethod_Log
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassPrivateField_HelperMethod_Log_20F96CFA.FunctionObject_ClassConstructor_B2B50D0B_Greeter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-	.field private initonly class [System.Runtime]System.Object _privateBrand
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0,
-			class [System.Runtime]System.Object capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x21c5
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassPrivateField_HelperMethod_Log_20F96CFA.FunctionObject_ClassConstructor_B2B50D0B_Greeter::_transitionalScopes
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class [System.Runtime]System.Object FunctionObjects.Classes_ClassPrivateField_HelperMethod_Log_20F96CFA.FunctionObject_ClassConstructor_B2B50D0B_Greeter::_privateBrand
-		IL_0014: ret
-	} // end of method FunctionObject_ClassConstructor_B2B50D0B_Greeter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21db
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_B2B50D0B_Greeter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21de
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_B2B50D0B_Greeter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21e1
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_B2B50D0B_Greeter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ed
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_B2B50D0B_Greeter::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassPrivateField_HelperMethod_Log_20F96CFA.FunctionObject_ClassConstructor_B2B50D0B_Greeter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassPrivateField_HelperMethod_Log_20F96CFA.FunctionObject_ClassMethod_96735848_Greeter_logSecret
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21f9
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_96735848_Greeter_logSecret::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2201
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_96735848_Greeter_logSecret::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2204
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_96735848_Greeter_logSecret::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2207
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter
-		IL_0006: call instance object Modules.Classes_ClassPrivateField_HelperMethod_Log/Greeter::logSecret()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_96735848_Greeter_logSecret::CallCore
-
-} // end of class FunctionObjects.Classes_ClassPrivateField_HelperMethod_Log_20F96CFA.FunctionObject_ClassMethod_96735848_Greeter_logSecret
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateMethodAndAccessor_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateMethodAndAccessor_Log.verified.txt
@@ -111,6 +111,361 @@
 
 		} // end of class Scope_log
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_B44AC0DC_Counter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+			.field private initonly class [System.Runtime]System.Object _privateBrand
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0,
+					class [System.Runtime]System.Object capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x250a
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassConstructor_B44AC0DC_Counter::_transitionalScopes
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassConstructor_B44AC0DC_Counter::_privateBrand
+				IL_0014: ret
+			} // end of method FunctionObject_ClassConstructor_B44AC0DC_Counter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2520
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_B44AC0DC_Counter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2523
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_B44AC0DC_Counter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2526
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_B44AC0DC_Counter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2532
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_B44AC0DC_Counter::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_B44AC0DC_Counter
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class [System.Runtime]System.Object _privateBrand
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class [System.Runtime]System.Object capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x253e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double::_privateBrand
+				IL_000d: ret
+			} // end of method FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x254d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2550
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2553
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
+				IL_0006: call instance object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter::__jroc_priv_method_double()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double::CallCore
+
+		} // end of class FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class [System.Runtime]System.Object _privateBrand
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class [System.Runtime]System.Object capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2560
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret::_privateBrand
+				IL_000d: ret
+			} // end of method FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x256f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2572
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2575
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
+				IL_0006: call instance object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter::__jroc_priv_get_secret()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret::CallCore
+
+		} // end of class FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class [System.Runtime]System.Object _privateBrand
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class [System.Runtime]System.Object capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2582
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class [System.Runtime]System.Object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter/FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret::_privateBrand
+				IL_000d: ret
+			} // end of method FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2591
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2594
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2597
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter::__jroc_priv_set_secret(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret::CallCore
+
+		} // end of class FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_A23FC391_Counter_log
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x25ab
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_A23FC391_Counter_log::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x25b3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_A23FC391_Counter_log::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x25b6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_A23FC391_Counter_log::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x25b9
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
+				IL_0006: call instance object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter::log()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_A23FC391_Counter_log::CallCore
+
+		} // end of class FunctionObject_ClassMethod_A23FC391_Counter_log
+
 
 		// Fields
 		.field private object __jroc_priv_value
@@ -677,361 +1032,6 @@
 	} // end of method Classes_ClassPrivateMethodAndAccessor_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassPrivateMethodAndAccessor_Log
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassPrivateMethodAndAccessor_Log_2DB35D01.FunctionObject_ClassConstructor_B44AC0DC_Counter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-	.field private initonly class [System.Runtime]System.Object _privateBrand
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0,
-			class [System.Runtime]System.Object capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x250a
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassPrivateMethodAndAccessor_Log_2DB35D01.FunctionObject_ClassConstructor_B44AC0DC_Counter::_transitionalScopes
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class [System.Runtime]System.Object FunctionObjects.Classes_ClassPrivateMethodAndAccessor_Log_2DB35D01.FunctionObject_ClassConstructor_B44AC0DC_Counter::_privateBrand
-		IL_0014: ret
-	} // end of method FunctionObject_ClassConstructor_B44AC0DC_Counter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2520
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_B44AC0DC_Counter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2523
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_B44AC0DC_Counter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2526
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_B44AC0DC_Counter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2532
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_B44AC0DC_Counter::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassPrivateMethodAndAccessor_Log_2DB35D01.FunctionObject_ClassConstructor_B44AC0DC_Counter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassPrivateMethodAndAccessor_Log_2DB35D01.FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class [System.Runtime]System.Object _privateBrand
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class [System.Runtime]System.Object capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x253e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class [System.Runtime]System.Object FunctionObjects.Classes_ClassPrivateMethodAndAccessor_Log_2DB35D01.FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double::_privateBrand
-		IL_000d: ret
-	} // end of method FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x254d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2550
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2553
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-		IL_0006: call instance object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter::__jroc_priv_method_double()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double::CallCore
-
-} // end of class FunctionObjects.Classes_ClassPrivateMethodAndAccessor_Log_2DB35D01.FunctionObject_ClassMethod_62EC54FF_Counter___jroc_priv_method_double
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassPrivateMethodAndAccessor_Log_2DB35D01.FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class [System.Runtime]System.Object _privateBrand
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class [System.Runtime]System.Object capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2560
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class [System.Runtime]System.Object FunctionObjects.Classes_ClassPrivateMethodAndAccessor_Log_2DB35D01.FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret::_privateBrand
-		IL_000d: ret
-	} // end of method FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x256f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2572
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2575
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-		IL_0006: call instance object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter::__jroc_priv_get_secret()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret::CallCore
-
-} // end of class FunctionObjects.Classes_ClassPrivateMethodAndAccessor_Log_2DB35D01.FunctionObject_ClassGetter_E81D7A45_Counter_get___jroc_priv_get_secret
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassPrivateMethodAndAccessor_Log_2DB35D01.FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class [System.Runtime]System.Object _privateBrand
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class [System.Runtime]System.Object capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2582
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class [System.Runtime]System.Object FunctionObjects.Classes_ClassPrivateMethodAndAccessor_Log_2DB35D01.FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret::_privateBrand
-		IL_000d: ret
-	} // end of method FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2591
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2594
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2597
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter::__jroc_priv_set_secret(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret::CallCore
-
-} // end of class FunctionObjects.Classes_ClassPrivateMethodAndAccessor_Log_2DB35D01.FunctionObject_ClassSetter_DBC340B1_Counter_set___jroc_priv_set_secret
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassPrivateMethodAndAccessor_Log_2DB35D01.FunctionObject_ClassMethod_A23FC391_Counter_log
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x25ab
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_A23FC391_Counter_log::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x25b3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_A23FC391_Counter_log::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x25b6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_A23FC391_Counter_log::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x25b9
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter
-		IL_0006: call instance object Modules.Classes_ClassPrivateMethodAndAccessor_Log/Counter::log()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_A23FC391_Counter_log::CallCore
-
-} // end of class FunctionObjects.Classes_ClassPrivateMethodAndAccessor_Log_2DB35D01.FunctionObject_ClassMethod_A23FC391_Counter_log
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateProperty_HelperMethod_Log.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassPrivateProperty_HelperMethod_Log.verified.txt
@@ -51,6 +51,149 @@
 
 		} // end of class Scope_logSecret
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_38BA3FA4_Greeter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2139
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassPrivateProperty_HelperMethod_Log/Greeter/FunctionObject_ClassConstructor_38BA3FA4_Greeter::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_38BA3FA4_Greeter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2148
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_38BA3FA4_Greeter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x214b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_38BA3FA4_Greeter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x214e
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_38BA3FA4_Greeter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x215a
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_38BA3FA4_Greeter::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_38BA3FA4_Greeter
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_0FBCE2D5_Greeter_logSecret
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2166
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_0FBCE2D5_Greeter_logSecret::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x216e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_0FBCE2D5_Greeter_logSecret::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2171
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_0FBCE2D5_Greeter_logSecret::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2174
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassPrivateProperty_HelperMethod_Log/Greeter
+				IL_0006: call instance object Modules.Classes_ClassPrivateProperty_HelperMethod_Log/Greeter::logSecret()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_0FBCE2D5_Greeter_logSecret::CallCore
+
+		} // end of class FunctionObject_ClassMethod_0FBCE2D5_Greeter_logSecret
+
 
 		// Fields
 		.field public string _secret
@@ -200,149 +343,6 @@
 	} // end of method Classes_ClassPrivateProperty_HelperMethod_Log::__js_module_init__
 
 } // end of class Modules.Classes_ClassPrivateProperty_HelperMethod_Log
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassPrivateProperty_HelperMethod_Log_0EB37B87.FunctionObject_ClassConstructor_38BA3FA4_Greeter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2139
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassPrivateProperty_HelperMethod_Log_0EB37B87.FunctionObject_ClassConstructor_38BA3FA4_Greeter::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_38BA3FA4_Greeter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2148
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_38BA3FA4_Greeter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x214b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_38BA3FA4_Greeter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x214e
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_38BA3FA4_Greeter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x215a
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_38BA3FA4_Greeter::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassPrivateProperty_HelperMethod_Log_0EB37B87.FunctionObject_ClassConstructor_38BA3FA4_Greeter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassPrivateProperty_HelperMethod_Log_0EB37B87.FunctionObject_ClassMethod_0FBCE2D5_Greeter_logSecret
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2166
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_0FBCE2D5_Greeter_logSecret::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x216e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_0FBCE2D5_Greeter_logSecret::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2171
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_0FBCE2D5_Greeter_logSecret::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2174
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassPrivateProperty_HelperMethod_Log/Greeter
-		IL_0006: call instance object Modules.Classes_ClassPrivateProperty_HelperMethod_Log/Greeter::logSecret()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_0FBCE2D5_Greeter_logSecret::CallCore
-
-} // end of class FunctionObjects.Classes_ClassPrivateProperty_HelperMethod_Log_0EB37B87.FunctionObject_ClassMethod_0FBCE2D5_Greeter_logSecret
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassProperty_DefaultAndLog.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassProperty_DefaultAndLog.verified.txt
@@ -31,6 +31,89 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_EC4BBDDB_Greeter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2145
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassProperty_DefaultAndLog/Greeter/FunctionObject_ClassConstructor_EC4BBDDB_Greeter::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_EC4BBDDB_Greeter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2154
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_EC4BBDDB_Greeter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2157
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_EC4BBDDB_Greeter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x215a
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_EC4BBDDB_Greeter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2166
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_EC4BBDDB_Greeter::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_EC4BBDDB_Greeter
+
 
 		// Fields
 		.field public string message
@@ -173,89 +256,6 @@
 	} // end of method Classes_ClassProperty_DefaultAndLog::__js_module_init__
 
 } // end of class Modules.Classes_ClassProperty_DefaultAndLog
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassProperty_DefaultAndLog_A198156A.FunctionObject_ClassConstructor_EC4BBDDB_Greeter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2145
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassProperty_DefaultAndLog_A198156A.FunctionObject_ClassConstructor_EC4BBDDB_Greeter::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_EC4BBDDB_Greeter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2154
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_EC4BBDDB_Greeter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2157
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_EC4BBDDB_Greeter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x215a
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_EC4BBDDB_Greeter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2166
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_EC4BBDDB_Greeter::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassProperty_DefaultAndLog_A198156A.FunctionObject_ClassConstructor_EC4BBDDB_Greeter
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassStaticBlock_DeclarationOrder.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassStaticBlock_DeclarationOrder.verified.txt
@@ -31,6 +31,89 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_5DBD46D9_Example
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21dc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassStaticBlock_DeclarationOrder/Example/FunctionObject_ClassConstructor_5DBD46D9_Example::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_5DBD46D9_Example::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21eb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_5DBD46D9_Example::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21ee
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_5DBD46D9_Example::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f1
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_5DBD46D9_Example::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21fd
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_5DBD46D9_Example::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_5DBD46D9_Example
+
 
 		// Fields
 		.field public static object 'value'
@@ -223,89 +306,6 @@
 	} // end of method Classes_ClassStaticBlock_DeclarationOrder::__js_module_init__
 
 } // end of class Modules.Classes_ClassStaticBlock_DeclarationOrder
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassStaticBlock_DeclarationOrder_77E1B8F8.FunctionObject_ClassConstructor_5DBD46D9_Example
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21dc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassStaticBlock_DeclarationOrder_77E1B8F8.FunctionObject_ClassConstructor_5DBD46D9_Example::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_5DBD46D9_Example::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21eb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_5DBD46D9_Example::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21ee
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_5DBD46D9_Example::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f1
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_5DBD46D9_Example::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21fd
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_5DBD46D9_Example::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassStaticBlock_DeclarationOrder_77E1B8F8.FunctionObject_ClassConstructor_5DBD46D9_Example
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassWithMethod_HelloWorld.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassWithMethod_HelloWorld.verified.txt
@@ -51,6 +51,149 @@
 
 		} // end of class Scope_helloWorld
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_C6F9F277_Greeter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x210a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassWithMethod_HelloWorld/Greeter/FunctionObject_ClassConstructor_C6F9F277_Greeter::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_C6F9F277_Greeter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2119
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_C6F9F277_Greeter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x211c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_C6F9F277_Greeter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x211f
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_C6F9F277_Greeter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x212b
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_C6F9F277_Greeter::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_C6F9F277_Greeter
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_B367284E_Greeter_helloWorld
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2137
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_B367284E_Greeter_helloWorld::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x213f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_B367284E_Greeter_helloWorld::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2142
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_B367284E_Greeter_helloWorld::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2145
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassWithMethod_HelloWorld/Greeter
+				IL_0006: call instance object Modules.Classes_ClassWithMethod_HelloWorld/Greeter::helloWorld()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_B367284E_Greeter_helloWorld::CallCore
+
+		} // end of class FunctionObject_ClassMethod_B367284E_Greeter_helloWorld
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -174,149 +317,6 @@
 	} // end of method Classes_ClassWithMethod_HelloWorld::__js_module_init__
 
 } // end of class Modules.Classes_ClassWithMethod_HelloWorld
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassWithMethod_HelloWorld_9682C436.FunctionObject_ClassConstructor_C6F9F277_Greeter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x210a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassWithMethod_HelloWorld_9682C436.FunctionObject_ClassConstructor_C6F9F277_Greeter::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_C6F9F277_Greeter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2119
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_C6F9F277_Greeter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x211c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_C6F9F277_Greeter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x211f
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_C6F9F277_Greeter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x212b
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_C6F9F277_Greeter::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassWithMethod_HelloWorld_9682C436.FunctionObject_ClassConstructor_C6F9F277_Greeter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassWithMethod_HelloWorld_9682C436.FunctionObject_ClassMethod_B367284E_Greeter_helloWorld
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2137
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_B367284E_Greeter_helloWorld::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x213f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_B367284E_Greeter_helloWorld::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2142
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_B367284E_Greeter_helloWorld::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2145
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassWithMethod_HelloWorld/Greeter
-		IL_0006: call instance object Modules.Classes_ClassWithMethod_HelloWorld/Greeter::helloWorld()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_B367284E_Greeter_helloWorld::CallCore
-
-} // end of class FunctionObjects.Classes_ClassWithMethod_HelloWorld_9682C436.FunctionObject_ClassMethod_B367284E_Greeter_helloWorld
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassWithMethod_NoInstantiation.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassWithMethod_NoInstantiation.verified.txt
@@ -51,6 +51,150 @@
 
 		} // end of class Scope_hello
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_E2E07B97_Greeter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x20b2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassWithMethod_NoInstantiation/Greeter/FunctionObject_ClassConstructor_E2E07B97_Greeter::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_E2E07B97_Greeter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x20c1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_E2E07B97_Greeter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x20c4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_E2E07B97_Greeter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x20c7
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_E2E07B97_Greeter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x20d3
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_E2E07B97_Greeter::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_E2E07B97_Greeter
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_47BE6AB2_Greeter_hello
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x20df
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_47BE6AB2_Greeter_hello::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x20e7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_47BE6AB2_Greeter_hello::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x20ea
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_47BE6AB2_Greeter_hello::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x20ed
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ClassWithMethod_NoInstantiation/Greeter
+				IL_0006: call instance float64 Modules.Classes_ClassWithMethod_NoInstantiation/Greeter::hello()
+				IL_000b: box [System.Runtime]System.Double
+				IL_0010: ret
+			} // end of method FunctionObject_ClassMethod_47BE6AB2_Greeter_hello::CallCore
+
+		} // end of class FunctionObject_ClassMethod_47BE6AB2_Greeter_hello
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -140,150 +284,6 @@
 	} // end of method Classes_ClassWithMethod_NoInstantiation::__js_module_init__
 
 } // end of class Modules.Classes_ClassWithMethod_NoInstantiation
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassWithMethod_NoInstantiation_DCF6BB96.FunctionObject_ClassConstructor_E2E07B97_Greeter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x20b2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassWithMethod_NoInstantiation_DCF6BB96.FunctionObject_ClassConstructor_E2E07B97_Greeter::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_E2E07B97_Greeter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x20c1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_E2E07B97_Greeter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x20c4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_E2E07B97_Greeter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x20c7
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_E2E07B97_Greeter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x20d3
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_E2E07B97_Greeter::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassWithMethod_NoInstantiation_DCF6BB96.FunctionObject_ClassConstructor_E2E07B97_Greeter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassWithMethod_NoInstantiation_DCF6BB96.FunctionObject_ClassMethod_47BE6AB2_Greeter_hello
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x20df
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_47BE6AB2_Greeter_hello::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x20e7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_47BE6AB2_Greeter_hello::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x20ea
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_47BE6AB2_Greeter_hello::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x20ed
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ClassWithMethod_NoInstantiation/Greeter
-		IL_0006: call instance float64 Modules.Classes_ClassWithMethod_NoInstantiation/Greeter::hello()
-		IL_000b: box [System.Runtime]System.Double
-		IL_0010: ret
-	} // end of method FunctionObject_ClassMethod_47BE6AB2_Greeter_hello::CallCore
-
-} // end of class FunctionObjects.Classes_ClassWithMethod_NoInstantiation_DCF6BB96.FunctionObject_ClassMethod_47BE6AB2_Greeter_hello
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassWithStaticMethod_HelloWorld.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassWithStaticMethod_HelloWorld.verified.txt
@@ -51,6 +51,147 @@
 
 		} // end of class Scope_helloWorld
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_CA02D6DD_Greeter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x215f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter/FunctionObject_ClassConstructor_CA02D6DD_Greeter::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_CA02D6DD_Greeter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x216e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_CA02D6DD_Greeter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2171
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_CA02D6DD_Greeter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2174
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_CA02D6DD_Greeter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2180
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_CA02D6DD_Greeter::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_CA02D6DD_Greeter
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x218c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2194
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2197
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x219a
+				// Header size: 1
+				// Code size: 6 (0x6)
+				.maxstack 8
+
+				IL_0000: call object Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter::helloWorld()
+				IL_0005: ret
+			} // end of method FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld::CallCore
+
+		} // end of class FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -224,147 +365,6 @@
 	} // end of method Classes_ClassWithStaticMethod_HelloWorld::__js_module_init__
 
 } // end of class Modules.Classes_ClassWithStaticMethod_HelloWorld
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassWithStaticMethod_HelloWorld_5CBBC620.FunctionObject_ClassConstructor_CA02D6DD_Greeter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x215f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassWithStaticMethod_HelloWorld_5CBBC620.FunctionObject_ClassConstructor_CA02D6DD_Greeter::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_CA02D6DD_Greeter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x216e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_CA02D6DD_Greeter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2171
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_CA02D6DD_Greeter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2174
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_CA02D6DD_Greeter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2180
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_CA02D6DD_Greeter::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassWithStaticMethod_HelloWorld_5CBBC620.FunctionObject_ClassConstructor_CA02D6DD_Greeter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassWithStaticMethod_HelloWorld_5CBBC620.FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x218c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2194
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2197
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x219a
-		// Header size: 1
-		// Code size: 6 (0x6)
-		.maxstack 8
-
-		IL_0000: call object Modules.Classes_ClassWithStaticMethod_HelloWorld/Greeter::helloWorld()
-		IL_0005: ret
-	} // end of method FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld::CallCore
-
-} // end of class FunctionObjects.Classes_ClassWithStaticMethod_HelloWorld_5CBBC620.FunctionObject_ClassStaticMethod_6C2663DE_Greeter_helloWorld
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassWithStaticProperty_DefaultAndLog.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ClassWithStaticProperty_DefaultAndLog.verified.txt
@@ -31,6 +31,89 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_FEF6303D_Greeter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x20fc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ClassWithStaticProperty_DefaultAndLog/Greeter/FunctionObject_ClassConstructor_FEF6303D_Greeter::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_FEF6303D_Greeter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x210b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_FEF6303D_Greeter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x210e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_FEF6303D_Greeter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2111
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_FEF6303D_Greeter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x211d
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_FEF6303D_Greeter::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_FEF6303D_Greeter
+
 
 		// Fields
 		.field public static object message
@@ -157,89 +240,6 @@
 	} // end of method Classes_ClassWithStaticProperty_DefaultAndLog::__js_module_init__
 
 } // end of class Modules.Classes_ClassWithStaticProperty_DefaultAndLog
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ClassWithStaticProperty_DefaultAndLog_0DBA3640.FunctionObject_ClassConstructor_FEF6303D_Greeter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x20fc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ClassWithStaticProperty_DefaultAndLog_0DBA3640.FunctionObject_ClassConstructor_FEF6303D_Greeter::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_FEF6303D_Greeter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x210b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_FEF6303D_Greeter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x210e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_FEF6303D_Greeter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2111
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_FEF6303D_Greeter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x211d
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_FEF6303D_Greeter::ConstructCore
-
-} // end of class FunctionObjects.Classes_ClassWithStaticProperty_DefaultAndLog_0DBA3640.FunctionObject_ClassConstructor_FEF6303D_Greeter
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Constructor_ExplicitReturnThis.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Constructor_ExplicitReturnThis.verified.txt
@@ -51,6 +51,89 @@
 
 		} // end of class Scope_ctor
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_0A7F1BC0_WithExplicitReturn
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2183
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_Constructor_ExplicitReturnThis/WithExplicitReturn/FunctionObject_ClassConstructor_0A7F1BC0_WithExplicitReturn::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_0A7F1BC0_WithExplicitReturn::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2192
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_0A7F1BC0_WithExplicitReturn::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2195
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_0A7F1BC0_WithExplicitReturn::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2198
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_0A7F1BC0_WithExplicitReturn::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21a4
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_0A7F1BC0_WithExplicitReturn::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_0A7F1BC0_WithExplicitReturn
+
 
 		// Fields
 		.field assembly object __jroc_ctorReturn
@@ -124,6 +207,89 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_EAF968D6_WithVoidReturn
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21b0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_Constructor_ExplicitReturnThis/WithVoidReturn/FunctionObject_ClassConstructor_EAF968D6_WithVoidReturn::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_EAF968D6_WithVoidReturn::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21bf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_EAF968D6_WithVoidReturn::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21c2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_EAF968D6_WithVoidReturn::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21c5
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_EAF968D6_WithVoidReturn::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21d1
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_EAF968D6_WithVoidReturn::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_EAF968D6_WithVoidReturn
 
 
 		// Fields
@@ -264,172 +430,6 @@
 	} // end of method Classes_Constructor_ExplicitReturnThis::__js_module_init__
 
 } // end of class Modules.Classes_Constructor_ExplicitReturnThis
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Constructor_ExplicitReturnThis_C23A491F.FunctionObject_ClassConstructor_0A7F1BC0_WithExplicitReturn
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2183
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_Constructor_ExplicitReturnThis_C23A491F.FunctionObject_ClassConstructor_0A7F1BC0_WithExplicitReturn::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_0A7F1BC0_WithExplicitReturn::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2192
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_0A7F1BC0_WithExplicitReturn::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2195
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_0A7F1BC0_WithExplicitReturn::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2198
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_0A7F1BC0_WithExplicitReturn::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21a4
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_0A7F1BC0_WithExplicitReturn::ConstructCore
-
-} // end of class FunctionObjects.Classes_Constructor_ExplicitReturnThis_C23A491F.FunctionObject_ClassConstructor_0A7F1BC0_WithExplicitReturn
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Constructor_ExplicitReturnThis_C23A491F.FunctionObject_ClassConstructor_EAF968D6_WithVoidReturn
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21b0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_Constructor_ExplicitReturnThis_C23A491F.FunctionObject_ClassConstructor_EAF968D6_WithVoidReturn::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_EAF968D6_WithVoidReturn::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21bf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_EAF968D6_WithVoidReturn::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21c2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_EAF968D6_WithVoidReturn::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21c5
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_EAF968D6_WithVoidReturn::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21d1
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_EAF968D6_WithVoidReturn::ConstructCore
-
-} // end of class FunctionObjects.Classes_Constructor_ExplicitReturnThis_C23A491F.FunctionObject_ClassConstructor_EAF968D6_WithVoidReturn
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Constructor_ImplicitlyReturnsThis.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Constructor_ImplicitlyReturnsThis.verified.txt
@@ -51,6 +51,89 @@
 
 		} // end of class Scope_ctor
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_AC2B377B_Simple
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2293
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_Constructor_ImplicitlyReturnsThis/Simple/FunctionObject_ClassConstructor_AC2B377B_Simple::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_AC2B377B_Simple::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22a2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_AC2B377B_Simple::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22a5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_AC2B377B_Simple::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22a8
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_AC2B377B_Simple::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22b4
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_AC2B377B_Simple::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_AC2B377B_Simple
+
 
 		// Fields
 		.field public float64 'value'
@@ -120,6 +203,89 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_5D6F96DB_WithParams
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x22c0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_Constructor_ImplicitlyReturnsThis/WithParams/FunctionObject_ClassConstructor_5D6F96DB_WithParams::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_5D6F96DB_WithParams::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22cf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_5D6F96DB_WithParams::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22d2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_5D6F96DB_WithParams::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22d5
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_5D6F96DB_WithParams::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22e1
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_5D6F96DB_WithParams::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_5D6F96DB_WithParams
 
 
 		// Fields
@@ -343,172 +509,6 @@
 	} // end of method Classes_Constructor_ImplicitlyReturnsThis::__js_module_init__
 
 } // end of class Modules.Classes_Constructor_ImplicitlyReturnsThis
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Constructor_ImplicitlyReturnsThis_8B82FAC4.FunctionObject_ClassConstructor_AC2B377B_Simple
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2293
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_Constructor_ImplicitlyReturnsThis_8B82FAC4.FunctionObject_ClassConstructor_AC2B377B_Simple::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_AC2B377B_Simple::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22a2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_AC2B377B_Simple::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22a5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_AC2B377B_Simple::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22a8
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_AC2B377B_Simple::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22b4
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_AC2B377B_Simple::ConstructCore
-
-} // end of class FunctionObjects.Classes_Constructor_ImplicitlyReturnsThis_8B82FAC4.FunctionObject_ClassConstructor_AC2B377B_Simple
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Constructor_ImplicitlyReturnsThis_8B82FAC4.FunctionObject_ClassConstructor_5D6F96DB_WithParams
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x22c0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_Constructor_ImplicitlyReturnsThis_8B82FAC4.FunctionObject_ClassConstructor_5D6F96DB_WithParams::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_5D6F96DB_WithParams::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22cf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_5D6F96DB_WithParams::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22d2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_5D6F96DB_WithParams::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22d5
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_5D6F96DB_WithParams::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22e1
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_5D6F96DB_WithParams::ConstructCore
-
-} // end of class FunctionObjects.Classes_Constructor_ImplicitlyReturnsThis_8B82FAC4.FunctionObject_ClassConstructor_5D6F96DB_WithParams
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Constructor_ReturnObjectOverridesThis.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Constructor_ReturnObjectOverridesThis.verified.txt
@@ -51,6 +51,94 @@
 
 		} // end of class Scope_ctor
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_5FE4D647_A
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Classes_Constructor_ReturnObjectOverridesThis/Scope _environment0_Classes_Constructor_ReturnObjectOverridesThis
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Classes_Constructor_ReturnObjectOverridesThis/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x22e7
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Classes_Constructor_ReturnObjectOverridesThis/Scope Modules.Classes_Constructor_ReturnObjectOverridesThis/A/FunctionObject_ClassConstructor_5FE4D647_A::_environment0_Classes_Constructor_ReturnObjectOverridesThis
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.Classes_Constructor_ReturnObjectOverridesThis/A/FunctionObject_ClassConstructor_5FE4D647_A::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_ClassConstructor_5FE4D647_A::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22fd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_5FE4D647_A::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2300
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_5FE4D647_A::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2303
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_5FE4D647_A::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x230f
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_5FE4D647_A::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_5FE4D647_A
+
 
 		// Fields
 		.field private object[] _scopes
@@ -142,6 +230,89 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_60E4D7DA_B
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x231b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_Constructor_ReturnObjectOverridesThis/B/FunctionObject_ClassConstructor_60E4D7DA_B::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_60E4D7DA_B::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x232a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_60E4D7DA_B::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x232d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_60E4D7DA_B::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2330
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_60E4D7DA_B::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x233c
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_60E4D7DA_B::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_60E4D7DA_B
 
 
 		// Fields
@@ -383,177 +554,6 @@
 	} // end of method Classes_Constructor_ReturnObjectOverridesThis::__js_module_init__
 
 } // end of class Modules.Classes_Constructor_ReturnObjectOverridesThis
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Constructor_ReturnObjectOverridesThis_2996E455.FunctionObject_ClassConstructor_5FE4D647_A
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Classes_Constructor_ReturnObjectOverridesThis/Scope _environment0_Classes_Constructor_ReturnObjectOverridesThis
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Classes_Constructor_ReturnObjectOverridesThis/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x22e7
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Classes_Constructor_ReturnObjectOverridesThis/Scope FunctionObjects.Classes_Constructor_ReturnObjectOverridesThis_2996E455.FunctionObject_ClassConstructor_5FE4D647_A::_environment0_Classes_Constructor_ReturnObjectOverridesThis
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Classes_Constructor_ReturnObjectOverridesThis_2996E455.FunctionObject_ClassConstructor_5FE4D647_A::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_ClassConstructor_5FE4D647_A::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22fd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_5FE4D647_A::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2300
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_5FE4D647_A::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2303
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_5FE4D647_A::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x230f
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_5FE4D647_A::ConstructCore
-
-} // end of class FunctionObjects.Classes_Constructor_ReturnObjectOverridesThis_2996E455.FunctionObject_ClassConstructor_5FE4D647_A
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Constructor_ReturnObjectOverridesThis_2996E455.FunctionObject_ClassConstructor_60E4D7DA_B
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x231b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_Constructor_ReturnObjectOverridesThis_2996E455.FunctionObject_ClassConstructor_60E4D7DA_B::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_60E4D7DA_B::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x232a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_60E4D7DA_B::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x232d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_60E4D7DA_B::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2330
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_60E4D7DA_B::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x233c
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_60E4D7DA_B::ConstructCore
-
-} // end of class FunctionObjects.Classes_Constructor_ReturnObjectOverridesThis_2996E455.FunctionObject_ClassConstructor_60E4D7DA_B
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_DeclareEmptyClass.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_DeclareEmptyClass.verified.txt
@@ -31,6 +31,89 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_D3CE27CC_Foo
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x209e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_DeclareEmptyClass/Foo/FunctionObject_ClassConstructor_D3CE27CC_Foo::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_D3CE27CC_Foo::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x20ad
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_D3CE27CC_Foo::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x20b0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_D3CE27CC_Foo::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x20b3
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_D3CE27CC_Foo::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x20bf
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_D3CE27CC_Foo::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_D3CE27CC_Foo
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -105,89 +188,6 @@
 	} // end of method Classes_DeclareEmptyClass::__js_module_init__
 
 } // end of class Modules.Classes_DeclareEmptyClass
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_DeclareEmptyClass_851D52DD.FunctionObject_ClassConstructor_D3CE27CC_Foo
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x209e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_DeclareEmptyClass_851D52DD.FunctionObject_ClassConstructor_D3CE27CC_Foo::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_D3CE27CC_Foo::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x20ad
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_D3CE27CC_Foo::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x20b0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_D3CE27CC_Foo::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x20b3
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_D3CE27CC_Foo::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x20bf
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_D3CE27CC_Foo::ConstructCore
-
-} // end of class FunctionObjects.Classes_DeclareEmptyClass_851D52DD.FunctionObject_ClassConstructor_D3CE27CC_Foo
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_DefaultParameterValue_Constructor.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_DefaultParameterValue_Constructor.verified.txt
@@ -93,6 +93,149 @@
 
 		} // end of class Scope_display
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_7BAAAA4E_Person
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x26de
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_DefaultParameterValue_Constructor/Person/FunctionObject_ClassConstructor_7BAAAA4E_Person::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_7BAAAA4E_Person::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x26ed
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_7BAAAA4E_Person::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x26f0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_7BAAAA4E_Person::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x26f3
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_7BAAAA4E_Person::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26ff
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_7BAAAA4E_Person::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_7BAAAA4E_Person
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_85CC56A3_Person_display
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x270b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_85CC56A3_Person_display::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2713
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_85CC56A3_Person_display::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2716
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_85CC56A3_Person_display::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2719
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_DefaultParameterValue_Constructor/Person
+				IL_0006: call instance object Modules.Classes_DefaultParameterValue_Constructor/Person::display()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_85CC56A3_Person_display::CallCore
+
+		} // end of class FunctionObject_ClassMethod_85CC56A3_Person_display
+
 
 		// Fields
 		.field public object name
@@ -266,6 +409,149 @@
 			} // end of method Scope_volume::.ctor
 
 		} // end of class Scope_volume
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_9983F234_Box
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2726
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_DefaultParameterValue_Constructor/Box/FunctionObject_ClassConstructor_9983F234_Box::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_9983F234_Box::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2735
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_9983F234_Box::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2738
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_9983F234_Box::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x273b
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_9983F234_Box::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2747
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_9983F234_Box::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_9983F234_Box
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_3225487D_Box_volume
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2753
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_3225487D_Box_volume::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x275b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_3225487D_Box_volume::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x275e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_3225487D_Box_volume::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2761
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_DefaultParameterValue_Constructor/Box
+				IL_0006: call instance object Modules.Classes_DefaultParameterValue_Constructor/Box::volume()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_3225487D_Box_volume::CallCore
+
+		} // end of class FunctionObject_ClassMethod_3225487D_Box_volume
 
 
 		// Fields
@@ -446,6 +732,149 @@
 			} // end of method Scope_area::.ctor
 
 		} // end of class Scope_area
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_7B6BA518_Rectangle
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x276e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_DefaultParameterValue_Constructor/Rectangle/FunctionObject_ClassConstructor_7B6BA518_Rectangle::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_7B6BA518_Rectangle::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x277d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_7B6BA518_Rectangle::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2780
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_7B6BA518_Rectangle::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2783
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_7B6BA518_Rectangle::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x278f
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_7B6BA518_Rectangle::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_7B6BA518_Rectangle
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_840B970A_Rectangle_area
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x279b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_840B970A_Rectangle_area::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x27a3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_840B970A_Rectangle_area::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x27a6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_840B970A_Rectangle_area::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x27a9
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_DefaultParameterValue_Constructor/Rectangle
+				IL_0006: call instance object Modules.Classes_DefaultParameterValue_Constructor/Rectangle::area()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_840B970A_Rectangle_area::CallCore
+
+		} // end of class FunctionObject_ClassMethod_840B970A_Rectangle_area
 
 
 		// Fields
@@ -909,435 +1338,6 @@
 	} // end of method Classes_DefaultParameterValue_Constructor::__js_module_init__
 
 } // end of class Modules.Classes_DefaultParameterValue_Constructor
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_DefaultParameterValue_Constructor_3F4629A2.FunctionObject_ClassConstructor_7BAAAA4E_Person
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x26de
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_DefaultParameterValue_Constructor_3F4629A2.FunctionObject_ClassConstructor_7BAAAA4E_Person::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_7BAAAA4E_Person::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x26ed
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_7BAAAA4E_Person::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x26f0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_7BAAAA4E_Person::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x26f3
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_7BAAAA4E_Person::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26ff
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_7BAAAA4E_Person::ConstructCore
-
-} // end of class FunctionObjects.Classes_DefaultParameterValue_Constructor_3F4629A2.FunctionObject_ClassConstructor_7BAAAA4E_Person
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_DefaultParameterValue_Constructor_3F4629A2.FunctionObject_ClassMethod_85CC56A3_Person_display
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x270b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_85CC56A3_Person_display::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2713
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_85CC56A3_Person_display::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2716
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_85CC56A3_Person_display::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2719
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_DefaultParameterValue_Constructor/Person
-		IL_0006: call instance object Modules.Classes_DefaultParameterValue_Constructor/Person::display()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_85CC56A3_Person_display::CallCore
-
-} // end of class FunctionObjects.Classes_DefaultParameterValue_Constructor_3F4629A2.FunctionObject_ClassMethod_85CC56A3_Person_display
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_DefaultParameterValue_Constructor_3F4629A2.FunctionObject_ClassConstructor_9983F234_Box
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2726
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_DefaultParameterValue_Constructor_3F4629A2.FunctionObject_ClassConstructor_9983F234_Box::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_9983F234_Box::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2735
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_9983F234_Box::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2738
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_9983F234_Box::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x273b
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_9983F234_Box::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2747
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_9983F234_Box::ConstructCore
-
-} // end of class FunctionObjects.Classes_DefaultParameterValue_Constructor_3F4629A2.FunctionObject_ClassConstructor_9983F234_Box
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_DefaultParameterValue_Constructor_3F4629A2.FunctionObject_ClassMethod_3225487D_Box_volume
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2753
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_3225487D_Box_volume::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x275b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_3225487D_Box_volume::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x275e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_3225487D_Box_volume::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2761
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_DefaultParameterValue_Constructor/Box
-		IL_0006: call instance object Modules.Classes_DefaultParameterValue_Constructor/Box::volume()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_3225487D_Box_volume::CallCore
-
-} // end of class FunctionObjects.Classes_DefaultParameterValue_Constructor_3F4629A2.FunctionObject_ClassMethod_3225487D_Box_volume
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_DefaultParameterValue_Constructor_3F4629A2.FunctionObject_ClassConstructor_7B6BA518_Rectangle
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x276e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_DefaultParameterValue_Constructor_3F4629A2.FunctionObject_ClassConstructor_7B6BA518_Rectangle::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_7B6BA518_Rectangle::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x277d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_7B6BA518_Rectangle::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2780
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_7B6BA518_Rectangle::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2783
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_7B6BA518_Rectangle::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x278f
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_7B6BA518_Rectangle::ConstructCore
-
-} // end of class FunctionObjects.Classes_DefaultParameterValue_Constructor_3F4629A2.FunctionObject_ClassConstructor_7B6BA518_Rectangle
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_DefaultParameterValue_Constructor_3F4629A2.FunctionObject_ClassMethod_840B970A_Rectangle_area
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x279b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_840B970A_Rectangle_area::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x27a3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_840B970A_Rectangle_area::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x27a6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_840B970A_Rectangle_area::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x27a9
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_DefaultParameterValue_Constructor/Rectangle
-		IL_0006: call instance object Modules.Classes_DefaultParameterValue_Constructor/Rectangle::area()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_840B970A_Rectangle_area::CallCore
-
-} // end of class FunctionObjects.Classes_DefaultParameterValue_Constructor_3F4629A2.FunctionObject_ClassMethod_840B970A_Rectangle_area
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_DefaultParameterValue_Method.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_DefaultParameterValue_Method.verified.txt
@@ -199,6 +199,356 @@
 
 		} // end of class Scope_calculate
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_99088752_Calculator
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x241d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_DefaultParameterValue_Method/Calculator/FunctionObject_ClassConstructor_99088752_Calculator::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_99088752_Calculator::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x242c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_99088752_Calculator::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x242f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_99088752_Calculator::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2432
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_99088752_Calculator::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x243e
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_99088752_Calculator::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_99088752_Calculator
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_EAF53F0C_Calculator_add
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x244a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_EAF53F0C_Calculator_add::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2452
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_EAF53F0C_Calculator_add::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2455
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_EAF53F0C_Calculator_add::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2458
+				// Header size: 1
+				// Code size: 26 (0x1a)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_DefaultParameterValue_Method/Calculator
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call instance object Modules.Classes_DefaultParameterValue_Method/Calculator::'add'(object, object)
+				IL_0019: ret
+			} // end of method FunctionObject_ClassMethod_EAF53F0C_Calculator_add::CallCore
+
+		} // end of class FunctionObject_ClassMethod_EAF53F0C_Calculator_add
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_E8EF129D_Calculator_multiply
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2473
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_E8EF129D_Calculator_multiply::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x247b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_E8EF129D_Calculator_multiply::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x247e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_E8EF129D_Calculator_multiply::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2481
+				// Header size: 1
+				// Code size: 33 (0x21)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_DefaultParameterValue_Method/Calculator
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: ldarg.2
+				IL_0015: ldc.i4.2
+				IL_0016: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001b: call instance object Modules.Classes_DefaultParameterValue_Method/Calculator::multiply(object, object, object)
+				IL_0020: ret
+			} // end of method FunctionObject_ClassMethod_E8EF129D_Calculator_multiply::CallCore
+
+		} // end of class FunctionObject_ClassMethod_E8EF129D_Calculator_multiply
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_71FF28E2_Calculator_greet
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x24a3
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_71FF28E2_Calculator_greet::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24ab
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_71FF28E2_Calculator_greet::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24ae
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_71FF28E2_Calculator_greet::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24b1
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_DefaultParameterValue_Method/Calculator
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.Classes_DefaultParameterValue_Method/Calculator::greet(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassMethod_71FF28E2_Calculator_greet::CallCore
+
+		} // end of class FunctionObject_ClassMethod_71FF28E2_Calculator_greet
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_E8CC79A7_Calculator_calculate
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x24c5
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_E8CC79A7_Calculator_calculate::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24cd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_E8CC79A7_Calculator_calculate::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24d0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_E8CC79A7_Calculator_calculate::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24d3
+				// Header size: 1
+				// Code size: 33 (0x21)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_DefaultParameterValue_Method/Calculator
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: ldarg.2
+				IL_0015: ldc.i4.2
+				IL_0016: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001b: call instance object Modules.Classes_DefaultParameterValue_Method/Calculator::calculate(object, object, object)
+				IL_0020: ret
+			} // end of method FunctionObject_ClassMethod_E8CC79A7_Calculator_calculate::CallCore
+
+		} // end of class FunctionObject_ClassMethod_E8CC79A7_Calculator_calculate
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -602,356 +952,6 @@
 	} // end of method Classes_DefaultParameterValue_Method::__js_module_init__
 
 } // end of class Modules.Classes_DefaultParameterValue_Method
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_DefaultParameterValue_Method_27796D67.FunctionObject_ClassConstructor_99088752_Calculator
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x241d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_DefaultParameterValue_Method_27796D67.FunctionObject_ClassConstructor_99088752_Calculator::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_99088752_Calculator::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x242c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_99088752_Calculator::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x242f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_99088752_Calculator::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2432
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_99088752_Calculator::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x243e
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_99088752_Calculator::ConstructCore
-
-} // end of class FunctionObjects.Classes_DefaultParameterValue_Method_27796D67.FunctionObject_ClassConstructor_99088752_Calculator
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_DefaultParameterValue_Method_27796D67.FunctionObject_ClassMethod_EAF53F0C_Calculator_add
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x244a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_EAF53F0C_Calculator_add::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2452
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_EAF53F0C_Calculator_add::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2455
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_EAF53F0C_Calculator_add::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2458
-		// Header size: 1
-		// Code size: 26 (0x1a)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_DefaultParameterValue_Method/Calculator
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call instance object Modules.Classes_DefaultParameterValue_Method/Calculator::'add'(object, object)
-		IL_0019: ret
-	} // end of method FunctionObject_ClassMethod_EAF53F0C_Calculator_add::CallCore
-
-} // end of class FunctionObjects.Classes_DefaultParameterValue_Method_27796D67.FunctionObject_ClassMethod_EAF53F0C_Calculator_add
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_DefaultParameterValue_Method_27796D67.FunctionObject_ClassMethod_E8EF129D_Calculator_multiply
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2473
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_E8EF129D_Calculator_multiply::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x247b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_E8EF129D_Calculator_multiply::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x247e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_E8EF129D_Calculator_multiply::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2481
-		// Header size: 1
-		// Code size: 33 (0x21)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_DefaultParameterValue_Method/Calculator
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: ldarg.2
-		IL_0015: ldc.i4.2
-		IL_0016: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001b: call instance object Modules.Classes_DefaultParameterValue_Method/Calculator::multiply(object, object, object)
-		IL_0020: ret
-	} // end of method FunctionObject_ClassMethod_E8EF129D_Calculator_multiply::CallCore
-
-} // end of class FunctionObjects.Classes_DefaultParameterValue_Method_27796D67.FunctionObject_ClassMethod_E8EF129D_Calculator_multiply
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_DefaultParameterValue_Method_27796D67.FunctionObject_ClassMethod_71FF28E2_Calculator_greet
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x24a3
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_71FF28E2_Calculator_greet::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24ab
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_71FF28E2_Calculator_greet::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24ae
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_71FF28E2_Calculator_greet::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24b1
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_DefaultParameterValue_Method/Calculator
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.Classes_DefaultParameterValue_Method/Calculator::greet(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassMethod_71FF28E2_Calculator_greet::CallCore
-
-} // end of class FunctionObjects.Classes_DefaultParameterValue_Method_27796D67.FunctionObject_ClassMethod_71FF28E2_Calculator_greet
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_DefaultParameterValue_Method_27796D67.FunctionObject_ClassMethod_E8CC79A7_Calculator_calculate
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x24c5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_E8CC79A7_Calculator_calculate::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24cd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_E8CC79A7_Calculator_calculate::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24d0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_E8CC79A7_Calculator_calculate::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24d3
-		// Header size: 1
-		// Code size: 33 (0x21)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_DefaultParameterValue_Method/Calculator
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: ldarg.2
-		IL_0015: ldc.i4.2
-		IL_0016: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001b: call instance object Modules.Classes_DefaultParameterValue_Method/Calculator::calculate(object, object, object)
-		IL_0020: ret
-	} // end of method FunctionObject_ClassMethod_E8CC79A7_Calculator_calculate::CallCore
-
-} // end of class FunctionObjects.Classes_DefaultParameterValue_Method_27796D67.FunctionObject_ClassMethod_E8CC79A7_Calculator_calculate
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ForLoopMin.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_ForLoopMin.verified.txt
@@ -73,6 +73,150 @@
 
 		} // end of class Scope_run
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_889FA173_C
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x215a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_ForLoopMin/C/FunctionObject_ClassConstructor_889FA173_C::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_889FA173_C::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2169
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_889FA173_C::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x216c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_889FA173_C::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x216f
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_889FA173_C::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x217b
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_889FA173_C::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_889FA173_C
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_A226B3E5_C_run
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2187
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_A226B3E5_C_run::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x218f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_A226B3E5_C_run::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2192
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_A226B3E5_C_run::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2195
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_ForLoopMin/C
+				IL_0006: call instance float64 Modules.Classes_ForLoopMin/C::run()
+				IL_000b: box [System.Runtime]System.Double
+				IL_0010: ret
+			} // end of method FunctionObject_ClassMethod_A226B3E5_C_run::CallCore
+
+		} // end of class FunctionObject_ClassMethod_A226B3E5_C_run
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -229,150 +373,6 @@
 	} // end of method Classes_ForLoopMin::__js_module_init__
 
 } // end of class Modules.Classes_ForLoopMin
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ForLoopMin_9F657D6F.FunctionObject_ClassConstructor_889FA173_C
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x215a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_ForLoopMin_9F657D6F.FunctionObject_ClassConstructor_889FA173_C::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_889FA173_C::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2169
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_889FA173_C::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x216c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_889FA173_C::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x216f
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_889FA173_C::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x217b
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_889FA173_C::ConstructCore
-
-} // end of class FunctionObjects.Classes_ForLoopMin_9F657D6F.FunctionObject_ClassConstructor_889FA173_C
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_ForLoopMin_9F657D6F.FunctionObject_ClassMethod_A226B3E5_C_run
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2187
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_A226B3E5_C_run::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x218f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_A226B3E5_C_run::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2192
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_A226B3E5_C_run::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2195
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_ForLoopMin/C
-		IL_0006: call instance float64 Modules.Classes_ForLoopMin/C::run()
-		IL_000b: box [System.Runtime]System.Double
-		IL_0010: ret
-	} // end of method FunctionObject_ClassMethod_A226B3E5_C_run::CallCore
-
-} // end of class FunctionObjects.Classes_ForLoopMin_9F657D6F.FunctionObject_ClassMethod_A226B3E5_C_run
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_NestedClassExtendsGlobal.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_NestedClassExtendsGlobal.verified.txt
@@ -55,6 +55,149 @@
 
 			} // end of class Scope_n
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_0C45EDF4_NestedDerived
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Method begins at RVA 0x23c7
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived/FunctionObject_ClassConstructor_0C45EDF4_NestedDerived::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject_ClassConstructor_0C45EDF4_NestedDerived::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x23d6
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_ClassConstructor_0C45EDF4_NestedDerived::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x23d9
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_ClassConstructor_0C45EDF4_NestedDerived::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x23dc
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+					IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+					IL_000a: throw
+				} // end of method FunctionObject_ClassConstructor_0C45EDF4_NestedDerived::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x23e8
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+					IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+					IL_000a: throw
+				} // end of method FunctionObject_ClassConstructor_0C45EDF4_NestedDerived::ConstructCore
+
+			} // end of class FunctionObject_ClassConstructor_0C45EDF4_NestedDerived
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_A5621FA9_NestedDerived_n
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x23f4
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_ClassMethod_A5621FA9_NestedDerived_n::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x23fc
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_ClassMethod_A5621FA9_NestedDerived_n::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x23ff
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_ClassMethod_A5621FA9_NestedDerived_n::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2402
+					// Header size: 1
+					// Code size: 12 (0xc)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: castclass Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived
+					IL_0006: call instance object Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived::n()
+					IL_000b: ret
+				} // end of method FunctionObject_ClassMethod_A5621FA9_NestedDerived_n::CallCore
+
+			} // end of class FunctionObject_ClassMethod_A5621FA9_NestedDerived_n
+
 
 			// Methods
 			.method public hidebysig specialname rtspecialname 
@@ -120,6 +263,101 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_82BB358F_makeAndRun
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2396
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_82BB358F_makeAndRun::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x239e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_82BB358F_makeAndRun::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x23a1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_82BB358F_makeAndRun::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x23a4
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_82BB358F_makeAndRun::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23b0
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_82BB358F_makeAndRun::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23b8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_82BB358F_makeAndRun::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_82BB358F_makeAndRun
 
 
 		// Methods
@@ -326,6 +564,150 @@
 
 		} // end of class Scope_m
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_F01B26D3_GlobalBase
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2349
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase/FunctionObject_ClassConstructor_F01B26D3_GlobalBase::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_F01B26D3_GlobalBase::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2358
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_F01B26D3_GlobalBase::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x235b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_F01B26D3_GlobalBase::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x235e
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_F01B26D3_GlobalBase::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x236a
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_F01B26D3_GlobalBase::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_F01B26D3_GlobalBase
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2376
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x237e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2381
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2384
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase
+				IL_0006: call instance float64 Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase::m()
+				IL_000b: box [System.Runtime]System.Double
+				IL_0010: ret
+			} // end of method FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m::CallCore
+
+		} // end of class FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -406,7 +788,7 @@
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Classes_Inheritance_NestedClassExtendsGlobal/Scope,
-			[1] class FunctionObjects.Classes_Inheritance_NestedClassExtendsGlobal_73ED4C20.FunctionObject_FunctionDeclaration_82BB358F_makeAndRun,
+			[1] class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/FunctionObject_FunctionDeclaration_82BB358F_makeAndRun,
 			[2] object,
 			[3] object[],
 			[4] class [System.Runtime]System.Type,
@@ -422,13 +804,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.Classes_Inheritance_NestedClassExtendsGlobal_73ED4C20.FunctionObject_FunctionDeclaration_82BB358F_makeAndRun::.ctor()
+		IL_0011: newobj instance void Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/FunctionObject_FunctionDeclaration_82BB358F_makeAndRun::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "makeAndRun"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Classes_Inheritance_NestedClassExtendsGlobal_73ED4C20.FunctionObject_FunctionDeclaration_82BB358F_makeAndRun>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/FunctionObject_FunctionDeclaration_82BB358F_makeAndRun>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: ldtoken Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase
@@ -516,388 +898,6 @@
 	} // end of method Classes_Inheritance_NestedClassExtendsGlobal::__js_module_init__
 
 } // end of class Modules.Classes_Inheritance_NestedClassExtendsGlobal
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Inheritance_NestedClassExtendsGlobal_73ED4C20.FunctionObject_ClassConstructor_F01B26D3_GlobalBase
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2349
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_Inheritance_NestedClassExtendsGlobal_73ED4C20.FunctionObject_ClassConstructor_F01B26D3_GlobalBase::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_F01B26D3_GlobalBase::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2358
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_F01B26D3_GlobalBase::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x235b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_F01B26D3_GlobalBase::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x235e
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_F01B26D3_GlobalBase::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x236a
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_F01B26D3_GlobalBase::ConstructCore
-
-} // end of class FunctionObjects.Classes_Inheritance_NestedClassExtendsGlobal_73ED4C20.FunctionObject_ClassConstructor_F01B26D3_GlobalBase
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Inheritance_NestedClassExtendsGlobal_73ED4C20.FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2376
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x237e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2381
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2384
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase
-		IL_0006: call instance float64 Modules.Classes_Inheritance_NestedClassExtendsGlobal/GlobalBase::m()
-		IL_000b: box [System.Runtime]System.Double
-		IL_0010: ret
-	} // end of method FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m::CallCore
-
-} // end of class FunctionObjects.Classes_Inheritance_NestedClassExtendsGlobal_73ED4C20.FunctionObject_ClassMethod_C3B86AF7_GlobalBase_m
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Inheritance_NestedClassExtendsGlobal_73ED4C20.FunctionObject_FunctionDeclaration_82BB358F_makeAndRun
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2396
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_82BB358F_makeAndRun::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x239e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_82BB358F_makeAndRun::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23a1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_82BB358F_makeAndRun::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23a4
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_82BB358F_makeAndRun::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23b0
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_82BB358F_makeAndRun::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23b8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_82BB358F_makeAndRun::ConstructCore
-
-} // end of class FunctionObjects.Classes_Inheritance_NestedClassExtendsGlobal_73ED4C20.FunctionObject_FunctionDeclaration_82BB358F_makeAndRun
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Inheritance_NestedClassExtendsGlobal_73ED4C20.FunctionObject_ClassConstructor_0C45EDF4_NestedDerived
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x23c7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_Inheritance_NestedClassExtendsGlobal_73ED4C20.FunctionObject_ClassConstructor_0C45EDF4_NestedDerived::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_0C45EDF4_NestedDerived::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23d6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_0C45EDF4_NestedDerived::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23d9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_0C45EDF4_NestedDerived::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23dc
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_0C45EDF4_NestedDerived::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23e8
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_0C45EDF4_NestedDerived::ConstructCore
-
-} // end of class FunctionObjects.Classes_Inheritance_NestedClassExtendsGlobal_73ED4C20.FunctionObject_ClassConstructor_0C45EDF4_NestedDerived
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Inheritance_NestedClassExtendsGlobal_73ED4C20.FunctionObject_ClassMethod_A5621FA9_NestedDerived_n
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x23f4
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_A5621FA9_NestedDerived_n::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23fc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_A5621FA9_NestedDerived_n::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23ff
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_A5621FA9_NestedDerived_n::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2402
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived
-		IL_0006: call instance object Modules.Classes_Inheritance_NestedClassExtendsGlobal/makeAndRun/NestedDerived::n()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_A5621FA9_NestedDerived_n::CallCore
-
-} // end of class FunctionObjects.Classes_Inheritance_NestedClassExtendsGlobal_73ED4C20.FunctionObject_ClassMethod_A5621FA9_NestedDerived_n
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperCapturedScopeVar.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperCapturedScopeVar.verified.txt
@@ -55,6 +55,150 @@
 
 			} // end of class Scope_m
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_D9ED61CF_Base
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Method begins at RVA 0x23b3
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base/FunctionObject_ClassConstructor_D9ED61CF_Base::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject_ClassConstructor_D9ED61CF_Base::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x23c2
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_ClassConstructor_D9ED61CF_Base::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x23c5
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_ClassConstructor_D9ED61CF_Base::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x23c8
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+					IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+					IL_000a: throw
+				} // end of method FunctionObject_ClassConstructor_D9ED61CF_Base::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x23d4
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+					IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+					IL_000a: throw
+				} // end of method FunctionObject_ClassConstructor_D9ED61CF_Base::ConstructCore
+
+			} // end of class FunctionObject_ClassConstructor_D9ED61CF_Base
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_85F9A249_Base_m
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x23e0
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_ClassMethod_85F9A249_Base_m::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x23e8
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_ClassMethod_85F9A249_Base_m::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x23eb
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_ClassMethod_85F9A249_Base_m::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x23ee
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: castclass Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base
+					IL_0006: call instance float64 Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base::m()
+					IL_000b: box [System.Runtime]System.Double
+					IL_0010: ret
+				} // end of method FunctionObject_ClassMethod_85F9A249_Base_m::CallCore
+
+			} // end of class FunctionObject_ClassMethod_85F9A249_Base_m
+
 
 			// Fields
 			.field private object[] _scopes
@@ -147,6 +291,149 @@
 
 			} // end of class Scope_n
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_9C573247_Derived
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						object[] capture0
+					) cil managed 
+				{
+					// Method begins at RVA 0x2400
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld object[] Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived/FunctionObject_ClassConstructor_9C573247_Derived::_transitionalScopes
+					IL_000d: ret
+				} // end of method FunctionObject_ClassConstructor_9C573247_Derived::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x240f
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_ClassConstructor_9C573247_Derived::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2412
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_ClassConstructor_9C573247_Derived::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2415
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+					IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+					IL_000a: throw
+				} // end of method FunctionObject_ClassConstructor_9C573247_Derived::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2421
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+					IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+					IL_000a: throw
+				} // end of method FunctionObject_ClassConstructor_9C573247_Derived::ConstructCore
+
+			} // end of class FunctionObject_ClassConstructor_9C573247_Derived
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_95B677B6_Derived_n
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x242d
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_ClassMethod_95B677B6_Derived_n::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2435
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_ClassMethod_95B677B6_Derived_n::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2438
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_ClassMethod_95B677B6_Derived_n::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x243b
+					// Header size: 1
+					// Code size: 12 (0xc)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: castclass Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
+					IL_0006: call instance object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::n()
+					IL_000b: ret
+				} // end of method FunctionObject_ClassMethod_95B677B6_Derived_n::CallCore
+
+			} // end of class FunctionObject_ClassMethod_95B677B6_Derived_n
+
 
 			// Fields
 			.field private object[] _scopes
@@ -224,6 +511,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2161B7CD_outer
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope _environment0_Classes_Inheritance_SuperCapturedScopeVar
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x236f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/FunctionObject_FunctionDeclaration_2161B7CD_outer::_environment0_Classes_Inheritance_SuperCapturedScopeVar
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_2161B7CD_outer::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x237e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2161B7CD_outer::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2381
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2161B7CD_outer::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2384
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/FunctionObject_FunctionDeclaration_2161B7CD_outer::_environment0_Classes_Inheritance_SuperCapturedScopeVar
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer::__js_call__(class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_2161B7CD_outer::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2396
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/FunctionObject_FunctionDeclaration_2161B7CD_outer::_environment0_Classes_Inheritance_SuperCapturedScopeVar
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer::__js_call__(class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_2161B7CD_outer::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23a4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_2161B7CD_outer::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_2161B7CD_outer
 
 
 		// Methods
@@ -535,7 +929,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope,
-			[1] class FunctionObjects.Classes_Inheritance_SuperCapturedScopeVar_7C730DC3.FunctionObject_FunctionDeclaration_2161B7CD_outer,
+			[1] class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/FunctionObject_FunctionDeclaration_2161B7CD_outer,
 			[2] object[]
 		)
 
@@ -552,13 +946,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope
-		IL_0019: newobj instance void FunctionObjects.Classes_Inheritance_SuperCapturedScopeVar_7C730DC3.FunctionObject_FunctionDeclaration_2161B7CD_outer::.ctor(class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope)
+		IL_0019: newobj instance void Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/FunctionObject_FunctionDeclaration_2161B7CD_outer::.ctor(class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "outer"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Classes_Inheritance_SuperCapturedScopeVar_7C730DC3.FunctionObject_FunctionDeclaration_2161B7CD_outer>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/FunctionObject_FunctionDeclaration_2161B7CD_outer>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
@@ -570,400 +964,6 @@
 	} // end of method Classes_Inheritance_SuperCapturedScopeVar::__js_module_init__
 
 } // end of class Modules.Classes_Inheritance_SuperCapturedScopeVar
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Inheritance_SuperCapturedScopeVar_7C730DC3.FunctionObject_FunctionDeclaration_2161B7CD_outer
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope _environment0_Classes_Inheritance_SuperCapturedScopeVar
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x236f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope FunctionObjects.Classes_Inheritance_SuperCapturedScopeVar_7C730DC3.FunctionObject_FunctionDeclaration_2161B7CD_outer::_environment0_Classes_Inheritance_SuperCapturedScopeVar
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_2161B7CD_outer::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x237e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2161B7CD_outer::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2381
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2161B7CD_outer::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2384
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope FunctionObjects.Classes_Inheritance_SuperCapturedScopeVar_7C730DC3.FunctionObject_FunctionDeclaration_2161B7CD_outer::_environment0_Classes_Inheritance_SuperCapturedScopeVar
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer::__js_call__(class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_2161B7CD_outer::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2396
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope FunctionObjects.Classes_Inheritance_SuperCapturedScopeVar_7C730DC3.FunctionObject_FunctionDeclaration_2161B7CD_outer::_environment0_Classes_Inheritance_SuperCapturedScopeVar
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer::__js_call__(class Modules.Classes_Inheritance_SuperCapturedScopeVar/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_2161B7CD_outer::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23a4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_2161B7CD_outer::ConstructCore
-
-} // end of class FunctionObjects.Classes_Inheritance_SuperCapturedScopeVar_7C730DC3.FunctionObject_FunctionDeclaration_2161B7CD_outer
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Inheritance_SuperCapturedScopeVar_7C730DC3.FunctionObject_ClassConstructor_D9ED61CF_Base
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x23b3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_Inheritance_SuperCapturedScopeVar_7C730DC3.FunctionObject_ClassConstructor_D9ED61CF_Base::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_D9ED61CF_Base::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23c2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_D9ED61CF_Base::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23c5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_D9ED61CF_Base::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23c8
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_D9ED61CF_Base::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23d4
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_D9ED61CF_Base::ConstructCore
-
-} // end of class FunctionObjects.Classes_Inheritance_SuperCapturedScopeVar_7C730DC3.FunctionObject_ClassConstructor_D9ED61CF_Base
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Inheritance_SuperCapturedScopeVar_7C730DC3.FunctionObject_ClassMethod_85F9A249_Base_m
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x23e0
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_85F9A249_Base_m::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23e8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_85F9A249_Base_m::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23eb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_85F9A249_Base_m::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23ee
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base
-		IL_0006: call instance float64 Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Base::m()
-		IL_000b: box [System.Runtime]System.Double
-		IL_0010: ret
-	} // end of method FunctionObject_ClassMethod_85F9A249_Base_m::CallCore
-
-} // end of class FunctionObjects.Classes_Inheritance_SuperCapturedScopeVar_7C730DC3.FunctionObject_ClassMethod_85F9A249_Base_m
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Inheritance_SuperCapturedScopeVar_7C730DC3.FunctionObject_ClassConstructor_9C573247_Derived
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2400
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_Inheritance_SuperCapturedScopeVar_7C730DC3.FunctionObject_ClassConstructor_9C573247_Derived::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_9C573247_Derived::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x240f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_9C573247_Derived::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2412
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_9C573247_Derived::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2415
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_9C573247_Derived::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2421
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_9C573247_Derived::ConstructCore
-
-} // end of class FunctionObjects.Classes_Inheritance_SuperCapturedScopeVar_7C730DC3.FunctionObject_ClassConstructor_9C573247_Derived
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Inheritance_SuperCapturedScopeVar_7C730DC3.FunctionObject_ClassMethod_95B677B6_Derived_n
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x242d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_95B677B6_Derived_n::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2435
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_95B677B6_Derived_n::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2438
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_95B677B6_Derived_n::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x243b
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived
-		IL_0006: call instance object Modules.Classes_Inheritance_SuperCapturedScopeVar/outer/Derived::n()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_95B677B6_Derived_n::CallCore
-
-} // end of class FunctionObjects.Classes_Inheritance_SuperCapturedScopeVar_7C730DC3.FunctionObject_ClassMethod_95B677B6_Derived_n
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperConstructor_Args.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperConstructor_Args.verified.txt
@@ -51,6 +51,89 @@
 
 		} // end of class Scope_ctor
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_AD8F3CC5_B
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21df
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_Inheritance_SuperConstructor_Args/B/FunctionObject_ClassConstructor_AD8F3CC5_B::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_AD8F3CC5_B::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21ee
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_AD8F3CC5_B::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21f1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_AD8F3CC5_B::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f4
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_AD8F3CC5_B::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2200
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_AD8F3CC5_B::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_AD8F3CC5_B
+
 
 		// Fields
 		.field public object x
@@ -122,6 +205,89 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_A78F3353_D
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x220c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_Inheritance_SuperConstructor_Args/D/FunctionObject_ClassConstructor_A78F3353_D::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_A78F3353_D::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x221b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_A78F3353_D::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x221e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_A78F3353_D::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2221
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_A78F3353_D::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x222d
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_A78F3353_D::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_A78F3353_D
 
 
 		// Methods
@@ -285,172 +451,6 @@
 	} // end of method Classes_Inheritance_SuperConstructor_Args::__js_module_init__
 
 } // end of class Modules.Classes_Inheritance_SuperConstructor_Args
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Inheritance_SuperConstructor_Args_A6C22100.FunctionObject_ClassConstructor_AD8F3CC5_B
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21df
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_Inheritance_SuperConstructor_Args_A6C22100.FunctionObject_ClassConstructor_AD8F3CC5_B::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_AD8F3CC5_B::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21ee
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_AD8F3CC5_B::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21f1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_AD8F3CC5_B::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f4
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_AD8F3CC5_B::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2200
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_AD8F3CC5_B::ConstructCore
-
-} // end of class FunctionObjects.Classes_Inheritance_SuperConstructor_Args_A6C22100.FunctionObject_ClassConstructor_AD8F3CC5_B
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Inheritance_SuperConstructor_Args_A6C22100.FunctionObject_ClassConstructor_A78F3353_D
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x220c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_Inheritance_SuperConstructor_Args_A6C22100.FunctionObject_ClassConstructor_A78F3353_D::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_A78F3353_D::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x221b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_A78F3353_D::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x221e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_A78F3353_D::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2221
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_A78F3353_D::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x222d
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_A78F3353_D::ConstructCore
-
-} // end of class FunctionObjects.Classes_Inheritance_SuperConstructor_Args_A6C22100.FunctionObject_ClassConstructor_A78F3353_D
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperMethodCall.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_SuperMethodCall.verified.txt
@@ -51,6 +51,150 @@
 
 		} // end of class Scope_m
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_1D7D808A_B
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x22c0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_Inheritance_SuperMethodCall/B/FunctionObject_ClassConstructor_1D7D808A_B::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_1D7D808A_B::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22cf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_1D7D808A_B::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22d2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_1D7D808A_B::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22d5
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_1D7D808A_B::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22e1
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_1D7D808A_B::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_1D7D808A_B
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_1807B0B6_B_m
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x22ed
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_1807B0B6_B_m::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22f5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_1807B0B6_B_m::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22f8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_1807B0B6_B_m::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22fb
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_Inheritance_SuperMethodCall/B
+				IL_0006: call instance float64 Modules.Classes_Inheritance_SuperMethodCall/B::m()
+				IL_000b: box [System.Runtime]System.Double
+				IL_0010: ret
+			} // end of method FunctionObject_ClassMethod_1807B0B6_B_m::CallCore
+
+		} // end of class FunctionObject_ClassMethod_1807B0B6_B_m
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -129,6 +273,149 @@
 			} // end of method Scope_m::.ctor
 
 		} // end of class Scope_m
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_177D7718_D
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x230d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_Inheritance_SuperMethodCall/D/FunctionObject_ClassConstructor_177D7718_D::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_177D7718_D::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x231c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_177D7718_D::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x231f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_177D7718_D::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2322
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_177D7718_D::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x232e
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_177D7718_D::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_177D7718_D
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_8204A1AC_D_m
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x233a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_8204A1AC_D_m::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2342
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_8204A1AC_D_m::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2345
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_8204A1AC_D_m::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2348
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_Inheritance_SuperMethodCall/D
+				IL_0006: call instance object Modules.Classes_Inheritance_SuperMethodCall/D::m()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_8204A1AC_D_m::CallCore
+
+		} // end of class FunctionObject_ClassMethod_8204A1AC_D_m
 
 
 		// Methods
@@ -418,293 +705,6 @@
 	} // end of method Classes_Inheritance_SuperMethodCall::__js_module_init__
 
 } // end of class Modules.Classes_Inheritance_SuperMethodCall
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Inheritance_SuperMethodCall_F06B0BC5.FunctionObject_ClassConstructor_1D7D808A_B
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x22c0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_Inheritance_SuperMethodCall_F06B0BC5.FunctionObject_ClassConstructor_1D7D808A_B::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_1D7D808A_B::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22cf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_1D7D808A_B::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22d2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_1D7D808A_B::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22d5
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_1D7D808A_B::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22e1
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_1D7D808A_B::ConstructCore
-
-} // end of class FunctionObjects.Classes_Inheritance_SuperMethodCall_F06B0BC5.FunctionObject_ClassConstructor_1D7D808A_B
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Inheritance_SuperMethodCall_F06B0BC5.FunctionObject_ClassMethod_1807B0B6_B_m
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x22ed
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_1807B0B6_B_m::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22f5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_1807B0B6_B_m::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22f8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_1807B0B6_B_m::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22fb
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_Inheritance_SuperMethodCall/B
-		IL_0006: call instance float64 Modules.Classes_Inheritance_SuperMethodCall/B::m()
-		IL_000b: box [System.Runtime]System.Double
-		IL_0010: ret
-	} // end of method FunctionObject_ClassMethod_1807B0B6_B_m::CallCore
-
-} // end of class FunctionObjects.Classes_Inheritance_SuperMethodCall_F06B0BC5.FunctionObject_ClassMethod_1807B0B6_B_m
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Inheritance_SuperMethodCall_F06B0BC5.FunctionObject_ClassConstructor_177D7718_D
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x230d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_Inheritance_SuperMethodCall_F06B0BC5.FunctionObject_ClassConstructor_177D7718_D::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_177D7718_D::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x231c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_177D7718_D::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x231f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_177D7718_D::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2322
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_177D7718_D::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x232e
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_177D7718_D::ConstructCore
-
-} // end of class FunctionObjects.Classes_Inheritance_SuperMethodCall_F06B0BC5.FunctionObject_ClassConstructor_177D7718_D
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Inheritance_SuperMethodCall_F06B0BC5.FunctionObject_ClassMethod_8204A1AC_D_m
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x233a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_8204A1AC_D_m::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2342
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_8204A1AC_D_m::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2345
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_8204A1AC_D_m::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2348
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_Inheritance_SuperMethodCall/D
-		IL_0006: call instance object Modules.Classes_Inheritance_SuperMethodCall/D::m()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_8204A1AC_D_m::CallCore
-
-} // end of class FunctionObjects.Classes_Inheritance_SuperMethodCall_F06B0BC5.FunctionObject_ClassMethod_8204A1AC_D_m
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_ThisBeforeSuper_Throws.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Inheritance_ThisBeforeSuper_Throws.verified.txt
@@ -51,6 +51,89 @@
 
 		} // end of class Scope_ctor
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_4745A670_B
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x22c3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_Inheritance_ThisBeforeSuper_Throws/B/FunctionObject_ClassConstructor_4745A670_B::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_4745A670_B::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22d2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_4745A670_B::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22d5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_4745A670_B::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22d8
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_4745A670_B::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22e4
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_4745A670_B::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_4745A670_B
+
 
 		// Fields
 		.field public object x
@@ -164,6 +247,89 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_4D45AFE2_D
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x22f0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_Inheritance_ThisBeforeSuper_Throws/D/FunctionObject_ClassConstructor_4D45AFE2_D::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_4D45AFE2_D::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22ff
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_4D45AFE2_D::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2302
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_4D45AFE2_D::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2305
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_4D45AFE2_D::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2311
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_4D45AFE2_D::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_4D45AFE2_D
 
 
 		// Methods
@@ -408,172 +574,6 @@
 	} // end of method Classes_Inheritance_ThisBeforeSuper_Throws::__js_module_init__
 
 } // end of class Modules.Classes_Inheritance_ThisBeforeSuper_Throws
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Inheritance_ThisBeforeSuper_Throws_DFB3A7BF.FunctionObject_ClassConstructor_4745A670_B
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x22c3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_Inheritance_ThisBeforeSuper_Throws_DFB3A7BF.FunctionObject_ClassConstructor_4745A670_B::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_4745A670_B::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22d2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_4745A670_B::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22d5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_4745A670_B::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22d8
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_4745A670_B::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22e4
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_4745A670_B::ConstructCore
-
-} // end of class FunctionObjects.Classes_Inheritance_ThisBeforeSuper_Throws_DFB3A7BF.FunctionObject_ClassConstructor_4745A670_B
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Inheritance_ThisBeforeSuper_Throws_DFB3A7BF.FunctionObject_ClassConstructor_4D45AFE2_D
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x22f0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_Inheritance_ThisBeforeSuper_Throws_DFB3A7BF.FunctionObject_ClassConstructor_4D45AFE2_D::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_4D45AFE2_D::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22ff
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_4D45AFE2_D::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2302
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_4D45AFE2_D::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2305
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_4D45AFE2_D::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2311
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_4D45AFE2_D::ConstructCore
-
-} // end of class FunctionObjects.Classes_Inheritance_ThisBeforeSuper_Throws_DFB3A7BF.FunctionObject_ClassConstructor_4D45AFE2_D
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_IntrinsicInheritance_ExtendsArray_SuperLength.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_IntrinsicInheritance_ExtendsArray_SuperLength.verified.txt
@@ -51,6 +51,89 @@
 
 		} // end of class Scope_ctor
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_13C3A4AD_NodeList
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2448
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/NodeList/FunctionObject_ClassConstructor_13C3A4AD_NodeList::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_13C3A4AD_NodeList::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2457
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_13C3A4AD_NodeList::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x245a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_13C3A4AD_NodeList::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x245d
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_13C3A4AD_NodeList::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2469
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_13C3A4AD_NodeList::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_13C3A4AD_NodeList
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -168,6 +251,89 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_FCCAD460_Y
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2475
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength/Y/FunctionObject_ClassConstructor_FCCAD460_Y::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_FCCAD460_Y::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2484
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_FCCAD460_Y::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2487
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_FCCAD460_Y::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x248a
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_FCCAD460_Y::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2496
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_FCCAD460_Y::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_FCCAD460_Y
 
 
 		// Methods
@@ -472,172 +638,6 @@
 	} // end of method Classes_IntrinsicInheritance_ExtendsArray_SuperLength::__js_module_init__
 
 } // end of class Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperLength
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_IntrinsicInheritance_ExtendsArray_SuperLength_FBEDFCD4.FunctionObject_ClassConstructor_13C3A4AD_NodeList
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2448
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_IntrinsicInheritance_ExtendsArray_SuperLength_FBEDFCD4.FunctionObject_ClassConstructor_13C3A4AD_NodeList::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_13C3A4AD_NodeList::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2457
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_13C3A4AD_NodeList::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x245a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_13C3A4AD_NodeList::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x245d
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_13C3A4AD_NodeList::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2469
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_13C3A4AD_NodeList::ConstructCore
-
-} // end of class FunctionObjects.Classes_IntrinsicInheritance_ExtendsArray_SuperLength_FBEDFCD4.FunctionObject_ClassConstructor_13C3A4AD_NodeList
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_IntrinsicInheritance_ExtendsArray_SuperLength_FBEDFCD4.FunctionObject_ClassConstructor_FCCAD460_Y
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2475
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_IntrinsicInheritance_ExtendsArray_SuperLength_FBEDFCD4.FunctionObject_ClassConstructor_FCCAD460_Y::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_FCCAD460_Y::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2484
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_FCCAD460_Y::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2487
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_FCCAD460_Y::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x248a
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_FCCAD460_Y::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2496
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_FCCAD460_Y::ConstructCore
-
-} // end of class FunctionObjects.Classes_IntrinsicInheritance_ExtendsArray_SuperLength_FBEDFCD4.FunctionObject_ClassConstructor_FCCAD460_Y
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_IntrinsicInheritance_ExtendsArray_SuperNoArgs.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_IntrinsicInheritance_ExtendsArray_SuperNoArgs.verified.txt
@@ -51,6 +51,89 @@
 
 		} // end of class Scope_ctor
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_84833B4B_Z
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x219a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperNoArgs/Z/FunctionObject_ClassConstructor_84833B4B_Z::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_84833B4B_Z::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21a9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_84833B4B_Z::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21ac
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_84833B4B_Z::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21af
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_84833B4B_Z::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21bb
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_84833B4B_Z::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_84833B4B_Z
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -202,89 +285,6 @@
 	} // end of method Classes_IntrinsicInheritance_ExtendsArray_SuperNoArgs::__js_module_init__
 
 } // end of class Modules.Classes_IntrinsicInheritance_ExtendsArray_SuperNoArgs
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_IntrinsicInheritance_ExtendsArray_SuperNoArgs_1EB127C2.FunctionObject_ClassConstructor_84833B4B_Z
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x219a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_IntrinsicInheritance_ExtendsArray_SuperNoArgs_1EB127C2.FunctionObject_ClassConstructor_84833B4B_Z::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_84833B4B_Z::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21a9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_84833B4B_Z::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21ac
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_84833B4B_Z::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21af
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_84833B4B_Z::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21bb
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_84833B4B_Z::ConstructCore
-
-} // end of class FunctionObjects.Classes_IntrinsicInheritance_ExtendsArray_SuperNoArgs_1EB127C2.FunctionObject_ClassConstructor_84833B4B_Z
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Method_DefaultReturnUndefined.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_Method_DefaultReturnUndefined.verified.txt
@@ -131,6 +131,330 @@
 
 		} // end of class Scope_returnsThis
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_10F28F0E_Calculator
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2440
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_Method_DefaultReturnUndefined/Calculator/FunctionObject_ClassConstructor_10F28F0E_Calculator::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_10F28F0E_Calculator::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x244f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_10F28F0E_Calculator::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2452
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_10F28F0E_Calculator::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2455
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_10F28F0E_Calculator::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2461
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_10F28F0E_Calculator::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_10F28F0E_Calculator
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x246d
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2475
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2478
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x247b
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_Method_DefaultReturnUndefined/Calculator
+				IL_0006: call instance object Modules.Classes_Method_DefaultReturnUndefined/Calculator::doNothing()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing::CallCore
+
+		} // end of class FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2488
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2490
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2493
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2496
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_Method_DefaultReturnUndefined/Calculator
+				IL_0006: call instance object Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsUndefined()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined::CallCore
+
+		} // end of class FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x24a3
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24ab
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24ae
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24b1
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_Method_DefaultReturnUndefined/Calculator
+				IL_0006: call instance float64 Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsValue()
+				IL_000b: box [System.Runtime]System.Double
+				IL_0010: ret
+			} // end of method FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue::CallCore
+
+		} // end of class FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x24c3
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24cb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24ce
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24d1
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Classes_Method_DefaultReturnUndefined/Calculator
+				IL_0006: call instance class Modules.Classes_Method_DefaultReturnUndefined/Calculator Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsThis()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis::CallCore
+
+		} // end of class FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis
+
 
 		// Fields
 		.field public float64 'value'
@@ -635,330 +959,6 @@
 	} // end of method Classes_Method_DefaultReturnUndefined::__js_module_init__
 
 } // end of class Modules.Classes_Method_DefaultReturnUndefined
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Method_DefaultReturnUndefined_F4642E5B.FunctionObject_ClassConstructor_10F28F0E_Calculator
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2440
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_Method_DefaultReturnUndefined_F4642E5B.FunctionObject_ClassConstructor_10F28F0E_Calculator::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_10F28F0E_Calculator::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x244f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_10F28F0E_Calculator::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2452
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_10F28F0E_Calculator::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2455
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_10F28F0E_Calculator::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2461
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_10F28F0E_Calculator::ConstructCore
-
-} // end of class FunctionObjects.Classes_Method_DefaultReturnUndefined_F4642E5B.FunctionObject_ClassConstructor_10F28F0E_Calculator
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Method_DefaultReturnUndefined_F4642E5B.FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x246d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2475
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2478
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x247b
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_Method_DefaultReturnUndefined/Calculator
-		IL_0006: call instance object Modules.Classes_Method_DefaultReturnUndefined/Calculator::doNothing()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing::CallCore
-
-} // end of class FunctionObjects.Classes_Method_DefaultReturnUndefined_F4642E5B.FunctionObject_ClassMethod_C3D2BBE5_Calculator_doNothing
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Method_DefaultReturnUndefined_F4642E5B.FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2488
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2490
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2493
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2496
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_Method_DefaultReturnUndefined/Calculator
-		IL_0006: call instance object Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsUndefined()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined::CallCore
-
-} // end of class FunctionObjects.Classes_Method_DefaultReturnUndefined_F4642E5B.FunctionObject_ClassMethod_0EC6C134_Calculator_returnsUndefined
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Method_DefaultReturnUndefined_F4642E5B.FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x24a3
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24ab
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24ae
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24b1
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_Method_DefaultReturnUndefined/Calculator
-		IL_0006: call instance float64 Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsValue()
-		IL_000b: box [System.Runtime]System.Double
-		IL_0010: ret
-	} // end of method FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue::CallCore
-
-} // end of class FunctionObjects.Classes_Method_DefaultReturnUndefined_F4642E5B.FunctionObject_ClassMethod_81FCDEB1_Calculator_returnsValue
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_Method_DefaultReturnUndefined_F4642E5B.FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x24c3
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24cb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24ce
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24d1
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Classes_Method_DefaultReturnUndefined/Calculator
-		IL_0006: call instance class Modules.Classes_Method_DefaultReturnUndefined/Calculator Modules.Classes_Method_DefaultReturnUndefined/Calculator::returnsThis()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis::CallCore
-
-} // end of class FunctionObjects.Classes_Method_DefaultReturnUndefined_F4642E5B.FunctionObject_ClassMethod_64FB46F4_Calculator_returnsThis
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_PrimeCtor_BitArrayAdd.verified.txt
+++ b/tests/Jroc.Tests/Classes/Snapshots/GeneratorTests.Classes_PrimeCtor_BitArrayAdd.verified.txt
@@ -51,6 +51,89 @@
 
 		} // end of class Scope_ctor
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_AEE7AD70_BitArray
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21cb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Classes_PrimeCtor_BitArrayAdd/BitArray/FunctionObject_ClassConstructor_AEE7AD70_BitArray::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_AEE7AD70_BitArray::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21da
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_AEE7AD70_BitArray::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21dd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_AEE7AD70_BitArray::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21e0
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_AEE7AD70_BitArray::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21ec
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_AEE7AD70_BitArray::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_AEE7AD70_BitArray
+
 
 		// Fields
 		.field public float64 n
@@ -122,6 +205,94 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_920AE9BF_PrimeSieve
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Classes_PrimeCtor_BitArrayAdd/Scope _environment0_Classes_PrimeCtor_BitArrayAdd
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Classes_PrimeCtor_BitArrayAdd/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f8
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Classes_PrimeCtor_BitArrayAdd/Scope Modules.Classes_PrimeCtor_BitArrayAdd/PrimeSieve/FunctionObject_ClassConstructor_920AE9BF_PrimeSieve::_environment0_Classes_PrimeCtor_BitArrayAdd
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.Classes_PrimeCtor_BitArrayAdd/PrimeSieve/FunctionObject_ClassConstructor_920AE9BF_PrimeSieve::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_ClassConstructor_920AE9BF_PrimeSieve::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x220e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_920AE9BF_PrimeSieve::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2211
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_920AE9BF_PrimeSieve::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2214
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_920AE9BF_PrimeSieve::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2220
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_920AE9BF_PrimeSieve::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_920AE9BF_PrimeSieve
 
 
 		// Fields
@@ -306,177 +477,6 @@
 	} // end of method Classes_PrimeCtor_BitArrayAdd::__js_module_init__
 
 } // end of class Modules.Classes_PrimeCtor_BitArrayAdd
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_PrimeCtor_BitArrayAdd_FDDA6B69.FunctionObject_ClassConstructor_AEE7AD70_BitArray
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21cb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Classes_PrimeCtor_BitArrayAdd_FDDA6B69.FunctionObject_ClassConstructor_AEE7AD70_BitArray::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_AEE7AD70_BitArray::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21da
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_AEE7AD70_BitArray::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21dd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_AEE7AD70_BitArray::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21e0
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_AEE7AD70_BitArray::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ec
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_AEE7AD70_BitArray::ConstructCore
-
-} // end of class FunctionObjects.Classes_PrimeCtor_BitArrayAdd_FDDA6B69.FunctionObject_ClassConstructor_AEE7AD70_BitArray
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Classes_PrimeCtor_BitArrayAdd_FDDA6B69.FunctionObject_ClassConstructor_920AE9BF_PrimeSieve
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Classes_PrimeCtor_BitArrayAdd/Scope _environment0_Classes_PrimeCtor_BitArrayAdd
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Classes_PrimeCtor_BitArrayAdd/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f8
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Classes_PrimeCtor_BitArrayAdd/Scope FunctionObjects.Classes_PrimeCtor_BitArrayAdd_FDDA6B69.FunctionObject_ClassConstructor_920AE9BF_PrimeSieve::_environment0_Classes_PrimeCtor_BitArrayAdd
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Classes_PrimeCtor_BitArrayAdd_FDDA6B69.FunctionObject_ClassConstructor_920AE9BF_PrimeSieve::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_ClassConstructor_920AE9BF_PrimeSieve::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x220e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_920AE9BF_PrimeSieve::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2211
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_920AE9BF_PrimeSieve::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2214
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_920AE9BF_PrimeSieve::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2220
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_920AE9BF_PrimeSieve::ConstructCore
-
-} // end of class FunctionObjects.Classes_PrimeCtor_BitArrayAdd_FDDA6B69.FunctionObject_ClassConstructor_920AE9BF_PrimeSieve
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/CoercionOptimization/Snapshots/GeneratorTests.CoercionCSE_BoxedDoubleToNumber_NoCse.verified.txt
+++ b/tests/Jroc.Tests/CoercionOptimization/Snapshots/GeneratorTests.CoercionCSE_BoxedDoubleToNumber_NoCse.verified.txt
@@ -31,6 +31,109 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6B059E1F_compute
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21a1
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_6B059E1F_compute::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21a9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6B059E1F_compute::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21ac
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6B059E1F_compute::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21af
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: call object Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/compute::__js_call__(object, float64)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_6B059E1F_compute::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21c7
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: call object Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/compute::__js_call__(object, float64)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_6B059E1F_compute::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21db
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6B059E1F_compute::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_6B059E1F_compute
+
 
 		// Methods
 		.method public hidebysig static 
@@ -124,7 +227,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/Scope,
-			[1] class FunctionObjects.CoercionCSE_BoxedDoubleToNumber_NoCse_52934F97.FunctionObject_FunctionDeclaration_6B059E1F_compute,
+			[1] class Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/compute/FunctionObject_FunctionDeclaration_6B059E1F_compute,
 			[2] object[],
 			[3] object,
 			[4] object,
@@ -141,13 +244,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.CoercionCSE_BoxedDoubleToNumber_NoCse_52934F97.FunctionObject_FunctionDeclaration_6B059E1F_compute::.ctor()
+		IL_0011: newobj instance void Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/compute/FunctionObject_FunctionDeclaration_6B059E1F_compute::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "compute"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.CoercionCSE_BoxedDoubleToNumber_NoCse_52934F97.FunctionObject_FunctionDeclaration_6B059E1F_compute>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/compute/FunctionObject_FunctionDeclaration_6B059E1F_compute>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -211,109 +314,6 @@
 	} // end of method CoercionCSE_BoxedDoubleToNumber_NoCse::__js_module_init__
 
 } // end of class Modules.CoercionCSE_BoxedDoubleToNumber_NoCse
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CoercionCSE_BoxedDoubleToNumber_NoCse_52934F97.FunctionObject_FunctionDeclaration_6B059E1F_compute
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21a1
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_6B059E1F_compute::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21a9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6B059E1F_compute::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21ac
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6B059E1F_compute::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21af
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: call object Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/compute::__js_call__(object, float64)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_6B059E1F_compute::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21c7
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: call object Modules.CoercionCSE_BoxedDoubleToNumber_NoCse/compute::__js_call__(object, float64)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_6B059E1F_compute::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21db
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6B059E1F_compute::ConstructCore
-
-} // end of class FunctionObjects.CoercionCSE_BoxedDoubleToNumber_NoCse_52934F97.FunctionObject_FunctionDeclaration_6B059E1F_compute
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/CoercionOptimization/Snapshots/GeneratorTests.NumericInference_ExponentiationLoop_NoBoxing.verified.txt
+++ b/tests/Jroc.Tests/CoercionOptimization/Snapshots/GeneratorTests.NumericInference_ExponentiationLoop_NoBoxing.verified.txt
@@ -53,6 +53,118 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B5D0B4A9_arith
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2173
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_B5D0B4A9_arith::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x217b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B5D0B4A9_arith::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x217e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B5D0B4A9_arith::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2181
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_B5D0B4A9_arith::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2189
+				// Header size: 1
+				// Code size: 16 (0x10)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call float64 Modules.NumericInference_ExponentiationLoop_NoBoxing/arith::__js_call__(object)
+				IL_000a: box [System.Runtime]System.Double
+				IL_000f: ret
+			} // end of method FunctionObject_FunctionDeclaration_B5D0B4A9_arith::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x219a
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call float64 Modules.NumericInference_ExponentiationLoop_NoBoxing/arith::__js_call__(object)
+				IL_0006: box [System.Runtime]System.Double
+				IL_000b: ret
+			} // end of method FunctionObject_FunctionDeclaration_B5D0B4A9_arith::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21a7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B5D0B4A9_arith::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_B5D0B4A9_arith
+
 
 		// Methods
 		.method public hidebysig static 
@@ -185,7 +297,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.NumericInference_ExponentiationLoop_NoBoxing/Scope,
-			[1] class FunctionObjects.NumericInference_ExponentiationLoop_NoBoxing_AC191332.FunctionObject_FunctionDeclaration_B5D0B4A9_arith,
+			[1] class Modules.NumericInference_ExponentiationLoop_NoBoxing/arith/FunctionObject_FunctionDeclaration_B5D0B4A9_arith,
 			[2] object[],
 			[3] object,
 			[4] float64,
@@ -201,13 +313,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.NumericInference_ExponentiationLoop_NoBoxing_AC191332.FunctionObject_FunctionDeclaration_B5D0B4A9_arith::.ctor()
+		IL_0011: newobj instance void Modules.NumericInference_ExponentiationLoop_NoBoxing/arith/FunctionObject_FunctionDeclaration_B5D0B4A9_arith::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "arith"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.0
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.NumericInference_ExponentiationLoop_NoBoxing_AC191332.FunctionObject_FunctionDeclaration_B5D0B4A9_arith>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.NumericInference_ExponentiationLoop_NoBoxing/arith/FunctionObject_FunctionDeclaration_B5D0B4A9_arith>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: ldstr "console"
@@ -229,118 +341,6 @@
 	} // end of method NumericInference_ExponentiationLoop_NoBoxing::__js_module_init__
 
 } // end of class Modules.NumericInference_ExponentiationLoop_NoBoxing
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.NumericInference_ExponentiationLoop_NoBoxing_AC191332.FunctionObject_FunctionDeclaration_B5D0B4A9_arith
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2173
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_B5D0B4A9_arith::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x217b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B5D0B4A9_arith::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x217e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B5D0B4A9_arith::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2181
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_B5D0B4A9_arith::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2189
-		// Header size: 1
-		// Code size: 16 (0x10)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call float64 Modules.NumericInference_ExponentiationLoop_NoBoxing/arith::__js_call__(object)
-		IL_000a: box [System.Runtime]System.Double
-		IL_000f: ret
-	} // end of method FunctionObject_FunctionDeclaration_B5D0B4A9_arith::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x219a
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call float64 Modules.NumericInference_ExponentiationLoop_NoBoxing/arith::__js_call__(object)
-		IL_0006: box [System.Runtime]System.Double
-		IL_000b: ret
-	} // end of method FunctionObject_FunctionDeclaration_B5D0B4A9_arith::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21a7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B5D0B4A9_arith::ConstructCore
-
-} // end of class FunctionObjects.NumericInference_ExponentiationLoop_NoBoxing_AC191332.FunctionObject_FunctionDeclaration_B5D0B4A9_arith
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_Class.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_Class.verified.txt
@@ -207,6 +207,221 @@
 
 		} // end of class Scope_multiply
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_4A903940_Calculator
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x231f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.CommonJS_Export_Class_Lib/Calculator/FunctionObject_ClassConstructor_4A903940_Calculator::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_4A903940_Calculator::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x232e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_4A903940_Calculator::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2331
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_4A903940_Calculator::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2334
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_4A903940_Calculator::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2340
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_4A903940_Calculator::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_4A903940_Calculator
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_C6420A76_Calculator_add
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x234c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_C6420A76_Calculator_add::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2354
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_C6420A76_Calculator_add::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2357
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_C6420A76_Calculator_add::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x235a
+				// Header size: 1
+				// Code size: 26 (0x1a)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.CommonJS_Export_Class_Lib/Calculator
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call instance object Modules.CommonJS_Export_Class_Lib/Calculator::'add'(object, object)
+				IL_0019: ret
+			} // end of method FunctionObject_ClassMethod_C6420A76_Calculator_add::CallCore
+
+		} // end of class FunctionObject_ClassMethod_C6420A76_Calculator_add
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_56B18E5B_Calculator_multiply
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2375
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_56B18E5B_Calculator_multiply::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x237d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_56B18E5B_Calculator_multiply::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2380
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_56B18E5B_Calculator_multiply::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2383
+				// Header size: 1
+				// Code size: 26 (0x1a)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.CommonJS_Export_Class_Lib/Calculator
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call instance object Modules.CommonJS_Export_Class_Lib/Calculator::multiply(object, object)
+				IL_0019: ret
+			} // end of method FunctionObject_ClassMethod_56B18E5B_Calculator_multiply::CallCore
+
+		} // end of class FunctionObject_ClassMethod_56B18E5B_Calculator_multiply
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -456,221 +671,6 @@
 	} // end of method CommonJS_Export_Class_Lib::__js_module_init__
 
 } // end of class Modules.CommonJS_Export_Class_Lib
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Export_Class_Lib_517C3ED9.FunctionObject_ClassConstructor_4A903940_Calculator
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x231f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.CommonJS_Export_Class_Lib_517C3ED9.FunctionObject_ClassConstructor_4A903940_Calculator::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_4A903940_Calculator::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x232e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_4A903940_Calculator::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2331
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_4A903940_Calculator::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2334
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_4A903940_Calculator::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2340
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_4A903940_Calculator::ConstructCore
-
-} // end of class FunctionObjects.CommonJS_Export_Class_Lib_517C3ED9.FunctionObject_ClassConstructor_4A903940_Calculator
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Export_Class_Lib_517C3ED9.FunctionObject_ClassMethod_C6420A76_Calculator_add
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x234c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_C6420A76_Calculator_add::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2354
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_C6420A76_Calculator_add::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2357
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_C6420A76_Calculator_add::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x235a
-		// Header size: 1
-		// Code size: 26 (0x1a)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.CommonJS_Export_Class_Lib/Calculator
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call instance object Modules.CommonJS_Export_Class_Lib/Calculator::'add'(object, object)
-		IL_0019: ret
-	} // end of method FunctionObject_ClassMethod_C6420A76_Calculator_add::CallCore
-
-} // end of class FunctionObjects.CommonJS_Export_Class_Lib_517C3ED9.FunctionObject_ClassMethod_C6420A76_Calculator_add
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Export_Class_Lib_517C3ED9.FunctionObject_ClassMethod_56B18E5B_Calculator_multiply
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2375
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_56B18E5B_Calculator_multiply::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x237d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_56B18E5B_Calculator_multiply::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2380
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_56B18E5B_Calculator_multiply::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2383
-		// Header size: 1
-		// Code size: 26 (0x1a)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.CommonJS_Export_Class_Lib/Calculator
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call instance object Modules.CommonJS_Export_Class_Lib/Calculator::multiply(object, object)
-		IL_0019: ret
-	} // end of method FunctionObject_ClassMethod_56B18E5B_Calculator_multiply::CallCore
-
-} // end of class FunctionObjects.CommonJS_Export_Class_Lib_517C3ED9.FunctionObject_ClassMethod_56B18E5B_Calculator_multiply
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ClassWithConstructor.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ClassWithConstructor.verified.txt
@@ -243,6 +243,149 @@
 
 		} // end of class Scope_greet
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_8A4450FF_Person
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x231d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.CommonJS_Export_ClassWithConstructor_Lib/Person/FunctionObject_ClassConstructor_8A4450FF_Person::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_8A4450FF_Person::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x232c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_8A4450FF_Person::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x232f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_8A4450FF_Person::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2332
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_8A4450FF_Person::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x233e
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_8A4450FF_Person::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_8A4450FF_Person
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_FC1697C3_Person_greet
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x234a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_FC1697C3_Person_greet::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2352
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_FC1697C3_Person_greet::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2355
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_FC1697C3_Person_greet::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2358
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.CommonJS_Export_ClassWithConstructor_Lib/Person
+				IL_0006: call instance object Modules.CommonJS_Export_ClassWithConstructor_Lib/Person::greet()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_FC1697C3_Person_greet::CallCore
+
+		} // end of class FunctionObject_ClassMethod_FC1697C3_Person_greet
+
 
 		// Fields
 		.field public object name
@@ -444,149 +587,6 @@
 	} // end of method CommonJS_Export_ClassWithConstructor_Lib::__js_module_init__
 
 } // end of class Modules.CommonJS_Export_ClassWithConstructor_Lib
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Export_ClassWithConstructor_Lib_125797BF.FunctionObject_ClassConstructor_8A4450FF_Person
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x231d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.CommonJS_Export_ClassWithConstructor_Lib_125797BF.FunctionObject_ClassConstructor_8A4450FF_Person::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_8A4450FF_Person::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x232c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_8A4450FF_Person::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x232f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_8A4450FF_Person::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2332
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_8A4450FF_Person::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x233e
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_8A4450FF_Person::ConstructCore
-
-} // end of class FunctionObjects.CommonJS_Export_ClassWithConstructor_Lib_125797BF.FunctionObject_ClassConstructor_8A4450FF_Person
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Export_ClassWithConstructor_Lib_125797BF.FunctionObject_ClassMethod_FC1697C3_Person_greet
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x234a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_FC1697C3_Person_greet::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2352
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_FC1697C3_Person_greet::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2355
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_FC1697C3_Person_greet::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2358
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.CommonJS_Export_ClassWithConstructor_Lib/Person
-		IL_0006: call instance object Modules.CommonJS_Export_ClassWithConstructor_Lib/Person::greet()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_FC1697C3_Person_greet::CallCore
-
-} // end of class FunctionObjects.CommonJS_Export_ClassWithConstructor_Lib_125797BF.FunctionObject_ClassMethod_FC1697C3_Person_greet
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_Function.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_Function.verified.txt
@@ -104,6 +104,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8633A077_greet
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2129
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_8633A077_greet::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2131
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8633A077_greet::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2134
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8633A077_greet::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2137
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.CommonJS_Export_Function_Lib/greet::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_8633A077_greet::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x214a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.CommonJS_Export_Function_Lib/greet::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8633A077_greet::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2159
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8633A077_greet::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_8633A077_greet
+
 
 		// Methods
 		.method public hidebysig static 
@@ -181,7 +282,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Export_Function_Lib/Scope,
-			[1] class FunctionObjects.CommonJS_Export_Function_Lib_548AACBF.FunctionObject_FunctionDeclaration_8633A077_greet,
+			[1] class Modules.CommonJS_Export_Function_Lib/greet/FunctionObject_FunctionDeclaration_8633A077_greet,
 			[2] object[]
 		)
 
@@ -194,13 +295,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.CommonJS_Export_Function_Lib_548AACBF.FunctionObject_FunctionDeclaration_8633A077_greet::.ctor()
+		IL_0011: newobj instance void Modules.CommonJS_Export_Function_Lib/greet/FunctionObject_FunctionDeclaration_8633A077_greet::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "greet"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.CommonJS_Export_Function_Lib_548AACBF.FunctionObject_FunctionDeclaration_8633A077_greet>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_Function_Lib/greet/FunctionObject_FunctionDeclaration_8633A077_greet>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -214,107 +315,6 @@
 	} // end of method CommonJS_Export_Function_Lib::__js_module_init__
 
 } // end of class Modules.CommonJS_Export_Function_Lib
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Export_Function_Lib_548AACBF.FunctionObject_FunctionDeclaration_8633A077_greet
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2129
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_8633A077_greet::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2131
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8633A077_greet::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2134
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8633A077_greet::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2137
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.CommonJS_Export_Function_Lib/greet::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_8633A077_greet::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x214a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.CommonJS_Export_Function_Lib/greet::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8633A077_greet::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2159
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8633A077_greet::ConstructCore
-
-} // end of class FunctionObjects.CommonJS_Export_Function_Lib_548AACBF.FunctionObject_FunctionDeclaration_8633A077_greet
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_NestedObjects.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_NestedObjects.verified.txt
@@ -202,6 +202,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6FDBE108_L9C14
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x238b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_6FDBE108_L9C14::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2393
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_6FDBE108_L9C14::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2396
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_6FDBE108_L9C14::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2399
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L9C13::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionExpression_6FDBE108_L9C14::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23b3
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L9C13::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionExpression_6FDBE108_L9C14::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23c9
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_6FDBE108_L9C14::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_6FDBE108_L9C14
+
 
 		// Methods
 		.method public hidebysig static 
@@ -256,6 +363,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_04FF31D5_L12C19
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x23d8
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_04FF31D5_L12C19::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x23e0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_04FF31D5_L12C19::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x23e3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_04FF31D5_L12C19::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x23e6
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L12C18::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionExpression_04FF31D5_L12C19::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2400
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L12C18::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionExpression_04FF31D5_L12C19::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2416
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_04FF31D5_L12C19::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_04FF31D5_L12C19
+
 
 		// Methods
 		.method public hidebysig static 
@@ -307,6 +521,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6A528E57_L18C20
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2425
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_6A528E57_L18C20::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x242d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_6A528E57_L18C20::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2430
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_6A528E57_L18C20::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2433
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L18C19::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_6A528E57_L18C20::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2446
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L18C19::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_6A528E57_L18C20::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2455
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_6A528E57_L18C20::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_6A528E57_L18C20
 
 
 		// Methods
@@ -375,10 +690,10 @@
 		.locals init (
 			[0] class Modules.CommonJS_Export_NestedObjects_Lib/Scope,
 			[1] object[],
-			[2] class FunctionObjects.CommonJS_Export_NestedObjects_Lib_218F739C.FunctionObject_FunctionExpression_6FDBE108_L9C14,
-			[3] class FunctionObjects.CommonJS_Export_NestedObjects_Lib_218F739C.FunctionObject_FunctionExpression_04FF31D5_L12C19,
+			[2] class Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L9C13/FunctionObject_FunctionExpression_6FDBE108_L9C14,
+			[3] class Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L12C18/FunctionObject_FunctionExpression_04FF31D5_L12C19,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[5] class FunctionObjects.CommonJS_Export_NestedObjects_Lib_218F739C.FunctionObject_FunctionExpression_6A528E57_L18C20,
+			[5] class Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L18C19/FunctionObject_FunctionExpression_6A528E57_L18C20,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
 
@@ -392,13 +707,13 @@
 		IL_000f: ldloc.0
 		IL_0010: stelem.ref
 		IL_0011: stloc.1
-		IL_0012: newobj instance void FunctionObjects.CommonJS_Export_NestedObjects_Lib_218F739C.FunctionObject_FunctionExpression_6FDBE108_L9C14::.ctor()
+		IL_0012: newobj instance void Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L9C13/FunctionObject_FunctionExpression_6FDBE108_L9C14::.ctor()
 		IL_0017: ldc.i4.2
 		IL_0018: conv.r8
 		IL_0019: ldstr ""
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.CommonJS_Export_NestedObjects_Lib_218F739C.FunctionObject_FunctionExpression_6FDBE108_L9C14>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L9C13/FunctionObject_FunctionExpression_6FDBE108_L9C14>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.2
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -407,13 +722,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.1
-		IL_0031: newobj instance void FunctionObjects.CommonJS_Export_NestedObjects_Lib_218F739C.FunctionObject_FunctionExpression_04FF31D5_L12C19::.ctor()
+		IL_0031: newobj instance void Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L12C18/FunctionObject_FunctionExpression_04FF31D5_L12C19::.ctor()
 		IL_0036: ldc.i4.2
 		IL_0037: conv.r8
 		IL_0038: ldstr ""
 		IL_003d: ldc.i4.0
 		IL_003e: ldc.i4.1
-		IL_003f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.CommonJS_Export_NestedObjects_Lib_218F739C.FunctionObject_FunctionExpression_04FF31D5_L12C19>(!!0, float64, string, bool, bool)
+		IL_003f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L12C18/FunctionObject_FunctionExpression_04FF31D5_L12C19>(!!0, float64, string, bool, bool)
 		IL_0044: stloc.3
 		IL_0045: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_004a: dup
@@ -432,13 +747,13 @@
 		IL_006c: ldloc.0
 		IL_006d: stelem.ref
 		IL_006e: stloc.1
-		IL_006f: newobj instance void FunctionObjects.CommonJS_Export_NestedObjects_Lib_218F739C.FunctionObject_FunctionExpression_6A528E57_L18C20::.ctor()
+		IL_006f: newobj instance void Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L18C19/FunctionObject_FunctionExpression_6A528E57_L18C20::.ctor()
 		IL_0074: ldc.i4.1
 		IL_0075: conv.r8
 		IL_0076: ldstr ""
 		IL_007b: ldc.i4.0
 		IL_007c: ldc.i4.1
-		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.CommonJS_Export_NestedObjects_Lib_218F739C.FunctionObject_FunctionExpression_6A528E57_L18C20>(!!0, float64, string, bool, bool)
+		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L18C19/FunctionObject_FunctionExpression_6A528E57_L18C20>(!!0, float64, string, bool, bool)
 		IL_0082: stloc.s 5
 		IL_0084: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0089: dup
@@ -478,321 +793,6 @@
 	} // end of method CommonJS_Export_NestedObjects_Lib::__js_module_init__
 
 } // end of class Modules.CommonJS_Export_NestedObjects_Lib
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Export_NestedObjects_Lib_218F739C.FunctionObject_FunctionExpression_6FDBE108_L9C14
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x238b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_6FDBE108_L9C14::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2393
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6FDBE108_L9C14::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2396
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6FDBE108_L9C14::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2399
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L9C13::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_6FDBE108_L9C14::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23b3
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L9C13::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_6FDBE108_L9C14::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23c9
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_6FDBE108_L9C14::ConstructCore
-
-} // end of class FunctionObjects.CommonJS_Export_NestedObjects_Lib_218F739C.FunctionObject_FunctionExpression_6FDBE108_L9C14
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Export_NestedObjects_Lib_218F739C.FunctionObject_FunctionExpression_04FF31D5_L12C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x23d8
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_04FF31D5_L12C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23e0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_04FF31D5_L12C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23e3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_04FF31D5_L12C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23e6
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L12C18::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_04FF31D5_L12C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2400
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L12C18::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_04FF31D5_L12C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2416
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_04FF31D5_L12C19::ConstructCore
-
-} // end of class FunctionObjects.CommonJS_Export_NestedObjects_Lib_218F739C.FunctionObject_FunctionExpression_04FF31D5_L12C19
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Export_NestedObjects_Lib_218F739C.FunctionObject_FunctionExpression_6A528E57_L18C20
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2425
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_6A528E57_L18C20::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x242d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6A528E57_L18C20::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2430
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6A528E57_L18C20::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2433
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L18C19::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_6A528E57_L18C20::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2446
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.CommonJS_Export_NestedObjects_Lib/FunctionExpression_L18C19::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_6A528E57_L18C20::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2455
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_6A528E57_L18C20::ConstructCore
-
-} // end of class FunctionObjects.CommonJS_Export_NestedObjects_Lib_218F739C.FunctionObject_FunctionExpression_6A528E57_L18C20
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ObjectWithClosure.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ObjectWithClosure.verified.txt
@@ -145,6 +145,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope _environment0_CommonJS_Export_ObjectWithClosure_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x22e2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope Modules.CommonJS_Export_ObjectWithClosure_Lib/multiplyModuleFactor/FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::_environment0_CommonJS_Export_ObjectWithClosure_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22f1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22f4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22f7
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope Modules.CommonJS_Export_ObjectWithClosure_Lib/multiplyModuleFactor/FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::_environment0_CommonJS_Export_ObjectWithClosure_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.CommonJS_Export_ObjectWithClosure_Lib/multiplyModuleFactor::__js_call__(class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2310
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope Modules.CommonJS_Export_ObjectWithClosure_Lib/multiplyModuleFactor/FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::_environment0_CommonJS_Export_ObjectWithClosure_Lib
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.CommonJS_Export_ObjectWithClosure_Lib/multiplyModuleFactor::__js_call__(class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2325
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor
+
 
 		// Methods
 		.method public hidebysig static 
@@ -210,6 +323,129 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D71C6A35_multiply
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope _environment0_CommonJS_Export_ObjectWithClosure_Lib
+				.field private initonly class Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/Scope _environment1_createCalculator
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope capture0,
+						class Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2386
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply/FunctionObject_FunctionDeclaration_D71C6A35_multiply::_environment0_CommonJS_Export_ObjectWithClosure_Lib
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/Scope Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply/FunctionObject_FunctionDeclaration_D71C6A35_multiply::_environment1_createCalculator
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply/FunctionObject_FunctionDeclaration_D71C6A35_multiply::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionDeclaration_D71C6A35_multiply::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x23a3
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_D71C6A35_multiply::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x23a6
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_D71C6A35_multiply::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x23a9
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply/FunctionObject_FunctionDeclaration_D71C6A35_multiply::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionDeclaration_D71C6A35_multiply::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x23c2
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply/FunctionObject_FunctionDeclaration_D71C6A35_multiply::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionDeclaration_D71C6A35_multiply::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x23d7
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionDeclaration_D71C6A35_multiply::ConstructCore
+
+			} // end of class FunctionObject_FunctionDeclaration_D71C6A35_multiply
 
 
 			// Methods
@@ -277,6 +513,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_92111878_createCalculator
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope _environment0_CommonJS_Export_ObjectWithClosure_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2334
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/FunctionObject_FunctionDeclaration_92111878_createCalculator::_environment0_CommonJS_Export_ObjectWithClosure_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_92111878_createCalculator::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2343
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_92111878_createCalculator::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2346
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_92111878_createCalculator::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2349
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/FunctionObject_FunctionDeclaration_92111878_createCalculator::_environment0_CommonJS_Export_ObjectWithClosure_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator::__js_call__(class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_92111878_createCalculator::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2362
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/FunctionObject_FunctionDeclaration_92111878_createCalculator::_environment0_CommonJS_Export_ObjectWithClosure_Lib
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator::__js_call__(class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_92111878_createCalculator::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2377
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_92111878_createCalculator::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_92111878_createCalculator
+
 
 		// Methods
 		.method public hidebysig static 
@@ -297,7 +646,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/Scope,
-				[1] class FunctionObjects.CommonJS_Export_ObjectWithClosure_Lib_5CD9AE99.FunctionObject_FunctionDeclaration_D71C6A35_multiply,
+				[1] class Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply/FunctionObject_FunctionDeclaration_D71C6A35_multiply,
 				[2] object[],
 				[3] object,
 				[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
@@ -328,13 +677,13 @@
 			IL_0026: ldelem.ref
 			IL_0027: castclass Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/Scope
 			IL_002c: ldloc.2
-			IL_002d: newobj instance void FunctionObjects.CommonJS_Export_ObjectWithClosure_Lib_5CD9AE99.FunctionObject_FunctionDeclaration_D71C6A35_multiply::.ctor(class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope, class Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/Scope, object[])
+			IL_002d: newobj instance void Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply/FunctionObject_FunctionDeclaration_D71C6A35_multiply::.ctor(class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope, class Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/Scope, object[])
 			IL_0032: ldc.i4.1
 			IL_0033: conv.r8
 			IL_0034: ldstr "multiply"
 			IL_0039: ldc.i4.0
 			IL_003a: ldc.i4.1
-			IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.CommonJS_Export_ObjectWithClosure_Lib_5CD9AE99.FunctionObject_FunctionDeclaration_D71C6A35_multiply>(!!0, float64, string, bool, bool)
+			IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply/FunctionObject_FunctionDeclaration_D71C6A35_multiply>(!!0, float64, string, bool, bool)
 			IL_0040: stloc.1
 			IL_0041: nop
 			IL_0042: ldloc.0
@@ -408,8 +757,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope,
-			[1] class FunctionObjects.CommonJS_Export_ObjectWithClosure_Lib_5CD9AE99.FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor,
-			[2] class FunctionObjects.CommonJS_Export_ObjectWithClosure_Lib_5CD9AE99.FunctionObject_FunctionDeclaration_92111878_createCalculator,
+			[1] class Modules.CommonJS_Export_ObjectWithClosure_Lib/multiplyModuleFactor/FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor,
+			[2] class Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/FunctionObject_FunctionDeclaration_92111878_createCalculator,
 			[3] object[],
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
@@ -427,13 +776,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope
-		IL_0019: newobj instance void FunctionObjects.CommonJS_Export_ObjectWithClosure_Lib_5CD9AE99.FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::.ctor(class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope)
+		IL_0019: newobj instance void Modules.CommonJS_Export_ObjectWithClosure_Lib/multiplyModuleFactor/FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::.ctor(class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope)
 		IL_001e: ldc.i4.1
 		IL_001f: conv.r8
 		IL_0020: ldstr "multiplyModuleFactor"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.CommonJS_Export_ObjectWithClosure_Lib_5CD9AE99.FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_ObjectWithClosure_Lib/multiplyModuleFactor/FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: ldc.i4.1
 		IL_002e: newarr [System.Runtime]System.Object
@@ -446,13 +795,13 @@
 		IL_0039: ldc.i4.0
 		IL_003a: ldelem.ref
 		IL_003b: castclass Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope
-		IL_0040: newobj instance void FunctionObjects.CommonJS_Export_ObjectWithClosure_Lib_5CD9AE99.FunctionObject_FunctionDeclaration_92111878_createCalculator::.ctor(class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope)
+		IL_0040: newobj instance void Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/FunctionObject_FunctionDeclaration_92111878_createCalculator::.ctor(class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope)
 		IL_0045: ldc.i4.1
 		IL_0046: conv.r8
 		IL_0047: ldstr "createCalculator"
 		IL_004c: ldc.i4.0
 		IL_004d: ldc.i4.1
-		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.CommonJS_Export_ObjectWithClosure_Lib_5CD9AE99.FunctionObject_FunctionDeclaration_92111878_createCalculator>(!!0, float64, string, bool, bool)
+		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/FunctionObject_FunctionDeclaration_92111878_createCalculator>(!!0, float64, string, bool, bool)
 		IL_0053: stloc.2
 		IL_0054: nop
 		IL_0055: ldloc.0
@@ -480,355 +829,6 @@
 	} // end of method CommonJS_Export_ObjectWithClosure_Lib::__js_module_init__
 
 } // end of class Modules.CommonJS_Export_ObjectWithClosure_Lib
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Export_ObjectWithClosure_Lib_5CD9AE99.FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope _environment0_CommonJS_Export_ObjectWithClosure_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x22e2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope FunctionObjects.CommonJS_Export_ObjectWithClosure_Lib_5CD9AE99.FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::_environment0_CommonJS_Export_ObjectWithClosure_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22f1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22f4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22f7
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope FunctionObjects.CommonJS_Export_ObjectWithClosure_Lib_5CD9AE99.FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::_environment0_CommonJS_Export_ObjectWithClosure_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.CommonJS_Export_ObjectWithClosure_Lib/multiplyModuleFactor::__js_call__(class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2310
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope FunctionObjects.CommonJS_Export_ObjectWithClosure_Lib_5CD9AE99.FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::_environment0_CommonJS_Export_ObjectWithClosure_Lib
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.CommonJS_Export_ObjectWithClosure_Lib/multiplyModuleFactor::__js_call__(class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2325
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor::ConstructCore
-
-} // end of class FunctionObjects.CommonJS_Export_ObjectWithClosure_Lib_5CD9AE99.FunctionObject_FunctionDeclaration_DC575487_multiplyModuleFactor
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Export_ObjectWithClosure_Lib_5CD9AE99.FunctionObject_FunctionDeclaration_92111878_createCalculator
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope _environment0_CommonJS_Export_ObjectWithClosure_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2334
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope FunctionObjects.CommonJS_Export_ObjectWithClosure_Lib_5CD9AE99.FunctionObject_FunctionDeclaration_92111878_createCalculator::_environment0_CommonJS_Export_ObjectWithClosure_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_92111878_createCalculator::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2343
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_92111878_createCalculator::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2346
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_92111878_createCalculator::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2349
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope FunctionObjects.CommonJS_Export_ObjectWithClosure_Lib_5CD9AE99.FunctionObject_FunctionDeclaration_92111878_createCalculator::_environment0_CommonJS_Export_ObjectWithClosure_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator::__js_call__(class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_92111878_createCalculator::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2362
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope FunctionObjects.CommonJS_Export_ObjectWithClosure_Lib_5CD9AE99.FunctionObject_FunctionDeclaration_92111878_createCalculator::_environment0_CommonJS_Export_ObjectWithClosure_Lib
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator::__js_call__(class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_92111878_createCalculator::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2377
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_92111878_createCalculator::ConstructCore
-
-} // end of class FunctionObjects.CommonJS_Export_ObjectWithClosure_Lib_5CD9AE99.FunctionObject_FunctionDeclaration_92111878_createCalculator
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Export_ObjectWithClosure_Lib_5CD9AE99.FunctionObject_FunctionDeclaration_D71C6A35_multiply
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope _environment0_CommonJS_Export_ObjectWithClosure_Lib
-	.field private initonly class Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/Scope _environment1_createCalculator
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope capture0,
-			class Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2386
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/Scope FunctionObjects.CommonJS_Export_ObjectWithClosure_Lib_5CD9AE99.FunctionObject_FunctionDeclaration_D71C6A35_multiply::_environment0_CommonJS_Export_ObjectWithClosure_Lib
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/Scope FunctionObjects.CommonJS_Export_ObjectWithClosure_Lib_5CD9AE99.FunctionObject_FunctionDeclaration_D71C6A35_multiply::_environment1_createCalculator
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.CommonJS_Export_ObjectWithClosure_Lib_5CD9AE99.FunctionObject_FunctionDeclaration_D71C6A35_multiply::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionDeclaration_D71C6A35_multiply::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23a3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D71C6A35_multiply::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23a6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D71C6A35_multiply::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23a9
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.CommonJS_Export_ObjectWithClosure_Lib_5CD9AE99.FunctionObject_FunctionDeclaration_D71C6A35_multiply::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_D71C6A35_multiply::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23c2
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.CommonJS_Export_ObjectWithClosure_Lib_5CD9AE99.FunctionObject_FunctionDeclaration_D71C6A35_multiply::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.CommonJS_Export_ObjectWithClosure_Lib/createCalculator/multiply::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_D71C6A35_multiply::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23d7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D71C6A35_multiply::ConstructCore
-
-} // end of class FunctionObjects.CommonJS_Export_ObjectWithClosure_Lib_5CD9AE99.FunctionObject_FunctionDeclaration_D71C6A35_multiply
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ObjectWithFunctions.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Export_ObjectWithFunctions.verified.txt
@@ -142,6 +142,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F4A13FE0_foo
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2253
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_F4A13FE0_foo::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x225b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F4A13FE0_foo::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x225e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F4A13FE0_foo::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2261
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.CommonJS_Export_ObjectWithFunctions_Lib/foo::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_F4A13FE0_foo::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x226d
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.CommonJS_Export_ObjectWithFunctions_Lib/foo::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_F4A13FE0_foo::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2275
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F4A13FE0_foo::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_F4A13FE0_foo
+
 
 		// Methods
 		.method public hidebysig static 
@@ -186,6 +281,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DA97E8EB_add
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2284
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_DA97E8EB_add::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x228c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DA97E8EB_add::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x228f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DA97E8EB_add::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2292
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.CommonJS_Export_ObjectWithFunctions_Lib/'add'::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_DA97E8EB_add::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22ac
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.CommonJS_Export_ObjectWithFunctions_Lib/'add'::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_DA97E8EB_add::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22c2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DA97E8EB_add::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_DA97E8EB_add
 
 
 		// Methods
@@ -240,6 +442,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F2971258_multiply
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x22d1
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_F2971258_multiply::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22d9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F2971258_multiply::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22dc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F2971258_multiply::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22df
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.CommonJS_Export_ObjectWithFunctions_Lib/multiply::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_F2971258_multiply::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22f9
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.CommonJS_Export_ObjectWithFunctions_Lib/multiply::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_F2971258_multiply::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x230f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F2971258_multiply::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_F2971258_multiply
 
 
 		// Methods
@@ -317,9 +626,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Export_ObjectWithFunctions_Lib/Scope,
-			[1] class FunctionObjects.CommonJS_Export_ObjectWithFunctions_Lib_3C8D4725.FunctionObject_FunctionDeclaration_F4A13FE0_foo,
-			[2] class FunctionObjects.CommonJS_Export_ObjectWithFunctions_Lib_3C8D4725.FunctionObject_FunctionDeclaration_DA97E8EB_add,
-			[3] class FunctionObjects.CommonJS_Export_ObjectWithFunctions_Lib_3C8D4725.FunctionObject_FunctionDeclaration_F2971258_multiply,
+			[1] class Modules.CommonJS_Export_ObjectWithFunctions_Lib/foo/FunctionObject_FunctionDeclaration_F4A13FE0_foo,
+			[2] class Modules.CommonJS_Export_ObjectWithFunctions_Lib/'add'/FunctionObject_FunctionDeclaration_DA97E8EB_add,
+			[3] class Modules.CommonJS_Export_ObjectWithFunctions_Lib/multiply/FunctionObject_FunctionDeclaration_F2971258_multiply,
 			[4] object[],
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
@@ -333,13 +642,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 4
-		IL_0012: newobj instance void FunctionObjects.CommonJS_Export_ObjectWithFunctions_Lib_3C8D4725.FunctionObject_FunctionDeclaration_F4A13FE0_foo::.ctor()
+		IL_0012: newobj instance void Modules.CommonJS_Export_ObjectWithFunctions_Lib/foo/FunctionObject_FunctionDeclaration_F4A13FE0_foo::.ctor()
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "foo"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.CommonJS_Export_ObjectWithFunctions_Lib_3C8D4725.FunctionObject_FunctionDeclaration_F4A13FE0_foo>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_ObjectWithFunctions_Lib/foo/FunctionObject_FunctionDeclaration_F4A13FE0_foo>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -348,13 +657,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 4
-		IL_0032: newobj instance void FunctionObjects.CommonJS_Export_ObjectWithFunctions_Lib_3C8D4725.FunctionObject_FunctionDeclaration_DA97E8EB_add::.ctor()
+		IL_0032: newobj instance void Modules.CommonJS_Export_ObjectWithFunctions_Lib/'add'/FunctionObject_FunctionDeclaration_DA97E8EB_add::.ctor()
 		IL_0037: ldc.i4.2
 		IL_0038: conv.r8
 		IL_0039: ldstr "add"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.CommonJS_Export_ObjectWithFunctions_Lib_3C8D4725.FunctionObject_FunctionDeclaration_DA97E8EB_add>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_ObjectWithFunctions_Lib/'add'/FunctionObject_FunctionDeclaration_DA97E8EB_add>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -363,13 +672,13 @@
 		IL_004e: ldloc.0
 		IL_004f: stelem.ref
 		IL_0050: stloc.s 4
-		IL_0052: newobj instance void FunctionObjects.CommonJS_Export_ObjectWithFunctions_Lib_3C8D4725.FunctionObject_FunctionDeclaration_F2971258_multiply::.ctor()
+		IL_0052: newobj instance void Modules.CommonJS_Export_ObjectWithFunctions_Lib/multiply/FunctionObject_FunctionDeclaration_F2971258_multiply::.ctor()
 		IL_0057: ldc.i4.2
 		IL_0058: conv.r8
 		IL_0059: ldstr "multiply"
 		IL_005e: ldc.i4.0
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.CommonJS_Export_ObjectWithFunctions_Lib_3C8D4725.FunctionObject_FunctionDeclaration_F2971258_multiply>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Export_ObjectWithFunctions_Lib/multiply/FunctionObject_FunctionDeclaration_F2971258_multiply>(!!0, float64, string, bool, bool)
 		IL_0065: stloc.3
 		IL_0066: nop
 		IL_0067: nop
@@ -399,315 +708,6 @@
 	} // end of method CommonJS_Export_ObjectWithFunctions_Lib::__js_module_init__
 
 } // end of class Modules.CommonJS_Export_ObjectWithFunctions_Lib
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Export_ObjectWithFunctions_Lib_3C8D4725.FunctionObject_FunctionDeclaration_F4A13FE0_foo
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2253
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_F4A13FE0_foo::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x225b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F4A13FE0_foo::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x225e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F4A13FE0_foo::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2261
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.CommonJS_Export_ObjectWithFunctions_Lib/foo::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_F4A13FE0_foo::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x226d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.CommonJS_Export_ObjectWithFunctions_Lib/foo::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_F4A13FE0_foo::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2275
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F4A13FE0_foo::ConstructCore
-
-} // end of class FunctionObjects.CommonJS_Export_ObjectWithFunctions_Lib_3C8D4725.FunctionObject_FunctionDeclaration_F4A13FE0_foo
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Export_ObjectWithFunctions_Lib_3C8D4725.FunctionObject_FunctionDeclaration_DA97E8EB_add
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2284
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_DA97E8EB_add::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x228c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DA97E8EB_add::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x228f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DA97E8EB_add::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2292
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.CommonJS_Export_ObjectWithFunctions_Lib/'add'::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_DA97E8EB_add::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22ac
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.CommonJS_Export_ObjectWithFunctions_Lib/'add'::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_DA97E8EB_add::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22c2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DA97E8EB_add::ConstructCore
-
-} // end of class FunctionObjects.CommonJS_Export_ObjectWithFunctions_Lib_3C8D4725.FunctionObject_FunctionDeclaration_DA97E8EB_add
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Export_ObjectWithFunctions_Lib_3C8D4725.FunctionObject_FunctionDeclaration_F2971258_multiply
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x22d1
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_F2971258_multiply::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22d9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F2971258_multiply::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22dc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F2971258_multiply::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22df
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.CommonJS_Export_ObjectWithFunctions_Lib/multiply::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_F2971258_multiply::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22f9
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.CommonJS_Export_ObjectWithFunctions_Lib/multiply::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_F2971258_multiply::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x230f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F2971258_multiply::ConstructCore
-
-} // end of class FunctionObjects.CommonJS_Export_ObjectWithFunctions_Lib_3C8D4725.FunctionObject_FunctionDeclaration_F2971258_multiply
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_ChainedAssignment.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_ChainedAssignment.verified.txt
@@ -119,6 +119,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E01CF02F_L8C10
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2179
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_E01CF02F_L8C10::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2181
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E01CF02F_L8C10::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2184
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E01CF02F_L8C10::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2187
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.CommonJS_Module_Exports_ChainedAssignment_Lib/FunctionExpression_L8C9::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_E01CF02F_L8C10::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x219a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.CommonJS_Module_Exports_ChainedAssignment_Lib/FunctionExpression_L8C9::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E01CF02F_L8C10::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21a9
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E01CF02F_L8C10::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_E01CF02F_L8C10
+
 
 		// Methods
 		.method public hidebysig static 
@@ -186,7 +287,7 @@
 		.locals init (
 			[0] class Modules.CommonJS_Module_Exports_ChainedAssignment_Lib/Scope,
 			[1] object[],
-			[2] class FunctionObjects.CommonJS_Module_Exports_ChainedAssignment_Lib_C77E9F2E.FunctionObject_FunctionExpression_E01CF02F_L8C10,
+			[2] class Modules.CommonJS_Module_Exports_ChainedAssignment_Lib/FunctionExpression_L8C9/FunctionObject_FunctionExpression_E01CF02F_L8C10,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[4] object
 		)
@@ -201,13 +302,13 @@
 		IL_000f: ldloc.0
 		IL_0010: stelem.ref
 		IL_0011: stloc.1
-		IL_0012: newobj instance void FunctionObjects.CommonJS_Module_Exports_ChainedAssignment_Lib_C77E9F2E.FunctionObject_FunctionExpression_E01CF02F_L8C10::.ctor()
+		IL_0012: newobj instance void Modules.CommonJS_Module_Exports_ChainedAssignment_Lib/FunctionExpression_L8C9/FunctionObject_FunctionExpression_E01CF02F_L8C10::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr ""
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.CommonJS_Module_Exports_ChainedAssignment_Lib_C77E9F2E.FunctionObject_FunctionExpression_E01CF02F_L8C10>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Module_Exports_ChainedAssignment_Lib/FunctionExpression_L8C9/FunctionObject_FunctionExpression_E01CF02F_L8C10>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.2
 		IL_0026: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_002b: dup
@@ -231,107 +332,6 @@
 	} // end of method CommonJS_Module_Exports_ChainedAssignment_Lib::__js_module_init__
 
 } // end of class Modules.CommonJS_Module_Exports_ChainedAssignment_Lib
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Module_Exports_ChainedAssignment_Lib_C77E9F2E.FunctionObject_FunctionExpression_E01CF02F_L8C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2179
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_E01CF02F_L8C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2181
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E01CF02F_L8C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2184
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E01CF02F_L8C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2187
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.CommonJS_Module_Exports_ChainedAssignment_Lib/FunctionExpression_L8C9::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_E01CF02F_L8C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x219a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.CommonJS_Module_Exports_ChainedAssignment_Lib/FunctionExpression_L8C9::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E01CF02F_L8C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21a9
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E01CF02F_L8C10::ConstructCore
-
-} // end of class FunctionObjects.CommonJS_Module_Exports_ChainedAssignment_Lib_C77E9F2E.FunctionObject_FunctionExpression_E01CF02F_L8C10
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_ClassExpression_ExtendsArray.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_ClassExpression_ExtendsArray.verified.txt
@@ -115,6 +115,152 @@
 
 		} // end of class Scope_item
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_A071EBE1_NodeList
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2288
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList/FunctionObject_ClassConstructor_A071EBE1_NodeList::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_A071EBE1_NodeList::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2297
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_A071EBE1_NodeList::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x229a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_A071EBE1_NodeList::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x229d
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_A071EBE1_NodeList::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22a9
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_A071EBE1_NodeList::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_A071EBE1_NodeList
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_017B4079_NodeList_item
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x22b5
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_017B4079_NodeList_item::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22bd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_017B4079_NodeList_item::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22c0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_017B4079_NodeList_item::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22c3
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList::item(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassMethod_017B4079_NodeList_item::CallCore
+
+		} // end of class FunctionObject_ClassMethod_017B4079_NodeList_item
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -406,152 +552,6 @@
 	} // end of method CommonJS_Module_Exports_ClassExpression_ExtendsArray::__js_module_init__
 
 } // end of class Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Module_Exports_ClassExpression_ExtendsArray_4A6B1DF8.FunctionObject_ClassConstructor_A071EBE1_NodeList
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2288
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.CommonJS_Module_Exports_ClassExpression_ExtendsArray_4A6B1DF8.FunctionObject_ClassConstructor_A071EBE1_NodeList::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_A071EBE1_NodeList::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2297
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_A071EBE1_NodeList::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x229a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_A071EBE1_NodeList::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x229d
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_A071EBE1_NodeList::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22a9
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_A071EBE1_NodeList::ConstructCore
-
-} // end of class FunctionObjects.CommonJS_Module_Exports_ClassExpression_ExtendsArray_4A6B1DF8.FunctionObject_ClassConstructor_A071EBE1_NodeList
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Module_Exports_ClassExpression_ExtendsArray_4A6B1DF8.FunctionObject_ClassMethod_017B4079_NodeList_item
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x22b5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_017B4079_NodeList_item::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22bd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_017B4079_NodeList_item::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22c0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_017B4079_NodeList_item::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22c3
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.CommonJS_Module_Exports_ClassExpression_ExtendsArray/NodeList::item(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassMethod_017B4079_NodeList_item::CallCore
-
-} // end of class FunctionObjects.CommonJS_Module_Exports_ClassExpression_ExtendsArray_4A6B1DF8.FunctionObject_ClassMethod_017B4079_NodeList_item
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_Function.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Module_Exports_Function.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C0CD2D41_greet
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x214c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_C0CD2D41_greet::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2154
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C0CD2D41_greet::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2157
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C0CD2D41_greet::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x215a
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.CommonJS_Module_Exports_Function/greet::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_C0CD2D41_greet::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x216d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.CommonJS_Module_Exports_Function/greet::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C0CD2D41_greet::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x217c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C0CD2D41_greet::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C0CD2D41_greet
+
 
 		// Methods
 		.method public hidebysig static 
@@ -108,7 +209,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Module_Exports_Function/Scope,
-			[1] class FunctionObjects.CommonJS_Module_Exports_Function_2711951D.FunctionObject_FunctionDeclaration_C0CD2D41_greet,
+			[1] class Modules.CommonJS_Module_Exports_Function/greet/FunctionObject_FunctionDeclaration_C0CD2D41_greet,
 			[2] object,
 			[3] object[],
 			[4] object,
@@ -125,13 +226,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.CommonJS_Module_Exports_Function_2711951D.FunctionObject_FunctionDeclaration_C0CD2D41_greet::.ctor()
+		IL_0011: newobj instance void Modules.CommonJS_Module_Exports_Function/greet/FunctionObject_FunctionDeclaration_C0CD2D41_greet::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "greet"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.CommonJS_Module_Exports_Function_2711951D.FunctionObject_FunctionDeclaration_C0CD2D41_greet>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Module_Exports_Function/greet/FunctionObject_FunctionDeclaration_C0CD2D41_greet>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -183,107 +284,6 @@
 	} // end of method CommonJS_Module_Exports_Function::__js_module_init__
 
 } // end of class Modules.CommonJS_Module_Exports_Function
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Module_Exports_Function_2711951D.FunctionObject_FunctionDeclaration_C0CD2D41_greet
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x214c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_C0CD2D41_greet::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2154
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C0CD2D41_greet::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2157
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C0CD2D41_greet::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x215a
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.CommonJS_Module_Exports_Function/greet::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_C0CD2D41_greet::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x216d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.CommonJS_Module_Exports_Function/greet::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C0CD2D41_greet::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x217c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C0CD2D41_greet::ConstructCore
-
-} // end of class FunctionObjects.CommonJS_Module_Exports_Function_2711951D.FunctionObject_FunctionDeclaration_C0CD2D41_greet
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Basic.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Basic.verified.txt
@@ -145,6 +145,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.CommonJS_Require_Basic/Scope _environment0_CommonJS_Require_Basic
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.CommonJS_Require_Basic/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x24fa
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.CommonJS_Require_Basic/Scope Modules.CommonJS_Require_Basic/commonFunctionName/FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::_environment0_CommonJS_Require_Basic
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2509
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x250c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x250f
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.CommonJS_Require_Basic/Scope Modules.CommonJS_Require_Basic/commonFunctionName/FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::_environment0_CommonJS_Require_Basic
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.CommonJS_Require_Basic/commonFunctionName::__js_call__(class Modules.CommonJS_Require_Basic/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2521
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.CommonJS_Require_Basic/Scope Modules.CommonJS_Require_Basic/commonFunctionName/FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::_environment0_CommonJS_Require_Basic
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.CommonJS_Require_Basic/commonFunctionName::__js_call__(class Modules.CommonJS_Require_Basic/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x252f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName
+
 
 		// Methods
 		.method public hidebysig static 
@@ -237,6 +344,149 @@
 			} // end of method Scope_Log::.ctor
 
 		} // end of class Scope_Log
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_9A3BC299_CommonClassName
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x24b2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.CommonJS_Require_Basic/CommonClassName/FunctionObject_ClassConstructor_9A3BC299_CommonClassName::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_9A3BC299_CommonClassName::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24c1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_9A3BC299_CommonClassName::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24c4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_9A3BC299_CommonClassName::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24c7
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_9A3BC299_CommonClassName::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24d3
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_9A3BC299_CommonClassName::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_9A3BC299_CommonClassName
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_CB32A0F2_CommonClassName_Log
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x24df
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_CB32A0F2_CommonClassName_Log::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24e7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_CB32A0F2_CommonClassName_Log::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24ea
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_CB32A0F2_CommonClassName_Log::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24ed
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.CommonJS_Require_Basic/CommonClassName
+				IL_0006: call instance object Modules.CommonJS_Require_Basic/CommonClassName::Log()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_CB32A0F2_CommonClassName_Log::CallCore
+
+		} // end of class FunctionObject_ClassMethod_CB32A0F2_CommonClassName_Log
 
 
 		// Fields
@@ -363,7 +613,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Require_Basic/Scope,
-			[1] class FunctionObjects.CommonJS_Require_Basic_4B6551B2.FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName,
+			[1] class Modules.CommonJS_Require_Basic/commonFunctionName/FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[4] class Modules.CommonJS_Require_Basic/ArrowFunction_L3C9/FunctionObject,
@@ -384,13 +634,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.CommonJS_Require_Basic/Scope
-		IL_0019: newobj instance void FunctionObjects.CommonJS_Require_Basic_4B6551B2.FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::.ctor(class Modules.CommonJS_Require_Basic/Scope)
+		IL_0019: newobj instance void Modules.CommonJS_Require_Basic/commonFunctionName/FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::.ctor(class Modules.CommonJS_Require_Basic/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "commonFunctionName"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.CommonJS_Require_Basic_4B6551B2.FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_Basic/commonFunctionName/FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldc.i4.1
@@ -628,6 +878,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.CommonJS_Require_Dependency/Scope _environment0_CommonJS_Require_Dependency
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.CommonJS_Require_Dependency/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x25a3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.CommonJS_Require_Dependency/Scope Modules.CommonJS_Require_Dependency/commonFunctionName/FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::_environment0_CommonJS_Require_Dependency
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x25b2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x25b5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x25b8
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.CommonJS_Require_Dependency/Scope Modules.CommonJS_Require_Dependency/commonFunctionName/FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::_environment0_CommonJS_Require_Dependency
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.CommonJS_Require_Dependency/commonFunctionName::__js_call__(class Modules.CommonJS_Require_Dependency/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25ca
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.CommonJS_Require_Dependency/Scope Modules.CommonJS_Require_Dependency/commonFunctionName/FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::_environment0_CommonJS_Require_Dependency
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.CommonJS_Require_Dependency/commonFunctionName::__js_call__(class Modules.CommonJS_Require_Dependency/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25d8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName
+
 
 		// Methods
 		.method public hidebysig static 
@@ -720,6 +1077,149 @@
 			} // end of method Scope_Log::.ctor
 
 		} // end of class Scope_Log
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_561FA58C_CommonClassName
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x255b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.CommonJS_Require_Dependency/CommonClassName/FunctionObject_ClassConstructor_561FA58C_CommonClassName::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_561FA58C_CommonClassName::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x256a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_561FA58C_CommonClassName::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x256d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_561FA58C_CommonClassName::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2570
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_561FA58C_CommonClassName::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x257c
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_561FA58C_CommonClassName::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_561FA58C_CommonClassName
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_CF5CE551_CommonClassName_Log
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2588
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_CF5CE551_CommonClassName_Log::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2590
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_CF5CE551_CommonClassName_Log::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2593
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_CF5CE551_CommonClassName_Log::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2596
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.CommonJS_Require_Dependency/CommonClassName
+				IL_0006: call instance object Modules.CommonJS_Require_Dependency/CommonClassName::Log()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_CF5CE551_CommonClassName_Log::CallCore
+
+		} // end of class FunctionObject_ClassMethod_CF5CE551_CommonClassName_Log
 
 
 		// Fields
@@ -846,7 +1346,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Require_Dependency/Scope,
-			[1] class FunctionObjects.CommonJS_Require_Dependency_8F3FE45D.FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName,
+			[1] class Modules.CommonJS_Require_Dependency/commonFunctionName/FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[4] class Modules.CommonJS_Require_Dependency/ArrowFunction_L3C9/FunctionObject,
@@ -867,13 +1367,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.CommonJS_Require_Dependency/Scope
-		IL_0019: newobj instance void FunctionObjects.CommonJS_Require_Dependency_8F3FE45D.FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::.ctor(class Modules.CommonJS_Require_Dependency/Scope)
+		IL_0019: newobj instance void Modules.CommonJS_Require_Dependency/commonFunctionName/FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::.ctor(class Modules.CommonJS_Require_Dependency/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "commonFunctionName"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.CommonJS_Require_Dependency_8F3FE45D.FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_Dependency/commonFunctionName/FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldc.i4.1
@@ -957,506 +1457,6 @@
 	} // end of method CommonJS_Require_Dependency::__js_module_init__
 
 } // end of class Modules.CommonJS_Require_Dependency
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Require_Basic_4B6551B2.FunctionObject_ClassConstructor_9A3BC299_CommonClassName
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x24b2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.CommonJS_Require_Basic_4B6551B2.FunctionObject_ClassConstructor_9A3BC299_CommonClassName::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_9A3BC299_CommonClassName::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24c1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_9A3BC299_CommonClassName::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24c4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_9A3BC299_CommonClassName::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24c7
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_9A3BC299_CommonClassName::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24d3
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_9A3BC299_CommonClassName::ConstructCore
-
-} // end of class FunctionObjects.CommonJS_Require_Basic_4B6551B2.FunctionObject_ClassConstructor_9A3BC299_CommonClassName
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Require_Basic_4B6551B2.FunctionObject_ClassMethod_CB32A0F2_CommonClassName_Log
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x24df
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_CB32A0F2_CommonClassName_Log::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24e7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_CB32A0F2_CommonClassName_Log::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24ea
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_CB32A0F2_CommonClassName_Log::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24ed
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.CommonJS_Require_Basic/CommonClassName
-		IL_0006: call instance object Modules.CommonJS_Require_Basic/CommonClassName::Log()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_CB32A0F2_CommonClassName_Log::CallCore
-
-} // end of class FunctionObjects.CommonJS_Require_Basic_4B6551B2.FunctionObject_ClassMethod_CB32A0F2_CommonClassName_Log
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Require_Basic_4B6551B2.FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.CommonJS_Require_Basic/Scope _environment0_CommonJS_Require_Basic
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.CommonJS_Require_Basic/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x24fa
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.CommonJS_Require_Basic/Scope FunctionObjects.CommonJS_Require_Basic_4B6551B2.FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::_environment0_CommonJS_Require_Basic
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2509
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x250c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x250f
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.CommonJS_Require_Basic/Scope FunctionObjects.CommonJS_Require_Basic_4B6551B2.FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::_environment0_CommonJS_Require_Basic
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.CommonJS_Require_Basic/commonFunctionName::__js_call__(class Modules.CommonJS_Require_Basic/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2521
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.CommonJS_Require_Basic/Scope FunctionObjects.CommonJS_Require_Basic_4B6551B2.FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::_environment0_CommonJS_Require_Basic
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.CommonJS_Require_Basic/commonFunctionName::__js_call__(class Modules.CommonJS_Require_Basic/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x252f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName::ConstructCore
-
-} // end of class FunctionObjects.CommonJS_Require_Basic_4B6551B2.FunctionObject_FunctionDeclaration_8B39A2E3_commonFunctionName
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Require_Dependency_8F3FE45D.FunctionObject_ClassConstructor_561FA58C_CommonClassName
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x255b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.CommonJS_Require_Dependency_8F3FE45D.FunctionObject_ClassConstructor_561FA58C_CommonClassName::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_561FA58C_CommonClassName::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x256a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_561FA58C_CommonClassName::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x256d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_561FA58C_CommonClassName::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2570
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_561FA58C_CommonClassName::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x257c
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_561FA58C_CommonClassName::ConstructCore
-
-} // end of class FunctionObjects.CommonJS_Require_Dependency_8F3FE45D.FunctionObject_ClassConstructor_561FA58C_CommonClassName
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Require_Dependency_8F3FE45D.FunctionObject_ClassMethod_CF5CE551_CommonClassName_Log
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2588
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_CF5CE551_CommonClassName_Log::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2590
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_CF5CE551_CommonClassName_Log::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2593
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_CF5CE551_CommonClassName_Log::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2596
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.CommonJS_Require_Dependency/CommonClassName
-		IL_0006: call instance object Modules.CommonJS_Require_Dependency/CommonClassName::Log()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_CF5CE551_CommonClassName_Log::CallCore
-
-} // end of class FunctionObjects.CommonJS_Require_Dependency_8F3FE45D.FunctionObject_ClassMethod_CF5CE551_CommonClassName_Log
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Require_Dependency_8F3FE45D.FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.CommonJS_Require_Dependency/Scope _environment0_CommonJS_Require_Dependency
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.CommonJS_Require_Dependency/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x25a3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.CommonJS_Require_Dependency/Scope FunctionObjects.CommonJS_Require_Dependency_8F3FE45D.FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::_environment0_CommonJS_Require_Dependency
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x25b2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x25b5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x25b8
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.CommonJS_Require_Dependency/Scope FunctionObjects.CommonJS_Require_Dependency_8F3FE45D.FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::_environment0_CommonJS_Require_Dependency
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.CommonJS_Require_Dependency/commonFunctionName::__js_call__(class Modules.CommonJS_Require_Dependency/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25ca
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.CommonJS_Require_Dependency/Scope FunctionObjects.CommonJS_Require_Dependency_8F3FE45D.FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::_environment0_CommonJS_Require_Dependency
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.CommonJS_Require_Dependency/commonFunctionName::__js_call__(class Modules.CommonJS_Require_Dependency/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25d8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName::ConstructCore
-
-} // end of class FunctionObjects.CommonJS_Require_Dependency_8F3FE45D.FunctionObject_FunctionDeclaration_0BA111FE_commonFunctionName
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Captures_Shadowed_Global_URL.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Captures_Shadowed_Global_URL.verified.txt
@@ -31,6 +31,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5086E7D4_L6C12
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope _environment0_CommonJS_Require_Captures_Shadowed_Global_URL
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2241
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope Modules.CommonJS_Require_Captures_Shadowed_Global_URL/FunctionExpression_descriptor/FunctionObject_FunctionExpression_5086E7D4_L6C12::_environment0_CommonJS_Require_Captures_Shadowed_Global_URL
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_5086E7D4_L6C12::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2250
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5086E7D4_L6C12::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2253
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5086E7D4_L6C12::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2256
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope Modules.CommonJS_Require_Captures_Shadowed_Global_URL/FunctionExpression_descriptor/FunctionObject_FunctionExpression_5086E7D4_L6C12::_environment0_CommonJS_Require_Captures_Shadowed_Global_URL
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.CommonJS_Require_Captures_Shadowed_Global_URL/FunctionExpression_descriptor::__js_call__(class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_5086E7D4_L6C12::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x226f
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope Modules.CommonJS_Require_Captures_Shadowed_Global_URL/FunctionExpression_descriptor/FunctionObject_FunctionExpression_5086E7D4_L6C12::_environment0_CommonJS_Require_Captures_Shadowed_Global_URL
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.CommonJS_Require_Captures_Shadowed_Global_URL/FunctionExpression_descriptor::__js_call__(class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_5086E7D4_L6C12::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2284
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_5086E7D4_L6C12::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_5086E7D4_L6C12
+
 
 		// Methods
 		.method public hidebysig static 
@@ -186,7 +299,7 @@
 			[1] class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/ObjectLiterals/L5C18_descriptor,
 			[2] object,
 			[3] object[],
-			[4] class FunctionObjects.CommonJS_Require_Captures_Shadowed_Global_URL_2FC26CBB.FunctionObject_FunctionExpression_5086E7D4_L6C12,
+			[4] class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/FunctionExpression_descriptor/FunctionObject_FunctionExpression_5086E7D4_L6C12,
 			[5] object
 		)
 
@@ -211,13 +324,13 @@
 		IL_0026: ldc.i4.0
 		IL_0027: ldelem.ref
 		IL_0028: castclass Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope
-		IL_002d: newobj instance void FunctionObjects.CommonJS_Require_Captures_Shadowed_Global_URL_2FC26CBB.FunctionObject_FunctionExpression_5086E7D4_L6C12::.ctor(class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope)
+		IL_002d: newobj instance void Modules.CommonJS_Require_Captures_Shadowed_Global_URL/FunctionExpression_descriptor/FunctionObject_FunctionExpression_5086E7D4_L6C12::.ctor(class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope)
 		IL_0032: ldc.i4.1
 		IL_0033: conv.r8
 		IL_0034: ldstr ""
 		IL_0039: ldc.i4.0
 		IL_003a: ldc.i4.1
-		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.CommonJS_Require_Captures_Shadowed_Global_URL_2FC26CBB.FunctionObject_FunctionExpression_5086E7D4_L6C12>(!!0, float64, string, bool, bool)
+		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/FunctionExpression_descriptor/FunctionObject_FunctionExpression_5086E7D4_L6C12>(!!0, float64, string, bool, bool)
 		IL_0040: stloc.s 4
 		IL_0042: newobj instance void Modules.CommonJS_Require_Captures_Shadowed_Global_URL/ObjectLiterals/L5C18_descriptor::.ctor()
 		IL_0047: stloc.1
@@ -271,6 +384,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2293
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x229b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x229e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22a1
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/LocalURL::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22b4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/LocalURL::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22c3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL
+
 
 		// Methods
 		.method public hidebysig static 
@@ -323,6 +537,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_83E896B1_L7C30
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x22d2
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_83E896B1_L7C30::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22da
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_83E896B1_L7C30::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22dd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_83E896B1_L7C30::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22e0
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/FunctionExpression_L7C29::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_83E896B1_L7C30::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22f3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/FunctionExpression_L7C29::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_83E896B1_L7C30::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2302
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_83E896B1_L7C30::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_83E896B1_L7C30
 
 
 		// Methods
@@ -407,10 +722,10 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/Scope,
-			[1] class FunctionObjects.CommonJS_Require_Captures_Shadowed_Global_URL_Lib_8290B26B.FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL,
+			[1] class Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/LocalURL/FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL,
 			[2] object[],
 			[3] object,
-			[4] class FunctionObjects.CommonJS_Require_Captures_Shadowed_Global_URL_Lib_8290B26B.FunctionObject_FunctionExpression_83E896B1_L7C30
+			[4] class Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/FunctionExpression_L7C29/FunctionObject_FunctionExpression_83E896B1_L7C30
 		)
 
 		IL_0000: newobj instance void Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/Scope::.ctor()
@@ -422,13 +737,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.CommonJS_Require_Captures_Shadowed_Global_URL_Lib_8290B26B.FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL::.ctor()
+		IL_0011: newobj instance void Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/LocalURL/FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "LocalURL"
 		IL_001d: ldc.i4.1
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.CommonJS_Require_Captures_Shadowed_Global_URL_Lib_8290B26B.FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/LocalURL/FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -443,13 +758,13 @@
 		IL_003b: ldloc.0
 		IL_003c: stelem.ref
 		IL_003d: stloc.2
-		IL_003e: newobj instance void FunctionObjects.CommonJS_Require_Captures_Shadowed_Global_URL_Lib_8290B26B.FunctionObject_FunctionExpression_83E896B1_L7C30::.ctor()
+		IL_003e: newobj instance void Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/FunctionExpression_L7C29/FunctionObject_FunctionExpression_83E896B1_L7C30::.ctor()
 		IL_0043: ldc.i4.1
 		IL_0044: conv.r8
 		IL_0045: ldstr ""
 		IL_004a: ldc.i4.1
 		IL_004b: ldc.i4.1
-		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.CommonJS_Require_Captures_Shadowed_Global_URL_Lib_8290B26B.FunctionObject_FunctionExpression_83E896B1_L7C30>(!!0, float64, string, bool, bool)
+		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/FunctionExpression_L7C29/FunctionObject_FunctionExpression_83E896B1_L7C30>(!!0, float64, string, bool, bool)
 		IL_0051: stloc.s 4
 		IL_0053: ldloc.3
 		IL_0054: ldstr "resolve"
@@ -467,321 +782,6 @@
 	} // end of method CommonJS_Require_Captures_Shadowed_Global_URL_Lib::__js_module_init__
 
 } // end of class Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Require_Captures_Shadowed_Global_URL_2FC26CBB.FunctionObject_FunctionExpression_5086E7D4_L6C12
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope _environment0_CommonJS_Require_Captures_Shadowed_Global_URL
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2241
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope FunctionObjects.CommonJS_Require_Captures_Shadowed_Global_URL_2FC26CBB.FunctionObject_FunctionExpression_5086E7D4_L6C12::_environment0_CommonJS_Require_Captures_Shadowed_Global_URL
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5086E7D4_L6C12::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2250
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5086E7D4_L6C12::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2253
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5086E7D4_L6C12::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2256
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope FunctionObjects.CommonJS_Require_Captures_Shadowed_Global_URL_2FC26CBB.FunctionObject_FunctionExpression_5086E7D4_L6C12::_environment0_CommonJS_Require_Captures_Shadowed_Global_URL
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.CommonJS_Require_Captures_Shadowed_Global_URL/FunctionExpression_descriptor::__js_call__(class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_5086E7D4_L6C12::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x226f
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope FunctionObjects.CommonJS_Require_Captures_Shadowed_Global_URL_2FC26CBB.FunctionObject_FunctionExpression_5086E7D4_L6C12::_environment0_CommonJS_Require_Captures_Shadowed_Global_URL
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.CommonJS_Require_Captures_Shadowed_Global_URL/FunctionExpression_descriptor::__js_call__(class Modules.CommonJS_Require_Captures_Shadowed_Global_URL/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_5086E7D4_L6C12::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2284
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5086E7D4_L6C12::ConstructCore
-
-} // end of class FunctionObjects.CommonJS_Require_Captures_Shadowed_Global_URL_2FC26CBB.FunctionObject_FunctionExpression_5086E7D4_L6C12
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Require_Captures_Shadowed_Global_URL_Lib_8290B26B.FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2293
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x229b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x229e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22a1
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/LocalURL::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22b4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/LocalURL::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22c3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL::ConstructCore
-
-} // end of class FunctionObjects.CommonJS_Require_Captures_Shadowed_Global_URL_Lib_8290B26B.FunctionObject_FunctionDeclaration_75CA4D4E_LocalURL
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Require_Captures_Shadowed_Global_URL_Lib_8290B26B.FunctionObject_FunctionExpression_83E896B1_L7C30
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x22d2
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_83E896B1_L7C30::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22da
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_83E896B1_L7C30::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22dd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_83E896B1_L7C30::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22e0
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/FunctionExpression_L7C29::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_83E896B1_L7C30::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22f3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.CommonJS_Require_Captures_Shadowed_Global_URL_Lib/FunctionExpression_L7C29::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_83E896B1_L7C30::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2302
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_83E896B1_L7C30::ConstructCore
-
-} // end of class FunctionObjects.CommonJS_Require_Captures_Shadowed_Global_URL_Lib_8290B26B.FunctionObject_FunctionExpression_83E896B1_L7C30
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_NestedNameConflict.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_NestedNameConflict.verified.txt
@@ -211,6 +211,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.b/Scope _environment0_b
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.b/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2523
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.b/Scope Modules.b/commonFunctionName/FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::_environment0_b
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2532
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2535
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2538
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.b/Scope Modules.b/commonFunctionName/FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::_environment0_b
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.b/commonFunctionName::__js_call__(class Modules.b/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x254a
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.b/Scope Modules.b/commonFunctionName/FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::_environment0_b
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.b/commonFunctionName::__js_call__(class Modules.b/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2558
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName
+
 
 		// Methods
 		.method public hidebysig static 
@@ -303,6 +410,149 @@
 			} // end of method Scope_Log::.ctor
 
 		} // end of class Scope_Log
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_E9658844_CommonClassName
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x24db
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.b/CommonClassName/FunctionObject_ClassConstructor_E9658844_CommonClassName::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_E9658844_CommonClassName::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24ea
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_E9658844_CommonClassName::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24ed
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_E9658844_CommonClassName::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24f0
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_E9658844_CommonClassName::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24fc
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_E9658844_CommonClassName::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_E9658844_CommonClassName
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_65FB7589_CommonClassName_Log
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2508
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_65FB7589_CommonClassName_Log::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2510
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_65FB7589_CommonClassName_Log::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2513
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_65FB7589_CommonClassName_Log::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2516
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.b/CommonClassName
+				IL_0006: call instance object Modules.b/CommonClassName::Log()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_65FB7589_CommonClassName_Log::CallCore
+
+		} // end of class FunctionObject_ClassMethod_65FB7589_CommonClassName_Log
 
 
 		// Fields
@@ -429,7 +679,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.b/Scope,
-			[1] class FunctionObjects.b_E70C2DE5.FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName,
+			[1] class Modules.b/commonFunctionName/FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[4] class Modules.b/ArrowFunction_L3C9/FunctionObject,
@@ -450,13 +700,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.b/Scope
-		IL_0019: newobj instance void FunctionObjects.b_E70C2DE5.FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::.ctor(class Modules.b/Scope)
+		IL_0019: newobj instance void Modules.b/commonFunctionName/FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::.ctor(class Modules.b/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "commonFunctionName"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.b_E70C2DE5.FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.b/commonFunctionName/FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldc.i4.1
@@ -683,6 +933,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.helpers_b/Scope _environment0_helpers_b
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.helpers_b/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x25cc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.helpers_b/Scope Modules.helpers_b/commonFunctionName/FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::_environment0_helpers_b
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x25db
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x25de
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x25e1
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.helpers_b/Scope Modules.helpers_b/commonFunctionName/FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::_environment0_helpers_b
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.helpers_b/commonFunctionName::__js_call__(class Modules.helpers_b/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25f3
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.helpers_b/Scope Modules.helpers_b/commonFunctionName/FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::_environment0_helpers_b
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.helpers_b/commonFunctionName::__js_call__(class Modules.helpers_b/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2601
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName
+
 
 		// Methods
 		.method public hidebysig static 
@@ -775,6 +1132,149 @@
 			} // end of method Scope_Log::.ctor
 
 		} // end of class Scope_Log
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_FB2DD5B6_CommonClassName
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2584
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.helpers_b/CommonClassName/FunctionObject_ClassConstructor_FB2DD5B6_CommonClassName::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_FB2DD5B6_CommonClassName::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2593
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_FB2DD5B6_CommonClassName::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2596
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_FB2DD5B6_CommonClassName::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2599
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_FB2DD5B6_CommonClassName::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25a5
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_FB2DD5B6_CommonClassName::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_FB2DD5B6_CommonClassName
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_BBBCD817_CommonClassName_Log
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x25b1
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_BBBCD817_CommonClassName_Log::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x25b9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_BBBCD817_CommonClassName_Log::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x25bc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_BBBCD817_CommonClassName_Log::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x25bf
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.helpers_b/CommonClassName
+				IL_0006: call instance object Modules.helpers_b/CommonClassName::Log()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_BBBCD817_CommonClassName_Log::CallCore
+
+		} // end of class FunctionObject_ClassMethod_BBBCD817_CommonClassName_Log
 
 
 		// Fields
@@ -901,7 +1401,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.helpers_b/Scope,
-			[1] class FunctionObjects.helpers_b_E09423E7.FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName,
+			[1] class Modules.helpers_b/commonFunctionName/FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[4] class Modules.helpers_b/ArrowFunction_L3C9/FunctionObject,
@@ -922,13 +1422,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.helpers_b/Scope
-		IL_0019: newobj instance void FunctionObjects.helpers_b_E09423E7.FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::.ctor(class Modules.helpers_b/Scope)
+		IL_0019: newobj instance void Modules.helpers_b/commonFunctionName/FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::.ctor(class Modules.helpers_b/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "commonFunctionName"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.helpers_b_E09423E7.FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.helpers_b/commonFunctionName/FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldc.i4.1
@@ -1012,506 +1512,6 @@
 	} // end of method helpers_b::__js_module_init__
 
 } // end of class Modules.helpers_b
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.b_E70C2DE5.FunctionObject_ClassConstructor_E9658844_CommonClassName
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x24db
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.b_E70C2DE5.FunctionObject_ClassConstructor_E9658844_CommonClassName::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_E9658844_CommonClassName::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24ea
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_E9658844_CommonClassName::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24ed
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_E9658844_CommonClassName::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24f0
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_E9658844_CommonClassName::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24fc
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_E9658844_CommonClassName::ConstructCore
-
-} // end of class FunctionObjects.b_E70C2DE5.FunctionObject_ClassConstructor_E9658844_CommonClassName
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.b_E70C2DE5.FunctionObject_ClassMethod_65FB7589_CommonClassName_Log
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2508
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_65FB7589_CommonClassName_Log::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2510
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_65FB7589_CommonClassName_Log::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2513
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_65FB7589_CommonClassName_Log::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2516
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.b/CommonClassName
-		IL_0006: call instance object Modules.b/CommonClassName::Log()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_65FB7589_CommonClassName_Log::CallCore
-
-} // end of class FunctionObjects.b_E70C2DE5.FunctionObject_ClassMethod_65FB7589_CommonClassName_Log
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.b_E70C2DE5.FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.b/Scope _environment0_b
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.b/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2523
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.b/Scope FunctionObjects.b_E70C2DE5.FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::_environment0_b
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2532
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2535
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2538
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.b/Scope FunctionObjects.b_E70C2DE5.FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::_environment0_b
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.b/commonFunctionName::__js_call__(class Modules.b/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x254a
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.b/Scope FunctionObjects.b_E70C2DE5.FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::_environment0_b
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.b/commonFunctionName::__js_call__(class Modules.b/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2558
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName::ConstructCore
-
-} // end of class FunctionObjects.b_E70C2DE5.FunctionObject_FunctionDeclaration_51B714E6_commonFunctionName
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.helpers_b_E09423E7.FunctionObject_ClassConstructor_FB2DD5B6_CommonClassName
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2584
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.helpers_b_E09423E7.FunctionObject_ClassConstructor_FB2DD5B6_CommonClassName::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_FB2DD5B6_CommonClassName::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2593
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_FB2DD5B6_CommonClassName::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2596
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_FB2DD5B6_CommonClassName::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2599
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_FB2DD5B6_CommonClassName::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25a5
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_FB2DD5B6_CommonClassName::ConstructCore
-
-} // end of class FunctionObjects.helpers_b_E09423E7.FunctionObject_ClassConstructor_FB2DD5B6_CommonClassName
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.helpers_b_E09423E7.FunctionObject_ClassMethod_BBBCD817_CommonClassName_Log
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x25b1
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_BBBCD817_CommonClassName_Log::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x25b9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_BBBCD817_CommonClassName_Log::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x25bc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_BBBCD817_CommonClassName_Log::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x25bf
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.helpers_b/CommonClassName
-		IL_0006: call instance object Modules.helpers_b/CommonClassName::Log()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_BBBCD817_CommonClassName_Log::CallCore
-
-} // end of class FunctionObjects.helpers_b_E09423E7.FunctionObject_ClassMethod_BBBCD817_CommonClassName_Log
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.helpers_b_E09423E7.FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.helpers_b/Scope _environment0_helpers_b
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.helpers_b/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x25cc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.helpers_b/Scope FunctionObjects.helpers_b_E09423E7.FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::_environment0_helpers_b
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x25db
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x25de
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x25e1
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.helpers_b/Scope FunctionObjects.helpers_b_E09423E7.FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::_environment0_helpers_b
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.helpers_b/commonFunctionName::__js_call__(class Modules.helpers_b/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25f3
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.helpers_b/Scope FunctionObjects.helpers_b_E09423E7.FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::_environment0_helpers_b
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.helpers_b/commonFunctionName::__js_call__(class Modules.helpers_b/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2601
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName::ConstructCore
-
-} // end of class FunctionObjects.helpers_b_E09423E7.FunctionObject_FunctionDeclaration_B36C1D18_commonFunctionName
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_OptionalChain_InNestedFunction.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_OptionalChain_InNestedFunction.verified.txt
@@ -95,6 +95,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_074F556E_loadValue
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope _environment0_CommonJS_Require_OptionalChain_InNestedFunction
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21be
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue/FunctionObject_FunctionDeclaration_074F556E_loadValue::_environment0_CommonJS_Require_OptionalChain_InNestedFunction
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_074F556E_loadValue::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21cd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_074F556E_loadValue::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21d0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_074F556E_loadValue::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21d3
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue/FunctionObject_FunctionDeclaration_074F556E_loadValue::_environment0_CommonJS_Require_OptionalChain_InNestedFunction
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue::__js_call__(class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_074F556E_loadValue::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21e5
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue/FunctionObject_FunctionDeclaration_074F556E_loadValue::_environment0_CommonJS_Require_OptionalChain_InNestedFunction
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue::__js_call__(class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_074F556E_loadValue::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_074F556E_loadValue::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_074F556E_loadValue
+
 
 		// Methods
 		.method public hidebysig static 
@@ -227,7 +334,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope,
-			[1] class FunctionObjects.CommonJS_Require_OptionalChain_InNestedFunction_70683E3E.FunctionObject_FunctionDeclaration_074F556E_loadValue,
+			[1] class Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue/FunctionObject_FunctionDeclaration_074F556E_loadValue,
 			[2] object[],
 			[3] object,
 			[4] object
@@ -250,13 +357,13 @@
 		IL_001e: ldc.i4.0
 		IL_001f: ldelem.ref
 		IL_0020: castclass Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope
-		IL_0025: newobj instance void FunctionObjects.CommonJS_Require_OptionalChain_InNestedFunction_70683E3E.FunctionObject_FunctionDeclaration_074F556E_loadValue::.ctor(class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope)
+		IL_0025: newobj instance void Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue/FunctionObject_FunctionDeclaration_074F556E_loadValue::.ctor(class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope)
 		IL_002a: ldc.i4.0
 		IL_002b: conv.r8
 		IL_002c: ldstr "loadValue"
 		IL_0031: ldc.i4.0
 		IL_0032: ldc.i4.1
-		IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.CommonJS_Require_OptionalChain_InNestedFunction_70683E3E.FunctionObject_FunctionDeclaration_074F556E_loadValue>(!!0, float64, string, bool, bool)
+		IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue/FunctionObject_FunctionDeclaration_074F556E_loadValue>(!!0, float64, string, bool, bool)
 		IL_0038: stloc.1
 		IL_0039: nop
 		IL_003a: nop
@@ -341,113 +448,6 @@
 	} // end of method CommonJS_Require_OptionalChain_Lib::__js_module_init__
 
 } // end of class Modules.CommonJS_Require_OptionalChain_Lib
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Require_OptionalChain_InNestedFunction_70683E3E.FunctionObject_FunctionDeclaration_074F556E_loadValue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope _environment0_CommonJS_Require_OptionalChain_InNestedFunction
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21be
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope FunctionObjects.CommonJS_Require_OptionalChain_InNestedFunction_70683E3E.FunctionObject_FunctionDeclaration_074F556E_loadValue::_environment0_CommonJS_Require_OptionalChain_InNestedFunction
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_074F556E_loadValue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21cd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_074F556E_loadValue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21d0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_074F556E_loadValue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21d3
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope FunctionObjects.CommonJS_Require_OptionalChain_InNestedFunction_70683E3E.FunctionObject_FunctionDeclaration_074F556E_loadValue::_environment0_CommonJS_Require_OptionalChain_InNestedFunction
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue::__js_call__(class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_074F556E_loadValue::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21e5
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope FunctionObjects.CommonJS_Require_OptionalChain_InNestedFunction_70683E3E.FunctionObject_FunctionDeclaration_074F556E_loadValue::_environment0_CommonJS_Require_OptionalChain_InNestedFunction
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.CommonJS_Require_OptionalChain_InNestedFunction/loadValue::__js_call__(class Modules.CommonJS_Require_OptionalChain_InNestedFunction/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_074F556E_loadValue::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_074F556E_loadValue::ConstructCore
-
-} // end of class FunctionObjects.CommonJS_Require_OptionalChain_InNestedFunction_70683E3E.FunctionObject_FunctionDeclaration_074F556E_loadValue
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Shadowed_Parameter.verified.txt
+++ b/tests/Jroc.Tests/CommonJS/Snapshots/GeneratorTests.CommonJS_Require_Shadowed_Parameter.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9681A6B4_test
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2135
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_9681A6B4_test::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x213d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9681A6B4_test::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2140
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9681A6B4_test::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2143
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.CommonJS_Require_Shadowed_Parameter/test::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_9681A6B4_test::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2156
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.CommonJS_Require_Shadowed_Parameter/test::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9681A6B4_test::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2165
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9681A6B4_test::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9681A6B4_test
+
 
 		// Methods
 		.method public hidebysig static 
@@ -230,7 +331,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.CommonJS_Require_Shadowed_Parameter/Scope,
-			[1] class FunctionObjects.CommonJS_Require_Shadowed_Parameter_64FDFF0D.FunctionObject_FunctionDeclaration_9681A6B4_test,
+			[1] class Modules.CommonJS_Require_Shadowed_Parameter/test/FunctionObject_FunctionDeclaration_9681A6B4_test,
 			[2] object[],
 			[3] object,
 			[4] object[],
@@ -247,13 +348,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.CommonJS_Require_Shadowed_Parameter_64FDFF0D.FunctionObject_FunctionDeclaration_9681A6B4_test::.ctor()
+		IL_0011: newobj instance void Modules.CommonJS_Require_Shadowed_Parameter/test/FunctionObject_FunctionDeclaration_9681A6B4_test::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "test"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.CommonJS_Require_Shadowed_Parameter_64FDFF0D.FunctionObject_FunctionDeclaration_9681A6B4_test>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.CommonJS_Require_Shadowed_Parameter/test/FunctionObject_FunctionDeclaration_9681A6B4_test>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -293,107 +394,6 @@
 	} // end of method CommonJS_Require_Shadowed_Parameter::__js_module_init__
 
 } // end of class Modules.CommonJS_Require_Shadowed_Parameter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CommonJS_Require_Shadowed_Parameter_64FDFF0D.FunctionObject_FunctionDeclaration_9681A6B4_test
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2135
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_9681A6B4_test::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x213d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9681A6B4_test::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2140
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9681A6B4_test::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2143
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.CommonJS_Require_Shadowed_Parameter/test::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_9681A6B4_test::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2156
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.CommonJS_Require_Shadowed_Parameter/test::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9681A6B4_test::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2165
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9681A6B4_test::ConstructCore
-
-} // end of class FunctionObjects.CommonJS_Require_Shadowed_Parameter_64FDFF0D.FunctionObject_FunctionDeclaration_9681A6B4_test
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/CompoundAssignment/Snapshots/GeneratorTests.CompoundAssignment_LocalVarIndex.verified.txt
+++ b/tests/Jroc.Tests/CompoundAssignment/Snapshots/GeneratorTests.CompoundAssignment_LocalVarIndex.verified.txt
@@ -71,6 +71,149 @@
 
 		} // end of class Scope_test
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_3F6DB619_TestClass
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21d1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.CompoundAssignment_LocalVarIndex/TestClass/FunctionObject_ClassConstructor_3F6DB619_TestClass::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_3F6DB619_TestClass::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21e0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_3F6DB619_TestClass::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21e3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_3F6DB619_TestClass::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21e6
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_3F6DB619_TestClass::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f2
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_3F6DB619_TestClass::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_3F6DB619_TestClass
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_49028540_TestClass_test
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21fe
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_49028540_TestClass_test::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2206
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_49028540_TestClass_test::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2209
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_49028540_TestClass_test::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x220c
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.CompoundAssignment_LocalVarIndex/TestClass
+				IL_0006: call instance object Modules.CompoundAssignment_LocalVarIndex/TestClass::test()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_49028540_TestClass_test::CallCore
+
+		} // end of class FunctionObject_ClassMethod_49028540_TestClass_test
+
 
 		// Fields
 		.field public class [JavaScriptRuntime]JavaScriptRuntime.Int32Array arr
@@ -263,149 +406,6 @@
 	} // end of method CompoundAssignment_LocalVarIndex::__js_module_init__
 
 } // end of class Modules.CompoundAssignment_LocalVarIndex
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CompoundAssignment_LocalVarIndex_ABF93992.FunctionObject_ClassConstructor_3F6DB619_TestClass
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21d1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.CompoundAssignment_LocalVarIndex_ABF93992.FunctionObject_ClassConstructor_3F6DB619_TestClass::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_3F6DB619_TestClass::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21e0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_3F6DB619_TestClass::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21e3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_3F6DB619_TestClass::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21e6
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_3F6DB619_TestClass::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f2
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_3F6DB619_TestClass::ConstructCore
-
-} // end of class FunctionObjects.CompoundAssignment_LocalVarIndex_ABF93992.FunctionObject_ClassConstructor_3F6DB619_TestClass
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.CompoundAssignment_LocalVarIndex_ABF93992.FunctionObject_ClassMethod_49028540_TestClass_test
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21fe
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_49028540_TestClass_test::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2206
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_49028540_TestClass_test::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2209
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_49028540_TestClass_test::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x220c
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.CompoundAssignment_LocalVarIndex/TestClass
-		IL_0006: call instance object Modules.CompoundAssignment_LocalVarIndex/TestClass::test()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_49028540_TestClass_test::CallCore
-
-} // end of class FunctionObjects.CompoundAssignment_LocalVarIndex_ABF93992.FunctionObject_ClassMethod_49028540_TestClass_test
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_Conditional_Ternary_ShortCircuit.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_Conditional_Ternary_ShortCircuit.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CCCFA6D2_bump
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope _environment0_ControlFlow_Conditional_Ternary_ShortCircuit
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x216b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump/FunctionObject_FunctionDeclaration_CCCFA6D2_bump::_environment0_ControlFlow_Conditional_Ternary_ShortCircuit
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_CCCFA6D2_bump::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x217a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CCCFA6D2_bump::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x217d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CCCFA6D2_bump::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2180
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump/FunctionObject_FunctionDeclaration_CCCFA6D2_bump::_environment0_ControlFlow_Conditional_Ternary_ShortCircuit
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump::__js_call__(class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_CCCFA6D2_bump::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2192
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump/FunctionObject_FunctionDeclaration_CCCFA6D2_bump::_environment0_ControlFlow_Conditional_Ternary_ShortCircuit
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump::__js_call__(class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_CCCFA6D2_bump::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21a0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_CCCFA6D2_bump::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_CCCFA6D2_bump
+
 
 		// Methods
 		.method public hidebysig static 
@@ -115,7 +222,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope,
-			[1] class FunctionObjects.ControlFlow_Conditional_Ternary_ShortCircuit_345A95FF.FunctionObject_FunctionDeclaration_CCCFA6D2_bump,
+			[1] class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump/FunctionObject_FunctionDeclaration_CCCFA6D2_bump,
 			[2] object,
 			[3] object,
 			[4] object[],
@@ -137,13 +244,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope
-		IL_001b: newobj instance void FunctionObjects.ControlFlow_Conditional_Ternary_ShortCircuit_345A95FF.FunctionObject_FunctionDeclaration_CCCFA6D2_bump::.ctor(class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope)
+		IL_001b: newobj instance void Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump/FunctionObject_FunctionDeclaration_CCCFA6D2_bump::.ctor(class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope)
 		IL_0020: ldc.i4.0
 		IL_0021: conv.r8
 		IL_0022: ldstr "bump"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ControlFlow_Conditional_Ternary_ShortCircuit_345A95FF.FunctionObject_FunctionDeclaration_CCCFA6D2_bump>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump/FunctionObject_FunctionDeclaration_CCCFA6D2_bump>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: nop
 		IL_0030: ldloc.0
@@ -198,113 +305,6 @@
 	} // end of method ControlFlow_Conditional_Ternary_ShortCircuit::__js_module_init__
 
 } // end of class Modules.ControlFlow_Conditional_Ternary_ShortCircuit
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ControlFlow_Conditional_Ternary_ShortCircuit_345A95FF.FunctionObject_FunctionDeclaration_CCCFA6D2_bump
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope _environment0_ControlFlow_Conditional_Ternary_ShortCircuit
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x216b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope FunctionObjects.ControlFlow_Conditional_Ternary_ShortCircuit_345A95FF.FunctionObject_FunctionDeclaration_CCCFA6D2_bump::_environment0_ControlFlow_Conditional_Ternary_ShortCircuit
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_CCCFA6D2_bump::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x217a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CCCFA6D2_bump::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x217d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CCCFA6D2_bump::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2180
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope FunctionObjects.ControlFlow_Conditional_Ternary_ShortCircuit_345A95FF.FunctionObject_FunctionDeclaration_CCCFA6D2_bump::_environment0_ControlFlow_Conditional_Ternary_ShortCircuit
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump::__js_call__(class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_CCCFA6D2_bump::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2192
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope FunctionObjects.ControlFlow_Conditional_Ternary_ShortCircuit_345A95FF.FunctionObject_FunctionDeclaration_CCCFA6D2_bump::_environment0_ControlFlow_Conditional_Ternary_ShortCircuit
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.ControlFlow_Conditional_Ternary_ShortCircuit/bump::__js_call__(class Modules.ControlFlow_Conditional_Ternary_ShortCircuit/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_CCCFA6D2_bump::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21a0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_CCCFA6D2_bump::ConstructCore
-
-} // end of class FunctionObjects.ControlFlow_Conditional_Ternary_ShortCircuit_345A95FF.FunctionObject_FunctionDeclaration_CCCFA6D2_bump
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForIn_ClassFields_BaseAndDerived.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForIn_ClassFields_BaseAndDerived.verified.txt
@@ -51,6 +51,89 @@
 
 		} // end of class Scope_ctor
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_EA345C77_Base
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2272
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.ControlFlow_ForIn_ClassFields_BaseAndDerived/Base/FunctionObject_ClassConstructor_EA345C77_Base::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_EA345C77_Base::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2281
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_EA345C77_Base::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2284
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_EA345C77_Base::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2287
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_EA345C77_Base::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2293
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_EA345C77_Base::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_EA345C77_Base
+
 
 		// Fields
 		.field public float64 base
@@ -120,6 +203,89 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_E4082CCF_Derived
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x229f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.ControlFlow_ForIn_ClassFields_BaseAndDerived/Derived/FunctionObject_ClassConstructor_E4082CCF_Derived::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_E4082CCF_Derived::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22ae
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_E4082CCF_Derived::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22b1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_E4082CCF_Derived::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22b4
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_E4082CCF_Derived::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22c0
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_E4082CCF_Derived::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_E4082CCF_Derived
 
 
 		// Fields
@@ -375,172 +541,6 @@
 	} // end of method ControlFlow_ForIn_ClassFields_BaseAndDerived::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForIn_ClassFields_BaseAndDerived
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ControlFlow_ForIn_ClassFields_BaseAndDerived_8557B427.FunctionObject_ClassConstructor_EA345C77_Base
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2272
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.ControlFlow_ForIn_ClassFields_BaseAndDerived_8557B427.FunctionObject_ClassConstructor_EA345C77_Base::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_EA345C77_Base::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2281
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_EA345C77_Base::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2284
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_EA345C77_Base::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2287
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_EA345C77_Base::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2293
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_EA345C77_Base::ConstructCore
-
-} // end of class FunctionObjects.ControlFlow_ForIn_ClassFields_BaseAndDerived_8557B427.FunctionObject_ClassConstructor_EA345C77_Base
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ControlFlow_ForIn_ClassFields_BaseAndDerived_8557B427.FunctionObject_ClassConstructor_E4082CCF_Derived
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x229f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.ControlFlow_ForIn_ClassFields_BaseAndDerived_8557B427.FunctionObject_ClassConstructor_E4082CCF_Derived::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_E4082CCF_Derived::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22ae
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_E4082CCF_Derived::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22b1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_E4082CCF_Derived::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22b4
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_E4082CCF_Derived::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22c0
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_E4082CCF_Derived::ConstructCore
-
-} // end of class FunctionObjects.ControlFlow_ForIn_ClassFields_BaseAndDerived_8557B427.FunctionObject_ClassConstructor_E4082CCF_Derived
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForIn_Let_PerIterationBinding.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForIn_Let_PerIterationBinding.verified.txt
@@ -31,6 +31,118 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_55CDB75E_L8C14
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.ControlFlow_ForIn_Let_PerIterationBinding/Scope_ForIn_L7C5 _environment1_ForIn_L7C5
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.ControlFlow_ForIn_Let_PerIterationBinding/Scope_ForIn_L7C5 capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x2239
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.ControlFlow_ForIn_Let_PerIterationBinding/Scope_ForIn_L7C5 Modules.ControlFlow_ForIn_Let_PerIterationBinding/FunctionExpression_L8C13/FunctionObject_FunctionExpression_55CDB75E_L8C14::_environment1_ForIn_L7C5
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.ControlFlow_ForIn_Let_PerIterationBinding/FunctionExpression_L8C13/FunctionObject_FunctionExpression_55CDB75E_L8C14::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionExpression_55CDB75E_L8C14::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x224f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_55CDB75E_L8C14::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2252
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_55CDB75E_L8C14::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2255
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.ControlFlow_ForIn_Let_PerIterationBinding/FunctionExpression_L8C13/FunctionObject_FunctionExpression_55CDB75E_L8C14::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.ControlFlow_ForIn_Let_PerIterationBinding/FunctionExpression_L8C13::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_55CDB75E_L8C14::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2267
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.ControlFlow_ForIn_Let_PerIterationBinding/FunctionExpression_L8C13/FunctionObject_FunctionExpression_55CDB75E_L8C14::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.ControlFlow_ForIn_Let_PerIterationBinding/FunctionExpression_L8C13::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_55CDB75E_L8C14::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2275
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_55CDB75E_L8C14::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_55CDB75E_L8C14
+
 
 		// Methods
 		.method public hidebysig static 
@@ -196,7 +308,7 @@
 			[9] object,
 			[10] bool,
 			[11] object[],
-			[12] class FunctionObjects.ControlFlow_ForIn_Let_PerIterationBinding_77EB3473.FunctionObject_FunctionExpression_55CDB75E_L8C14,
+			[12] class Modules.ControlFlow_ForIn_Let_PerIterationBinding/FunctionExpression_L8C13/FunctionObject_FunctionExpression_55CDB75E_L8C14,
 			[13] class Modules.ControlFlow_ForIn_Let_PerIterationBinding/Scope_ForIn_L7C5,
 			[14] object
 		)
@@ -259,13 +371,13 @@
 			IL_00a0: ldelem.ref
 			IL_00a1: castclass Modules.ControlFlow_ForIn_Let_PerIterationBinding/Scope_ForIn_L7C5
 			IL_00a6: ldloc.s 11
-			IL_00a8: newobj instance void FunctionObjects.ControlFlow_ForIn_Let_PerIterationBinding_77EB3473.FunctionObject_FunctionExpression_55CDB75E_L8C14::.ctor(class Modules.ControlFlow_ForIn_Let_PerIterationBinding/Scope_ForIn_L7C5, object[])
+			IL_00a8: newobj instance void Modules.ControlFlow_ForIn_Let_PerIterationBinding/FunctionExpression_L8C13/FunctionObject_FunctionExpression_55CDB75E_L8C14::.ctor(class Modules.ControlFlow_ForIn_Let_PerIterationBinding/Scope_ForIn_L7C5, object[])
 			IL_00ad: ldc.i4.0
 			IL_00ae: conv.r8
 			IL_00af: ldstr ""
 			IL_00b4: ldc.i4.0
 			IL_00b5: ldc.i4.1
-			IL_00b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ControlFlow_ForIn_Let_PerIterationBinding_77EB3473.FunctionObject_FunctionExpression_55CDB75E_L8C14>(!!0, float64, string, bool, bool)
+			IL_00b6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForIn_Let_PerIterationBinding/FunctionExpression_L8C13/FunctionObject_FunctionExpression_55CDB75E_L8C14>(!!0, float64, string, bool, bool)
 			IL_00bb: stloc.s 12
 			IL_00bd: ldloc.1
 			IL_00be: ldloc.s 12
@@ -353,118 +465,6 @@
 	} // end of method ControlFlow_ForIn_Let_PerIterationBinding::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForIn_Let_PerIterationBinding
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ControlFlow_ForIn_Let_PerIterationBinding_77EB3473.FunctionObject_FunctionExpression_55CDB75E_L8C14
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ControlFlow_ForIn_Let_PerIterationBinding/Scope_ForIn_L7C5 _environment1_ForIn_L7C5
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ControlFlow_ForIn_Let_PerIterationBinding/Scope_ForIn_L7C5 capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x2239
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ControlFlow_ForIn_Let_PerIterationBinding/Scope_ForIn_L7C5 FunctionObjects.ControlFlow_ForIn_Let_PerIterationBinding_77EB3473.FunctionObject_FunctionExpression_55CDB75E_L8C14::_environment1_ForIn_L7C5
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.ControlFlow_ForIn_Let_PerIterationBinding_77EB3473.FunctionObject_FunctionExpression_55CDB75E_L8C14::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_55CDB75E_L8C14::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x224f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_55CDB75E_L8C14::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2252
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_55CDB75E_L8C14::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2255
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.ControlFlow_ForIn_Let_PerIterationBinding_77EB3473.FunctionObject_FunctionExpression_55CDB75E_L8C14::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.ControlFlow_ForIn_Let_PerIterationBinding/FunctionExpression_L8C13::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_55CDB75E_L8C14::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2267
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.ControlFlow_ForIn_Let_PerIterationBinding_77EB3473.FunctionObject_FunctionExpression_55CDB75E_L8C14::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.ControlFlow_ForIn_Let_PerIterationBinding/FunctionExpression_L8C13::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_55CDB75E_L8C14::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2275
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_55CDB75E_L8C14::ConstructCore
-
-} // end of class FunctionObjects.ControlFlow_ForIn_Let_PerIterationBinding_77EB3473.FunctionObject_FunctionExpression_55CDB75E_L8C14
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForIn_Shadowing_NoDuplicateKeys.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForIn_Shadowing_NoDuplicateKeys.verified.txt
@@ -51,6 +51,89 @@
 
 		} // end of class Scope_ctor
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_190F5919_Base
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x22b4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.ControlFlow_ForIn_Shadowing_NoDuplicateKeys/Base/FunctionObject_ClassConstructor_190F5919_Base::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_190F5919_Base::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22c3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_190F5919_Base::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22c6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_190F5919_Base::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22c9
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_190F5919_Base::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22d5
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_190F5919_Base::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_190F5919_Base
+
 
 		// Fields
 		.field public float64 x
@@ -120,6 +203,89 @@
 			} // end of method Scope_ctor::.ctor
 
 		} // end of class Scope_ctor
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_B41CF45D_Derived
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x22e1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.ControlFlow_ForIn_Shadowing_NoDuplicateKeys/Derived/FunctionObject_ClassConstructor_B41CF45D_Derived::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_B41CF45D_Derived::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22f0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_B41CF45D_Derived::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22f3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_B41CF45D_Derived::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22f6
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_B41CF45D_Derived::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2302
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_B41CF45D_Derived::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_B41CF45D_Derived
 
 
 		// Fields
@@ -393,172 +559,6 @@
 	} // end of method ControlFlow_ForIn_Shadowing_NoDuplicateKeys::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForIn_Shadowing_NoDuplicateKeys
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ControlFlow_ForIn_Shadowing_NoDuplicateKeys_BB808825.FunctionObject_ClassConstructor_190F5919_Base
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x22b4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.ControlFlow_ForIn_Shadowing_NoDuplicateKeys_BB808825.FunctionObject_ClassConstructor_190F5919_Base::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_190F5919_Base::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22c3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_190F5919_Base::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22c6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_190F5919_Base::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22c9
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_190F5919_Base::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22d5
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_190F5919_Base::ConstructCore
-
-} // end of class FunctionObjects.ControlFlow_ForIn_Shadowing_NoDuplicateKeys_BB808825.FunctionObject_ClassConstructor_190F5919_Base
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ControlFlow_ForIn_Shadowing_NoDuplicateKeys_BB808825.FunctionObject_ClassConstructor_B41CF45D_Derived
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x22e1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.ControlFlow_ForIn_Shadowing_NoDuplicateKeys_BB808825.FunctionObject_ClassConstructor_B41CF45D_Derived::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_B41CF45D_Derived::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22f0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_B41CF45D_Derived::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22f3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_B41CF45D_Derived::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22f6
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_B41CF45D_Derived::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2302
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_B41CF45D_Derived::ConstructCore
-
-} // end of class FunctionObjects.ControlFlow_ForIn_Shadowing_NoDuplicateKeys_BB808825.FunctionObject_ClassConstructor_B41CF45D_Derived
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_ClosureCallback.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_ClosureCallback.verified.txt
@@ -84,6 +84,118 @@
 
 			} // end of class Scope_ForOf_L5C9
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A72D72D3_inner
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.ControlFlow_ForOf_ClosureCallback/outer/Scope _environment1_outer
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.ControlFlow_ForOf_ClosureCallback/outer/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x22a8
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.ControlFlow_ForOf_ClosureCallback/outer/Scope Modules.ControlFlow_ForOf_ClosureCallback/outer/inner/FunctionObject_FunctionExpression_A72D72D3_inner::_environment1_outer
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.ControlFlow_ForOf_ClosureCallback/outer/inner/FunctionObject_FunctionExpression_A72D72D3_inner::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionExpression_A72D72D3_inner::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x22be
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_A72D72D3_inner::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x22c1
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_A72D72D3_inner::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x22c4
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_ClosureCallback/outer/inner/FunctionObject_FunctionExpression_A72D72D3_inner::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.ControlFlow_ForOf_ClosureCallback/outer/inner::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_A72D72D3_inner::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x22d6
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_ClosureCallback/outer/inner/FunctionObject_FunctionExpression_A72D72D3_inner::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.ControlFlow_ForOf_ClosureCallback/outer/inner::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_A72D72D3_inner::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x22e4
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_A72D72D3_inner::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_A72D72D3_inner
+
 
 			// Methods
 			.method public hidebysig static 
@@ -230,6 +342,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C2A801E0_outer
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.ControlFlow_ForOf_ClosureCallback/Scope _environment0_ControlFlow_ForOf_ClosureCallback
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.ControlFlow_ForOf_ClosureCallback/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2256
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.ControlFlow_ForOf_ClosureCallback/Scope Modules.ControlFlow_ForOf_ClosureCallback/outer/FunctionObject_FunctionDeclaration_C2A801E0_outer::_environment0_ControlFlow_ForOf_ClosureCallback
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C2A801E0_outer::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2265
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C2A801E0_outer::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2268
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C2A801E0_outer::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x226b
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ControlFlow_ForOf_ClosureCallback/Scope Modules.ControlFlow_ForOf_ClosureCallback/outer/FunctionObject_FunctionDeclaration_C2A801E0_outer::_environment0_ControlFlow_ForOf_ClosureCallback
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.ControlFlow_ForOf_ClosureCallback/outer::__js_call__(class Modules.ControlFlow_ForOf_ClosureCallback/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_C2A801E0_outer::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2284
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ControlFlow_ForOf_ClosureCallback/Scope Modules.ControlFlow_ForOf_ClosureCallback/outer/FunctionObject_FunctionDeclaration_C2A801E0_outer::_environment0_ControlFlow_ForOf_ClosureCallback
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.ControlFlow_ForOf_ClosureCallback/outer::__js_call__(class Modules.ControlFlow_ForOf_ClosureCallback/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_C2A801E0_outer::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2299
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C2A801E0_outer::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C2A801E0_outer
+
 
 		// Methods
 		.method public hidebysig static 
@@ -251,7 +476,7 @@
 			.locals init (
 				[0] class Modules.ControlFlow_ForOf_ClosureCallback/outer/Scope,
 				[1] object[],
-				[2] class FunctionObjects.ControlFlow_ForOf_ClosureCallback_BBB8024A.FunctionObject_FunctionExpression_A72D72D3_inner
+				[2] class Modules.ControlFlow_ForOf_ClosureCallback/outer/inner/FunctionObject_FunctionExpression_A72D72D3_inner
 			)
 
 			IL_0000: newobj instance void Modules.ControlFlow_ForOf_ClosureCallback/outer/Scope::.ctor()
@@ -275,13 +500,13 @@
 			IL_001e: ldelem.ref
 			IL_001f: castclass Modules.ControlFlow_ForOf_ClosureCallback/outer/Scope
 			IL_0024: ldloc.1
-			IL_0025: newobj instance void FunctionObjects.ControlFlow_ForOf_ClosureCallback_BBB8024A.FunctionObject_FunctionExpression_A72D72D3_inner::.ctor(class Modules.ControlFlow_ForOf_ClosureCallback/outer/Scope, object[])
+			IL_0025: newobj instance void Modules.ControlFlow_ForOf_ClosureCallback/outer/inner/FunctionObject_FunctionExpression_A72D72D3_inner::.ctor(class Modules.ControlFlow_ForOf_ClosureCallback/outer/Scope, object[])
 			IL_002a: ldc.i4.0
 			IL_002b: conv.r8
 			IL_002c: ldstr "inner"
 			IL_0031: ldc.i4.1
 			IL_0032: ldc.i4.1
-			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ControlFlow_ForOf_ClosureCallback_BBB8024A.FunctionObject_FunctionExpression_A72D72D3_inner>(!!0, float64, string, bool, bool)
+			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_ClosureCallback/outer/inner/FunctionObject_FunctionExpression_A72D72D3_inner>(!!0, float64, string, bool, bool)
 			IL_0038: stloc.2
 			IL_0039: ldc.i4.0
 			IL_003a: newarr [System.Runtime]System.Object
@@ -325,6 +550,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_45644ADB_L11C7
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x22f3
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_45644ADB_L11C7::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22fb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_45644ADB_L11C7::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22fe
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_45644ADB_L11C7::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2301
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.ControlFlow_ForOf_ClosureCallback/FunctionExpression_L11C6::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_45644ADB_L11C7::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2314
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.ControlFlow_ForOf_ClosureCallback/FunctionExpression_L11C6::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_45644ADB_L11C7::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2323
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_45644ADB_L11C7::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_45644ADB_L11C7
 
 
 		// Methods
@@ -399,10 +725,10 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_ForOf_ClosureCallback/Scope,
-			[1] class FunctionObjects.ControlFlow_ForOf_ClosureCallback_BBB8024A.FunctionObject_FunctionDeclaration_C2A801E0_outer,
+			[1] class Modules.ControlFlow_ForOf_ClosureCallback/outer/FunctionObject_FunctionDeclaration_C2A801E0_outer,
 			[2] object[],
 			[3] object[],
-			[4] class FunctionObjects.ControlFlow_ForOf_ClosureCallback_BBB8024A.FunctionObject_FunctionExpression_45644ADB_L11C7
+			[4] class Modules.ControlFlow_ForOf_ClosureCallback/FunctionExpression_L11C6/FunctionObject_FunctionExpression_45644ADB_L11C7
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_ForOf_ClosureCallback/Scope::.ctor()
@@ -418,13 +744,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.ControlFlow_ForOf_ClosureCallback/Scope
-		IL_0019: newobj instance void FunctionObjects.ControlFlow_ForOf_ClosureCallback_BBB8024A.FunctionObject_FunctionDeclaration_C2A801E0_outer::.ctor(class Modules.ControlFlow_ForOf_ClosureCallback/Scope)
+		IL_0019: newobj instance void Modules.ControlFlow_ForOf_ClosureCallback/outer/FunctionObject_FunctionDeclaration_C2A801E0_outer::.ctor(class Modules.ControlFlow_ForOf_ClosureCallback/Scope)
 		IL_001e: ldc.i4.1
 		IL_001f: conv.r8
 		IL_0020: ldstr "outer"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ControlFlow_ForOf_ClosureCallback_BBB8024A.FunctionObject_FunctionDeclaration_C2A801E0_outer>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_ClosureCallback/outer/FunctionObject_FunctionDeclaration_C2A801E0_outer>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
@@ -437,13 +763,13 @@
 		IL_003d: ldloc.0
 		IL_003e: stelem.ref
 		IL_003f: stloc.3
-		IL_0040: newobj instance void FunctionObjects.ControlFlow_ForOf_ClosureCallback_BBB8024A.FunctionObject_FunctionExpression_45644ADB_L11C7::.ctor()
+		IL_0040: newobj instance void Modules.ControlFlow_ForOf_ClosureCallback/FunctionExpression_L11C6/FunctionObject_FunctionExpression_45644ADB_L11C7::.ctor()
 		IL_0045: ldc.i4.1
 		IL_0046: conv.r8
 		IL_0047: ldstr ""
 		IL_004c: ldc.i4.0
 		IL_004d: ldc.i4.1
-		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ControlFlow_ForOf_ClosureCallback_BBB8024A.FunctionObject_FunctionExpression_45644ADB_L11C7>(!!0, float64, string, bool, bool)
+		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_ClosureCallback/FunctionExpression_L11C6/FunctionObject_FunctionExpression_45644ADB_L11C7>(!!0, float64, string, bool, bool)
 		IL_0053: stloc.s 4
 		IL_0055: ldloc.1
 		IL_0056: ldloc.2
@@ -454,332 +780,6 @@
 	} // end of method ControlFlow_ForOf_ClosureCallback::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForOf_ClosureCallback
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ControlFlow_ForOf_ClosureCallback_BBB8024A.FunctionObject_FunctionDeclaration_C2A801E0_outer
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ControlFlow_ForOf_ClosureCallback/Scope _environment0_ControlFlow_ForOf_ClosureCallback
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ControlFlow_ForOf_ClosureCallback/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2256
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ControlFlow_ForOf_ClosureCallback/Scope FunctionObjects.ControlFlow_ForOf_ClosureCallback_BBB8024A.FunctionObject_FunctionDeclaration_C2A801E0_outer::_environment0_ControlFlow_ForOf_ClosureCallback
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C2A801E0_outer::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2265
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C2A801E0_outer::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2268
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C2A801E0_outer::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x226b
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ControlFlow_ForOf_ClosureCallback/Scope FunctionObjects.ControlFlow_ForOf_ClosureCallback_BBB8024A.FunctionObject_FunctionDeclaration_C2A801E0_outer::_environment0_ControlFlow_ForOf_ClosureCallback
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.ControlFlow_ForOf_ClosureCallback/outer::__js_call__(class Modules.ControlFlow_ForOf_ClosureCallback/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_C2A801E0_outer::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2284
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ControlFlow_ForOf_ClosureCallback/Scope FunctionObjects.ControlFlow_ForOf_ClosureCallback_BBB8024A.FunctionObject_FunctionDeclaration_C2A801E0_outer::_environment0_ControlFlow_ForOf_ClosureCallback
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.ControlFlow_ForOf_ClosureCallback/outer::__js_call__(class Modules.ControlFlow_ForOf_ClosureCallback/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_C2A801E0_outer::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2299
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C2A801E0_outer::ConstructCore
-
-} // end of class FunctionObjects.ControlFlow_ForOf_ClosureCallback_BBB8024A.FunctionObject_FunctionDeclaration_C2A801E0_outer
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ControlFlow_ForOf_ClosureCallback_BBB8024A.FunctionObject_FunctionExpression_A72D72D3_inner
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ControlFlow_ForOf_ClosureCallback/outer/Scope _environment1_outer
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ControlFlow_ForOf_ClosureCallback/outer/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x22a8
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ControlFlow_ForOf_ClosureCallback/outer/Scope FunctionObjects.ControlFlow_ForOf_ClosureCallback_BBB8024A.FunctionObject_FunctionExpression_A72D72D3_inner::_environment1_outer
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.ControlFlow_ForOf_ClosureCallback_BBB8024A.FunctionObject_FunctionExpression_A72D72D3_inner::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_A72D72D3_inner::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22be
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A72D72D3_inner::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22c1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A72D72D3_inner::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22c4
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.ControlFlow_ForOf_ClosureCallback_BBB8024A.FunctionObject_FunctionExpression_A72D72D3_inner::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.ControlFlow_ForOf_ClosureCallback/outer/inner::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_A72D72D3_inner::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22d6
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.ControlFlow_ForOf_ClosureCallback_BBB8024A.FunctionObject_FunctionExpression_A72D72D3_inner::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.ControlFlow_ForOf_ClosureCallback/outer/inner::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_A72D72D3_inner::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22e4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A72D72D3_inner::ConstructCore
-
-} // end of class FunctionObjects.ControlFlow_ForOf_ClosureCallback_BBB8024A.FunctionObject_FunctionExpression_A72D72D3_inner
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ControlFlow_ForOf_ClosureCallback_BBB8024A.FunctionObject_FunctionExpression_45644ADB_L11C7
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x22f3
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_45644ADB_L11C7::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22fb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_45644ADB_L11C7::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22fe
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_45644ADB_L11C7::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2301
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.ControlFlow_ForOf_ClosureCallback/FunctionExpression_L11C6::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_45644ADB_L11C7::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2314
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.ControlFlow_ForOf_ClosureCallback/FunctionExpression_L11C6::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_45644ADB_L11C7::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2323
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_45644ADB_L11C7::ConstructCore
-
-} // end of class FunctionObjects.ControlFlow_ForOf_ClosureCallback_BBB8024A.FunctionObject_FunctionExpression_45644ADB_L11C7
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_CustomIterable_IteratorProtocol.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_CustomIterable_IteratorProtocol.verified.txt
@@ -35,6 +35,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D8C5ABFF_L9C13
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope _environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
+				.field private initonly class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope _environment1_FunctionExpression_iterable
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope capture0,
+						class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2a1f
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_D8C5ABFF_L9C13::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_D8C5ABFF_L9C13::_environment1_FunctionExpression_iterable
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_D8C5ABFF_L9C13::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_D8C5ABFF_L9C13::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2a3c
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_D8C5ABFF_L9C13::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2a3f
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_D8C5ABFF_L9C13::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2a42
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_D8C5ABFF_L9C13::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_D8C5ABFF_L9C13::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2a54
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_D8C5ABFF_L9C13::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_D8C5ABFF_L9C13::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2a62
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_D8C5ABFF_L9C13::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_D8C5ABFF_L9C13
+
 
 			// Methods
 			.method public hidebysig static 
@@ -163,6 +280,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_4C68785C_L15C15
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope _environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
+				.field private initonly class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope _environment1_FunctionExpression_iterable
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope capture0,
+						class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2a71
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14/FunctionObject_FunctionExpression_4C68785C_L15C15::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14/FunctionObject_FunctionExpression_4C68785C_L15C15::_environment1_FunctionExpression_iterable
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14/FunctionObject_FunctionExpression_4C68785C_L15C15::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_4C68785C_L15C15::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2a8e
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_4C68785C_L15C15::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2a91
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_4C68785C_L15C15::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2a94
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14/FunctionObject_FunctionExpression_4C68785C_L15C15::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_4C68785C_L15C15::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2aa6
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14/FunctionObject_FunctionExpression_4C68785C_L15C15::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_4C68785C_L15C15::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2ab4
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_4C68785C_L15C15::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_4C68785C_L15C15
+
 
 			// Methods
 			.method public hidebysig static 
@@ -241,6 +475,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F805EA4E_L6C22
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope _environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x29db
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionObject_FunctionExpression_F805EA4E_L6C22::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_F805EA4E_L6C22::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x29ea
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F805EA4E_L6C22::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x29ed
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F805EA4E_L6C22::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x29f0
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionObject_FunctionExpression_F805EA4E_L6C22::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable::__js_call__(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_F805EA4E_L6C22::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a02
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionObject_FunctionExpression_F805EA4E_L6C22::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable::__js_call__(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_F805EA4E_L6C22::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a10
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_F805EA4E_L6C22::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_F805EA4E_L6C22
+
 
 		// Methods
 		.method public hidebysig static 
@@ -261,8 +602,8 @@
 			.locals init (
 				[0] class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope,
 				[1] object[],
-				[2] class FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_D8C5ABFF_L9C13,
-				[3] class FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_4C68785C_L15C15,
+				[2] class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_D8C5ABFF_L9C13,
+				[3] class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14/FunctionObject_FunctionExpression_4C68785C_L15C15,
 				[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
@@ -292,13 +633,13 @@
 			IL_0033: ldelem.ref
 			IL_0034: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope
 			IL_0039: ldloc.1
-			IL_003a: newobj instance void FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_D8C5ABFF_L9C13::.ctor(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope, object[])
+			IL_003a: newobj instance void Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_D8C5ABFF_L9C13::.ctor(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope, object[])
 			IL_003f: ldc.i4.0
 			IL_0040: conv.r8
 			IL_0041: ldstr ""
 			IL_0046: ldc.i4.0
 			IL_0047: ldc.i4.1
-			IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_D8C5ABFF_L9C13>(!!0, float64, string, bool, bool)
+			IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_D8C5ABFF_L9C13>(!!0, float64, string, bool, bool)
 			IL_004d: stloc.2
 			IL_004e: ldc.i4.2
 			IL_004f: newarr [System.Runtime]System.Object
@@ -320,13 +661,13 @@
 			IL_0067: ldelem.ref
 			IL_0068: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope
 			IL_006d: ldloc.1
-			IL_006e: newobj instance void FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_4C68785C_L15C15::.ctor(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope, object[])
+			IL_006e: newobj instance void Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14/FunctionObject_FunctionExpression_4C68785C_L15C15::.ctor(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope, object[])
 			IL_0073: ldc.i4.0
 			IL_0074: conv.r8
 			IL_0075: ldstr ""
 			IL_007a: ldc.i4.0
 			IL_007b: ldc.i4.1
-			IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_4C68785C_L15C15>(!!0, float64, string, bool, bool)
+			IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14/FunctionObject_FunctionExpression_4C68785C_L15C15>(!!0, float64, string, bool, bool)
 			IL_0081: stloc.3
 			IL_0082: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0087: dup
@@ -371,6 +712,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_062080D6_L51C13
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope _environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
+				.field private initonly class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope _environment1_FunctionExpression_iterableThrow
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope capture0,
+						class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2b07
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow/FunctionObject_FunctionExpression_062080D6_L51C13::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow/FunctionObject_FunctionExpression_062080D6_L51C13::_environment1_FunctionExpression_iterableThrow
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow/FunctionObject_FunctionExpression_062080D6_L51C13::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_062080D6_L51C13::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2b24
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_062080D6_L51C13::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2b27
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_062080D6_L51C13::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2b2a
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow/FunctionObject_FunctionExpression_062080D6_L51C13::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_062080D6_L51C13::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2b3c
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow/FunctionObject_FunctionExpression_062080D6_L51C13::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_062080D6_L51C13::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2b4a
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_062080D6_L51C13::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_062080D6_L51C13
 
 
 			// Methods
@@ -483,6 +941,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_4A63F24F_L56C15
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope _environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
+				.field private initonly class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope _environment1_FunctionExpression_iterableThrow
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope capture0,
+						class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2b59
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14/FunctionObject_FunctionExpression_4A63F24F_L56C15::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14/FunctionObject_FunctionExpression_4A63F24F_L56C15::_environment1_FunctionExpression_iterableThrow
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14/FunctionObject_FunctionExpression_4A63F24F_L56C15::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_4A63F24F_L56C15::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2b76
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_4A63F24F_L56C15::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2b79
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_4A63F24F_L56C15::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2b7c
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14/FunctionObject_FunctionExpression_4A63F24F_L56C15::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_4A63F24F_L56C15::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2b8e
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14/FunctionObject_FunctionExpression_4A63F24F_L56C15::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_4A63F24F_L56C15::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2b9c
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_4A63F24F_L56C15::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_4A63F24F_L56C15
+
 
 			// Methods
 			.method public hidebysig static 
@@ -561,6 +1136,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_815CE0CE_L48C22
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope _environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ac3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionObject_FunctionExpression_815CE0CE_L48C22::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_815CE0CE_L48C22::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2ad2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_815CE0CE_L48C22::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2ad5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_815CE0CE_L48C22::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ad8
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionObject_FunctionExpression_815CE0CE_L48C22::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow::__js_call__(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_815CE0CE_L48C22::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2aea
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionObject_FunctionExpression_815CE0CE_L48C22::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow::__js_call__(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_815CE0CE_L48C22::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2af8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_815CE0CE_L48C22::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_815CE0CE_L48C22
+
 
 		// Methods
 		.method public hidebysig static 
@@ -581,8 +1263,8 @@
 			.locals init (
 				[0] class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope,
 				[1] object[],
-				[2] class FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_062080D6_L51C13,
-				[3] class FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_4A63F24F_L56C15,
+				[2] class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow/FunctionObject_FunctionExpression_062080D6_L51C13,
+				[3] class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14/FunctionObject_FunctionExpression_4A63F24F_L56C15,
 				[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
 
@@ -612,13 +1294,13 @@
 			IL_0033: ldelem.ref
 			IL_0034: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope
 			IL_0039: ldloc.1
-			IL_003a: newobj instance void FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_062080D6_L51C13::.ctor(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope, object[])
+			IL_003a: newobj instance void Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow/FunctionObject_FunctionExpression_062080D6_L51C13::.ctor(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope, object[])
 			IL_003f: ldc.i4.0
 			IL_0040: conv.r8
 			IL_0041: ldstr ""
 			IL_0046: ldc.i4.0
 			IL_0047: ldc.i4.1
-			IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_062080D6_L51C13>(!!0, float64, string, bool, bool)
+			IL_0048: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow/FunctionObject_FunctionExpression_062080D6_L51C13>(!!0, float64, string, bool, bool)
 			IL_004d: stloc.2
 			IL_004e: ldc.i4.2
 			IL_004f: newarr [System.Runtime]System.Object
@@ -640,13 +1322,13 @@
 			IL_0067: ldelem.ref
 			IL_0068: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope
 			IL_006d: ldloc.1
-			IL_006e: newobj instance void FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_4A63F24F_L56C15::.ctor(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope, object[])
+			IL_006e: newobj instance void Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14/FunctionObject_FunctionExpression_4A63F24F_L56C15::.ctor(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope, object[])
 			IL_0073: ldc.i4.0
 			IL_0074: conv.r8
 			IL_0075: ldstr ""
 			IL_007a: ldc.i4.0
 			IL_007b: ldc.i4.1
-			IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_4A63F24F_L56C15>(!!0, float64, string, bool, bool)
+			IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14/FunctionObject_FunctionExpression_4A63F24F_L56C15>(!!0, float64, string, bool, bool)
 			IL_0081: stloc.3
 			IL_0082: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0087: dup
@@ -988,11 +1670,11 @@
 			[26] object,
 			[27] object,
 			[28] object[],
-			[29] class FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_F805EA4E_L6C22,
+			[29] class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionObject_FunctionExpression_F805EA4E_L6C22,
 			[30] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[31] bool,
 			[32] object,
-			[33] class FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_815CE0CE_L48C22
+			[33] class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionObject_FunctionExpression_815CE0CE_L48C22
 		)
 
 		IL_0000: newobj instance void Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope::.ctor()
@@ -1016,13 +1698,13 @@
 		IL_0035: ldc.i4.0
 		IL_0036: ldelem.ref
 		IL_0037: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope
-		IL_003c: newobj instance void FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_F805EA4E_L6C22::.ctor(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope)
+		IL_003c: newobj instance void Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionObject_FunctionExpression_F805EA4E_L6C22::.ctor(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope)
 		IL_0041: ldc.i4.0
 		IL_0042: conv.r8
 		IL_0043: ldstr ""
 		IL_0048: ldc.i4.0
 		IL_0049: ldc.i4.1
-		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_F805EA4E_L6C22>(!!0, float64, string, bool, bool)
+		IL_004a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionObject_FunctionExpression_F805EA4E_L6C22>(!!0, float64, string, bool, bool)
 		IL_004f: stloc.s 29
 		IL_0051: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0056: stloc.s 30
@@ -1337,13 +2019,13 @@
 		IL_036a: ldc.i4.0
 		IL_036b: ldelem.ref
 		IL_036c: castclass Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope
-		IL_0371: newobj instance void FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_815CE0CE_L48C22::.ctor(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope)
+		IL_0371: newobj instance void Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionObject_FunctionExpression_815CE0CE_L48C22::.ctor(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope)
 		IL_0376: ldc.i4.0
 		IL_0377: conv.r8
 		IL_0378: ldstr ""
 		IL_037d: ldc.i4.0
 		IL_037e: ldc.i4.1
-		IL_037f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_815CE0CE_L48C22>(!!0, float64, string, bool, bool)
+		IL_037f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionObject_FunctionExpression_815CE0CE_L48C22>(!!0, float64, string, bool, bool)
 		IL_0384: stloc.s 33
 		IL_0386: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_038b: stloc.s 30
@@ -1478,688 +2160,6 @@
 	} // end of method ControlFlow_ForOf_CustomIterable_IteratorProtocol::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_F805EA4E_L6C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope _environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x29db
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_F805EA4E_L6C22::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F805EA4E_L6C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x29ea
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F805EA4E_L6C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x29ed
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F805EA4E_L6C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x29f0
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_F805EA4E_L6C22::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable::__js_call__(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_F805EA4E_L6C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a02
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_F805EA4E_L6C22::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable::__js_call__(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_F805EA4E_L6C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a10
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F805EA4E_L6C22::ConstructCore
-
-} // end of class FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_F805EA4E_L6C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_D8C5ABFF_L9C13
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope _environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
-	.field private initonly class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope _environment1_FunctionExpression_iterable
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope capture0,
-			class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a1f
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_D8C5ABFF_L9C13::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_D8C5ABFF_L9C13::_environment1_FunctionExpression_iterable
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_D8C5ABFF_L9C13::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_D8C5ABFF_L9C13::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a3c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D8C5ABFF_L9C13::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a3f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D8C5ABFF_L9C13::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a42
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_D8C5ABFF_L9C13::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_D8C5ABFF_L9C13::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a54
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_D8C5ABFF_L9C13::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_D8C5ABFF_L9C13::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a62
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D8C5ABFF_L9C13::ConstructCore
-
-} // end of class FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_D8C5ABFF_L9C13
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_4C68785C_L15C15
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope _environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
-	.field private initonly class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope _environment1_FunctionExpression_iterable
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope capture0,
-			class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a71
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_4C68785C_L15C15::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/Scope FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_4C68785C_L15C15::_environment1_FunctionExpression_iterable
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_4C68785C_L15C15::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_4C68785C_L15C15::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a8e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_4C68785C_L15C15::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a91
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_4C68785C_L15C15::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a94
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_4C68785C_L15C15::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_4C68785C_L15C15::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2aa6
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_4C68785C_L15C15::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterable/FunctionExpression_iterable_L15C14::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_4C68785C_L15C15::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ab4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_4C68785C_L15C15::ConstructCore
-
-} // end of class FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_4C68785C_L15C15
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_815CE0CE_L48C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope _environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ac3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_815CE0CE_L48C22::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_815CE0CE_L48C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2ad2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_815CE0CE_L48C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2ad5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_815CE0CE_L48C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ad8
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_815CE0CE_L48C22::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow::__js_call__(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_815CE0CE_L48C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2aea
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_815CE0CE_L48C22::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow::__js_call__(class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_815CE0CE_L48C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2af8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_815CE0CE_L48C22::ConstructCore
-
-} // end of class FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_815CE0CE_L48C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_062080D6_L51C13
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope _environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
-	.field private initonly class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope _environment1_FunctionExpression_iterableThrow
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope capture0,
-			class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b07
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_062080D6_L51C13::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_062080D6_L51C13::_environment1_FunctionExpression_iterableThrow
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_062080D6_L51C13::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_062080D6_L51C13::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2b24
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_062080D6_L51C13::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2b27
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_062080D6_L51C13::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b2a
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_062080D6_L51C13::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_062080D6_L51C13::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b3c
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_062080D6_L51C13::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_062080D6_L51C13::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b4a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_062080D6_L51C13::ConstructCore
-
-} // end of class FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_062080D6_L51C13
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_4A63F24F_L56C15
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope _environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
-	.field private initonly class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope _environment1_FunctionExpression_iterableThrow
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope capture0,
-			class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b59
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/Scope FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_4A63F24F_L56C15::_environment0_ControlFlow_ForOf_CustomIterable_IteratorProtocol
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/Scope FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_4A63F24F_L56C15::_environment1_FunctionExpression_iterableThrow
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_4A63F24F_L56C15::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_4A63F24F_L56C15::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2b76
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_4A63F24F_L56C15::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2b79
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_4A63F24F_L56C15::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b7c
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_4A63F24F_L56C15::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_4A63F24F_L56C15::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b8e
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_4A63F24F_L56C15::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.ControlFlow_ForOf_CustomIterable_IteratorProtocol/FunctionExpression_iterableThrow/FunctionExpression_iterableThrow_L56C14::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_4A63F24F_L56C15::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b9c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_4A63F24F_L56C15::ConstructCore
-
-} // end of class FunctionObjects.ControlFlow_ForOf_CustomIterable_IteratorProtocol_33EDFE68.FunctionObject_FunctionExpression_4A63F24F_L56C15
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding.verified.txt
@@ -31,6 +31,118 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_163EAF2D_L6C14
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/Scope_ForOf_L5C5 _environment1_ForOf_L5C5
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/Scope_ForOf_L5C5 capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x22c5
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/Scope_ForOf_L5C5 Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/FunctionExpression_L6C13/FunctionObject_FunctionExpression_163EAF2D_L6C14::_environment1_ForOf_L5C5
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/FunctionExpression_L6C13/FunctionObject_FunctionExpression_163EAF2D_L6C14::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionExpression_163EAF2D_L6C14::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22db
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_163EAF2D_L6C14::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22de
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_163EAF2D_L6C14::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22e1
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/FunctionExpression_L6C13/FunctionObject_FunctionExpression_163EAF2D_L6C14::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/FunctionExpression_L6C13::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_163EAF2D_L6C14::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22f3
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/FunctionExpression_L6C13/FunctionObject_FunctionExpression_163EAF2D_L6C14::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/FunctionExpression_L6C13::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_163EAF2D_L6C14::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2301
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_163EAF2D_L6C14::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_163EAF2D_L6C14
+
 
 		// Methods
 		.method public hidebysig static 
@@ -197,7 +309,7 @@
 			[10] object,
 			[11] bool,
 			[12] object[],
-			[13] class FunctionObjects.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding_93ECC0B9.FunctionObject_FunctionExpression_163EAF2D_L6C14,
+			[13] class Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/FunctionExpression_L6C13/FunctionObject_FunctionExpression_163EAF2D_L6C14,
 			[14] class Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/Scope_ForOf_L5C5,
 			[15] object
 		)
@@ -290,13 +402,13 @@
 				IL_00f6: ldelem.ref
 				IL_00f7: castclass Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/Scope_ForOf_L5C5
 				IL_00fc: ldloc.s 12
-				IL_00fe: newobj instance void FunctionObjects.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding_93ECC0B9.FunctionObject_FunctionExpression_163EAF2D_L6C14::.ctor(class Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/Scope_ForOf_L5C5, object[])
+				IL_00fe: newobj instance void Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/FunctionExpression_L6C13/FunctionObject_FunctionExpression_163EAF2D_L6C14::.ctor(class Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/Scope_ForOf_L5C5, object[])
 				IL_0103: ldc.i4.0
 				IL_0104: conv.r8
 				IL_0105: ldstr ""
 				IL_010a: ldc.i4.0
 				IL_010b: ldc.i4.1
-				IL_010c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding_93ECC0B9.FunctionObject_FunctionExpression_163EAF2D_L6C14>(!!0, float64, string, bool, bool)
+				IL_010c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/FunctionExpression_L6C13/FunctionObject_FunctionExpression_163EAF2D_L6C14>(!!0, float64, string, bool, bool)
 				IL_0111: stloc.s 13
 				IL_0113: ldloc.1
 				IL_0114: ldloc.s 13
@@ -407,118 +519,6 @@
 	} // end of method ControlFlow_ForOf_Let_Destructuring_PerIterationBinding::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding_93ECC0B9.FunctionObject_FunctionExpression_163EAF2D_L6C14
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/Scope_ForOf_L5C5 _environment1_ForOf_L5C5
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/Scope_ForOf_L5C5 capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x22c5
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/Scope_ForOf_L5C5 FunctionObjects.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding_93ECC0B9.FunctionObject_FunctionExpression_163EAF2D_L6C14::_environment1_ForOf_L5C5
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding_93ECC0B9.FunctionObject_FunctionExpression_163EAF2D_L6C14::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_163EAF2D_L6C14::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22db
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_163EAF2D_L6C14::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22de
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_163EAF2D_L6C14::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22e1
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding_93ECC0B9.FunctionObject_FunctionExpression_163EAF2D_L6C14::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/FunctionExpression_L6C13::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_163EAF2D_L6C14::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22f3
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding_93ECC0B9.FunctionObject_FunctionExpression_163EAF2D_L6C14::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding/FunctionExpression_L6C13::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_163EAF2D_L6C14::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2301
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_163EAF2D_L6C14::ConstructCore
-
-} // end of class FunctionObjects.ControlFlow_ForOf_Let_Destructuring_PerIterationBinding_93ECC0B9.FunctionObject_FunctionExpression_163EAF2D_L6C14
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_Let_PerIterationBinding.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_ForOf_Let_PerIterationBinding.verified.txt
@@ -31,6 +31,118 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C4DB1299_L6C14
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.ControlFlow_ForOf_Let_PerIterationBinding/Scope_ForOf_L5C5 _environment1_ForOf_L5C5
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.ControlFlow_ForOf_Let_PerIterationBinding/Scope_ForOf_L5C5 capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x2261
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.ControlFlow_ForOf_Let_PerIterationBinding/Scope_ForOf_L5C5 Modules.ControlFlow_ForOf_Let_PerIterationBinding/FunctionExpression_L6C13/FunctionObject_FunctionExpression_C4DB1299_L6C14::_environment1_ForOf_L5C5
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.ControlFlow_ForOf_Let_PerIterationBinding/FunctionExpression_L6C13/FunctionObject_FunctionExpression_C4DB1299_L6C14::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionExpression_C4DB1299_L6C14::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2277
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C4DB1299_L6C14::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x227a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C4DB1299_L6C14::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x227d
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.ControlFlow_ForOf_Let_PerIterationBinding/FunctionExpression_L6C13/FunctionObject_FunctionExpression_C4DB1299_L6C14::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.ControlFlow_ForOf_Let_PerIterationBinding/FunctionExpression_L6C13::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_C4DB1299_L6C14::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x228f
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.ControlFlow_ForOf_Let_PerIterationBinding/FunctionExpression_L6C13/FunctionObject_FunctionExpression_C4DB1299_L6C14::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.ControlFlow_ForOf_Let_PerIterationBinding/FunctionExpression_L6C13::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_C4DB1299_L6C14::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x229d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_C4DB1299_L6C14::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_C4DB1299_L6C14
+
 
 		// Methods
 		.method public hidebysig static 
@@ -197,7 +309,7 @@
 			[10] object,
 			[11] bool,
 			[12] object[],
-			[13] class FunctionObjects.ControlFlow_ForOf_Let_PerIterationBinding_74889661.FunctionObject_FunctionExpression_C4DB1299_L6C14,
+			[13] class Modules.ControlFlow_ForOf_Let_PerIterationBinding/FunctionExpression_L6C13/FunctionObject_FunctionExpression_C4DB1299_L6C14,
 			[14] class Modules.ControlFlow_ForOf_Let_PerIterationBinding/Scope_ForOf_L5C5,
 			[15] object
 		)
@@ -262,13 +374,13 @@
 				IL_0094: ldelem.ref
 				IL_0095: castclass Modules.ControlFlow_ForOf_Let_PerIterationBinding/Scope_ForOf_L5C5
 				IL_009a: ldloc.s 12
-				IL_009c: newobj instance void FunctionObjects.ControlFlow_ForOf_Let_PerIterationBinding_74889661.FunctionObject_FunctionExpression_C4DB1299_L6C14::.ctor(class Modules.ControlFlow_ForOf_Let_PerIterationBinding/Scope_ForOf_L5C5, object[])
+				IL_009c: newobj instance void Modules.ControlFlow_ForOf_Let_PerIterationBinding/FunctionExpression_L6C13/FunctionObject_FunctionExpression_C4DB1299_L6C14::.ctor(class Modules.ControlFlow_ForOf_Let_PerIterationBinding/Scope_ForOf_L5C5, object[])
 				IL_00a1: ldc.i4.0
 				IL_00a2: conv.r8
 				IL_00a3: ldstr ""
 				IL_00a8: ldc.i4.0
 				IL_00a9: ldc.i4.1
-				IL_00aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ControlFlow_ForOf_Let_PerIterationBinding_74889661.FunctionObject_FunctionExpression_C4DB1299_L6C14>(!!0, float64, string, bool, bool)
+				IL_00aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_ForOf_Let_PerIterationBinding/FunctionExpression_L6C13/FunctionObject_FunctionExpression_C4DB1299_L6C14>(!!0, float64, string, bool, bool)
 				IL_00af: stloc.s 13
 				IL_00b1: ldloc.1
 				IL_00b2: ldloc.s 13
@@ -379,118 +491,6 @@
 	} // end of method ControlFlow_ForOf_Let_PerIterationBinding::__js_module_init__
 
 } // end of class Modules.ControlFlow_ForOf_Let_PerIterationBinding
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ControlFlow_ForOf_Let_PerIterationBinding_74889661.FunctionObject_FunctionExpression_C4DB1299_L6C14
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ControlFlow_ForOf_Let_PerIterationBinding/Scope_ForOf_L5C5 _environment1_ForOf_L5C5
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ControlFlow_ForOf_Let_PerIterationBinding/Scope_ForOf_L5C5 capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x2261
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ControlFlow_ForOf_Let_PerIterationBinding/Scope_ForOf_L5C5 FunctionObjects.ControlFlow_ForOf_Let_PerIterationBinding_74889661.FunctionObject_FunctionExpression_C4DB1299_L6C14::_environment1_ForOf_L5C5
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.ControlFlow_ForOf_Let_PerIterationBinding_74889661.FunctionObject_FunctionExpression_C4DB1299_L6C14::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_C4DB1299_L6C14::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2277
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C4DB1299_L6C14::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x227a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C4DB1299_L6C14::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x227d
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.ControlFlow_ForOf_Let_PerIterationBinding_74889661.FunctionObject_FunctionExpression_C4DB1299_L6C14::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.ControlFlow_ForOf_Let_PerIterationBinding/FunctionExpression_L6C13::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_C4DB1299_L6C14::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x228f
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.ControlFlow_ForOf_Let_PerIterationBinding_74889661.FunctionObject_FunctionExpression_C4DB1299_L6C14::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.ControlFlow_ForOf_Let_PerIterationBinding/FunctionExpression_L6C13::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_C4DB1299_L6C14::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x229d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C4DB1299_L6C14::ConstructCore
-
-} // end of class FunctionObjects.ControlFlow_ForOf_Let_PerIterationBinding_74889661.FunctionObject_FunctionExpression_C4DB1299_L6C14
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_LabeledStatement_CapturesParentVar.verified.txt
+++ b/tests/Jroc.Tests/ControlFlow/Snapshots/GeneratorTests.ControlFlow_LabeledStatement_CapturesParentVar.verified.txt
@@ -35,6 +35,107 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DE156F42_L5C27
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2265
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_DE156F42_L5C27::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x226d
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_DE156F42_L5C27::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2270
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_DE156F42_L5C27::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2273
+					// Header size: 1
+					// Code size: 18 (0x12)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: ldarg.2
+					IL_0006: ldc.i4.0
+					IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000c: call object Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionExpression_NodeTraversal::__js_call__(object, object)
+					IL_0011: ret
+				} // end of method FunctionObject_FunctionExpression_DE156F42_L5C27::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2286
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: ldarg.2
+					IL_0002: ldc.i4.0
+					IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0008: call object Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionExpression_NodeTraversal::__js_call__(object, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_DE156F42_L5C27::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2295
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_DE156F42_L5C27::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_DE156F42_L5C27
+
 
 			// Methods
 			.method public hidebysig static 
@@ -116,6 +217,118 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A6260E1E_nextNode
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/Scope _environment1_outer
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x22a4
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/Scope Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/nextNode/FunctionObject_FunctionExpression_A6260E1E_nextNode::_environment1_outer
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/nextNode/FunctionObject_FunctionExpression_A6260E1E_nextNode::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionExpression_A6260E1E_nextNode::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x22ba
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_A6260E1E_nextNode::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x22bd
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_A6260E1E_nextNode::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x22c0
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/nextNode/FunctionObject_FunctionExpression_A6260E1E_nextNode::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/nextNode::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_A6260E1E_nextNode::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x22d2
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/nextNode/FunctionObject_FunctionExpression_A6260E1E_nextNode::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/nextNode::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_A6260E1E_nextNode::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x22e0
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_A6260E1E_nextNode::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_A6260E1E_nextNode
 
 
 			// Methods
@@ -227,6 +440,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E39E6AE2_outer
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope _environment0_ControlFlow_LabeledStatement_CapturesParentVar
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2221
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionObject_FunctionDeclaration_E39E6AE2_outer::_environment0_ControlFlow_LabeledStatement_CapturesParentVar
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E39E6AE2_outer::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2230
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E39E6AE2_outer::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2233
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E39E6AE2_outer::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2236
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionObject_FunctionDeclaration_E39E6AE2_outer::_environment0_ControlFlow_LabeledStatement_CapturesParentVar
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer::__js_call__(class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_E39E6AE2_outer::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2248
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionObject_FunctionDeclaration_E39E6AE2_outer::_environment0_ControlFlow_LabeledStatement_CapturesParentVar
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer::__js_call__(class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_E39E6AE2_outer::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2256
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E39E6AE2_outer::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E39E6AE2_outer
+
 
 		// Methods
 		.method public hidebysig static 
@@ -247,9 +567,9 @@
 			.locals init (
 				[0] class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/Scope,
 				[1] object[],
-				[2] class FunctionObjects.ControlFlow_LabeledStatement_CapturesParentVar_CA1708B0.FunctionObject_FunctionExpression_DE156F42_L5C27,
+				[2] class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionExpression_NodeTraversal/FunctionObject_FunctionExpression_DE156F42_L5C27,
 				[3] class Modules.ControlFlow_LabeledStatement_CapturesParentVar/ObjectLiterals/L4C23_NodeTraversal,
-				[4] class FunctionObjects.ControlFlow_LabeledStatement_CapturesParentVar_CA1708B0.FunctionObject_FunctionExpression_A6260E1E_nextNode
+				[4] class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/nextNode/FunctionObject_FunctionExpression_A6260E1E_nextNode
 			)
 
 			IL_0000: newobj instance void Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/Scope::.ctor()
@@ -261,13 +581,13 @@
 			IL_000e: ldarg.0
 			IL_000f: stelem.ref
 			IL_0010: stloc.1
-			IL_0011: newobj instance void FunctionObjects.ControlFlow_LabeledStatement_CapturesParentVar_CA1708B0.FunctionObject_FunctionExpression_DE156F42_L5C27::.ctor()
+			IL_0011: newobj instance void Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionExpression_NodeTraversal/FunctionObject_FunctionExpression_DE156F42_L5C27::.ctor()
 			IL_0016: ldc.i4.1
 			IL_0017: conv.r8
 			IL_0018: ldstr ""
 			IL_001d: ldc.i4.0
 			IL_001e: ldc.i4.1
-			IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ControlFlow_LabeledStatement_CapturesParentVar_CA1708B0.FunctionObject_FunctionExpression_DE156F42_L5C27>(!!0, float64, string, bool, bool)
+			IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionExpression_NodeTraversal/FunctionObject_FunctionExpression_DE156F42_L5C27>(!!0, float64, string, bool, bool)
 			IL_0024: stloc.2
 			IL_0025: newobj instance void Modules.ControlFlow_LabeledStatement_CapturesParentVar/ObjectLiterals/L4C23_NodeTraversal::.ctor()
 			IL_002a: stloc.3
@@ -293,13 +613,13 @@
 			IL_004a: ldelem.ref
 			IL_004b: castclass Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/Scope
 			IL_0050: ldloc.1
-			IL_0051: newobj instance void FunctionObjects.ControlFlow_LabeledStatement_CapturesParentVar_CA1708B0.FunctionObject_FunctionExpression_A6260E1E_nextNode::.ctor(class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/Scope, object[])
+			IL_0051: newobj instance void Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/nextNode/FunctionObject_FunctionExpression_A6260E1E_nextNode::.ctor(class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/Scope, object[])
 			IL_0056: ldc.i4.0
 			IL_0057: conv.r8
 			IL_0058: ldstr "nextNode"
 			IL_005d: ldc.i4.1
 			IL_005e: ldc.i4.1
-			IL_005f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ControlFlow_LabeledStatement_CapturesParentVar_CA1708B0.FunctionObject_FunctionExpression_A6260E1E_nextNode>(!!0, float64, string, bool, bool)
+			IL_005f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/nextNode/FunctionObject_FunctionExpression_A6260E1E_nextNode>(!!0, float64, string, bool, bool)
 			IL_0064: stloc.s 4
 			IL_0066: ldloc.s 4
 			IL_0068: ret
@@ -413,7 +733,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope,
-			[1] class FunctionObjects.ControlFlow_LabeledStatement_CapturesParentVar_CA1708B0.FunctionObject_FunctionDeclaration_E39E6AE2_outer,
+			[1] class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionObject_FunctionDeclaration_E39E6AE2_outer,
 			[2] object[],
 			[3] object
 		)
@@ -431,13 +751,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope
-		IL_0019: newobj instance void FunctionObjects.ControlFlow_LabeledStatement_CapturesParentVar_CA1708B0.FunctionObject_FunctionDeclaration_E39E6AE2_outer::.ctor(class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope)
+		IL_0019: newobj instance void Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionObject_FunctionDeclaration_E39E6AE2_outer::.ctor(class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "outer"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ControlFlow_LabeledStatement_CapturesParentVar_CA1708B0.FunctionObject_FunctionDeclaration_E39E6AE2_outer>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionObject_FunctionDeclaration_E39E6AE2_outer>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
@@ -457,326 +777,6 @@
 	} // end of method ControlFlow_LabeledStatement_CapturesParentVar::__js_module_init__
 
 } // end of class Modules.ControlFlow_LabeledStatement_CapturesParentVar
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ControlFlow_LabeledStatement_CapturesParentVar_CA1708B0.FunctionObject_FunctionDeclaration_E39E6AE2_outer
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope _environment0_ControlFlow_LabeledStatement_CapturesParentVar
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2221
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope FunctionObjects.ControlFlow_LabeledStatement_CapturesParentVar_CA1708B0.FunctionObject_FunctionDeclaration_E39E6AE2_outer::_environment0_ControlFlow_LabeledStatement_CapturesParentVar
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E39E6AE2_outer::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2230
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E39E6AE2_outer::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2233
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E39E6AE2_outer::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2236
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope FunctionObjects.ControlFlow_LabeledStatement_CapturesParentVar_CA1708B0.FunctionObject_FunctionDeclaration_E39E6AE2_outer::_environment0_ControlFlow_LabeledStatement_CapturesParentVar
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer::__js_call__(class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_E39E6AE2_outer::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2248
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope FunctionObjects.ControlFlow_LabeledStatement_CapturesParentVar_CA1708B0.FunctionObject_FunctionDeclaration_E39E6AE2_outer::_environment0_ControlFlow_LabeledStatement_CapturesParentVar
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer::__js_call__(class Modules.ControlFlow_LabeledStatement_CapturesParentVar/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_E39E6AE2_outer::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2256
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E39E6AE2_outer::ConstructCore
-
-} // end of class FunctionObjects.ControlFlow_LabeledStatement_CapturesParentVar_CA1708B0.FunctionObject_FunctionDeclaration_E39E6AE2_outer
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ControlFlow_LabeledStatement_CapturesParentVar_CA1708B0.FunctionObject_FunctionExpression_DE156F42_L5C27
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2265
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_DE156F42_L5C27::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x226d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DE156F42_L5C27::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2270
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DE156F42_L5C27::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2273
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionExpression_NodeTraversal::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_DE156F42_L5C27::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2286
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/FunctionExpression_NodeTraversal::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DE156F42_L5C27::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2295
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DE156F42_L5C27::ConstructCore
-
-} // end of class FunctionObjects.ControlFlow_LabeledStatement_CapturesParentVar_CA1708B0.FunctionObject_FunctionExpression_DE156F42_L5C27
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ControlFlow_LabeledStatement_CapturesParentVar_CA1708B0.FunctionObject_FunctionExpression_A6260E1E_nextNode
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/Scope _environment1_outer
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x22a4
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/Scope FunctionObjects.ControlFlow_LabeledStatement_CapturesParentVar_CA1708B0.FunctionObject_FunctionExpression_A6260E1E_nextNode::_environment1_outer
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.ControlFlow_LabeledStatement_CapturesParentVar_CA1708B0.FunctionObject_FunctionExpression_A6260E1E_nextNode::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_A6260E1E_nextNode::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22ba
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A6260E1E_nextNode::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22bd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A6260E1E_nextNode::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22c0
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.ControlFlow_LabeledStatement_CapturesParentVar_CA1708B0.FunctionObject_FunctionExpression_A6260E1E_nextNode::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/nextNode::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_A6260E1E_nextNode::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22d2
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.ControlFlow_LabeledStatement_CapturesParentVar_CA1708B0.FunctionObject_FunctionExpression_A6260E1E_nextNode::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.ControlFlow_LabeledStatement_CapturesParentVar/outer/nextNode::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_A6260E1E_nextNode::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22e0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A6260E1E_nextNode::ConstructCore
-
-} // end of class FunctionObjects.ControlFlow_LabeledStatement_CapturesParentVar_CA1708B0.FunctionObject_FunctionExpression_A6260E1E_nextNode
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Cleanup_Order.verified.txt
+++ b/tests/Jroc.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Cleanup_Order.verified.txt
@@ -174,6 +174,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_09CA7F68_L19C2
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.FinalizationRegistry_Cleanup_Order/Scope _environment0_FinalizationRegistry_Cleanup_Order
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.FinalizationRegistry_Cleanup_Order/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x24ae
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.FinalizationRegistry_Cleanup_Order/Scope Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1/FunctionObject_FunctionExpression_09CA7F68_L19C2::_environment0_FinalizationRegistry_Cleanup_Order
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_09CA7F68_L19C2::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24bd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_09CA7F68_L19C2::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24c0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_09CA7F68_L19C2::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24c3
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.FinalizationRegistry_Cleanup_Order/Scope Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1/FunctionObject_FunctionExpression_09CA7F68_L19C2::_environment0_FinalizationRegistry_Cleanup_Order
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1::__js_call__(class Modules.FinalizationRegistry_Cleanup_Order/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_09CA7F68_L19C2::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24d5
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.FinalizationRegistry_Cleanup_Order/Scope Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1/FunctionObject_FunctionExpression_09CA7F68_L19C2::_environment0_FinalizationRegistry_Cleanup_Order
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1::__js_call__(class Modules.FinalizationRegistry_Cleanup_Order/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_09CA7F68_L19C2::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24e3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_09CA7F68_L19C2::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_09CA7F68_L19C2
+
 
 		// Methods
 		.method public hidebysig static 
@@ -716,7 +823,7 @@
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry,
 			[10] object,
 			[11] object,
-			[12] class FunctionObjects.FinalizationRegistry_Cleanup_Order_44133D4E.FunctionObject_FunctionExpression_09CA7F68_L19C2,
+			[12] class Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1/FunctionObject_FunctionExpression_09CA7F68_L19C2,
 			[13] class Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C13/FunctionObject,
 			[14] class [JavaScriptRuntime]JavaScriptRuntime.Promise,
 			[15] class Modules.FinalizationRegistry_Cleanup_Order/ArrowFunction_L24C42/FunctionObject,
@@ -879,13 +986,13 @@
 		IL_01ae: ldc.i4.0
 		IL_01af: ldelem.ref
 		IL_01b0: castclass Modules.FinalizationRegistry_Cleanup_Order/Scope
-		IL_01b5: newobj instance void FunctionObjects.FinalizationRegistry_Cleanup_Order_44133D4E.FunctionObject_FunctionExpression_09CA7F68_L19C2::.ctor(class Modules.FinalizationRegistry_Cleanup_Order/Scope)
+		IL_01b5: newobj instance void Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1/FunctionObject_FunctionExpression_09CA7F68_L19C2::.ctor(class Modules.FinalizationRegistry_Cleanup_Order/Scope)
 		IL_01ba: ldc.i4.0
 		IL_01bb: conv.r8
 		IL_01bc: ldstr ""
 		IL_01c1: ldc.i4.0
 		IL_01c2: ldc.i4.1
-		IL_01c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.FinalizationRegistry_Cleanup_Order_44133D4E.FunctionObject_FunctionExpression_09CA7F68_L19C2>(!!0, float64, string, bool, bool)
+		IL_01c3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1/FunctionObject_FunctionExpression_09CA7F68_L19C2>(!!0, float64, string, bool, bool)
 		IL_01c8: stloc.s 12
 		IL_01ca: ldc.i4.0
 		IL_01cb: newarr [System.Runtime]System.Object
@@ -989,113 +1096,6 @@
 	} // end of method FinalizationRegistry_Cleanup_Order::__js_module_init__
 
 } // end of class Modules.FinalizationRegistry_Cleanup_Order
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.FinalizationRegistry_Cleanup_Order_44133D4E.FunctionObject_FunctionExpression_09CA7F68_L19C2
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.FinalizationRegistry_Cleanup_Order/Scope _environment0_FinalizationRegistry_Cleanup_Order
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.FinalizationRegistry_Cleanup_Order/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x24ae
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.FinalizationRegistry_Cleanup_Order/Scope FunctionObjects.FinalizationRegistry_Cleanup_Order_44133D4E.FunctionObject_FunctionExpression_09CA7F68_L19C2::_environment0_FinalizationRegistry_Cleanup_Order
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_09CA7F68_L19C2::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24bd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_09CA7F68_L19C2::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24c0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_09CA7F68_L19C2::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24c3
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.FinalizationRegistry_Cleanup_Order/Scope FunctionObjects.FinalizationRegistry_Cleanup_Order_44133D4E.FunctionObject_FunctionExpression_09CA7F68_L19C2::_environment0_FinalizationRegistry_Cleanup_Order
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1::__js_call__(class Modules.FinalizationRegistry_Cleanup_Order/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_09CA7F68_L19C2::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24d5
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.FinalizationRegistry_Cleanup_Order/Scope FunctionObjects.FinalizationRegistry_Cleanup_Order_44133D4E.FunctionObject_FunctionExpression_09CA7F68_L19C2::_environment0_FinalizationRegistry_Cleanup_Order
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.FinalizationRegistry_Cleanup_Order/FunctionExpression_L19C1::__js_call__(class Modules.FinalizationRegistry_Cleanup_Order/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_09CA7F68_L19C2::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24e3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_09CA7F68_L19C2::ConstructCore
-
-} // end of class FunctionObjects.FinalizationRegistry_Cleanup_Order_44133D4E.FunctionObject_FunctionExpression_09CA7F68_L19C2
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Unregister_Basic.verified.txt
+++ b/tests/Jroc.Tests/FinalizationRegistry/Snapshots/GeneratorTests.FinalizationRegistry_Unregister_Basic.verified.txt
@@ -169,6 +169,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DD94D475_L9C2
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.FinalizationRegistry_Unregister_Basic/Scope _environment0_FinalizationRegistry_Unregister_Basic
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.FinalizationRegistry_Unregister_Basic/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x239c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.FinalizationRegistry_Unregister_Basic/Scope Modules.FinalizationRegistry_Unregister_Basic/FunctionExpression_L9C1/FunctionObject_FunctionExpression_DD94D475_L9C2::_environment0_FinalizationRegistry_Unregister_Basic
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_DD94D475_L9C2::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x23ab
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_DD94D475_L9C2::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x23ae
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_DD94D475_L9C2::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x23b1
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.FinalizationRegistry_Unregister_Basic/Scope Modules.FinalizationRegistry_Unregister_Basic/FunctionExpression_L9C1/FunctionObject_FunctionExpression_DD94D475_L9C2::_environment0_FinalizationRegistry_Unregister_Basic
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.FinalizationRegistry_Unregister_Basic/FunctionExpression_L9C1::__js_call__(class Modules.FinalizationRegistry_Unregister_Basic/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_DD94D475_L9C2::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23c3
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.FinalizationRegistry_Unregister_Basic/Scope Modules.FinalizationRegistry_Unregister_Basic/FunctionExpression_L9C1/FunctionObject_FunctionExpression_DD94D475_L9C2::_environment0_FinalizationRegistry_Unregister_Basic
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.FinalizationRegistry_Unregister_Basic/FunctionExpression_L9C1::__js_call__(class Modules.FinalizationRegistry_Unregister_Basic/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_DD94D475_L9C2::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23d1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_DD94D475_L9C2::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_DD94D475_L9C2
+
 
 		// Methods
 		.method public hidebysig static 
@@ -455,7 +562,7 @@
 			[7] class Modules.FinalizationRegistry_Unregister_Basic/ArrowFunction_L4C43/FunctionObject,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.FinalizationRegistry,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[10] class FunctionObjects.FinalizationRegistry_Unregister_Basic_0ACB432C.FunctionObject_FunctionExpression_DD94D475_L9C2,
+			[10] class Modules.FinalizationRegistry_Unregister_Basic/FunctionExpression_L9C1/FunctionObject_FunctionExpression_DD94D475_L9C2,
 			[11] object,
 			[12] object,
 			[13] class Modules.FinalizationRegistry_Unregister_Basic/ArrowFunction_L26C14/FunctionObject
@@ -512,13 +619,13 @@
 		IL_0074: ldc.i4.0
 		IL_0075: ldelem.ref
 		IL_0076: castclass Modules.FinalizationRegistry_Unregister_Basic/Scope
-		IL_007b: newobj instance void FunctionObjects.FinalizationRegistry_Unregister_Basic_0ACB432C.FunctionObject_FunctionExpression_DD94D475_L9C2::.ctor(class Modules.FinalizationRegistry_Unregister_Basic/Scope)
+		IL_007b: newobj instance void Modules.FinalizationRegistry_Unregister_Basic/FunctionExpression_L9C1/FunctionObject_FunctionExpression_DD94D475_L9C2::.ctor(class Modules.FinalizationRegistry_Unregister_Basic/Scope)
 		IL_0080: ldc.i4.0
 		IL_0081: conv.r8
 		IL_0082: ldstr ""
 		IL_0087: ldc.i4.0
 		IL_0088: ldc.i4.1
-		IL_0089: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.FinalizationRegistry_Unregister_Basic_0ACB432C.FunctionObject_FunctionExpression_DD94D475_L9C2>(!!0, float64, string, bool, bool)
+		IL_0089: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.FinalizationRegistry_Unregister_Basic/FunctionExpression_L9C1/FunctionObject_FunctionExpression_DD94D475_L9C2>(!!0, float64, string, bool, bool)
 		IL_008e: stloc.s 10
 		IL_0090: ldc.i4.0
 		IL_0091: newarr [System.Runtime]System.Object
@@ -663,113 +770,6 @@
 	} // end of method FinalizationRegistry_Unregister_Basic::__js_module_init__
 
 } // end of class Modules.FinalizationRegistry_Unregister_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.FinalizationRegistry_Unregister_Basic_0ACB432C.FunctionObject_FunctionExpression_DD94D475_L9C2
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.FinalizationRegistry_Unregister_Basic/Scope _environment0_FinalizationRegistry_Unregister_Basic
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.FinalizationRegistry_Unregister_Basic/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x239c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.FinalizationRegistry_Unregister_Basic/Scope FunctionObjects.FinalizationRegistry_Unregister_Basic_0ACB432C.FunctionObject_FunctionExpression_DD94D475_L9C2::_environment0_FinalizationRegistry_Unregister_Basic
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DD94D475_L9C2::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23ab
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DD94D475_L9C2::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23ae
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DD94D475_L9C2::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23b1
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.FinalizationRegistry_Unregister_Basic/Scope FunctionObjects.FinalizationRegistry_Unregister_Basic_0ACB432C.FunctionObject_FunctionExpression_DD94D475_L9C2::_environment0_FinalizationRegistry_Unregister_Basic
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.FinalizationRegistry_Unregister_Basic/FunctionExpression_L9C1::__js_call__(class Modules.FinalizationRegistry_Unregister_Basic/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_DD94D475_L9C2::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23c3
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.FinalizationRegistry_Unregister_Basic/Scope FunctionObjects.FinalizationRegistry_Unregister_Basic_0ACB432C.FunctionObject_FunctionExpression_DD94D475_L9C2::_environment0_FinalizationRegistry_Unregister_Basic
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.FinalizationRegistry_Unregister_Basic/FunctionExpression_L9C1::__js_call__(class Modules.FinalizationRegistry_Unregister_Basic/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_DD94D475_L9C2::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23d1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DD94D475_L9C2::ConstructCore
-
-} // end of class FunctionObjects.FinalizationRegistry_Unregister_Basic_0ACB432C.FunctionObject_FunctionExpression_DD94D475_L9C2
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Apply_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Apply_Basic.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_58D97871_add
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2108
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_58D97871_add::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2110
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_58D97871_add::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2113
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_58D97871_add::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2116
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Function_Apply_Basic/'add'::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_58D97871_add::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2130
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Function_Apply_Basic/'add'::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_58D97871_add::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2146
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_58D97871_add::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_58D97871_add
+
 
 		// Methods
 		.method public hidebysig static 
@@ -105,7 +212,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Apply_Basic/Scope,
-			[1] class FunctionObjects.Function_Apply_Basic_2E856767.FunctionObject_FunctionDeclaration_58D97871_add,
+			[1] class Modules.Function_Apply_Basic/'add'/FunctionObject_FunctionDeclaration_58D97871_add,
 			[2] object[],
 			[3] object,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -121,13 +228,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.Function_Apply_Basic_2E856767.FunctionObject_FunctionDeclaration_58D97871_add::.ctor()
+		IL_0011: newobj instance void Modules.Function_Apply_Basic/'add'/FunctionObject_FunctionDeclaration_58D97871_add::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "add"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Apply_Basic_2E856767.FunctionObject_FunctionDeclaration_58D97871_add>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Apply_Basic/'add'/FunctionObject_FunctionDeclaration_58D97871_add>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -160,113 +267,6 @@
 	} // end of method Function_Apply_Basic::__js_module_init__
 
 } // end of class Modules.Function_Apply_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Apply_Basic_2E856767.FunctionObject_FunctionDeclaration_58D97871_add
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2108
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_58D97871_add::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2110
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_58D97871_add::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2113
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_58D97871_add::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2116
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Function_Apply_Basic/'add'::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_58D97871_add::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2130
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Function_Apply_Basic/'add'::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_58D97871_add::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2146
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_58D97871_add::ConstructCore
-
-} // end of class FunctionObjects.Function_Apply_Basic_2E856767.FunctionObject_FunctionDeclaration_58D97871_add
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Apply_NullArgArray_TreatedAsEmpty.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Apply_NullArgArray_TreatedAsEmpty.verified.txt
@@ -38,6 +38,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2102
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x210a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x210d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2110
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Function_Apply_NullArgArray_TreatedAsEmpty/countArgs::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x211c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Function_Apply_NullArgArray_TreatedAsEmpty/countArgs::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2124
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs
+
 
 		// Methods
 		.method public hidebysig static 
@@ -121,7 +216,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Apply_NullArgArray_TreatedAsEmpty/Scope,
-			[1] class FunctionObjects.Function_Apply_NullArgArray_TreatedAsEmpty_D8861CF6.FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs,
+			[1] class Modules.Function_Apply_NullArgArray_TreatedAsEmpty/countArgs/FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs,
 			[2] object[],
 			[3] object,
 			[4] object
@@ -136,13 +231,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.Function_Apply_NullArgArray_TreatedAsEmpty_D8861CF6.FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs::.ctor()
+		IL_0011: newobj instance void Modules.Function_Apply_NullArgArray_TreatedAsEmpty/countArgs/FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "countArgs"
 		IL_001d: ldc.i4.1
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Apply_NullArgArray_TreatedAsEmpty_D8861CF6.FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Apply_NullArgArray_TreatedAsEmpty/countArgs/FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -167,101 +262,6 @@
 	} // end of method Function_Apply_NullArgArray_TreatedAsEmpty::__js_module_init__
 
 } // end of class Modules.Function_Apply_NullArgArray_TreatedAsEmpty
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Apply_NullArgArray_TreatedAsEmpty_D8861CF6.FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2102
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x210a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x210d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2110
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Function_Apply_NullArgArray_TreatedAsEmpty/countArgs::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x211c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Function_Apply_NullArgArray_TreatedAsEmpty/countArgs::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2124
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs::ConstructCore
-
-} // end of class FunctionObjects.Function_Apply_NullArgArray_TreatedAsEmpty_D8861CF6.FunctionObject_FunctionDeclaration_D8AAA3E9_countArgs
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Apply_ThisArg.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Apply_ThisArg.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_992E512E_addBase
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2125
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_992E512E_addBase::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x212d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_992E512E_addBase::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2130
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_992E512E_addBase::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2133
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Function_Apply_ThisArg/addBase::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_992E512E_addBase::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2146
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Function_Apply_ThisArg/addBase::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_992E512E_addBase::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2155
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_992E512E_addBase::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_992E512E_addBase
+
 
 		// Methods
 		.method public hidebysig static 
@@ -110,7 +211,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Apply_ThisArg/Scope,
-			[1] class FunctionObjects.Function_Apply_ThisArg_F68AA75D.FunctionObject_FunctionDeclaration_992E512E_addBase,
+			[1] class Modules.Function_Apply_ThisArg/addBase/FunctionObject_FunctionDeclaration_992E512E_addBase,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object[],
 			[4] object,
@@ -127,13 +228,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.Function_Apply_ThisArg_F68AA75D.FunctionObject_FunctionDeclaration_992E512E_addBase::.ctor()
+		IL_0011: newobj instance void Modules.Function_Apply_ThisArg/addBase/FunctionObject_FunctionDeclaration_992E512E_addBase::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "addBase"
 		IL_001d: ldc.i4.1
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Apply_ThisArg_F68AA75D.FunctionObject_FunctionDeclaration_992E512E_addBase>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Apply_ThisArg/addBase/FunctionObject_FunctionDeclaration_992E512E_addBase>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -168,107 +269,6 @@
 	} // end of method Function_Apply_ThisArg::__js_module_init__
 
 } // end of class Modules.Function_Apply_ThisArg
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Apply_ThisArg_F68AA75D.FunctionObject_FunctionDeclaration_992E512E_addBase
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2125
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_992E512E_addBase::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x212d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_992E512E_addBase::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2130
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_992E512E_addBase::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2133
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Function_Apply_ThisArg/addBase::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_992E512E_addBase::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2146
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Function_Apply_ThisArg/addBase::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_992E512E_addBase::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2155
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_992E512E_addBase::ConstructCore
-
-} // end of class FunctionObjects.Function_Apply_ThisArg_F68AA75D.FunctionObject_FunctionDeclaration_992E512E_addBase
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_Basics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_Basics.verified.txt
@@ -38,6 +38,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C5119BBF_f
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2467
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_C5119BBF_f::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x246f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C5119BBF_f::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2472
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C5119BBF_f::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2475
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Function_Arguments_Basics/f::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_C5119BBF_f::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x248f
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Function_Arguments_Basics/f::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_C5119BBF_f::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24a5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C5119BBF_f::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C5119BBF_f
+
 
 		// Methods
 		.method public hidebysig static 
@@ -320,6 +427,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B57FDCE6_outer
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_Arguments_Basics/Scope _environment0_Function_Arguments_Basics
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_Arguments_Basics/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x24b4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_Arguments_Basics/Scope Modules.Function_Arguments_Basics/outer/FunctionObject_FunctionDeclaration_B57FDCE6_outer::_environment0_Function_Arguments_Basics
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B57FDCE6_outer::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24c3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B57FDCE6_outer::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24c6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B57FDCE6_outer::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24c9
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_Arguments_Basics/Scope Modules.Function_Arguments_Basics/outer/FunctionObject_FunctionDeclaration_B57FDCE6_outer::_environment0_Function_Arguments_Basics
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Function_Arguments_Basics/outer::__js_call__(class Modules.Function_Arguments_Basics/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_B57FDCE6_outer::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24e2
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_Arguments_Basics/Scope Modules.Function_Arguments_Basics/outer/FunctionObject_FunctionDeclaration_B57FDCE6_outer::_environment0_Function_Arguments_Basics
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Function_Arguments_Basics/outer::__js_call__(class Modules.Function_Arguments_Basics/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_B57FDCE6_outer::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24f7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B57FDCE6_outer::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_B57FDCE6_outer
+
 
 		// Methods
 		.method public hidebysig static 
@@ -437,6 +657,101 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C98AACFB_inner
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2561
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionDeclaration_C98AACFB_inner::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2569
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_C98AACFB_inner::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x256c
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_C98AACFB_inner::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x256f
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: call object Modules.Function_Arguments_Basics/g/inner::__js_call__(object)
+					IL_000a: ret
+				} // end of method FunctionObject_FunctionDeclaration_C98AACFB_inner::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x257b
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: call object Modules.Function_Arguments_Basics/g/inner::__js_call__(object)
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionDeclaration_C98AACFB_inner::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2583
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionDeclaration_C98AACFB_inner::ConstructCore
+
+			} // end of class FunctionObject_FunctionDeclaration_C98AACFB_inner
+
 
 			// Methods
 			.method public hidebysig static 
@@ -513,6 +828,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C4119A2C_g
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2530
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_C4119A2C_g::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2538
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C4119A2C_g::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x253b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C4119A2C_g::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x253e
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Function_Arguments_Basics/g::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_C4119A2C_g::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x254a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Function_Arguments_Basics/g::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_C4119A2C_g::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2552
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C4119A2C_g::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C4119A2C_g
+
 
 		// Methods
 		.method public hidebysig static 
@@ -529,7 +939,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_Arguments_Basics/g/Scope,
-				[1] class FunctionObjects.Function_Arguments_Basics_4F51A7DC.FunctionObject_FunctionDeclaration_C98AACFB_inner,
+				[1] class Modules.Function_Arguments_Basics/g/inner/FunctionObject_FunctionDeclaration_C98AACFB_inner,
 				[2] object[]
 			)
 
@@ -537,13 +947,13 @@
 			IL_0005: stloc.0
 			IL_0006: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_000b: stloc.2
-			IL_000c: newobj instance void FunctionObjects.Function_Arguments_Basics_4F51A7DC.FunctionObject_FunctionDeclaration_C98AACFB_inner::.ctor()
+			IL_000c: newobj instance void Modules.Function_Arguments_Basics/g/inner/FunctionObject_FunctionDeclaration_C98AACFB_inner::.ctor()
 			IL_0011: ldc.i4.0
 			IL_0012: conv.r8
 			IL_0013: ldstr "inner"
 			IL_0018: ldc.i4.1
 			IL_0019: ldc.i4.1
-			IL_001a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Arguments_Basics_4F51A7DC.FunctionObject_FunctionDeclaration_C98AACFB_inner>(!!0, float64, string, bool, bool)
+			IL_001a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_Basics/g/inner/FunctionObject_FunctionDeclaration_C98AACFB_inner>(!!0, float64, string, bool, bool)
 			IL_001f: stloc.1
 			IL_0020: nop
 			IL_0021: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
@@ -609,9 +1019,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Arguments_Basics/Scope,
-			[1] class FunctionObjects.Function_Arguments_Basics_4F51A7DC.FunctionObject_FunctionDeclaration_C5119BBF_f,
-			[2] class FunctionObjects.Function_Arguments_Basics_4F51A7DC.FunctionObject_FunctionDeclaration_B57FDCE6_outer,
-			[3] class FunctionObjects.Function_Arguments_Basics_4F51A7DC.FunctionObject_FunctionDeclaration_C4119A2C_g,
+			[1] class Modules.Function_Arguments_Basics/f/FunctionObject_FunctionDeclaration_C5119BBF_f,
+			[2] class Modules.Function_Arguments_Basics/outer/FunctionObject_FunctionDeclaration_B57FDCE6_outer,
+			[3] class Modules.Function_Arguments_Basics/g/FunctionObject_FunctionDeclaration_C4119A2C_g,
 			[4] object[]
 		)
 
@@ -624,13 +1034,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 4
-		IL_0012: newobj instance void FunctionObjects.Function_Arguments_Basics_4F51A7DC.FunctionObject_FunctionDeclaration_C5119BBF_f::.ctor()
+		IL_0012: newobj instance void Modules.Function_Arguments_Basics/f/FunctionObject_FunctionDeclaration_C5119BBF_f::.ctor()
 		IL_0017: ldc.i4.2
 		IL_0018: conv.r8
 		IL_0019: ldstr "f"
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Arguments_Basics_4F51A7DC.FunctionObject_FunctionDeclaration_C5119BBF_f>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_Basics/f/FunctionObject_FunctionDeclaration_C5119BBF_f>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -643,13 +1053,13 @@
 		IL_0034: ldc.i4.0
 		IL_0035: ldelem.ref
 		IL_0036: castclass Modules.Function_Arguments_Basics/Scope
-		IL_003b: newobj instance void FunctionObjects.Function_Arguments_Basics_4F51A7DC.FunctionObject_FunctionDeclaration_B57FDCE6_outer::.ctor(class Modules.Function_Arguments_Basics/Scope)
+		IL_003b: newobj instance void Modules.Function_Arguments_Basics/outer/FunctionObject_FunctionDeclaration_B57FDCE6_outer::.ctor(class Modules.Function_Arguments_Basics/Scope)
 		IL_0040: ldc.i4.1
 		IL_0041: conv.r8
 		IL_0042: ldstr "outer"
 		IL_0047: ldc.i4.1
 		IL_0048: ldc.i4.1
-		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Arguments_Basics_4F51A7DC.FunctionObject_FunctionDeclaration_B57FDCE6_outer>(!!0, float64, string, bool, bool)
+		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_Basics/outer/FunctionObject_FunctionDeclaration_B57FDCE6_outer>(!!0, float64, string, bool, bool)
 		IL_004e: stloc.2
 		IL_004f: ldc.i4.1
 		IL_0050: newarr [System.Runtime]System.Object
@@ -658,13 +1068,13 @@
 		IL_0057: ldloc.0
 		IL_0058: stelem.ref
 		IL_0059: stloc.s 4
-		IL_005b: newobj instance void FunctionObjects.Function_Arguments_Basics_4F51A7DC.FunctionObject_FunctionDeclaration_C4119A2C_g::.ctor()
+		IL_005b: newobj instance void Modules.Function_Arguments_Basics/g/FunctionObject_FunctionDeclaration_C4119A2C_g::.ctor()
 		IL_0060: ldc.i4.0
 		IL_0061: conv.r8
 		IL_0062: ldstr "g"
 		IL_0067: ldc.i4.0
 		IL_0068: ldc.i4.1
-		IL_0069: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Arguments_Basics_4F51A7DC.FunctionObject_FunctionDeclaration_C4119A2C_g>(!!0, float64, string, bool, bool)
+		IL_0069: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_Basics/g/FunctionObject_FunctionDeclaration_C4119A2C_g>(!!0, float64, string, bool, bool)
 		IL_006e: stloc.3
 		IL_006f: nop
 		IL_0070: nop
@@ -718,416 +1128,6 @@
 	} // end of method Function_Arguments_Basics::__js_module_init__
 
 } // end of class Modules.Function_Arguments_Basics
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Arguments_Basics_4F51A7DC.FunctionObject_FunctionDeclaration_C5119BBF_f
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2467
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_C5119BBF_f::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x246f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C5119BBF_f::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2472
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C5119BBF_f::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2475
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Function_Arguments_Basics/f::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_C5119BBF_f::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x248f
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Function_Arguments_Basics/f::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_C5119BBF_f::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24a5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C5119BBF_f::ConstructCore
-
-} // end of class FunctionObjects.Function_Arguments_Basics_4F51A7DC.FunctionObject_FunctionDeclaration_C5119BBF_f
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Arguments_Basics_4F51A7DC.FunctionObject_FunctionDeclaration_B57FDCE6_outer
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_Arguments_Basics/Scope _environment0_Function_Arguments_Basics
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_Arguments_Basics/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x24b4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_Arguments_Basics/Scope FunctionObjects.Function_Arguments_Basics_4F51A7DC.FunctionObject_FunctionDeclaration_B57FDCE6_outer::_environment0_Function_Arguments_Basics
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B57FDCE6_outer::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24c3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B57FDCE6_outer::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24c6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B57FDCE6_outer::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24c9
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_Arguments_Basics/Scope FunctionObjects.Function_Arguments_Basics_4F51A7DC.FunctionObject_FunctionDeclaration_B57FDCE6_outer::_environment0_Function_Arguments_Basics
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Function_Arguments_Basics/outer::__js_call__(class Modules.Function_Arguments_Basics/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_B57FDCE6_outer::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24e2
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_Arguments_Basics/Scope FunctionObjects.Function_Arguments_Basics_4F51A7DC.FunctionObject_FunctionDeclaration_B57FDCE6_outer::_environment0_Function_Arguments_Basics
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Function_Arguments_Basics/outer::__js_call__(class Modules.Function_Arguments_Basics/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_B57FDCE6_outer::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24f7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B57FDCE6_outer::ConstructCore
-
-} // end of class FunctionObjects.Function_Arguments_Basics_4F51A7DC.FunctionObject_FunctionDeclaration_B57FDCE6_outer
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Arguments_Basics_4F51A7DC.FunctionObject_FunctionDeclaration_C4119A2C_g
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2530
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_C4119A2C_g::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2538
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C4119A2C_g::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x253b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C4119A2C_g::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x253e
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Function_Arguments_Basics/g::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_C4119A2C_g::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x254a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Function_Arguments_Basics/g::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_C4119A2C_g::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2552
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C4119A2C_g::ConstructCore
-
-} // end of class FunctionObjects.Function_Arguments_Basics_4F51A7DC.FunctionObject_FunctionDeclaration_C4119A2C_g
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Arguments_Basics_4F51A7DC.FunctionObject_FunctionDeclaration_C98AACFB_inner
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2561
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_C98AACFB_inner::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2569
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C98AACFB_inner::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x256c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C98AACFB_inner::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x256f
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Function_Arguments_Basics/g/inner::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_C98AACFB_inner::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x257b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Function_Arguments_Basics/g/inner::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_C98AACFB_inner::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2583
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C98AACFB_inner::ConstructCore
-
-} // end of class FunctionObjects.Function_Arguments_Basics_4F51A7DC.FunctionObject_FunctionDeclaration_C98AACFB_inner
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_ComputedKey_TriggersBinding.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_ComputedKey_TriggersBinding.verified.txt
@@ -38,6 +38,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_357125B9_f
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x214f
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_357125B9_f::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2157
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_357125B9_f::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x215a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_357125B9_f::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x215d
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Function_Arguments_ComputedKey_TriggersBinding/f::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_357125B9_f::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2169
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Function_Arguments_ComputedKey_TriggersBinding/f::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_357125B9_f::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2171
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_357125B9_f::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_357125B9_f
+
 
 		// Methods
 		.method public hidebysig static 
@@ -146,7 +241,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Arguments_ComputedKey_TriggersBinding/Scope,
-			[1] class FunctionObjects.Function_Arguments_ComputedKey_TriggersBinding_73562136.FunctionObject_FunctionDeclaration_357125B9_f,
+			[1] class Modules.Function_Arguments_ComputedKey_TriggersBinding/f/FunctionObject_FunctionDeclaration_357125B9_f,
 			[2] object[]
 		)
 
@@ -159,13 +254,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.Function_Arguments_ComputedKey_TriggersBinding_73562136.FunctionObject_FunctionDeclaration_357125B9_f::.ctor()
+		IL_0011: newobj instance void Modules.Function_Arguments_ComputedKey_TriggersBinding/f/FunctionObject_FunctionDeclaration_357125B9_f::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "f"
 		IL_001d: ldc.i4.1
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Arguments_ComputedKey_TriggersBinding_73562136.FunctionObject_FunctionDeclaration_357125B9_f>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_ComputedKey_TriggersBinding/f/FunctionObject_FunctionDeclaration_357125B9_f>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -185,101 +280,6 @@
 	} // end of method Function_Arguments_ComputedKey_TriggersBinding::__js_module_init__
 
 } // end of class Modules.Function_Arguments_ComputedKey_TriggersBinding
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Arguments_ComputedKey_TriggersBinding_73562136.FunctionObject_FunctionDeclaration_357125B9_f
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x214f
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_357125B9_f::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2157
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_357125B9_f::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x215a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_357125B9_f::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x215d
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Function_Arguments_ComputedKey_TriggersBinding/f::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_357125B9_f::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2169
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Function_Arguments_ComputedKey_TriggersBinding/f::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_357125B9_f::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2171
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_357125B9_f::ConstructCore
-
-} // end of class FunctionObjects.Function_Arguments_ComputedKey_TriggersBinding_73562136.FunctionObject_FunctionDeclaration_357125B9_f
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_Length_Delete.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_Length_Delete.verified.txt
@@ -41,6 +41,128 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F98CF296_L3C17
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x23a7
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_F98CF296_L3C17::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x23af
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F98CF296_L3C17::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x23b2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F98CF296_L3C17::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x23b5
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_F98CF296_L3C17::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x23bd
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L3C16'::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionExpression_F98CF296_L3C17::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23d7
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L3C16'::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionExpression_F98CF296_L3C17::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23ed
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_F98CF296_L3C17::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_F98CF296_L3C17
+
 
 		// Methods
 		.method public hidebysig static 
@@ -219,6 +341,116 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_4B850177_L10C18
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x23fc
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_4B850177_L10C18::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2404
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_4B850177_L10C18::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2407
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_4B850177_L10C18::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x240a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_4B850177_L10C18::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2412
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L10C17'::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_4B850177_L10C18::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x241e
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L10C17'::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_4B850177_L10C18::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2426
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_4B850177_L10C18::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_4B850177_L10C18
+
 
 		// Methods
 		.method public hidebysig static 
@@ -290,8 +522,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Arguments_Length_Delete/Scope,
-			[1] class FunctionObjects.Function_Arguments_Length_Delete_2FA5433B.FunctionObject_FunctionExpression_F98CF296_L3C17,
-			[2] class FunctionObjects.Function_Arguments_Length_Delete_2FA5433B.FunctionObject_FunctionExpression_4B850177_L10C18,
+			[1] class Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L3C16'/FunctionObject_FunctionExpression_F98CF296_L3C17,
+			[2] class Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L10C17'/FunctionObject_FunctionExpression_4B850177_L10C18,
 			[3] object,
 			[4] object[],
 			[5] object,
@@ -310,13 +542,13 @@
 		IL_000f: ldloc.0
 		IL_0010: stelem.ref
 		IL_0011: stloc.s 4
-		IL_0013: newobj instance void FunctionObjects.Function_Arguments_Length_Delete_2FA5433B.FunctionObject_FunctionExpression_F98CF296_L3C17::.ctor()
+		IL_0013: newobj instance void Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L3C16'/FunctionObject_FunctionExpression_F98CF296_L3C17::.ctor()
 		IL_0018: ldc.i4.2
 		IL_0019: conv.r8
 		IL_001a: ldstr ""
 		IL_001f: ldc.i4.1
 		IL_0020: ldc.i4.0
-		IL_0021: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Arguments_Length_Delete_2FA5433B.FunctionObject_FunctionExpression_F98CF296_L3C17>(!!0, float64, string, bool, bool)
+		IL_0021: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L3C16'/FunctionObject_FunctionExpression_F98CF296_L3C17>(!!0, float64, string, bool, bool)
 		IL_0026: stloc.1
 		IL_0027: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_002c: stloc.s 4
@@ -335,13 +567,13 @@
 		IL_005b: ldloc.0
 		IL_005c: stelem.ref
 		IL_005d: stloc.s 4
-		IL_005f: newobj instance void FunctionObjects.Function_Arguments_Length_Delete_2FA5433B.FunctionObject_FunctionExpression_4B850177_L10C18::.ctor()
+		IL_005f: newobj instance void Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L10C17'/FunctionObject_FunctionExpression_4B850177_L10C18::.ctor()
 		IL_0064: ldc.i4.0
 		IL_0065: conv.r8
 		IL_0066: ldstr ""
 		IL_006b: ldc.i4.1
 		IL_006c: ldc.i4.0
-		IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Arguments_Length_Delete_2FA5433B.FunctionObject_FunctionExpression_4B850177_L10C18>(!!0, float64, string, bool, bool)
+		IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L10C17'/FunctionObject_FunctionExpression_4B850177_L10C18>(!!0, float64, string, bool, bool)
 		IL_0072: stloc.2
 		IL_0073: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_0078: stloc.s 4
@@ -431,238 +663,6 @@
 	} // end of method Function_Arguments_Length_Delete::__js_module_init__
 
 } // end of class Modules.Function_Arguments_Length_Delete
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Arguments_Length_Delete_2FA5433B.FunctionObject_FunctionExpression_F98CF296_L3C17
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x23a7
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_F98CF296_L3C17::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23af
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F98CF296_L3C17::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23b2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F98CF296_L3C17::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x23b5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_F98CF296_L3C17::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23bd
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L3C16'::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_F98CF296_L3C17::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23d7
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L3C16'::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_F98CF296_L3C17::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23ed
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F98CF296_L3C17::ConstructCore
-
-} // end of class FunctionObjects.Function_Arguments_Length_Delete_2FA5433B.FunctionObject_FunctionExpression_F98CF296_L3C17
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Arguments_Length_Delete_2FA5433B.FunctionObject_FunctionExpression_4B850177_L10C18
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x23fc
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_4B850177_L10C18::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2404
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_4B850177_L10C18::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2407
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_4B850177_L10C18::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x240a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_4B850177_L10C18::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2412
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L10C17'::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_4B850177_L10C18::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x241e
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Function_Arguments_Length_Delete/'<>DynamicFunction_L10C17'::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_4B850177_L10C18::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2426
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_4B850177_L10C18::ConstructCore
-
-} // end of class FunctionObjects.Function_Arguments_Length_Delete_2FA5433B.FunctionObject_FunctionExpression_4B850177_L10C18
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_MappedParameterAliasing.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_MappedParameterAliasing.verified.txt
@@ -41,6 +41,128 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5F0224F6_L3C17
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2323
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_5F0224F6_L3C17::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x232b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5F0224F6_L3C17::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x232e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5F0224F6_L3C17::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2331
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_5F0224F6_L3C17::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2339
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Function_Arguments_MappedParameterAliasing/'<>DynamicFunction_L3C16'::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionExpression_5F0224F6_L3C17::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2353
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Function_Arguments_MappedParameterAliasing/'<>DynamicFunction_L3C16'::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionExpression_5F0224F6_L3C17::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2369
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_5F0224F6_L3C17::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_5F0224F6_L3C17
+
 
 		// Methods
 		.method public hidebysig static 
@@ -293,7 +415,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Arguments_MappedParameterAliasing/Scope,
-			[1] class FunctionObjects.Function_Arguments_MappedParameterAliasing_D7E8C39B.FunctionObject_FunctionExpression_5F0224F6_L3C17,
+			[1] class Modules.Function_Arguments_MappedParameterAliasing/'<>DynamicFunction_L3C16'/FunctionObject_FunctionExpression_5F0224F6_L3C17,
 			[2] object[]
 		)
 
@@ -307,13 +429,13 @@
 		IL_000f: ldloc.0
 		IL_0010: stelem.ref
 		IL_0011: stloc.2
-		IL_0012: newobj instance void FunctionObjects.Function_Arguments_MappedParameterAliasing_D7E8C39B.FunctionObject_FunctionExpression_5F0224F6_L3C17::.ctor()
+		IL_0012: newobj instance void Modules.Function_Arguments_MappedParameterAliasing/'<>DynamicFunction_L3C16'/FunctionObject_FunctionExpression_5F0224F6_L3C17::.ctor()
 		IL_0017: ldc.i4.2
 		IL_0018: conv.r8
 		IL_0019: ldstr ""
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.0
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Arguments_MappedParameterAliasing_D7E8C39B.FunctionObject_FunctionExpression_5F0224F6_L3C17>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_MappedParameterAliasing/'<>DynamicFunction_L3C16'/FunctionObject_FunctionExpression_5F0224F6_L3C17>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_002b: stloc.2
@@ -329,128 +451,6 @@
 	} // end of method Function_Arguments_MappedParameterAliasing::__js_module_init__
 
 } // end of class Modules.Function_Arguments_MappedParameterAliasing
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Arguments_MappedParameterAliasing_D7E8C39B.FunctionObject_FunctionExpression_5F0224F6_L3C17
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2323
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_5F0224F6_L3C17::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x232b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5F0224F6_L3C17::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x232e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5F0224F6_L3C17::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2331
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_5F0224F6_L3C17::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2339
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Function_Arguments_MappedParameterAliasing/'<>DynamicFunction_L3C16'::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_5F0224F6_L3C17::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2353
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Function_Arguments_MappedParameterAliasing/'<>DynamicFunction_L3C16'::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_5F0224F6_L3C17::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2369
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5F0224F6_L3C17::ConstructCore
-
-} // end of class FunctionObjects.Function_Arguments_MappedParameterAliasing_D7E8C39B.FunctionObject_FunctionExpression_5F0224F6_L3C17
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_NoFalsePositive_ObjectLiteralKey.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_NoFalsePositive_ObjectLiteralKey.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_491D1403_f
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope _environment0_Function_Arguments_NoFalsePositive_ObjectLiteralKey
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2122
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/f/FunctionObject_FunctionDeclaration_491D1403_f::_environment0_Function_Arguments_NoFalsePositive_ObjectLiteralKey
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_491D1403_f::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2131
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_491D1403_f::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2134
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_491D1403_f::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2137
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/f/FunctionObject_FunctionDeclaration_491D1403_f::_environment0_Function_Arguments_NoFalsePositive_ObjectLiteralKey
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/f::__js_call__(class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_491D1403_f::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2149
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/f/FunctionObject_FunctionDeclaration_491D1403_f::_environment0_Function_Arguments_NoFalsePositive_ObjectLiteralKey
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/f::__js_call__(class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_491D1403_f::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2157
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_491D1403_f::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_491D1403_f
+
 
 		// Methods
 		.method public hidebysig static 
@@ -187,7 +294,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope,
-			[1] class FunctionObjects.Function_Arguments_NoFalsePositive_ObjectLiteralKey_128F2550.FunctionObject_FunctionDeclaration_491D1403_f,
+			[1] class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/f/FunctionObject_FunctionDeclaration_491D1403_f,
 			[2] object[]
 		)
 
@@ -204,13 +311,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope
-		IL_0019: newobj instance void FunctionObjects.Function_Arguments_NoFalsePositive_ObjectLiteralKey_128F2550.FunctionObject_FunctionDeclaration_491D1403_f::.ctor(class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope)
+		IL_0019: newobj instance void Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/f/FunctionObject_FunctionDeclaration_491D1403_f::.ctor(class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "f"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Arguments_NoFalsePositive_ObjectLiteralKey_128F2550.FunctionObject_FunctionDeclaration_491D1403_f>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/f/FunctionObject_FunctionDeclaration_491D1403_f>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
@@ -222,113 +329,6 @@
 	} // end of method Function_Arguments_NoFalsePositive_ObjectLiteralKey::__js_module_init__
 
 } // end of class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Arguments_NoFalsePositive_ObjectLiteralKey_128F2550.FunctionObject_FunctionDeclaration_491D1403_f
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope _environment0_Function_Arguments_NoFalsePositive_ObjectLiteralKey
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2122
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope FunctionObjects.Function_Arguments_NoFalsePositive_ObjectLiteralKey_128F2550.FunctionObject_FunctionDeclaration_491D1403_f::_environment0_Function_Arguments_NoFalsePositive_ObjectLiteralKey
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_491D1403_f::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2131
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_491D1403_f::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2134
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_491D1403_f::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2137
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope FunctionObjects.Function_Arguments_NoFalsePositive_ObjectLiteralKey_128F2550.FunctionObject_FunctionDeclaration_491D1403_f::_environment0_Function_Arguments_NoFalsePositive_ObjectLiteralKey
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/f::__js_call__(class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_491D1403_f::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2149
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope FunctionObjects.Function_Arguments_NoFalsePositive_ObjectLiteralKey_128F2550.FunctionObject_FunctionDeclaration_491D1403_f::_environment0_Function_Arguments_NoFalsePositive_ObjectLiteralKey
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/f::__js_call__(class Modules.Function_Arguments_NoFalsePositive_ObjectLiteralKey/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_491D1403_f::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2157
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_491D1403_f::ConstructCore
-
-} // end of class FunctionObjects.Function_Arguments_NoFalsePositive_ObjectLiteralKey_128F2550.FunctionObject_FunctionDeclaration_491D1403_f
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_Unmapped_StrictAndComplex.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Arguments_Unmapped_StrictAndComplex.verified.txt
@@ -38,6 +38,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F7970187_L3C19
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x23dd
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_F7970187_L3C19::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x23e5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F7970187_L3C19::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x23e8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F7970187_L3C19::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x23eb
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L3C18'::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_F7970187_L3C19::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23fe
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L3C18'::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_F7970187_L3C19::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x240d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_F7970187_L3C19::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_F7970187_L3C19
+
 
 		// Methods
 		.method public hidebysig static 
@@ -180,6 +281,122 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9B0AFD71_L9C20
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x241c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_9B0AFD71_L9C20::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2424
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_9B0AFD71_L9C20::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2427
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_9B0AFD71_L9C20::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x242a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_9B0AFD71_L9C20::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2432
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L9C19'::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_9B0AFD71_L9C20::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2445
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L9C19'::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_9B0AFD71_L9C20::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2454
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_9B0AFD71_L9C20::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_9B0AFD71_L9C20
 
 
 		// Methods
@@ -357,8 +574,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Arguments_Unmapped_StrictAndComplex/Scope,
-			[1] class FunctionObjects.Function_Arguments_Unmapped_StrictAndComplex_0A7B4B2A.FunctionObject_FunctionExpression_F7970187_L3C19,
-			[2] class FunctionObjects.Function_Arguments_Unmapped_StrictAndComplex_0A7B4B2A.FunctionObject_FunctionExpression_9B0AFD71_L9C20,
+			[1] class Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L3C18'/FunctionObject_FunctionExpression_F7970187_L3C19,
+			[2] class Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L9C19'/FunctionObject_FunctionExpression_9B0AFD71_L9C20,
 			[3] object[]
 		)
 
@@ -372,13 +589,13 @@
 		IL_000f: ldloc.0
 		IL_0010: stelem.ref
 		IL_0011: stloc.3
-		IL_0012: newobj instance void FunctionObjects.Function_Arguments_Unmapped_StrictAndComplex_0A7B4B2A.FunctionObject_FunctionExpression_F7970187_L3C19::.ctor()
+		IL_0012: newobj instance void Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L3C18'/FunctionObject_FunctionExpression_F7970187_L3C19::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr ""
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Arguments_Unmapped_StrictAndComplex_0A7B4B2A.FunctionObject_FunctionExpression_F7970187_L3C19>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L3C18'/FunctionObject_FunctionExpression_F7970187_L3C19>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_002b: stloc.3
@@ -395,13 +612,13 @@
 		IL_004a: ldloc.0
 		IL_004b: stelem.ref
 		IL_004c: stloc.3
-		IL_004d: newobj instance void FunctionObjects.Function_Arguments_Unmapped_StrictAndComplex_0A7B4B2A.FunctionObject_FunctionExpression_9B0AFD71_L9C20::.ctor()
+		IL_004d: newobj instance void Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L9C19'/FunctionObject_FunctionExpression_9B0AFD71_L9C20::.ctor()
 		IL_0052: ldc.i4.0
 		IL_0053: conv.r8
 		IL_0054: ldstr ""
 		IL_0059: ldc.i4.1
 		IL_005a: ldc.i4.0
-		IL_005b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Arguments_Unmapped_StrictAndComplex_0A7B4B2A.FunctionObject_FunctionExpression_9B0AFD71_L9C20>(!!0, float64, string, bool, bool)
+		IL_005b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L9C19'/FunctionObject_FunctionExpression_9B0AFD71_L9C20>(!!0, float64, string, bool, bool)
 		IL_0060: stloc.2
 		IL_0061: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 		IL_0066: stloc.3
@@ -415,223 +632,6 @@
 	} // end of method Function_Arguments_Unmapped_StrictAndComplex::__js_module_init__
 
 } // end of class Modules.Function_Arguments_Unmapped_StrictAndComplex
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Arguments_Unmapped_StrictAndComplex_0A7B4B2A.FunctionObject_FunctionExpression_F7970187_L3C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x23dd
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_F7970187_L3C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23e5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F7970187_L3C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23e8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F7970187_L3C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23eb
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L3C18'::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_F7970187_L3C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23fe
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L3C18'::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F7970187_L3C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x240d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F7970187_L3C19::ConstructCore
-
-} // end of class FunctionObjects.Function_Arguments_Unmapped_StrictAndComplex_0A7B4B2A.FunctionObject_FunctionExpression_F7970187_L3C19
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Arguments_Unmapped_StrictAndComplex_0A7B4B2A.FunctionObject_FunctionExpression_9B0AFD71_L9C20
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x241c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_9B0AFD71_L9C20::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2424
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9B0AFD71_L9C20::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2427
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9B0AFD71_L9C20::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x242a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_9B0AFD71_L9C20::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2432
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L9C19'::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_9B0AFD71_L9C20::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2445
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Function_Arguments_Unmapped_StrictAndComplex/'<>DynamicFunction_L9C19'::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_9B0AFD71_L9C20::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2454
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_9B0AFD71_L9C20::ConstructCore
-
-} // end of class FunctionObjects.Function_Arguments_Unmapped_StrictAndComplex_0A7B4B2A.FunctionObject_FunctionExpression_9B0AFD71_L9C20
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_Basic_PartialApplication.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_Basic_PartialApplication.verified.txt
@@ -31,6 +31,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_AAB1CA43_sum3
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2120
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_AAB1CA43_sum3::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2128
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_AAB1CA43_sum3::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x212b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_AAB1CA43_sum3::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x212e
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.2
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.Function_Bind_Basic_PartialApplication/sum3::__js_call__(object, object, object, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionDeclaration_AAB1CA43_sum3::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x214f
+				// Header size: 1
+				// Code size: 28 (0x1c)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: ldarg.2
+				IL_0010: ldc.i4.2
+				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0016: call object Modules.Function_Bind_Basic_PartialApplication/sum3::__js_call__(object, object, object, object)
+				IL_001b: ret
+			} // end of method FunctionObject_FunctionDeclaration_AAB1CA43_sum3::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x216c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_AAB1CA43_sum3::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_AAB1CA43_sum3
+
 
 		// Methods
 		.method public hidebysig static 
@@ -110,7 +223,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Bind_Basic_PartialApplication/Scope,
-			[1] class FunctionObjects.Function_Bind_Basic_PartialApplication_2A74EFD0.FunctionObject_FunctionDeclaration_AAB1CA43_sum3,
+			[1] class Modules.Function_Bind_Basic_PartialApplication/sum3/FunctionObject_FunctionDeclaration_AAB1CA43_sum3,
 			[2] object,
 			[3] object[],
 			[4] object,
@@ -126,13 +239,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.Function_Bind_Basic_PartialApplication_2A74EFD0.FunctionObject_FunctionDeclaration_AAB1CA43_sum3::.ctor()
+		IL_0011: newobj instance void Modules.Function_Bind_Basic_PartialApplication/sum3/FunctionObject_FunctionDeclaration_AAB1CA43_sum3::.ctor()
 		IL_0016: ldc.i4.3
 		IL_0017: conv.r8
 		IL_0018: ldstr "sum3"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Bind_Basic_PartialApplication_2A74EFD0.FunctionObject_FunctionDeclaration_AAB1CA43_sum3>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Bind_Basic_PartialApplication/sum3/FunctionObject_FunctionDeclaration_AAB1CA43_sum3>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -167,119 +280,6 @@
 	} // end of method Function_Bind_Basic_PartialApplication::__js_module_init__
 
 } // end of class Modules.Function_Bind_Basic_PartialApplication
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Bind_Basic_PartialApplication_2A74EFD0.FunctionObject_FunctionDeclaration_AAB1CA43_sum3
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2120
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_AAB1CA43_sum3::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2128
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_AAB1CA43_sum3::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x212b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_AAB1CA43_sum3::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x212e
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.2
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.Function_Bind_Basic_PartialApplication/sum3::__js_call__(object, object, object, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionDeclaration_AAB1CA43_sum3::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x214f
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: ldarg.2
-		IL_0010: ldc.i4.2
-		IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0016: call object Modules.Function_Bind_Basic_PartialApplication/sum3::__js_call__(object, object, object, object)
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionDeclaration_AAB1CA43_sum3::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x216c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_AAB1CA43_sum3::ConstructCore
-
-} // end of class FunctionObjects.Function_Bind_Basic_PartialApplication_2A74EFD0.FunctionObject_FunctionDeclaration_AAB1CA43_sum3
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_Construct_NewTargetAndPrototype.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_Construct_NewTargetAndPrototype.verified.txt
@@ -31,6 +31,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D0AE1FAE_C
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope _environment0_Function_Bind_Construct_NewTargetAndPrototype
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2356
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope Modules.Function_Bind_Construct_NewTargetAndPrototype/C/FunctionObject_FunctionDeclaration_D0AE1FAE_C::_environment0_Function_Bind_Construct_NewTargetAndPrototype
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D0AE1FAE_C::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2365
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D0AE1FAE_C::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2368
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D0AE1FAE_C::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x236b
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope Modules.Function_Bind_Construct_NewTargetAndPrototype/C/FunctionObject_FunctionDeclaration_D0AE1FAE_C::_environment0_Function_Bind_Construct_NewTargetAndPrototype
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Function_Bind_Construct_NewTargetAndPrototype/C::__js_call__(class Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_D0AE1FAE_C::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x238b
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope Modules.Function_Bind_Construct_NewTargetAndPrototype/C/FunctionObject_FunctionDeclaration_D0AE1FAE_C::_environment0_Function_Bind_Construct_NewTargetAndPrototype
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Function_Bind_Construct_NewTargetAndPrototype/C::__js_call__(class Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_D0AE1FAE_C::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23a7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D0AE1FAE_C::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_D0AE1FAE_C
+
 
 		// Methods
 		.method public hidebysig static 
@@ -166,7 +285,7 @@
 			[1] object,
 			[2] object,
 			[3] object[],
-			[4] class FunctionObjects.Function_Bind_Construct_NewTargetAndPrototype_C933B81A.FunctionObject_FunctionDeclaration_D0AE1FAE_C,
+			[4] class Modules.Function_Bind_Construct_NewTargetAndPrototype/C/FunctionObject_FunctionDeclaration_D0AE1FAE_C,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[6] object,
 			[7] object,
@@ -189,13 +308,13 @@
 		IL_0017: ldc.i4.0
 		IL_0018: ldelem.ref
 		IL_0019: castclass Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope
-		IL_001e: newobj instance void FunctionObjects.Function_Bind_Construct_NewTargetAndPrototype_C933B81A.FunctionObject_FunctionDeclaration_D0AE1FAE_C::.ctor(class Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope)
+		IL_001e: newobj instance void Modules.Function_Bind_Construct_NewTargetAndPrototype/C/FunctionObject_FunctionDeclaration_D0AE1FAE_C::.ctor(class Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope)
 		IL_0023: ldc.i4.2
 		IL_0024: conv.r8
 		IL_0025: ldstr "C"
 		IL_002a: ldc.i4.1
 		IL_002b: ldc.i4.1
-		IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Bind_Construct_NewTargetAndPrototype_C933B81A.FunctionObject_FunctionDeclaration_D0AE1FAE_C>(!!0, float64, string, bool, bool)
+		IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Bind_Construct_NewTargetAndPrototype/C/FunctionObject_FunctionDeclaration_D0AE1FAE_C>(!!0, float64, string, bool, bool)
 		IL_0031: stloc.s 4
 		IL_0033: ldloc.0
 		IL_0034: ldloc.s 4
@@ -358,125 +477,6 @@
 	} // end of method Function_Bind_Construct_NewTargetAndPrototype::__js_module_init__
 
 } // end of class Modules.Function_Bind_Construct_NewTargetAndPrototype
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Bind_Construct_NewTargetAndPrototype_C933B81A.FunctionObject_FunctionDeclaration_D0AE1FAE_C
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope _environment0_Function_Bind_Construct_NewTargetAndPrototype
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2356
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope FunctionObjects.Function_Bind_Construct_NewTargetAndPrototype_C933B81A.FunctionObject_FunctionDeclaration_D0AE1FAE_C::_environment0_Function_Bind_Construct_NewTargetAndPrototype
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D0AE1FAE_C::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2365
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D0AE1FAE_C::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2368
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D0AE1FAE_C::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x236b
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope FunctionObjects.Function_Bind_Construct_NewTargetAndPrototype_C933B81A.FunctionObject_FunctionDeclaration_D0AE1FAE_C::_environment0_Function_Bind_Construct_NewTargetAndPrototype
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Function_Bind_Construct_NewTargetAndPrototype/C::__js_call__(class Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_D0AE1FAE_C::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x238b
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope FunctionObjects.Function_Bind_Construct_NewTargetAndPrototype_C933B81A.FunctionObject_FunctionDeclaration_D0AE1FAE_C::_environment0_Function_Bind_Construct_NewTargetAndPrototype
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Function_Bind_Construct_NewTargetAndPrototype/C::__js_call__(class Modules.Function_Bind_Construct_NewTargetAndPrototype/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_D0AE1FAE_C::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23a7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D0AE1FAE_C::ConstructCore
-
-} // end of class FunctionObjects.Function_Bind_Construct_NewTargetAndPrototype_C933B81A.FunctionObject_FunctionDeclaration_D0AE1FAE_C
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_Metadata_LengthNameAndPrototype.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_Metadata_LengthNameAndPrototype.verified.txt
@@ -31,6 +31,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_52CA7D48_target
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2430
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_52CA7D48_target::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2438
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_52CA7D48_target::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x243b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_52CA7D48_target::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x243e
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.2
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.Function_Bind_Metadata_LengthNameAndPrototype/target::__js_call__(object, object, object, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionDeclaration_52CA7D48_target::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x245f
+				// Header size: 1
+				// Code size: 28 (0x1c)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: ldarg.2
+				IL_0010: ldc.i4.2
+				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0016: call object Modules.Function_Bind_Metadata_LengthNameAndPrototype/target::__js_call__(object, object, object, object)
+				IL_001b: ret
+			} // end of method FunctionObject_FunctionDeclaration_52CA7D48_target::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x247c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_52CA7D48_target::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_52CA7D48_target
+
 
 		// Methods
 		.method public hidebysig static 
@@ -110,7 +223,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Bind_Metadata_LengthNameAndPrototype/Scope,
-			[1] class FunctionObjects.Function_Bind_Metadata_LengthNameAndPrototype_7FBD7116.FunctionObject_FunctionDeclaration_52CA7D48_target,
+			[1] class Modules.Function_Bind_Metadata_LengthNameAndPrototype/target/FunctionObject_FunctionDeclaration_52CA7D48_target,
 			[2] object,
 			[3] object,
 			[4] object,
@@ -132,13 +245,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 6
-		IL_0012: newobj instance void FunctionObjects.Function_Bind_Metadata_LengthNameAndPrototype_7FBD7116.FunctionObject_FunctionDeclaration_52CA7D48_target::.ctor()
+		IL_0012: newobj instance void Modules.Function_Bind_Metadata_LengthNameAndPrototype/target/FunctionObject_FunctionDeclaration_52CA7D48_target::.ctor()
 		IL_0017: ldc.i4.3
 		IL_0018: conv.r8
 		IL_0019: ldstr "target"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Bind_Metadata_LengthNameAndPrototype_7FBD7116.FunctionObject_FunctionDeclaration_52CA7D48_target>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Bind_Metadata_LengthNameAndPrototype/target/FunctionObject_FunctionDeclaration_52CA7D48_target>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: nop
@@ -395,119 +508,6 @@
 	} // end of method Function_Bind_Metadata_LengthNameAndPrototype::__js_module_init__
 
 } // end of class Modules.Function_Bind_Metadata_LengthNameAndPrototype
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Bind_Metadata_LengthNameAndPrototype_7FBD7116.FunctionObject_FunctionDeclaration_52CA7D48_target
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2430
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_52CA7D48_target::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2438
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_52CA7D48_target::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x243b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_52CA7D48_target::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x243e
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.2
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.Function_Bind_Metadata_LengthNameAndPrototype/target::__js_call__(object, object, object, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionDeclaration_52CA7D48_target::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x245f
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: ldarg.2
-		IL_0010: ldc.i4.2
-		IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0016: call object Modules.Function_Bind_Metadata_LengthNameAndPrototype/target::__js_call__(object, object, object, object)
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionDeclaration_52CA7D48_target::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x247c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_52CA7D48_target::ConstructCore
-
-} // end of class FunctionObjects.Function_Bind_Metadata_LengthNameAndPrototype_7FBD7116.FunctionObject_FunctionDeclaration_52CA7D48_target
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_ThisBinding_IgnoresCallReceiver.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Bind_ThisBinding_IgnoresCallReceiver.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BA5A1879_addBase
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x214d
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_BA5A1879_addBase::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2155
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BA5A1879_addBase::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2158
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BA5A1879_addBase::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x215b
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Function_Bind_ThisBinding_IgnoresCallReceiver/addBase::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_BA5A1879_addBase::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x216e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Function_Bind_ThisBinding_IgnoresCallReceiver/addBase::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BA5A1879_addBase::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x217d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BA5A1879_addBase::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_BA5A1879_addBase
+
 
 		// Methods
 		.method public hidebysig static 
@@ -110,7 +211,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Bind_ThisBinding_IgnoresCallReceiver/Scope,
-			[1] class FunctionObjects.Function_Bind_ThisBinding_IgnoresCallReceiver_72034A6E.FunctionObject_FunctionDeclaration_BA5A1879_addBase,
+			[1] class Modules.Function_Bind_ThisBinding_IgnoresCallReceiver/addBase/FunctionObject_FunctionDeclaration_BA5A1879_addBase,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -128,13 +229,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 5
-		IL_0012: newobj instance void FunctionObjects.Function_Bind_ThisBinding_IgnoresCallReceiver_72034A6E.FunctionObject_FunctionDeclaration_BA5A1879_addBase::.ctor()
+		IL_0012: newobj instance void Modules.Function_Bind_ThisBinding_IgnoresCallReceiver/addBase/FunctionObject_FunctionDeclaration_BA5A1879_addBase::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "addBase"
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Bind_ThisBinding_IgnoresCallReceiver_72034A6E.FunctionObject_FunctionDeclaration_BA5A1879_addBase>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Bind_ThisBinding_IgnoresCallReceiver/addBase/FunctionObject_FunctionDeclaration_BA5A1879_addBase>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: nop
@@ -178,107 +279,6 @@
 	} // end of method Function_Bind_ThisBinding_IgnoresCallReceiver::__js_module_init__
 
 } // end of class Modules.Function_Bind_ThisBinding_IgnoresCallReceiver
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Bind_ThisBinding_IgnoresCallReceiver_72034A6E.FunctionObject_FunctionDeclaration_BA5A1879_addBase
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x214d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_BA5A1879_addBase::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2155
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BA5A1879_addBase::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2158
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BA5A1879_addBase::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x215b
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Function_Bind_ThisBinding_IgnoresCallReceiver/addBase::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_BA5A1879_addBase::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x216e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Function_Bind_ThisBinding_IgnoresCallReceiver/addBase::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BA5A1879_addBase::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x217d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BA5A1879_addBase::ConstructCore
-
-} // end of class FunctionObjects.Function_Bind_ThisBinding_IgnoresCallReceiver_72034A6E.FunctionObject_FunctionDeclaration_BA5A1879_addBase
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallViaVariable_Arity0.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallViaVariable_Arity0.verified.txt
@@ -31,6 +31,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_166E6F4C_getMessage
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x20cc
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_166E6F4C_getMessage::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x20d4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_166E6F4C_getMessage::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x20d7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_166E6F4C_getMessage::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x20da
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Function_CallViaVariable_Arity0/getMessage::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_166E6F4C_getMessage::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x20e6
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Function_CallViaVariable_Arity0/getMessage::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_166E6F4C_getMessage::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x20ee
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_166E6F4C_getMessage::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_166E6F4C_getMessage
+
 
 		// Methods
 		.method public hidebysig static 
@@ -97,8 +192,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_CallViaVariable_Arity0/Scope,
-			[1] class FunctionObjects.Function_CallViaVariable_Arity0_90C7CEBC.FunctionObject_FunctionDeclaration_166E6F4C_getMessage,
-			[2] class FunctionObjects.Function_CallViaVariable_Arity0_90C7CEBC.FunctionObject_FunctionDeclaration_166E6F4C_getMessage,
+			[1] class Modules.Function_CallViaVariable_Arity0/getMessage/FunctionObject_FunctionDeclaration_166E6F4C_getMessage,
+			[2] class Modules.Function_CallViaVariable_Arity0/getMessage/FunctionObject_FunctionDeclaration_166E6F4C_getMessage,
 			[3] object[],
 			[4] object,
 			[5] object
@@ -113,13 +208,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.Function_CallViaVariable_Arity0_90C7CEBC.FunctionObject_FunctionDeclaration_166E6F4C_getMessage::.ctor()
+		IL_0011: newobj instance void Modules.Function_CallViaVariable_Arity0/getMessage/FunctionObject_FunctionDeclaration_166E6F4C_getMessage::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "getMessage"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_CallViaVariable_Arity0_90C7CEBC.FunctionObject_FunctionDeclaration_166E6F4C_getMessage>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallViaVariable_Arity0/getMessage/FunctionObject_FunctionDeclaration_166E6F4C_getMessage>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -142,101 +237,6 @@
 	} // end of method Function_CallViaVariable_Arity0::__js_module_init__
 
 } // end of class Modules.Function_CallViaVariable_Arity0
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_CallViaVariable_Arity0_90C7CEBC.FunctionObject_FunctionDeclaration_166E6F4C_getMessage
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x20cc
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_166E6F4C_getMessage::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x20d4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_166E6F4C_getMessage::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x20d7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_166E6F4C_getMessage::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x20da
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Function_CallViaVariable_Arity0/getMessage::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_166E6F4C_getMessage::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x20e6
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Function_CallViaVariable_Arity0/getMessage::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_166E6F4C_getMessage::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x20ee
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_166E6F4C_getMessage::ConstructCore
-
-} // end of class FunctionObjects.Function_CallViaVariable_Arity0_90C7CEBC.FunctionObject_FunctionDeclaration_166E6F4C_getMessage
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallViaVariable_Arity1.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallViaVariable_Arity1.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CC42596D_addPrefix
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x20f0
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_CC42596D_addPrefix::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x20f8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CC42596D_addPrefix::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x20fb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CC42596D_addPrefix::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x20fe
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Function_CallViaVariable_Arity1/addPrefix::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_CC42596D_addPrefix::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2111
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Function_CallViaVariable_Arity1/addPrefix::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_CC42596D_addPrefix::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2120
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_CC42596D_addPrefix::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_CC42596D_addPrefix
+
 
 		// Methods
 		.method public hidebysig static 
@@ -104,8 +205,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_CallViaVariable_Arity1/Scope,
-			[1] class FunctionObjects.Function_CallViaVariable_Arity1_91C7D04F.FunctionObject_FunctionDeclaration_CC42596D_addPrefix,
-			[2] class FunctionObjects.Function_CallViaVariable_Arity1_91C7D04F.FunctionObject_FunctionDeclaration_CC42596D_addPrefix,
+			[1] class Modules.Function_CallViaVariable_Arity1/addPrefix/FunctionObject_FunctionDeclaration_CC42596D_addPrefix,
+			[2] class Modules.Function_CallViaVariable_Arity1/addPrefix/FunctionObject_FunctionDeclaration_CC42596D_addPrefix,
 			[3] object[],
 			[4] object,
 			[5] object
@@ -120,13 +221,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.Function_CallViaVariable_Arity1_91C7D04F.FunctionObject_FunctionDeclaration_CC42596D_addPrefix::.ctor()
+		IL_0011: newobj instance void Modules.Function_CallViaVariable_Arity1/addPrefix/FunctionObject_FunctionDeclaration_CC42596D_addPrefix::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "addPrefix"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_CallViaVariable_Arity1_91C7D04F.FunctionObject_FunctionDeclaration_CC42596D_addPrefix>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallViaVariable_Arity1/addPrefix/FunctionObject_FunctionDeclaration_CC42596D_addPrefix>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -153,107 +254,6 @@
 	} // end of method Function_CallViaVariable_Arity1::__js_module_init__
 
 } // end of class Modules.Function_CallViaVariable_Arity1
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_CallViaVariable_Arity1_91C7D04F.FunctionObject_FunctionDeclaration_CC42596D_addPrefix
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x20f0
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_CC42596D_addPrefix::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x20f8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CC42596D_addPrefix::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x20fb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CC42596D_addPrefix::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x20fe
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Function_CallViaVariable_Arity1/addPrefix::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_CC42596D_addPrefix::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2111
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Function_CallViaVariable_Arity1/addPrefix::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_CC42596D_addPrefix::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2120
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_CC42596D_addPrefix::ConstructCore
-
-} // end of class FunctionObjects.Function_CallViaVariable_Arity1_91C7D04F.FunctionObject_FunctionDeclaration_CC42596D_addPrefix
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallViaVariable_Arity2.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallViaVariable_Arity2.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5E16C7E8_add
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x20fc
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E16C7E8_add::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2104
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E16C7E8_add::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2107
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E16C7E8_add::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x210a
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Function_CallViaVariable_Arity2/'add'::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E16C7E8_add::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2124
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Function_CallViaVariable_Arity2/'add'::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E16C7E8_add::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x213a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E16C7E8_add::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_5E16C7E8_add
+
 
 		// Methods
 		.method public hidebysig static 
@@ -105,8 +212,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_CallViaVariable_Arity2/Scope,
-			[1] class FunctionObjects.Function_CallViaVariable_Arity2_92C7D1E2.FunctionObject_FunctionDeclaration_5E16C7E8_add,
-			[2] class FunctionObjects.Function_CallViaVariable_Arity2_92C7D1E2.FunctionObject_FunctionDeclaration_5E16C7E8_add,
+			[1] class Modules.Function_CallViaVariable_Arity2/'add'/FunctionObject_FunctionDeclaration_5E16C7E8_add,
+			[2] class Modules.Function_CallViaVariable_Arity2/'add'/FunctionObject_FunctionDeclaration_5E16C7E8_add,
 			[3] object[],
 			[4] object,
 			[5] object
@@ -121,13 +228,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.Function_CallViaVariable_Arity2_92C7D1E2.FunctionObject_FunctionDeclaration_5E16C7E8_add::.ctor()
+		IL_0011: newobj instance void Modules.Function_CallViaVariable_Arity2/'add'/FunctionObject_FunctionDeclaration_5E16C7E8_add::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "add"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_CallViaVariable_Arity2_92C7D1E2.FunctionObject_FunctionDeclaration_5E16C7E8_add>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallViaVariable_Arity2/'add'/FunctionObject_FunctionDeclaration_5E16C7E8_add>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -156,113 +263,6 @@
 	} // end of method Function_CallViaVariable_Arity2::__js_module_init__
 
 } // end of class Modules.Function_CallViaVariable_Arity2
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_CallViaVariable_Arity2_92C7D1E2.FunctionObject_FunctionDeclaration_5E16C7E8_add
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x20fc
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E16C7E8_add::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2104
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E16C7E8_add::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2107
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E16C7E8_add::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x210a
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Function_CallViaVariable_Arity2/'add'::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E16C7E8_add::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2124
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Function_CallViaVariable_Arity2/'add'::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E16C7E8_add::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x213a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E16C7E8_add::ConstructCore
-
-} // end of class FunctionObjects.Function_CallViaVariable_Arity2_92C7D1E2.FunctionObject_FunctionDeclaration_5E16C7E8_add
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallViaVariable_Arity3.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallViaVariable_Arity3.verified.txt
@@ -31,6 +31,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3BEFE3B8_add3
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2110
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_3BEFE3B8_add3::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2118
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3BEFE3B8_add3::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x211b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3BEFE3B8_add3::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x211e
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.2
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.Function_CallViaVariable_Arity3/add3::__js_call__(object, object, object, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionDeclaration_3BEFE3B8_add3::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x213f
+				// Header size: 1
+				// Code size: 28 (0x1c)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: ldarg.2
+				IL_0010: ldc.i4.2
+				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0016: call object Modules.Function_CallViaVariable_Arity3/add3::__js_call__(object, object, object, object)
+				IL_001b: ret
+			} // end of method FunctionObject_FunctionDeclaration_3BEFE3B8_add3::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x215c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3BEFE3B8_add3::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_3BEFE3B8_add3
+
 
 		// Methods
 		.method public hidebysig static 
@@ -110,8 +223,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_CallViaVariable_Arity3/Scope,
-			[1] class FunctionObjects.Function_CallViaVariable_Arity3_93C7D375.FunctionObject_FunctionDeclaration_3BEFE3B8_add3,
-			[2] class FunctionObjects.Function_CallViaVariable_Arity3_93C7D375.FunctionObject_FunctionDeclaration_3BEFE3B8_add3,
+			[1] class Modules.Function_CallViaVariable_Arity3/add3/FunctionObject_FunctionDeclaration_3BEFE3B8_add3,
+			[2] class Modules.Function_CallViaVariable_Arity3/add3/FunctionObject_FunctionDeclaration_3BEFE3B8_add3,
 			[3] object[],
 			[4] object,
 			[5] object
@@ -126,13 +239,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.Function_CallViaVariable_Arity3_93C7D375.FunctionObject_FunctionDeclaration_3BEFE3B8_add3::.ctor()
+		IL_0011: newobj instance void Modules.Function_CallViaVariable_Arity3/add3/FunctionObject_FunctionDeclaration_3BEFE3B8_add3::.ctor()
 		IL_0016: ldc.i4.3
 		IL_0017: conv.r8
 		IL_0018: ldstr "add3"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_CallViaVariable_Arity3_93C7D375.FunctionObject_FunctionDeclaration_3BEFE3B8_add3>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallViaVariable_Arity3/add3/FunctionObject_FunctionDeclaration_3BEFE3B8_add3>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -163,119 +276,6 @@
 	} // end of method Function_CallViaVariable_Arity3::__js_module_init__
 
 } // end of class Modules.Function_CallViaVariable_Arity3
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_CallViaVariable_Arity3_93C7D375.FunctionObject_FunctionDeclaration_3BEFE3B8_add3
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2110
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_3BEFE3B8_add3::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2118
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3BEFE3B8_add3::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x211b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3BEFE3B8_add3::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x211e
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.2
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.Function_CallViaVariable_Arity3/add3::__js_call__(object, object, object, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionDeclaration_3BEFE3B8_add3::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x213f
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: ldarg.2
-		IL_0010: ldc.i4.2
-		IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0016: call object Modules.Function_CallViaVariable_Arity3/add3::__js_call__(object, object, object, object)
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionDeclaration_3BEFE3B8_add3::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x215c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3BEFE3B8_add3::ConstructCore
-
-} // end of class FunctionObjects.Function_CallViaVariable_Arity3_93C7D375.FunctionObject_FunctionDeclaration_3BEFE3B8_add3
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallViaVariable_Arity4.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallViaVariable_Arity4.verified.txt
@@ -31,6 +31,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_242B42C2_add4
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2139
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_242B42C2_add4::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2141
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_242B42C2_add4::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2144
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_242B42C2_add4::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2147
+				// Header size: 1
+				// Code size: 39 (0x27)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.2
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: ldarg.2
+				IL_001b: ldc.i4.3
+				IL_001c: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0021: call object Modules.Function_CallViaVariable_Arity4/add4::__js_call__(object, object, object, object, object)
+				IL_0026: ret
+			} // end of method FunctionObject_FunctionDeclaration_242B42C2_add4::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x216f
+				// Header size: 1
+				// Code size: 35 (0x23)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: ldarg.2
+				IL_0010: ldc.i4.2
+				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0016: ldarg.2
+				IL_0017: ldc.i4.3
+				IL_0018: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001d: call object Modules.Function_CallViaVariable_Arity4/add4::__js_call__(object, object, object, object, object)
+				IL_0022: ret
+			} // end of method FunctionObject_FunctionDeclaration_242B42C2_add4::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2193
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_242B42C2_add4::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_242B42C2_add4
+
 
 		// Methods
 		.method public hidebysig static 
@@ -115,8 +234,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_CallViaVariable_Arity4/Scope,
-			[1] class FunctionObjects.Function_CallViaVariable_Arity4_8CC7C870.FunctionObject_FunctionDeclaration_242B42C2_add4,
-			[2] class FunctionObjects.Function_CallViaVariable_Arity4_8CC7C870.FunctionObject_FunctionDeclaration_242B42C2_add4,
+			[1] class Modules.Function_CallViaVariable_Arity4/add4/FunctionObject_FunctionDeclaration_242B42C2_add4,
+			[2] class Modules.Function_CallViaVariable_Arity4/add4/FunctionObject_FunctionDeclaration_242B42C2_add4,
 			[3] object[],
 			[4] object,
 			[5] object
@@ -131,13 +250,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.Function_CallViaVariable_Arity4_8CC7C870.FunctionObject_FunctionDeclaration_242B42C2_add4::.ctor()
+		IL_0011: newobj instance void Modules.Function_CallViaVariable_Arity4/add4/FunctionObject_FunctionDeclaration_242B42C2_add4::.ctor()
 		IL_0016: ldc.i4.4
 		IL_0017: conv.r8
 		IL_0018: ldstr "add4"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_CallViaVariable_Arity4_8CC7C870.FunctionObject_FunctionDeclaration_242B42C2_add4>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallViaVariable_Arity4/add4/FunctionObject_FunctionDeclaration_242B42C2_add4>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -184,125 +303,6 @@
 	} // end of method Function_CallViaVariable_Arity4::__js_module_init__
 
 } // end of class Modules.Function_CallViaVariable_Arity4
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_CallViaVariable_Arity4_8CC7C870.FunctionObject_FunctionDeclaration_242B42C2_add4
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2139
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_242B42C2_add4::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2141
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_242B42C2_add4::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2144
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_242B42C2_add4::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2147
-		// Header size: 1
-		// Code size: 39 (0x27)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.2
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: ldarg.2
-		IL_001b: ldc.i4.3
-		IL_001c: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0021: call object Modules.Function_CallViaVariable_Arity4/add4::__js_call__(object, object, object, object, object)
-		IL_0026: ret
-	} // end of method FunctionObject_FunctionDeclaration_242B42C2_add4::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x216f
-		// Header size: 1
-		// Code size: 35 (0x23)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: ldarg.2
-		IL_0010: ldc.i4.2
-		IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0016: ldarg.2
-		IL_0017: ldc.i4.3
-		IL_0018: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001d: call object Modules.Function_CallViaVariable_Arity4/add4::__js_call__(object, object, object, object, object)
-		IL_0022: ret
-	} // end of method FunctionObject_FunctionDeclaration_242B42C2_add4::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2193
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_242B42C2_add4::ConstructCore
-
-} // end of class FunctionObjects.Function_CallViaVariable_Arity4_8CC7C870.FunctionObject_FunctionDeclaration_242B42C2_add4
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Basic.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4E156218_f
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2131
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_4E156218_f::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2139
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4E156218_f::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x213c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4E156218_f::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x213f
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Function_Call_Basic/f::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_4E156218_f::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2159
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Function_Call_Basic/f::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_4E156218_f::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x216f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4E156218_f::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_4E156218_f
+
 
 		// Methods
 		.method public hidebysig static 
@@ -122,7 +229,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Basic/Scope,
-			[1] class FunctionObjects.Function_Call_Basic_23A91D0B.FunctionObject_FunctionDeclaration_4E156218_f,
+			[1] class Modules.Function_Call_Basic/f/FunctionObject_FunctionDeclaration_4E156218_f,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object[],
 			[4] object,
@@ -138,13 +245,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.Function_Call_Basic_23A91D0B.FunctionObject_FunctionDeclaration_4E156218_f::.ctor()
+		IL_0011: newobj instance void Modules.Function_Call_Basic/f/FunctionObject_FunctionDeclaration_4E156218_f::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "f"
 		IL_001d: ldc.i4.1
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Call_Basic_23A91D0B.FunctionObject_FunctionDeclaration_4E156218_f>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Call_Basic/f/FunctionObject_FunctionDeclaration_4E156218_f>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -174,113 +281,6 @@
 	} // end of method Function_Call_Basic::__js_module_init__
 
 } // end of class Modules.Function_Call_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Call_Basic_23A91D0B.FunctionObject_FunctionDeclaration_4E156218_f
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2131
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_4E156218_f::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2139
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4E156218_f::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x213c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4E156218_f::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x213f
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Function_Call_Basic/f::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_4E156218_f::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2159
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Function_Call_Basic/f::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_4E156218_f::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x216f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4E156218_f::ConstructCore
-
-} // end of class FunctionObjects.Function_Call_Basic_23A91D0B.FunctionObject_FunctionDeclaration_4E156218_f
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Basic.verified.txt
@@ -80,6 +80,113 @@
 
 		} // end of class Scope_For_L5C9
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_220DAEBA_dump
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_Call_Spread_Basic/Scope _environment0_Function_Call_Spread_Basic
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_Call_Spread_Basic/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21c6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_Call_Spread_Basic/Scope Modules.Function_Call_Spread_Basic/dump/FunctionObject_FunctionDeclaration_220DAEBA_dump::_environment0_Function_Call_Spread_Basic
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_220DAEBA_dump::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21d5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_220DAEBA_dump::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21d8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_220DAEBA_dump::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21db
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_Call_Spread_Basic/Scope Modules.Function_Call_Spread_Basic/dump/FunctionObject_FunctionDeclaration_220DAEBA_dump::_environment0_Function_Call_Spread_Basic
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_Call_Spread_Basic/dump::__js_call__(class Modules.Function_Call_Spread_Basic/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_220DAEBA_dump::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21ed
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_Call_Spread_Basic/Scope Modules.Function_Call_Spread_Basic/dump/FunctionObject_FunctionDeclaration_220DAEBA_dump::_environment0_Function_Call_Spread_Basic
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_Call_Spread_Basic/dump::__js_call__(class Modules.Function_Call_Spread_Basic/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_220DAEBA_dump::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21fb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_220DAEBA_dump::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_220DAEBA_dump
+
 
 		// Methods
 		.method public hidebysig static 
@@ -215,7 +322,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Spread_Basic/Scope,
-			[1] class FunctionObjects.Function_Call_Spread_Basic_D7449949.FunctionObject_FunctionDeclaration_220DAEBA_dump,
+			[1] class Modules.Function_Call_Spread_Basic/dump/FunctionObject_FunctionDeclaration_220DAEBA_dump,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] object[],
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -235,13 +342,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_Call_Spread_Basic/Scope
-		IL_0019: newobj instance void FunctionObjects.Function_Call_Spread_Basic_D7449949.FunctionObject_FunctionDeclaration_220DAEBA_dump::.ctor(class Modules.Function_Call_Spread_Basic/Scope)
+		IL_0019: newobj instance void Modules.Function_Call_Spread_Basic/dump/FunctionObject_FunctionDeclaration_220DAEBA_dump::.ctor(class Modules.Function_Call_Spread_Basic/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "dump"
 		IL_0025: ldc.i4.1
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Call_Spread_Basic_D7449949.FunctionObject_FunctionDeclaration_220DAEBA_dump>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Call_Spread_Basic/dump/FunctionObject_FunctionDeclaration_220DAEBA_dump>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
@@ -277,113 +384,6 @@
 	} // end of method Function_Call_Spread_Basic::__js_module_init__
 
 } // end of class Modules.Function_Call_Spread_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Call_Spread_Basic_D7449949.FunctionObject_FunctionDeclaration_220DAEBA_dump
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_Call_Spread_Basic/Scope _environment0_Function_Call_Spread_Basic
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_Call_Spread_Basic/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21c6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_Call_Spread_Basic/Scope FunctionObjects.Function_Call_Spread_Basic_D7449949.FunctionObject_FunctionDeclaration_220DAEBA_dump::_environment0_Function_Call_Spread_Basic
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_220DAEBA_dump::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21d5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_220DAEBA_dump::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21d8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_220DAEBA_dump::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21db
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_Call_Spread_Basic/Scope FunctionObjects.Function_Call_Spread_Basic_D7449949.FunctionObject_FunctionDeclaration_220DAEBA_dump::_environment0_Function_Call_Spread_Basic
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_Call_Spread_Basic/dump::__js_call__(class Modules.Function_Call_Spread_Basic/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_220DAEBA_dump::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ed
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_Call_Spread_Basic/Scope FunctionObjects.Function_Call_Spread_Basic_D7449949.FunctionObject_FunctionDeclaration_220DAEBA_dump::_environment0_Function_Call_Spread_Basic
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_Call_Spread_Basic/dump::__js_call__(class Modules.Function_Call_Spread_Basic/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_220DAEBA_dump::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21fb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_220DAEBA_dump::ConstructCore
-
-} // end of class FunctionObjects.Function_Call_Spread_Basic_D7449949.FunctionObject_FunctionDeclaration_220DAEBA_dump
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_EvaluationOrder.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_EvaluationOrder.verified.txt
@@ -80,6 +80,113 @@
 
 		} // end of class Scope_For_L5C9
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DC7F3656_dump
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_Call_Spread_EvaluationOrder/Scope _environment0_Function_Call_Spread_EvaluationOrder
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_Call_Spread_EvaluationOrder/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x22d2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_Call_Spread_EvaluationOrder/Scope Modules.Function_Call_Spread_EvaluationOrder/dump/FunctionObject_FunctionDeclaration_DC7F3656_dump::_environment0_Function_Call_Spread_EvaluationOrder
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DC7F3656_dump::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22e1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DC7F3656_dump::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22e4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DC7F3656_dump::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22e7
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_Call_Spread_EvaluationOrder/Scope Modules.Function_Call_Spread_EvaluationOrder/dump/FunctionObject_FunctionDeclaration_DC7F3656_dump::_environment0_Function_Call_Spread_EvaluationOrder
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_Call_Spread_EvaluationOrder/dump::__js_call__(class Modules.Function_Call_Spread_EvaluationOrder/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_DC7F3656_dump::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22f9
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_Call_Spread_EvaluationOrder/Scope Modules.Function_Call_Spread_EvaluationOrder/dump/FunctionObject_FunctionDeclaration_DC7F3656_dump::_environment0_Function_Call_Spread_EvaluationOrder
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_Call_Spread_EvaluationOrder/dump::__js_call__(class Modules.Function_Call_Spread_EvaluationOrder/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_DC7F3656_dump::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2307
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DC7F3656_dump::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_DC7F3656_dump
+
 
 		// Methods
 		.method public hidebysig static 
@@ -195,6 +302,109 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E6190FBC_arg
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2316
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6190FBC_arg::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x231e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6190FBC_arg::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2321
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6190FBC_arg::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2324
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: call object Modules.Function_Call_Spread_EvaluationOrder/arg::__js_call__(object, float64)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6190FBC_arg::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x233c
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: call object Modules.Function_Call_Spread_EvaluationOrder/arg::__js_call__(object, float64)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6190FBC_arg::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2350
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6190FBC_arg::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E6190FBC_arg
+
 
 		// Methods
 		.method public hidebysig static 
@@ -258,6 +468,101 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5C3E7DAF_spread
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x235f
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_5C3E7DAF_spread::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2367
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5C3E7DAF_spread::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x236a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5C3E7DAF_spread::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x236d
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_Call_Spread_EvaluationOrder/spread::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_5C3E7DAF_spread::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2379
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_Call_Spread_EvaluationOrder/spread::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_5C3E7DAF_spread::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2381
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5C3E7DAF_spread::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_5C3E7DAF_spread
 
 
 		// Methods
@@ -342,9 +647,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Spread_EvaluationOrder/Scope,
-			[1] class FunctionObjects.Function_Call_Spread_EvaluationOrder_CBE2DB1D.FunctionObject_FunctionDeclaration_DC7F3656_dump,
-			[2] class FunctionObjects.Function_Call_Spread_EvaluationOrder_CBE2DB1D.FunctionObject_FunctionDeclaration_E6190FBC_arg,
-			[3] class FunctionObjects.Function_Call_Spread_EvaluationOrder_CBE2DB1D.FunctionObject_FunctionDeclaration_5C3E7DAF_spread,
+			[1] class Modules.Function_Call_Spread_EvaluationOrder/dump/FunctionObject_FunctionDeclaration_DC7F3656_dump,
+			[2] class Modules.Function_Call_Spread_EvaluationOrder/arg/FunctionObject_FunctionDeclaration_E6190FBC_arg,
+			[3] class Modules.Function_Call_Spread_EvaluationOrder/spread/FunctionObject_FunctionDeclaration_5C3E7DAF_spread,
 			[4] object[],
 			[5] object[],
 			[6] object,
@@ -364,13 +669,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Function_Call_Spread_EvaluationOrder/Scope
-		IL_001b: newobj instance void FunctionObjects.Function_Call_Spread_EvaluationOrder_CBE2DB1D.FunctionObject_FunctionDeclaration_DC7F3656_dump::.ctor(class Modules.Function_Call_Spread_EvaluationOrder/Scope)
+		IL_001b: newobj instance void Modules.Function_Call_Spread_EvaluationOrder/dump/FunctionObject_FunctionDeclaration_DC7F3656_dump::.ctor(class Modules.Function_Call_Spread_EvaluationOrder/Scope)
 		IL_0020: ldc.i4.0
 		IL_0021: conv.r8
 		IL_0022: ldstr "dump"
 		IL_0027: ldc.i4.1
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Call_Spread_EvaluationOrder_CBE2DB1D.FunctionObject_FunctionDeclaration_DC7F3656_dump>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Call_Spread_EvaluationOrder/dump/FunctionObject_FunctionDeclaration_DC7F3656_dump>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: ldc.i4.1
 		IL_0030: newarr [System.Runtime]System.Object
@@ -379,13 +684,13 @@
 		IL_0037: ldloc.0
 		IL_0038: stelem.ref
 		IL_0039: stloc.s 4
-		IL_003b: newobj instance void FunctionObjects.Function_Call_Spread_EvaluationOrder_CBE2DB1D.FunctionObject_FunctionDeclaration_E6190FBC_arg::.ctor()
+		IL_003b: newobj instance void Modules.Function_Call_Spread_EvaluationOrder/arg/FunctionObject_FunctionDeclaration_E6190FBC_arg::.ctor()
 		IL_0040: ldc.i4.1
 		IL_0041: conv.r8
 		IL_0042: ldstr "arg"
 		IL_0047: ldc.i4.0
 		IL_0048: ldc.i4.1
-		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Call_Spread_EvaluationOrder_CBE2DB1D.FunctionObject_FunctionDeclaration_E6190FBC_arg>(!!0, float64, string, bool, bool)
+		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Call_Spread_EvaluationOrder/arg/FunctionObject_FunctionDeclaration_E6190FBC_arg>(!!0, float64, string, bool, bool)
 		IL_004e: stloc.2
 		IL_004f: ldc.i4.1
 		IL_0050: newarr [System.Runtime]System.Object
@@ -394,13 +699,13 @@
 		IL_0057: ldloc.0
 		IL_0058: stelem.ref
 		IL_0059: stloc.s 4
-		IL_005b: newobj instance void FunctionObjects.Function_Call_Spread_EvaluationOrder_CBE2DB1D.FunctionObject_FunctionDeclaration_5C3E7DAF_spread::.ctor()
+		IL_005b: newobj instance void Modules.Function_Call_Spread_EvaluationOrder/spread/FunctionObject_FunctionDeclaration_5C3E7DAF_spread::.ctor()
 		IL_0060: ldc.i4.0
 		IL_0061: conv.r8
 		IL_0062: ldstr "spread"
 		IL_0067: ldc.i4.0
 		IL_0068: ldc.i4.1
-		IL_0069: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Call_Spread_EvaluationOrder_CBE2DB1D.FunctionObject_FunctionDeclaration_5C3E7DAF_spread>(!!0, float64, string, bool, bool)
+		IL_0069: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Call_Spread_EvaluationOrder/spread/FunctionObject_FunctionDeclaration_5C3E7DAF_spread>(!!0, float64, string, bool, bool)
 		IL_006e: stloc.3
 		IL_006f: nop
 		IL_0070: nop
@@ -452,311 +757,6 @@
 	} // end of method Function_Call_Spread_EvaluationOrder::__js_module_init__
 
 } // end of class Modules.Function_Call_Spread_EvaluationOrder
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Call_Spread_EvaluationOrder_CBE2DB1D.FunctionObject_FunctionDeclaration_DC7F3656_dump
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_Call_Spread_EvaluationOrder/Scope _environment0_Function_Call_Spread_EvaluationOrder
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_Call_Spread_EvaluationOrder/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x22d2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_Call_Spread_EvaluationOrder/Scope FunctionObjects.Function_Call_Spread_EvaluationOrder_CBE2DB1D.FunctionObject_FunctionDeclaration_DC7F3656_dump::_environment0_Function_Call_Spread_EvaluationOrder
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DC7F3656_dump::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22e1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DC7F3656_dump::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22e4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DC7F3656_dump::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22e7
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_Call_Spread_EvaluationOrder/Scope FunctionObjects.Function_Call_Spread_EvaluationOrder_CBE2DB1D.FunctionObject_FunctionDeclaration_DC7F3656_dump::_environment0_Function_Call_Spread_EvaluationOrder
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_Call_Spread_EvaluationOrder/dump::__js_call__(class Modules.Function_Call_Spread_EvaluationOrder/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_DC7F3656_dump::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22f9
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_Call_Spread_EvaluationOrder/Scope FunctionObjects.Function_Call_Spread_EvaluationOrder_CBE2DB1D.FunctionObject_FunctionDeclaration_DC7F3656_dump::_environment0_Function_Call_Spread_EvaluationOrder
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_Call_Spread_EvaluationOrder/dump::__js_call__(class Modules.Function_Call_Spread_EvaluationOrder/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_DC7F3656_dump::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2307
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DC7F3656_dump::ConstructCore
-
-} // end of class FunctionObjects.Function_Call_Spread_EvaluationOrder_CBE2DB1D.FunctionObject_FunctionDeclaration_DC7F3656_dump
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Call_Spread_EvaluationOrder_CBE2DB1D.FunctionObject_FunctionDeclaration_E6190FBC_arg
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2316
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6190FBC_arg::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x231e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6190FBC_arg::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2321
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6190FBC_arg::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2324
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: call object Modules.Function_Call_Spread_EvaluationOrder/arg::__js_call__(object, float64)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6190FBC_arg::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x233c
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: call object Modules.Function_Call_Spread_EvaluationOrder/arg::__js_call__(object, float64)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6190FBC_arg::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2350
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6190FBC_arg::ConstructCore
-
-} // end of class FunctionObjects.Function_Call_Spread_EvaluationOrder_CBE2DB1D.FunctionObject_FunctionDeclaration_E6190FBC_arg
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Call_Spread_EvaluationOrder_CBE2DB1D.FunctionObject_FunctionDeclaration_5C3E7DAF_spread
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x235f
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_5C3E7DAF_spread::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2367
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5C3E7DAF_spread::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x236a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5C3E7DAF_spread::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x236d
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_Call_Spread_EvaluationOrder/spread::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_5C3E7DAF_spread::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2379
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_Call_Spread_EvaluationOrder/spread::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_5C3E7DAF_spread::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2381
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5C3E7DAF_spread::ConstructCore
-
-} // end of class FunctionObjects.Function_Call_Spread_EvaluationOrder_CBE2DB1D.FunctionObject_FunctionDeclaration_5C3E7DAF_spread
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Middle.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Middle.verified.txt
@@ -80,6 +80,113 @@
 
 		} // end of class Scope_For_L5C9
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_93D49E1D_dump
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_Call_Spread_Middle/Scope _environment0_Function_Call_Spread_Middle
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_Call_Spread_Middle/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21d2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_Call_Spread_Middle/Scope Modules.Function_Call_Spread_Middle/dump/FunctionObject_FunctionDeclaration_93D49E1D_dump::_environment0_Function_Call_Spread_Middle
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_93D49E1D_dump::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21e1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_93D49E1D_dump::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21e4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_93D49E1D_dump::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21e7
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_Call_Spread_Middle/Scope Modules.Function_Call_Spread_Middle/dump/FunctionObject_FunctionDeclaration_93D49E1D_dump::_environment0_Function_Call_Spread_Middle
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_Call_Spread_Middle/dump::__js_call__(class Modules.Function_Call_Spread_Middle/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_93D49E1D_dump::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f9
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_Call_Spread_Middle/Scope Modules.Function_Call_Spread_Middle/dump/FunctionObject_FunctionDeclaration_93D49E1D_dump::_environment0_Function_Call_Spread_Middle
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_Call_Spread_Middle/dump::__js_call__(class Modules.Function_Call_Spread_Middle/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_93D49E1D_dump::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2207
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_93D49E1D_dump::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_93D49E1D_dump
+
 
 		// Methods
 		.method public hidebysig static 
@@ -215,7 +322,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Spread_Middle/Scope,
-			[1] class FunctionObjects.Function_Call_Spread_Middle_7C290CE4.FunctionObject_FunctionDeclaration_93D49E1D_dump,
+			[1] class Modules.Function_Call_Spread_Middle/dump/FunctionObject_FunctionDeclaration_93D49E1D_dump,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -235,13 +342,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_Call_Spread_Middle/Scope
-		IL_0019: newobj instance void FunctionObjects.Function_Call_Spread_Middle_7C290CE4.FunctionObject_FunctionDeclaration_93D49E1D_dump::.ctor(class Modules.Function_Call_Spread_Middle/Scope)
+		IL_0019: newobj instance void Modules.Function_Call_Spread_Middle/dump/FunctionObject_FunctionDeclaration_93D49E1D_dump::.ctor(class Modules.Function_Call_Spread_Middle/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "dump"
 		IL_0025: ldc.i4.1
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Call_Spread_Middle_7C290CE4.FunctionObject_FunctionDeclaration_93D49E1D_dump>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Call_Spread_Middle/dump/FunctionObject_FunctionDeclaration_93D49E1D_dump>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
@@ -280,113 +387,6 @@
 	} // end of method Function_Call_Spread_Middle::__js_module_init__
 
 } // end of class Modules.Function_Call_Spread_Middle
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Call_Spread_Middle_7C290CE4.FunctionObject_FunctionDeclaration_93D49E1D_dump
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_Call_Spread_Middle/Scope _environment0_Function_Call_Spread_Middle
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_Call_Spread_Middle/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21d2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_Call_Spread_Middle/Scope FunctionObjects.Function_Call_Spread_Middle_7C290CE4.FunctionObject_FunctionDeclaration_93D49E1D_dump::_environment0_Function_Call_Spread_Middle
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_93D49E1D_dump::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21e1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_93D49E1D_dump::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21e4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_93D49E1D_dump::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21e7
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_Call_Spread_Middle/Scope FunctionObjects.Function_Call_Spread_Middle_7C290CE4.FunctionObject_FunctionDeclaration_93D49E1D_dump::_environment0_Function_Call_Spread_Middle
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_Call_Spread_Middle/dump::__js_call__(class Modules.Function_Call_Spread_Middle/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_93D49E1D_dump::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f9
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_Call_Spread_Middle/Scope FunctionObjects.Function_Call_Spread_Middle_7C290CE4.FunctionObject_FunctionDeclaration_93D49E1D_dump::_environment0_Function_Call_Spread_Middle
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_Call_Spread_Middle/dump::__js_call__(class Modules.Function_Call_Spread_Middle/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_93D49E1D_dump::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2207
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_93D49E1D_dump::ConstructCore
-
-} // end of class FunctionObjects.Function_Call_Spread_Middle_7C290CE4.FunctionObject_FunctionDeclaration_93D49E1D_dump
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Multiple.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_Multiple.verified.txt
@@ -80,6 +80,113 @@
 
 		} // end of class Scope_For_L5C9
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_27CD1BFE_dump
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_Call_Spread_Multiple/Scope _environment0_Function_Call_Spread_Multiple
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_Call_Spread_Multiple/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21e2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_Call_Spread_Multiple/Scope Modules.Function_Call_Spread_Multiple/dump/FunctionObject_FunctionDeclaration_27CD1BFE_dump::_environment0_Function_Call_Spread_Multiple
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_27CD1BFE_dump::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21f1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_27CD1BFE_dump::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21f4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_27CD1BFE_dump::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f7
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_Call_Spread_Multiple/Scope Modules.Function_Call_Spread_Multiple/dump/FunctionObject_FunctionDeclaration_27CD1BFE_dump::_environment0_Function_Call_Spread_Multiple
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_Call_Spread_Multiple/dump::__js_call__(class Modules.Function_Call_Spread_Multiple/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_27CD1BFE_dump::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2209
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_Call_Spread_Multiple/Scope Modules.Function_Call_Spread_Multiple/dump/FunctionObject_FunctionDeclaration_27CD1BFE_dump::_environment0_Function_Call_Spread_Multiple
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_Call_Spread_Multiple/dump::__js_call__(class Modules.Function_Call_Spread_Multiple/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_27CD1BFE_dump::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2217
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_27CD1BFE_dump::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_27CD1BFE_dump
+
 
 		// Methods
 		.method public hidebysig static 
@@ -215,7 +322,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Spread_Multiple/Scope,
-			[1] class FunctionObjects.Function_Call_Spread_Multiple_B38DBD65.FunctionObject_FunctionDeclaration_27CD1BFE_dump,
+			[1] class Modules.Function_Call_Spread_Multiple/dump/FunctionObject_FunctionDeclaration_27CD1BFE_dump,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -235,13 +342,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_Call_Spread_Multiple/Scope
-		IL_0019: newobj instance void FunctionObjects.Function_Call_Spread_Multiple_B38DBD65.FunctionObject_FunctionDeclaration_27CD1BFE_dump::.ctor(class Modules.Function_Call_Spread_Multiple/Scope)
+		IL_0019: newobj instance void Modules.Function_Call_Spread_Multiple/dump/FunctionObject_FunctionDeclaration_27CD1BFE_dump::.ctor(class Modules.Function_Call_Spread_Multiple/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "dump"
 		IL_0025: ldc.i4.1
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Call_Spread_Multiple_B38DBD65.FunctionObject_FunctionDeclaration_27CD1BFE_dump>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Call_Spread_Multiple/dump/FunctionObject_FunctionDeclaration_27CD1BFE_dump>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
@@ -286,113 +393,6 @@
 	} // end of method Function_Call_Spread_Multiple::__js_module_init__
 
 } // end of class Modules.Function_Call_Spread_Multiple
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Call_Spread_Multiple_B38DBD65.FunctionObject_FunctionDeclaration_27CD1BFE_dump
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_Call_Spread_Multiple/Scope _environment0_Function_Call_Spread_Multiple
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_Call_Spread_Multiple/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21e2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_Call_Spread_Multiple/Scope FunctionObjects.Function_Call_Spread_Multiple_B38DBD65.FunctionObject_FunctionDeclaration_27CD1BFE_dump::_environment0_Function_Call_Spread_Multiple
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_27CD1BFE_dump::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21f1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_27CD1BFE_dump::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21f4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_27CD1BFE_dump::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f7
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_Call_Spread_Multiple/Scope FunctionObjects.Function_Call_Spread_Multiple_B38DBD65.FunctionObject_FunctionDeclaration_27CD1BFE_dump::_environment0_Function_Call_Spread_Multiple
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_Call_Spread_Multiple/dump::__js_call__(class Modules.Function_Call_Spread_Multiple/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_27CD1BFE_dump::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2209
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_Call_Spread_Multiple/Scope FunctionObjects.Function_Call_Spread_Multiple_B38DBD65.FunctionObject_FunctionDeclaration_27CD1BFE_dump::_environment0_Function_Call_Spread_Multiple
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_Call_Spread_Multiple/dump::__js_call__(class Modules.Function_Call_Spread_Multiple/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_27CD1BFE_dump::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2217
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_27CD1BFE_dump::ConstructCore
-
-} // end of class FunctionObjects.Function_Call_Spread_Multiple_B38DBD65.FunctionObject_FunctionDeclaration_27CD1BFE_dump
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_StringIterable.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Call_Spread_StringIterable.verified.txt
@@ -80,6 +80,113 @@
 
 		} // end of class Scope_For_L5C9
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_ED7BED17_dump
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_Call_Spread_StringIterable/Scope _environment0_Function_Call_Spread_StringIterable
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_Call_Spread_StringIterable/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2192
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_Call_Spread_StringIterable/Scope Modules.Function_Call_Spread_StringIterable/dump/FunctionObject_FunctionDeclaration_ED7BED17_dump::_environment0_Function_Call_Spread_StringIterable
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_ED7BED17_dump::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21a1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_ED7BED17_dump::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21a4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_ED7BED17_dump::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21a7
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_Call_Spread_StringIterable/Scope Modules.Function_Call_Spread_StringIterable/dump/FunctionObject_FunctionDeclaration_ED7BED17_dump::_environment0_Function_Call_Spread_StringIterable
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_Call_Spread_StringIterable/dump::__js_call__(class Modules.Function_Call_Spread_StringIterable/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_ED7BED17_dump::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21b9
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_Call_Spread_StringIterable/Scope Modules.Function_Call_Spread_StringIterable/dump/FunctionObject_FunctionDeclaration_ED7BED17_dump::_environment0_Function_Call_Spread_StringIterable
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_Call_Spread_StringIterable/dump::__js_call__(class Modules.Function_Call_Spread_StringIterable/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_ED7BED17_dump::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21c7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_ED7BED17_dump::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_ED7BED17_dump
+
 
 		// Methods
 		.method public hidebysig static 
@@ -215,7 +322,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Call_Spread_StringIterable/Scope,
-			[1] class FunctionObjects.Function_Call_Spread_StringIterable_10CFDDA6.FunctionObject_FunctionDeclaration_ED7BED17_dump,
+			[1] class Modules.Function_Call_Spread_StringIterable/dump/FunctionObject_FunctionDeclaration_ED7BED17_dump,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[4] object[]
@@ -234,13 +341,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_Call_Spread_StringIterable/Scope
-		IL_0019: newobj instance void FunctionObjects.Function_Call_Spread_StringIterable_10CFDDA6.FunctionObject_FunctionDeclaration_ED7BED17_dump::.ctor(class Modules.Function_Call_Spread_StringIterable/Scope)
+		IL_0019: newobj instance void Modules.Function_Call_Spread_StringIterable/dump/FunctionObject_FunctionDeclaration_ED7BED17_dump::.ctor(class Modules.Function_Call_Spread_StringIterable/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "dump"
 		IL_0025: ldc.i4.1
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Call_Spread_StringIterable_10CFDDA6.FunctionObject_FunctionDeclaration_ED7BED17_dump>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Call_Spread_StringIterable/dump/FunctionObject_FunctionDeclaration_ED7BED17_dump>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
@@ -264,113 +371,6 @@
 	} // end of method Function_Call_Spread_StringIterable::__js_module_init__
 
 } // end of class Modules.Function_Call_Spread_StringIterable
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Call_Spread_StringIterable_10CFDDA6.FunctionObject_FunctionDeclaration_ED7BED17_dump
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_Call_Spread_StringIterable/Scope _environment0_Function_Call_Spread_StringIterable
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_Call_Spread_StringIterable/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2192
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_Call_Spread_StringIterable/Scope FunctionObjects.Function_Call_Spread_StringIterable_10CFDDA6.FunctionObject_FunctionDeclaration_ED7BED17_dump::_environment0_Function_Call_Spread_StringIterable
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_ED7BED17_dump::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21a1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_ED7BED17_dump::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21a4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_ED7BED17_dump::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21a7
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_Call_Spread_StringIterable/Scope FunctionObjects.Function_Call_Spread_StringIterable_10CFDDA6.FunctionObject_FunctionDeclaration_ED7BED17_dump::_environment0_Function_Call_Spread_StringIterable
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_Call_Spread_StringIterable/dump::__js_call__(class Modules.Function_Call_Spread_StringIterable/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_ED7BED17_dump::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21b9
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_Call_Spread_StringIterable/Scope FunctionObjects.Function_Call_Spread_StringIterable_10CFDDA6.FunctionObject_FunctionDeclaration_ED7BED17_dump::_environment0_Function_Call_Spread_StringIterable
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_Call_Spread_StringIterable/dump::__js_call__(class Modules.Function_Call_Spread_StringIterable/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_ED7BED17_dump::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21c7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_ED7BED17_dump::ConstructCore
-
-} // end of class FunctionObjects.Function_Call_Spread_StringIterable_10CFDDA6.FunctionObject_FunctionDeclaration_ED7BED17_dump
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallableArchitecture_InferredSignatureBaseline.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_CallableArchitecture_InferredSignatureBaseline.verified.txt
@@ -31,6 +31,103 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C1F8729A_returnNumber
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x231f
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_C1F8729A_returnNumber::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2327
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C1F8729A_returnNumber::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x232a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C1F8729A_returnNumber::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x232d
+				// Header size: 1
+				// Code size: 16 (0x10)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call float64 Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnNumber::__js_call__(object)
+				IL_000a: box [System.Runtime]System.Double
+				IL_000f: ret
+			} // end of method FunctionObject_FunctionDeclaration_C1F8729A_returnNumber::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x233e
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call float64 Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnNumber::__js_call__(object)
+				IL_0006: box [System.Runtime]System.Double
+				IL_000b: ret
+			} // end of method FunctionObject_FunctionDeclaration_C1F8729A_returnNumber::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x234b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C1F8729A_returnNumber::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C1F8729A_returnNumber
+
 
 		// Methods
 		.method public hidebysig static 
@@ -75,6 +172,101 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_81A3E649_returnBoolean
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x235a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_81A3E649_returnBoolean::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2362
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_81A3E649_returnBoolean::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2365
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_81A3E649_returnBoolean::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2368
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnBoolean::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_81A3E649_returnBoolean::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2374
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnBoolean::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_81A3E649_returnBoolean::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x237c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_81A3E649_returnBoolean::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_81A3E649_returnBoolean
 
 
 		// Methods
@@ -121,6 +313,109 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_35A8CC1F_negate
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x238b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_35A8CC1F_negate::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2393
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_35A8CC1F_negate::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2396
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_35A8CC1F_negate::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2399
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0011: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/negate::__js_call__(object, bool)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_35A8CC1F_negate::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23b1
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_000d: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/negate::__js_call__(object, bool)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_35A8CC1F_negate::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23c5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_35A8CC1F_negate::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_35A8CC1F_negate
 
 
 		// Methods
@@ -176,6 +471,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_743E93DE_returnString
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x23d4
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_743E93DE_returnString::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x23dc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_743E93DE_returnString::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x23df
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_743E93DE_returnString::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x23e2
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnString::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_743E93DE_returnString::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23ee
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnString::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_743E93DE_returnString::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23f6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_743E93DE_returnString::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_743E93DE_returnString
+
 
 		// Methods
 		.method public hidebysig static 
@@ -220,6 +610,109 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_192564F0_stringLength
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2405
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_192564F0_stringLength::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x240d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_192564F0_stringLength::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2410
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_192564F0_stringLength::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2413
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0011: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/stringLength::__js_call__(object, string)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_192564F0_stringLength::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x242b
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/stringLength::__js_call__(object, string)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_192564F0_stringLength::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x243f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_192564F0_stringLength::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_192564F0_stringLength
 
 
 		// Methods
@@ -269,6 +762,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_960EA86F_identity
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x244e
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_960EA86F_identity::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2456
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_960EA86F_identity::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2459
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_960EA86F_identity::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x245c
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/identity::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_960EA86F_identity::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x246f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/identity::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_960EA86F_identity::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x247e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_960EA86F_identity::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_960EA86F_identity
 
 
 		// Methods
@@ -350,12 +944,12 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_CallableArchitecture_InferredSignatureBaseline/Scope,
-			[1] class FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_C1F8729A_returnNumber,
-			[2] class FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_81A3E649_returnBoolean,
-			[3] class FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_35A8CC1F_negate,
-			[4] class FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_743E93DE_returnString,
-			[5] class FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_192564F0_stringLength,
-			[6] class FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_960EA86F_identity,
+			[1] class Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnNumber/FunctionObject_FunctionDeclaration_C1F8729A_returnNumber,
+			[2] class Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnBoolean/FunctionObject_FunctionDeclaration_81A3E649_returnBoolean,
+			[3] class Modules.Function_CallableArchitecture_InferredSignatureBaseline/negate/FunctionObject_FunctionDeclaration_35A8CC1F_negate,
+			[4] class Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnString/FunctionObject_FunctionDeclaration_743E93DE_returnString,
+			[5] class Modules.Function_CallableArchitecture_InferredSignatureBaseline/stringLength/FunctionObject_FunctionDeclaration_192564F0_stringLength,
+			[6] class Modules.Function_CallableArchitecture_InferredSignatureBaseline/identity/FunctionObject_FunctionDeclaration_960EA86F_identity,
 			[7] object[],
 			[8] object,
 			[9] object
@@ -370,13 +964,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 7
-		IL_0012: newobj instance void FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_C1F8729A_returnNumber::.ctor()
+		IL_0012: newobj instance void Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnNumber/FunctionObject_FunctionDeclaration_C1F8729A_returnNumber::.ctor()
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "returnNumber"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_C1F8729A_returnNumber>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnNumber/FunctionObject_FunctionDeclaration_C1F8729A_returnNumber>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -385,13 +979,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 7
-		IL_0032: newobj instance void FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_81A3E649_returnBoolean::.ctor()
+		IL_0032: newobj instance void Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnBoolean/FunctionObject_FunctionDeclaration_81A3E649_returnBoolean::.ctor()
 		IL_0037: ldc.i4.0
 		IL_0038: conv.r8
 		IL_0039: ldstr "returnBoolean"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_81A3E649_returnBoolean>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnBoolean/FunctionObject_FunctionDeclaration_81A3E649_returnBoolean>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -400,13 +994,13 @@
 		IL_004e: ldloc.0
 		IL_004f: stelem.ref
 		IL_0050: stloc.s 7
-		IL_0052: newobj instance void FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_35A8CC1F_negate::.ctor()
+		IL_0052: newobj instance void Modules.Function_CallableArchitecture_InferredSignatureBaseline/negate/FunctionObject_FunctionDeclaration_35A8CC1F_negate::.ctor()
 		IL_0057: ldc.i4.1
 		IL_0058: conv.r8
 		IL_0059: ldstr "negate"
 		IL_005e: ldc.i4.0
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_35A8CC1F_negate>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableArchitecture_InferredSignatureBaseline/negate/FunctionObject_FunctionDeclaration_35A8CC1F_negate>(!!0, float64, string, bool, bool)
 		IL_0065: stloc.3
 		IL_0066: ldc.i4.1
 		IL_0067: newarr [System.Runtime]System.Object
@@ -415,13 +1009,13 @@
 		IL_006e: ldloc.0
 		IL_006f: stelem.ref
 		IL_0070: stloc.s 7
-		IL_0072: newobj instance void FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_743E93DE_returnString::.ctor()
+		IL_0072: newobj instance void Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnString/FunctionObject_FunctionDeclaration_743E93DE_returnString::.ctor()
 		IL_0077: ldc.i4.0
 		IL_0078: conv.r8
 		IL_0079: ldstr "returnString"
 		IL_007e: ldc.i4.0
 		IL_007f: ldc.i4.1
-		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_743E93DE_returnString>(!!0, float64, string, bool, bool)
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnString/FunctionObject_FunctionDeclaration_743E93DE_returnString>(!!0, float64, string, bool, bool)
 		IL_0085: stloc.s 4
 		IL_0087: ldc.i4.1
 		IL_0088: newarr [System.Runtime]System.Object
@@ -430,13 +1024,13 @@
 		IL_008f: ldloc.0
 		IL_0090: stelem.ref
 		IL_0091: stloc.s 7
-		IL_0093: newobj instance void FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_192564F0_stringLength::.ctor()
+		IL_0093: newobj instance void Modules.Function_CallableArchitecture_InferredSignatureBaseline/stringLength/FunctionObject_FunctionDeclaration_192564F0_stringLength::.ctor()
 		IL_0098: ldc.i4.1
 		IL_0099: conv.r8
 		IL_009a: ldstr "stringLength"
 		IL_009f: ldc.i4.0
 		IL_00a0: ldc.i4.1
-		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_192564F0_stringLength>(!!0, float64, string, bool, bool)
+		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableArchitecture_InferredSignatureBaseline/stringLength/FunctionObject_FunctionDeclaration_192564F0_stringLength>(!!0, float64, string, bool, bool)
 		IL_00a6: stloc.s 5
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -445,13 +1039,13 @@
 		IL_00b0: ldloc.0
 		IL_00b1: stelem.ref
 		IL_00b2: stloc.s 7
-		IL_00b4: newobj instance void FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_960EA86F_identity::.ctor()
+		IL_00b4: newobj instance void Modules.Function_CallableArchitecture_InferredSignatureBaseline/identity/FunctionObject_FunctionDeclaration_960EA86F_identity::.ctor()
 		IL_00b9: ldc.i4.1
 		IL_00ba: conv.r8
 		IL_00bb: ldstr "identity"
 		IL_00c0: ldc.i4.0
 		IL_00c1: ldc.i4.1
-		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_960EA86F_identity>(!!0, float64, string, bool, bool)
+		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_CallableArchitecture_InferredSignatureBaseline/identity/FunctionObject_FunctionDeclaration_960EA86F_identity>(!!0, float64, string, bool, bool)
 		IL_00c7: stloc.s 6
 		IL_00c9: nop
 		IL_00ca: nop
@@ -569,600 +1163,6 @@
 	} // end of method Function_CallableArchitecture_InferredSignatureBaseline::__js_module_init__
 
 } // end of class Modules.Function_CallableArchitecture_InferredSignatureBaseline
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_C1F8729A_returnNumber
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x231f
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_C1F8729A_returnNumber::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2327
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C1F8729A_returnNumber::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x232a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C1F8729A_returnNumber::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x232d
-		// Header size: 1
-		// Code size: 16 (0x10)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call float64 Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnNumber::__js_call__(object)
-		IL_000a: box [System.Runtime]System.Double
-		IL_000f: ret
-	} // end of method FunctionObject_FunctionDeclaration_C1F8729A_returnNumber::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x233e
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call float64 Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnNumber::__js_call__(object)
-		IL_0006: box [System.Runtime]System.Double
-		IL_000b: ret
-	} // end of method FunctionObject_FunctionDeclaration_C1F8729A_returnNumber::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x234b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C1F8729A_returnNumber::ConstructCore
-
-} // end of class FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_C1F8729A_returnNumber
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_81A3E649_returnBoolean
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x235a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_81A3E649_returnBoolean::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2362
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_81A3E649_returnBoolean::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2365
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_81A3E649_returnBoolean::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2368
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnBoolean::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_81A3E649_returnBoolean::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2374
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnBoolean::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_81A3E649_returnBoolean::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x237c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_81A3E649_returnBoolean::ConstructCore
-
-} // end of class FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_81A3E649_returnBoolean
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_35A8CC1F_negate
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x238b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_35A8CC1F_negate::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2393
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_35A8CC1F_negate::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2396
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_35A8CC1F_negate::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2399
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-		IL_0011: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/negate::__js_call__(object, bool)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_35A8CC1F_negate::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23b1
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-		IL_000d: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/negate::__js_call__(object, bool)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_35A8CC1F_negate::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23c5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_35A8CC1F_negate::ConstructCore
-
-} // end of class FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_35A8CC1F_negate
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_743E93DE_returnString
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x23d4
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_743E93DE_returnString::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23dc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_743E93DE_returnString::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23df
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_743E93DE_returnString::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23e2
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnString::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_743E93DE_returnString::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23ee
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/returnString::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_743E93DE_returnString::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23f6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_743E93DE_returnString::ConstructCore
-
-} // end of class FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_743E93DE_returnString
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_192564F0_stringLength
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2405
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_192564F0_stringLength::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x240d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_192564F0_stringLength::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2410
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_192564F0_stringLength::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2413
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0011: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/stringLength::__js_call__(object, string)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_192564F0_stringLength::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x242b
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_000d: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/stringLength::__js_call__(object, string)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_192564F0_stringLength::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x243f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_192564F0_stringLength::ConstructCore
-
-} // end of class FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_192564F0_stringLength
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_960EA86F_identity
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x244e
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_960EA86F_identity::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2456
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_960EA86F_identity::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2459
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_960EA86F_identity::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x245c
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/identity::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_960EA86F_identity::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x246f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Function_CallableArchitecture_InferredSignatureBaseline/identity::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_960EA86F_identity::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x247e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_960EA86F_identity::ConstructCore
-
-} // end of class FunctionObjects.Function_CallableArchitecture_InferredSignatureBaseline_5F261612.FunctionObject_FunctionDeclaration_960EA86F_identity
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Capture_HasScopesParameter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Capture_HasScopesParameter.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_76C99FCD_captureOuter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_Capture_HasScopesParameter/Scope _environment0_Function_Capture_HasScopesParameter
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_Capture_HasScopesParameter/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x20e5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_Capture_HasScopesParameter/Scope Modules.Function_Capture_HasScopesParameter/captureOuter/FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::_environment0_Function_Capture_HasScopesParameter
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x20f4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x20f7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x20fa
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_Capture_HasScopesParameter/Scope Modules.Function_Capture_HasScopesParameter/captureOuter/FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::_environment0_Function_Capture_HasScopesParameter
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_Capture_HasScopesParameter/captureOuter::__js_call__(class Modules.Function_Capture_HasScopesParameter/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x210c
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_Capture_HasScopesParameter/Scope Modules.Function_Capture_HasScopesParameter/captureOuter/FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::_environment0_Function_Capture_HasScopesParameter
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_Capture_HasScopesParameter/captureOuter::__js_call__(class Modules.Function_Capture_HasScopesParameter/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x211a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_76C99FCD_captureOuter
+
 
 		// Methods
 		.method public hidebysig static 
@@ -103,7 +210,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Capture_HasScopesParameter/Scope,
-			[1] class FunctionObjects.Function_Capture_HasScopesParameter_CEC68461.FunctionObject_FunctionDeclaration_76C99FCD_captureOuter,
+			[1] class Modules.Function_Capture_HasScopesParameter/captureOuter/FunctionObject_FunctionDeclaration_76C99FCD_captureOuter,
 			[2] object[],
 			[3] object,
 			[4] object
@@ -122,13 +229,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_Capture_HasScopesParameter/Scope
-		IL_0019: newobj instance void FunctionObjects.Function_Capture_HasScopesParameter_CEC68461.FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::.ctor(class Modules.Function_Capture_HasScopesParameter/Scope)
+		IL_0019: newobj instance void Modules.Function_Capture_HasScopesParameter/captureOuter/FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::.ctor(class Modules.Function_Capture_HasScopesParameter/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "captureOuter"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Capture_HasScopesParameter_CEC68461.FunctionObject_FunctionDeclaration_76C99FCD_captureOuter>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Capture_HasScopesParameter/captureOuter/FunctionObject_FunctionDeclaration_76C99FCD_captureOuter>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldloc.0
@@ -153,113 +260,6 @@
 	} // end of method Function_Capture_HasScopesParameter::__js_module_init__
 
 } // end of class Modules.Function_Capture_HasScopesParameter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Capture_HasScopesParameter_CEC68461.FunctionObject_FunctionDeclaration_76C99FCD_captureOuter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_Capture_HasScopesParameter/Scope _environment0_Function_Capture_HasScopesParameter
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_Capture_HasScopesParameter/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x20e5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_Capture_HasScopesParameter/Scope FunctionObjects.Function_Capture_HasScopesParameter_CEC68461.FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::_environment0_Function_Capture_HasScopesParameter
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x20f4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x20f7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x20fa
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_Capture_HasScopesParameter/Scope FunctionObjects.Function_Capture_HasScopesParameter_CEC68461.FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::_environment0_Function_Capture_HasScopesParameter
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_Capture_HasScopesParameter/captureOuter::__js_call__(class Modules.Function_Capture_HasScopesParameter/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x210c
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_Capture_HasScopesParameter/Scope FunctionObjects.Function_Capture_HasScopesParameter_CEC68461.FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::_environment0_Function_Capture_HasScopesParameter
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_Capture_HasScopesParameter/captureOuter::__js_call__(class Modules.Function_Capture_HasScopesParameter/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x211a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_76C99FCD_captureOuter::ConstructCore
-
-} // end of class FunctionObjects.Function_Capture_HasScopesParameter_CEC68461.FunctionObject_FunctionDeclaration_76C99FCD_captureOuter
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ClosureEscapesScope_ObjectLiteralProperty.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ClosureEscapesScope_ObjectLiteralProperty.verified.txt
@@ -35,6 +35,124 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_434A5B2B_multiply
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/Scope _environment1_createCalculator
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x224a
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/Scope Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/multiply/FunctionObject_FunctionDeclaration_434A5B2B_multiply::_environment1_createCalculator
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/multiply/FunctionObject_FunctionDeclaration_434A5B2B_multiply::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionDeclaration_434A5B2B_multiply::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2260
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_434A5B2B_multiply::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2263
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_434A5B2B_multiply::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2266
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/multiply/FunctionObject_FunctionDeclaration_434A5B2B_multiply::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/multiply::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionDeclaration_434A5B2B_multiply::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x227f
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/multiply/FunctionObject_FunctionDeclaration_434A5B2B_multiply::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/multiply::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionDeclaration_434A5B2B_multiply::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2294
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionDeclaration_434A5B2B_multiply::ConstructCore
+
+			} // end of class FunctionObject_FunctionDeclaration_434A5B2B_multiply
+
 
 			// Methods
 			.method public hidebysig static 
@@ -101,6 +219,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0B167656_createCalculator
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope _environment0_Function_ClosureEscapesScope_ObjectLiteralProperty
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/FunctionObject_FunctionDeclaration_0B167656_createCalculator::_environment0_Function_ClosureEscapesScope_ObjectLiteralProperty
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0B167656_createCalculator::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2207
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0B167656_createCalculator::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x220a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0B167656_createCalculator::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x220d
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/FunctionObject_FunctionDeclaration_0B167656_createCalculator::_environment0_Function_ClosureEscapesScope_ObjectLiteralProperty
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator::__js_call__(class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_0B167656_createCalculator::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2226
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/FunctionObject_FunctionDeclaration_0B167656_createCalculator::_environment0_Function_ClosureEscapesScope_ObjectLiteralProperty
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator::__js_call__(class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_0B167656_createCalculator::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x223b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0B167656_createCalculator::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_0B167656_createCalculator
+
 
 		// Methods
 		.method public hidebysig static 
@@ -121,7 +352,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/Scope,
-				[1] class FunctionObjects.Function_ClosureEscapesScope_ObjectLiteralProperty_71E8F45F.FunctionObject_FunctionDeclaration_434A5B2B_multiply,
+				[1] class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/multiply/FunctionObject_FunctionDeclaration_434A5B2B_multiply,
 				[2] object[],
 				[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 			)
@@ -147,13 +378,13 @@
 			IL_001e: ldelem.ref
 			IL_001f: castclass Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/Scope
 			IL_0024: ldloc.2
-			IL_0025: newobj instance void FunctionObjects.Function_ClosureEscapesScope_ObjectLiteralProperty_71E8F45F.FunctionObject_FunctionDeclaration_434A5B2B_multiply::.ctor(class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/Scope, object[])
+			IL_0025: newobj instance void Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/multiply/FunctionObject_FunctionDeclaration_434A5B2B_multiply::.ctor(class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/Scope, object[])
 			IL_002a: ldc.i4.1
 			IL_002b: conv.r8
 			IL_002c: ldstr "multiply"
 			IL_0031: ldc.i4.0
 			IL_0032: ldc.i4.1
-			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_ClosureEscapesScope_ObjectLiteralProperty_71E8F45F.FunctionObject_FunctionDeclaration_434A5B2B_multiply>(!!0, float64, string, bool, bool)
+			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/multiply/FunctionObject_FunctionDeclaration_434A5B2B_multiply>(!!0, float64, string, bool, bool)
 			IL_0038: stloc.1
 			IL_0039: nop
 			IL_003a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -213,7 +444,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope,
-			[1] class FunctionObjects.Function_ClosureEscapesScope_ObjectLiteralProperty_71E8F45F.FunctionObject_FunctionDeclaration_0B167656_createCalculator,
+			[1] class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/FunctionObject_FunctionDeclaration_0B167656_createCalculator,
 			[2] object,
 			[3] object,
 			[4] object[],
@@ -234,13 +465,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope
-		IL_001b: newobj instance void FunctionObjects.Function_ClosureEscapesScope_ObjectLiteralProperty_71E8F45F.FunctionObject_FunctionDeclaration_0B167656_createCalculator::.ctor(class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope)
+		IL_001b: newobj instance void Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/FunctionObject_FunctionDeclaration_0B167656_createCalculator::.ctor(class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope)
 		IL_0020: ldc.i4.1
 		IL_0021: conv.r8
 		IL_0022: ldstr "createCalculator"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_ClosureEscapesScope_ObjectLiteralProperty_71E8F45F.FunctionObject_FunctionDeclaration_0B167656_createCalculator>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/FunctionObject_FunctionDeclaration_0B167656_createCalculator>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: nop
 		IL_0030: nop
@@ -298,237 +529,6 @@
 	} // end of method Function_ClosureEscapesScope_ObjectLiteralProperty::__js_module_init__
 
 } // end of class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ClosureEscapesScope_ObjectLiteralProperty_71E8F45F.FunctionObject_FunctionDeclaration_0B167656_createCalculator
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope _environment0_Function_ClosureEscapesScope_ObjectLiteralProperty
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope FunctionObjects.Function_ClosureEscapesScope_ObjectLiteralProperty_71E8F45F.FunctionObject_FunctionDeclaration_0B167656_createCalculator::_environment0_Function_ClosureEscapesScope_ObjectLiteralProperty
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0B167656_createCalculator::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2207
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0B167656_createCalculator::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x220a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0B167656_createCalculator::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x220d
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope FunctionObjects.Function_ClosureEscapesScope_ObjectLiteralProperty_71E8F45F.FunctionObject_FunctionDeclaration_0B167656_createCalculator::_environment0_Function_ClosureEscapesScope_ObjectLiteralProperty
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator::__js_call__(class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_0B167656_createCalculator::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2226
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope FunctionObjects.Function_ClosureEscapesScope_ObjectLiteralProperty_71E8F45F.FunctionObject_FunctionDeclaration_0B167656_createCalculator::_environment0_Function_ClosureEscapesScope_ObjectLiteralProperty
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator::__js_call__(class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_0B167656_createCalculator::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x223b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0B167656_createCalculator::ConstructCore
-
-} // end of class FunctionObjects.Function_ClosureEscapesScope_ObjectLiteralProperty_71E8F45F.FunctionObject_FunctionDeclaration_0B167656_createCalculator
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ClosureEscapesScope_ObjectLiteralProperty_71E8F45F.FunctionObject_FunctionDeclaration_434A5B2B_multiply
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/Scope _environment1_createCalculator
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x224a
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/Scope FunctionObjects.Function_ClosureEscapesScope_ObjectLiteralProperty_71E8F45F.FunctionObject_FunctionDeclaration_434A5B2B_multiply::_environment1_createCalculator
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Function_ClosureEscapesScope_ObjectLiteralProperty_71E8F45F.FunctionObject_FunctionDeclaration_434A5B2B_multiply::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_434A5B2B_multiply::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2260
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_434A5B2B_multiply::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2263
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_434A5B2B_multiply::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2266
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Function_ClosureEscapesScope_ObjectLiteralProperty_71E8F45F.FunctionObject_FunctionDeclaration_434A5B2B_multiply::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/multiply::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_434A5B2B_multiply::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x227f
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Function_ClosureEscapesScope_ObjectLiteralProperty_71E8F45F.FunctionObject_FunctionDeclaration_434A5B2B_multiply::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Function_ClosureEscapesScope_ObjectLiteralProperty/createCalculator/multiply::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_434A5B2B_multiply::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2294
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_434A5B2B_multiply::ConstructCore
-
-} // end of class FunctionObjects.Function_ClosureEscapesScope_ObjectLiteralProperty_71E8F45F.FunctionObject_FunctionDeclaration_434A5B2B_multiply
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ClosureMutatesOuterVariable.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ClosureMutatesOuterVariable.verified.txt
@@ -35,6 +35,118 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F0227F52_increment
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Function_ClosureMutatesOuterVariable/createCounter/Scope _environment1_createCounter
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Function_ClosureMutatesOuterVariable/createCounter/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x224d
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Function_ClosureMutatesOuterVariable/createCounter/Scope Modules.Function_ClosureMutatesOuterVariable/createCounter/increment/FunctionObject_FunctionDeclaration_F0227F52_increment::_environment1_createCounter
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Function_ClosureMutatesOuterVariable/createCounter/increment/FunctionObject_FunctionDeclaration_F0227F52_increment::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionDeclaration_F0227F52_increment::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2263
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_F0227F52_increment::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2266
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_F0227F52_increment::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2269
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Function_ClosureMutatesOuterVariable/createCounter/increment/FunctionObject_FunctionDeclaration_F0227F52_increment::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Function_ClosureMutatesOuterVariable/createCounter/increment::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionDeclaration_F0227F52_increment::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x227b
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Function_ClosureMutatesOuterVariable/createCounter/increment/FunctionObject_FunctionDeclaration_F0227F52_increment::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Function_ClosureMutatesOuterVariable/createCounter/increment::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionDeclaration_F0227F52_increment::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2289
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionDeclaration_F0227F52_increment::ConstructCore
+
+			} // end of class FunctionObject_FunctionDeclaration_F0227F52_increment
+
 
 			// Methods
 			.method public hidebysig static 
@@ -110,6 +222,121 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C97C56F8_createCounter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_ClosureMutatesOuterVariable/Scope _environment0_Function_ClosureMutatesOuterVariable
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_ClosureMutatesOuterVariable/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_ClosureMutatesOuterVariable/Scope Modules.Function_ClosureMutatesOuterVariable/createCounter/FunctionObject_FunctionDeclaration_C97C56F8_createCounter::_environment0_Function_ClosureMutatesOuterVariable
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C97C56F8_createCounter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2200
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C97C56F8_createCounter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2203
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C97C56F8_createCounter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2206
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_ClosureMutatesOuterVariable/Scope Modules.Function_ClosureMutatesOuterVariable/createCounter/FunctionObject_FunctionDeclaration_C97C56F8_createCounter::_environment0_Function_ClosureMutatesOuterVariable
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: call object Modules.Function_ClosureMutatesOuterVariable/createCounter::__js_call__(class Modules.Function_ClosureMutatesOuterVariable/Scope, object, float64)
+				IL_001c: ret
+			} // end of method FunctionObject_FunctionDeclaration_C97C56F8_createCounter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2224
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_ClosureMutatesOuterVariable/Scope Modules.Function_ClosureMutatesOuterVariable/createCounter/FunctionObject_FunctionDeclaration_C97C56F8_createCounter::_environment0_Function_ClosureMutatesOuterVariable
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0013: call object Modules.Function_ClosureMutatesOuterVariable/createCounter::__js_call__(class Modules.Function_ClosureMutatesOuterVariable/Scope, object, float64)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_C97C56F8_createCounter::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x223e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C97C56F8_createCounter::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C97C56F8_createCounter
+
 
 		// Methods
 		.method public hidebysig static 
@@ -130,7 +357,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_ClosureMutatesOuterVariable/createCounter/Scope,
-				[1] class FunctionObjects.Function_ClosureMutatesOuterVariable_032A657D.FunctionObject_FunctionDeclaration_F0227F52_increment,
+				[1] class Modules.Function_ClosureMutatesOuterVariable/createCounter/increment/FunctionObject_FunctionDeclaration_F0227F52_increment,
 				[2] object[]
 			)
 
@@ -152,13 +379,13 @@
 			IL_0017: ldelem.ref
 			IL_0018: castclass Modules.Function_ClosureMutatesOuterVariable/createCounter/Scope
 			IL_001d: ldloc.2
-			IL_001e: newobj instance void FunctionObjects.Function_ClosureMutatesOuterVariable_032A657D.FunctionObject_FunctionDeclaration_F0227F52_increment::.ctor(class Modules.Function_ClosureMutatesOuterVariable/createCounter/Scope, object[])
+			IL_001e: newobj instance void Modules.Function_ClosureMutatesOuterVariable/createCounter/increment/FunctionObject_FunctionDeclaration_F0227F52_increment::.ctor(class Modules.Function_ClosureMutatesOuterVariable/createCounter/Scope, object[])
 			IL_0023: ldc.i4.0
 			IL_0024: conv.r8
 			IL_0025: ldstr "increment"
 			IL_002a: ldc.i4.0
 			IL_002b: ldc.i4.1
-			IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_ClosureMutatesOuterVariable_032A657D.FunctionObject_FunctionDeclaration_F0227F52_increment>(!!0, float64, string, bool, bool)
+			IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ClosureMutatesOuterVariable/createCounter/increment/FunctionObject_FunctionDeclaration_F0227F52_increment>(!!0, float64, string, bool, bool)
 			IL_0031: stloc.1
 			IL_0032: ldloc.0
 			IL_0033: ldarg.2
@@ -216,7 +443,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ClosureMutatesOuterVariable/Scope,
-			[1] class FunctionObjects.Function_ClosureMutatesOuterVariable_032A657D.FunctionObject_FunctionDeclaration_C97C56F8_createCounter,
+			[1] class Modules.Function_ClosureMutatesOuterVariable/createCounter/FunctionObject_FunctionDeclaration_C97C56F8_createCounter,
 			[2] object,
 			[3] object[],
 			[4] object,
@@ -236,13 +463,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_ClosureMutatesOuterVariable/Scope
-		IL_0019: newobj instance void FunctionObjects.Function_ClosureMutatesOuterVariable_032A657D.FunctionObject_FunctionDeclaration_C97C56F8_createCounter::.ctor(class Modules.Function_ClosureMutatesOuterVariable/Scope)
+		IL_0019: newobj instance void Modules.Function_ClosureMutatesOuterVariable/createCounter/FunctionObject_FunctionDeclaration_C97C56F8_createCounter::.ctor(class Modules.Function_ClosureMutatesOuterVariable/Scope)
 		IL_001e: ldc.i4.1
 		IL_001f: conv.r8
 		IL_0020: ldstr "createCounter"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_ClosureMutatesOuterVariable_032A657D.FunctionObject_FunctionDeclaration_C97C56F8_createCounter>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ClosureMutatesOuterVariable/createCounter/FunctionObject_FunctionDeclaration_C97C56F8_createCounter>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
@@ -300,233 +527,6 @@
 	} // end of method Function_ClosureMutatesOuterVariable::__js_module_init__
 
 } // end of class Modules.Function_ClosureMutatesOuterVariable
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ClosureMutatesOuterVariable_032A657D.FunctionObject_FunctionDeclaration_C97C56F8_createCounter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_ClosureMutatesOuterVariable/Scope _environment0_Function_ClosureMutatesOuterVariable
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_ClosureMutatesOuterVariable/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_ClosureMutatesOuterVariable/Scope FunctionObjects.Function_ClosureMutatesOuterVariable_032A657D.FunctionObject_FunctionDeclaration_C97C56F8_createCounter::_environment0_Function_ClosureMutatesOuterVariable
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C97C56F8_createCounter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2200
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C97C56F8_createCounter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2203
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C97C56F8_createCounter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2206
-		// Header size: 1
-		// Code size: 29 (0x1d)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_ClosureMutatesOuterVariable/Scope FunctionObjects.Function_ClosureMutatesOuterVariable_032A657D.FunctionObject_FunctionDeclaration_C97C56F8_createCounter::_environment0_Function_ClosureMutatesOuterVariable
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0017: call object Modules.Function_ClosureMutatesOuterVariable/createCounter::__js_call__(class Modules.Function_ClosureMutatesOuterVariable/Scope, object, float64)
-		IL_001c: ret
-	} // end of method FunctionObject_FunctionDeclaration_C97C56F8_createCounter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2224
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_ClosureMutatesOuterVariable/Scope FunctionObjects.Function_ClosureMutatesOuterVariable_032A657D.FunctionObject_FunctionDeclaration_C97C56F8_createCounter::_environment0_Function_ClosureMutatesOuterVariable
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0013: call object Modules.Function_ClosureMutatesOuterVariable/createCounter::__js_call__(class Modules.Function_ClosureMutatesOuterVariable/Scope, object, float64)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_C97C56F8_createCounter::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x223e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C97C56F8_createCounter::ConstructCore
-
-} // end of class FunctionObjects.Function_ClosureMutatesOuterVariable_032A657D.FunctionObject_FunctionDeclaration_C97C56F8_createCounter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ClosureMutatesOuterVariable_032A657D.FunctionObject_FunctionDeclaration_F0227F52_increment
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_ClosureMutatesOuterVariable/createCounter/Scope _environment1_createCounter
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_ClosureMutatesOuterVariable/createCounter/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x224d
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_ClosureMutatesOuterVariable/createCounter/Scope FunctionObjects.Function_ClosureMutatesOuterVariable_032A657D.FunctionObject_FunctionDeclaration_F0227F52_increment::_environment1_createCounter
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Function_ClosureMutatesOuterVariable_032A657D.FunctionObject_FunctionDeclaration_F0227F52_increment::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_F0227F52_increment::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2263
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F0227F52_increment::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2266
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F0227F52_increment::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2269
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Function_ClosureMutatesOuterVariable_032A657D.FunctionObject_FunctionDeclaration_F0227F52_increment::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_ClosureMutatesOuterVariable/createCounter/increment::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_F0227F52_increment::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x227b
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Function_ClosureMutatesOuterVariable_032A657D.FunctionObject_FunctionDeclaration_F0227F52_increment::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_ClosureMutatesOuterVariable/createCounter/increment::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_F0227F52_increment::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2289
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F0227F52_increment::ConstructCore
-
-} // end of class FunctionObjects.Function_ClosureMutatesOuterVariable_032A657D.FunctionObject_FunctionDeclaration_F0227F52_increment
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Closure_CapturedBoolean_AssignAndRead.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Closure_CapturedBoolean_AssignAndRead.verified.txt
@@ -35,6 +35,118 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_70247B52_setTrue
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/Scope _environment1_outer
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x21b7
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/Scope Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue/FunctionObject_FunctionDeclaration_70247B52_setTrue::_environment1_outer
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue/FunctionObject_FunctionDeclaration_70247B52_setTrue::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionDeclaration_70247B52_setTrue::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x21cd
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_70247B52_setTrue::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x21d0
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_70247B52_setTrue::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x21d3
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue/FunctionObject_FunctionDeclaration_70247B52_setTrue::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionDeclaration_70247B52_setTrue::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x21e5
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue/FunctionObject_FunctionDeclaration_70247B52_setTrue::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionDeclaration_70247B52_setTrue::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x21f3
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionDeclaration_70247B52_setTrue::ConstructCore
+
+			} // end of class FunctionObject_FunctionDeclaration_70247B52_setTrue
+
 
 			// Methods
 			.method public hidebysig static 
@@ -93,6 +205,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2D7D3E81_outer
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope _environment0_Function_Closure_CapturedBoolean_AssignAndRead
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2173
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/FunctionObject_FunctionDeclaration_2D7D3E81_outer::_environment0_Function_Closure_CapturedBoolean_AssignAndRead
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_2D7D3E81_outer::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2182
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2D7D3E81_outer::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2185
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2D7D3E81_outer::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2188
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/FunctionObject_FunctionDeclaration_2D7D3E81_outer::_environment0_Function_Closure_CapturedBoolean_AssignAndRead
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer::__js_call__(class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_2D7D3E81_outer::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x219a
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/FunctionObject_FunctionDeclaration_2D7D3E81_outer::_environment0_Function_Closure_CapturedBoolean_AssignAndRead
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer::__js_call__(class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_2D7D3E81_outer::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21a8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_2D7D3E81_outer::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_2D7D3E81_outer
+
 
 		// Methods
 		.method public hidebysig static 
@@ -112,7 +331,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/Scope,
-				[1] class FunctionObjects.Function_Closure_CapturedBoolean_AssignAndRead_F9817BEF.FunctionObject_FunctionDeclaration_70247B52_setTrue,
+				[1] class Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue/FunctionObject_FunctionDeclaration_70247B52_setTrue,
 				[2] object[],
 				[3] object,
 				[4] object
@@ -136,13 +355,13 @@
 			IL_0017: ldelem.ref
 			IL_0018: castclass Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/Scope
 			IL_001d: ldloc.2
-			IL_001e: newobj instance void FunctionObjects.Function_Closure_CapturedBoolean_AssignAndRead_F9817BEF.FunctionObject_FunctionDeclaration_70247B52_setTrue::.ctor(class Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/Scope, object[])
+			IL_001e: newobj instance void Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue/FunctionObject_FunctionDeclaration_70247B52_setTrue::.ctor(class Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/Scope, object[])
 			IL_0023: ldc.i4.0
 			IL_0024: conv.r8
 			IL_0025: ldstr "setTrue"
 			IL_002a: ldc.i4.0
 			IL_002b: ldc.i4.1
-			IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Closure_CapturedBoolean_AssignAndRead_F9817BEF.FunctionObject_FunctionDeclaration_70247B52_setTrue>(!!0, float64, string, bool, bool)
+			IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue/FunctionObject_FunctionDeclaration_70247B52_setTrue>(!!0, float64, string, bool, bool)
 			IL_0031: stloc.1
 			IL_0032: ldloc.0
 			IL_0033: ldc.i4.0
@@ -232,7 +451,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope,
-			[1] class FunctionObjects.Function_Closure_CapturedBoolean_AssignAndRead_F9817BEF.FunctionObject_FunctionDeclaration_2D7D3E81_outer,
+			[1] class Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/FunctionObject_FunctionDeclaration_2D7D3E81_outer,
 			[2] object[]
 		)
 
@@ -249,13 +468,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope
-		IL_0019: newobj instance void FunctionObjects.Function_Closure_CapturedBoolean_AssignAndRead_F9817BEF.FunctionObject_FunctionDeclaration_2D7D3E81_outer::.ctor(class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope)
+		IL_0019: newobj instance void Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/FunctionObject_FunctionDeclaration_2D7D3E81_outer::.ctor(class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "outer"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Closure_CapturedBoolean_AssignAndRead_F9817BEF.FunctionObject_FunctionDeclaration_2D7D3E81_outer>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/FunctionObject_FunctionDeclaration_2D7D3E81_outer>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
@@ -267,225 +486,6 @@
 	} // end of method Function_Closure_CapturedBoolean_AssignAndRead::__js_module_init__
 
 } // end of class Modules.Function_Closure_CapturedBoolean_AssignAndRead
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Closure_CapturedBoolean_AssignAndRead_F9817BEF.FunctionObject_FunctionDeclaration_2D7D3E81_outer
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope _environment0_Function_Closure_CapturedBoolean_AssignAndRead
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2173
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope FunctionObjects.Function_Closure_CapturedBoolean_AssignAndRead_F9817BEF.FunctionObject_FunctionDeclaration_2D7D3E81_outer::_environment0_Function_Closure_CapturedBoolean_AssignAndRead
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_2D7D3E81_outer::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2182
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2D7D3E81_outer::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2185
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2D7D3E81_outer::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2188
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope FunctionObjects.Function_Closure_CapturedBoolean_AssignAndRead_F9817BEF.FunctionObject_FunctionDeclaration_2D7D3E81_outer::_environment0_Function_Closure_CapturedBoolean_AssignAndRead
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer::__js_call__(class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_2D7D3E81_outer::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x219a
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope FunctionObjects.Function_Closure_CapturedBoolean_AssignAndRead_F9817BEF.FunctionObject_FunctionDeclaration_2D7D3E81_outer::_environment0_Function_Closure_CapturedBoolean_AssignAndRead
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer::__js_call__(class Modules.Function_Closure_CapturedBoolean_AssignAndRead/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_2D7D3E81_outer::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21a8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_2D7D3E81_outer::ConstructCore
-
-} // end of class FunctionObjects.Function_Closure_CapturedBoolean_AssignAndRead_F9817BEF.FunctionObject_FunctionDeclaration_2D7D3E81_outer
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Closure_CapturedBoolean_AssignAndRead_F9817BEF.FunctionObject_FunctionDeclaration_70247B52_setTrue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/Scope _environment1_outer
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x21b7
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/Scope FunctionObjects.Function_Closure_CapturedBoolean_AssignAndRead_F9817BEF.FunctionObject_FunctionDeclaration_70247B52_setTrue::_environment1_outer
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Function_Closure_CapturedBoolean_AssignAndRead_F9817BEF.FunctionObject_FunctionDeclaration_70247B52_setTrue::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_70247B52_setTrue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21cd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_70247B52_setTrue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21d0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_70247B52_setTrue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21d3
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Function_Closure_CapturedBoolean_AssignAndRead_F9817BEF.FunctionObject_FunctionDeclaration_70247B52_setTrue::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_70247B52_setTrue::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21e5
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Function_Closure_CapturedBoolean_AssignAndRead_F9817BEF.FunctionObject_FunctionDeclaration_70247B52_setTrue::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_Closure_CapturedBoolean_AssignAndRead/outer/setTrue::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_70247B52_setTrue::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_70247B52_setTrue::ConstructCore
-
-} // end of class FunctionObjects.Function_Closure_CapturedBoolean_AssignAndRead_F9817BEF.FunctionObject_FunctionDeclaration_70247B52_setTrue
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructedInstance_ObjectSemantics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ConstructedInstance_ObjectSemantics.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_39521C09_Point
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2b1f
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_39521C09_Point::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2b27
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_39521C09_Point::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2b2a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_39521C09_Point::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b2d
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Function_ConstructedInstance_ObjectSemantics/Point::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_39521C09_Point::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b47
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Function_ConstructedInstance_ObjectSemantics/Point::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_39521C09_Point::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b5d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_39521C09_Point::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_39521C09_Point
+
 
 		// Methods
 		.method public hidebysig static 
@@ -91,6 +198,101 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7172515D_L8C23
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2b6c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_7172515D_L8C23::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2b74
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7172515D_L8C23::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2b77
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7172515D_L8C23::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b7a
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Function_ConstructedInstance_ObjectSemantics/FunctionExpression_L8C22::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_7172515D_L8C23::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b86
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Function_ConstructedInstance_ObjectSemantics/FunctionExpression_L8C22::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_7172515D_L8C23::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b8e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_7172515D_L8C23::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_7172515D_L8C23
 
 
 		// Methods
@@ -156,6 +358,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_39499524_ReturnObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_ConstructedInstance_ObjectSemantics/Scope _environment0_Function_ConstructedInstance_ObjectSemantics
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_ConstructedInstance_ObjectSemantics/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b9d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_ConstructedInstance_ObjectSemantics/Scope Modules.Function_ConstructedInstance_ObjectSemantics/ReturnObject/FunctionObject_FunctionDeclaration_39499524_ReturnObject::_environment0_Function_ConstructedInstance_ObjectSemantics
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_39499524_ReturnObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2bac
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_39499524_ReturnObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2baf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_39499524_ReturnObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bb2
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_ConstructedInstance_ObjectSemantics/Scope Modules.Function_ConstructedInstance_ObjectSemantics/ReturnObject/FunctionObject_FunctionDeclaration_39499524_ReturnObject::_environment0_Function_ConstructedInstance_ObjectSemantics
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_ConstructedInstance_ObjectSemantics/ReturnObject::__js_call__(class Modules.Function_ConstructedInstance_ObjectSemantics/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_39499524_ReturnObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bc4
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_ConstructedInstance_ObjectSemantics/Scope Modules.Function_ConstructedInstance_ObjectSemantics/ReturnObject/FunctionObject_FunctionDeclaration_39499524_ReturnObject::_environment0_Function_ConstructedInstance_ObjectSemantics
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_ConstructedInstance_ObjectSemantics/ReturnObject::__js_call__(class Modules.Function_ConstructedInstance_ObjectSemantics/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_39499524_ReturnObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bd2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_39499524_ReturnObject::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_39499524_ReturnObject
+
 
 		// Methods
 		.method public hidebysig static 
@@ -216,6 +525,103 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2be1
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2be9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2bec
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bef
+				// Header size: 1
+				// Code size: 16 (0x10)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call float64 Modules.Function_ConstructedInstance_ObjectSemantics/ReturnPrimitive::__js_call__(object)
+				IL_000a: box [System.Runtime]System.Double
+				IL_000f: ret
+			} // end of method FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c00
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call float64 Modules.Function_ConstructedInstance_ObjectSemantics/ReturnPrimitive::__js_call__(object)
+				IL_0006: box [System.Runtime]System.Double
+				IL_000b: ret
+			} // end of method FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c0d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive
+
 
 		// Methods
 		.method public hidebysig static 
@@ -271,6 +677,124 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9C50FAD2_L48C12
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/Scope _environment1_makeConstructor
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x2c6e
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/Scope Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionExpression_L48C11/FunctionObject_FunctionExpression_9C50FAD2_L48C12::_environment1_makeConstructor
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionExpression_L48C11/FunctionObject_FunctionExpression_9C50FAD2_L48C12::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionExpression_9C50FAD2_L48C12::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2c84
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_9C50FAD2_L48C12::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2c87
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_9C50FAD2_L48C12::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2c8a
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionExpression_L48C11/FunctionObject_FunctionExpression_9C50FAD2_L48C12::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionExpression_L48C11::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_9C50FAD2_L48C12::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2ca3
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionExpression_L48C11/FunctionObject_FunctionExpression_9C50FAD2_L48C12::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionExpression_L48C11::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_9C50FAD2_L48C12::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2cb8
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_9C50FAD2_L48C12::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_9C50FAD2_L48C12
 
 
 			// Methods
@@ -343,6 +867,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_ConstructedInstance_ObjectSemantics/Scope _environment0_Function_ConstructedInstance_ObjectSemantics
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_ConstructedInstance_ObjectSemantics/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c1c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_ConstructedInstance_ObjectSemantics/Scope Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::_environment0_Function_ConstructedInstance_ObjectSemantics
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2c2b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2c2e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c31
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_ConstructedInstance_ObjectSemantics/Scope Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::_environment0_Function_ConstructedInstance_ObjectSemantics
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor::__js_call__(class Modules.Function_ConstructedInstance_ObjectSemantics/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c4a
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_ConstructedInstance_ObjectSemantics/Scope Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::_environment0_Function_ConstructedInstance_ObjectSemantics
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor::__js_call__(class Modules.Function_ConstructedInstance_ObjectSemantics/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c5f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor
+
 
 		// Methods
 		.method public hidebysig static 
@@ -364,7 +1001,7 @@
 			.locals init (
 				[0] class Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/Scope,
 				[1] object[],
-				[2] class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionExpression_9C50FAD2_L48C12
+				[2] class Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionExpression_L48C11/FunctionObject_FunctionExpression_9C50FAD2_L48C12
 			)
 
 			IL_0000: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/Scope::.ctor()
@@ -388,13 +1025,13 @@
 			IL_001e: ldelem.ref
 			IL_001f: castclass Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/Scope
 			IL_0024: ldloc.1
-			IL_0025: newobj instance void FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionExpression_9C50FAD2_L48C12::.ctor(class Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/Scope, object[])
+			IL_0025: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionExpression_L48C11/FunctionObject_FunctionExpression_9C50FAD2_L48C12::.ctor(class Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/Scope, object[])
 			IL_002a: ldc.i4.1
 			IL_002b: conv.r8
 			IL_002c: ldstr ""
 			IL_0031: ldc.i4.1
 			IL_0032: ldc.i4.1
-			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionExpression_9C50FAD2_L48C12>(!!0, float64, string, bool, bool)
+			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionExpression_L48C11/FunctionObject_FunctionExpression_9C50FAD2_L48C12>(!!0, float64, string, bool, bool)
 			IL_0038: stloc.2
 			IL_0039: ldloc.2
 			IL_003a: ret
@@ -425,6 +1062,122 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_23475292_L61C18
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2cc7
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_23475292_L61C18::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2ccf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_23475292_L61C18::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2cd2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_23475292_L61C18::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2cd5
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_23475292_L61C18::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2cdd
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_23475292_L61C18::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2cf0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_23475292_L61C18::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2cff
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_23475292_L61C18::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_23475292_L61C18
 
 
 		// Methods
@@ -479,6 +1232,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2d0e
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2d16
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2d19
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d1c
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Function_ConstructedInstance_ObjectSemantics/PrimitivePrototype::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d28
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Function_ConstructedInstance_ObjectSemantics/PrimitivePrototype::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d30
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype
+
 
 		// Methods
 		.method public hidebysig static 
@@ -523,6 +1371,101 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9DD67922_NullPrototype
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2d3f
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_9DD67922_NullPrototype::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2d47
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9DD67922_NullPrototype::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2d4a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9DD67922_NullPrototype::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d4d
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Function_ConstructedInstance_ObjectSemantics/NullPrototype::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_9DD67922_NullPrototype::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d59
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Function_ConstructedInstance_ObjectSemantics/NullPrototype::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_9DD67922_NullPrototype::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d61
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9DD67922_NullPrototype::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9DD67922_NullPrototype
 
 
 		// Methods
@@ -588,6 +1531,150 @@
 			} // end of method Scope_read::.ctor
 
 		} // end of class Scope_read
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_3BB98598_PointReader
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d70
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Function_ConstructedInstance_ObjectSemantics/PointReader/FunctionObject_ClassConstructor_3BB98598_PointReader::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_3BB98598_PointReader::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2d7f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_3BB98598_PointReader::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2d82
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_3BB98598_PointReader::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d85
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_3BB98598_PointReader::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d91
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_3BB98598_PointReader::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_3BB98598_PointReader
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassStaticMethod_94C5E765_PointReader_read
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2d9d
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassStaticMethod_94C5E765_PointReader_read::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2da5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassStaticMethod_94C5E765_PointReader_read::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2da8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassStaticMethod_94C5E765_PointReader_read::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2dab
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.2
+				IL_0001: ldc.i4.0
+				IL_0002: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0007: call object Modules.Function_ConstructedInstance_ObjectSemantics/PointReader::read(object)
+				IL_000c: ret
+			} // end of method FunctionObject_ClassStaticMethod_94C5E765_PointReader_read::CallCore
+
+		} // end of class FunctionObject_ClassStaticMethod_94C5E765_PointReader_read
 
 
 		// Methods
@@ -694,24 +1781,24 @@
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Function_ConstructedInstance_ObjectSemantics/Scope,
-			[1] class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_39521C09_Point,
-			[2] class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_39499524_ReturnObject,
-			[3] class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive,
-			[4] class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor,
-			[5] class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype,
-			[6] class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_9DD67922_NullPrototype,
+			[1] class Modules.Function_ConstructedInstance_ObjectSemantics/Point/FunctionObject_FunctionDeclaration_39521C09_Point,
+			[2] class Modules.Function_ConstructedInstance_ObjectSemantics/ReturnObject/FunctionObject_FunctionDeclaration_39499524_ReturnObject,
+			[3] class Modules.Function_ConstructedInstance_ObjectSemantics/ReturnPrimitive/FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive,
+			[4] class Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor,
+			[5] class Modules.Function_ConstructedInstance_ObjectSemantics/PrimitivePrototype/FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype,
+			[6] class Modules.Function_ConstructedInstance_ObjectSemantics/NullPrototype/FunctionObject_FunctionDeclaration_9DD67922_NullPrototype,
 			[7] object,
 			[8] object,
 			[9] object,
 			[10] object,
 			[11] object,
 			[12] object,
-			[13] class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionExpression_23475292_L61C18,
+			[13] class Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject_FunctionExpression_23475292_L61C18,
 			[14] object,
 			[15] object,
 			[16] object[],
 			[17] object,
-			[18] class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionExpression_7172515D_L8C23,
+			[18] class Modules.Function_ConstructedInstance_ObjectSemantics/FunctionExpression_L8C22/FunctionObject_FunctionExpression_7172515D_L8C23,
 			[19] object,
 			[20] bool,
 			[21] object,
@@ -731,13 +1818,13 @@
 		IL_0013: ldloc.0
 		IL_0014: stelem.ref
 		IL_0015: stloc.s 16
-		IL_0017: newobj instance void FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_39521C09_Point::.ctor()
+		IL_0017: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/Point/FunctionObject_FunctionDeclaration_39521C09_Point::.ctor()
 		IL_001c: ldc.i4.2
 		IL_001d: conv.r8
 		IL_001e: ldstr "Point"
 		IL_0023: ldc.i4.1
 		IL_0024: ldc.i4.1
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_39521C09_Point>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/Point/FunctionObject_FunctionDeclaration_39521C09_Point>(!!0, float64, string, bool, bool)
 		IL_002a: stloc.1
 		IL_002b: ldc.i4.1
 		IL_002c: newarr [System.Runtime]System.Object
@@ -750,13 +1837,13 @@
 		IL_0039: ldc.i4.0
 		IL_003a: ldelem.ref
 		IL_003b: castclass Modules.Function_ConstructedInstance_ObjectSemantics/Scope
-		IL_0040: newobj instance void FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_39499524_ReturnObject::.ctor(class Modules.Function_ConstructedInstance_ObjectSemantics/Scope)
+		IL_0040: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/ReturnObject/FunctionObject_FunctionDeclaration_39499524_ReturnObject::.ctor(class Modules.Function_ConstructedInstance_ObjectSemantics/Scope)
 		IL_0045: ldc.i4.0
 		IL_0046: conv.r8
 		IL_0047: ldstr "ReturnObject"
 		IL_004c: ldc.i4.1
 		IL_004d: ldc.i4.1
-		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_39499524_ReturnObject>(!!0, float64, string, bool, bool)
+		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/ReturnObject/FunctionObject_FunctionDeclaration_39499524_ReturnObject>(!!0, float64, string, bool, bool)
 		IL_0053: stloc.2
 		IL_0054: ldc.i4.1
 		IL_0055: newarr [System.Runtime]System.Object
@@ -765,13 +1852,13 @@
 		IL_005c: ldloc.0
 		IL_005d: stelem.ref
 		IL_005e: stloc.s 16
-		IL_0060: newobj instance void FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive::.ctor()
+		IL_0060: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/ReturnPrimitive/FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive::.ctor()
 		IL_0065: ldc.i4.0
 		IL_0066: conv.r8
 		IL_0067: ldstr "ReturnPrimitive"
 		IL_006c: ldc.i4.1
 		IL_006d: ldc.i4.1
-		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive>(!!0, float64, string, bool, bool)
+		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/ReturnPrimitive/FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive>(!!0, float64, string, bool, bool)
 		IL_0073: stloc.3
 		IL_0074: ldc.i4.1
 		IL_0075: newarr [System.Runtime]System.Object
@@ -784,13 +1871,13 @@
 		IL_0082: ldc.i4.0
 		IL_0083: ldelem.ref
 		IL_0084: castclass Modules.Function_ConstructedInstance_ObjectSemantics/Scope
-		IL_0089: newobj instance void FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::.ctor(class Modules.Function_ConstructedInstance_ObjectSemantics/Scope)
+		IL_0089: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::.ctor(class Modules.Function_ConstructedInstance_ObjectSemantics/Scope)
 		IL_008e: ldc.i4.1
 		IL_008f: conv.r8
 		IL_0090: ldstr "makeConstructor"
 		IL_0095: ldc.i4.0
 		IL_0096: ldc.i4.1
-		IL_0097: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor>(!!0, float64, string, bool, bool)
+		IL_0097: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor>(!!0, float64, string, bool, bool)
 		IL_009c: stloc.s 4
 		IL_009e: ldc.i4.1
 		IL_009f: newarr [System.Runtime]System.Object
@@ -799,13 +1886,13 @@
 		IL_00a6: ldloc.0
 		IL_00a7: stelem.ref
 		IL_00a8: stloc.s 16
-		IL_00aa: newobj instance void FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype::.ctor()
+		IL_00aa: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/PrimitivePrototype/FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype::.ctor()
 		IL_00af: ldc.i4.0
 		IL_00b0: conv.r8
 		IL_00b1: ldstr "PrimitivePrototype"
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldc.i4.1
-		IL_00b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype>(!!0, float64, string, bool, bool)
+		IL_00b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/PrimitivePrototype/FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype>(!!0, float64, string, bool, bool)
 		IL_00bd: stloc.s 5
 		IL_00bf: ldc.i4.1
 		IL_00c0: newarr [System.Runtime]System.Object
@@ -814,13 +1901,13 @@
 		IL_00c7: ldloc.0
 		IL_00c8: stelem.ref
 		IL_00c9: stloc.s 16
-		IL_00cb: newobj instance void FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_9DD67922_NullPrototype::.ctor()
+		IL_00cb: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/NullPrototype/FunctionObject_FunctionDeclaration_9DD67922_NullPrototype::.ctor()
 		IL_00d0: ldc.i4.0
 		IL_00d1: conv.r8
 		IL_00d2: ldstr "NullPrototype"
 		IL_00d7: ldc.i4.0
 		IL_00d8: ldc.i4.1
-		IL_00d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_9DD67922_NullPrototype>(!!0, float64, string, bool, bool)
+		IL_00d9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/NullPrototype/FunctionObject_FunctionDeclaration_9DD67922_NullPrototype>(!!0, float64, string, bool, bool)
 		IL_00de: stloc.s 6
 		IL_00e0: nop
 		IL_00e1: nop
@@ -835,13 +1922,13 @@
 		IL_00f7: ldloc.0
 		IL_00f8: stelem.ref
 		IL_00f9: stloc.s 16
-		IL_00fb: newobj instance void FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionExpression_7172515D_L8C23::.ctor()
+		IL_00fb: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/FunctionExpression_L8C22/FunctionObject_FunctionExpression_7172515D_L8C23::.ctor()
 		IL_0100: ldc.i4.0
 		IL_0101: conv.r8
 		IL_0102: ldstr ""
 		IL_0107: ldc.i4.1
 		IL_0108: ldc.i4.1
-		IL_0109: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionExpression_7172515D_L8C23>(!!0, float64, string, bool, bool)
+		IL_0109: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/FunctionExpression_L8C22/FunctionObject_FunctionExpression_7172515D_L8C23>(!!0, float64, string, bool, bool)
 		IL_010e: stloc.s 18
 		IL_0110: ldloc.s 17
 		IL_0112: ldstr "sum"
@@ -1236,13 +2323,13 @@
 		IL_061e: ldloc.0
 		IL_061f: stelem.ref
 		IL_0620: stloc.s 16
-		IL_0622: newobj instance void FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionExpression_23475292_L61C18::.ctor()
+		IL_0622: newobj instance void Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject_FunctionExpression_23475292_L61C18::.ctor()
 		IL_0627: ldc.i4.1
 		IL_0628: conv.r8
 		IL_0629: ldstr ""
 		IL_062e: ldc.i4.1
 		IL_062f: ldc.i4.0
-		IL_0630: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionExpression_23475292_L61C18>(!!0, float64, string, bool, bool)
+		IL_0630: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'/FunctionObject_FunctionExpression_23475292_L61C18>(!!0, float64, string, bool, bool)
 		IL_0635: stloc.s 13
 		IL_0637: ldloc.s 13
 		IL_0639: ldc.i4.1
@@ -1466,1093 +2553,6 @@
 	} // end of method Function_ConstructedInstance_ObjectSemantics::__js_module_init__
 
 } // end of class Modules.Function_ConstructedInstance_ObjectSemantics
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_39521C09_Point
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2b1f
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_39521C09_Point::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2b27
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_39521C09_Point::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2b2a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_39521C09_Point::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b2d
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Function_ConstructedInstance_ObjectSemantics/Point::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_39521C09_Point::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b47
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Function_ConstructedInstance_ObjectSemantics/Point::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_39521C09_Point::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b5d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_39521C09_Point::ConstructCore
-
-} // end of class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_39521C09_Point
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionExpression_7172515D_L8C23
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2b6c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_7172515D_L8C23::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2b74
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7172515D_L8C23::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2b77
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7172515D_L8C23::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b7a
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Function_ConstructedInstance_ObjectSemantics/FunctionExpression_L8C22::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_7172515D_L8C23::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b86
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Function_ConstructedInstance_ObjectSemantics/FunctionExpression_L8C22::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_7172515D_L8C23::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b8e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7172515D_L8C23::ConstructCore
-
-} // end of class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionExpression_7172515D_L8C23
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_39499524_ReturnObject
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_ConstructedInstance_ObjectSemantics/Scope _environment0_Function_ConstructedInstance_ObjectSemantics
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_ConstructedInstance_ObjectSemantics/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b9d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_ConstructedInstance_ObjectSemantics/Scope FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_39499524_ReturnObject::_environment0_Function_ConstructedInstance_ObjectSemantics
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_39499524_ReturnObject::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2bac
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_39499524_ReturnObject::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2baf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_39499524_ReturnObject::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bb2
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_ConstructedInstance_ObjectSemantics/Scope FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_39499524_ReturnObject::_environment0_Function_ConstructedInstance_ObjectSemantics
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_ConstructedInstance_ObjectSemantics/ReturnObject::__js_call__(class Modules.Function_ConstructedInstance_ObjectSemantics/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_39499524_ReturnObject::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bc4
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_ConstructedInstance_ObjectSemantics/Scope FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_39499524_ReturnObject::_environment0_Function_ConstructedInstance_ObjectSemantics
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_ConstructedInstance_ObjectSemantics/ReturnObject::__js_call__(class Modules.Function_ConstructedInstance_ObjectSemantics/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_39499524_ReturnObject::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bd2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_39499524_ReturnObject::ConstructCore
-
-} // end of class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_39499524_ReturnObject
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2be1
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2be9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2bec
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bef
-		// Header size: 1
-		// Code size: 16 (0x10)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call float64 Modules.Function_ConstructedInstance_ObjectSemantics/ReturnPrimitive::__js_call__(object)
-		IL_000a: box [System.Runtime]System.Double
-		IL_000f: ret
-	} // end of method FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c00
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call float64 Modules.Function_ConstructedInstance_ObjectSemantics/ReturnPrimitive::__js_call__(object)
-		IL_0006: box [System.Runtime]System.Double
-		IL_000b: ret
-	} // end of method FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c0d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive::ConstructCore
-
-} // end of class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_9684536C_ReturnPrimitive
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_ConstructedInstance_ObjectSemantics/Scope _environment0_Function_ConstructedInstance_ObjectSemantics
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_ConstructedInstance_ObjectSemantics/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c1c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_ConstructedInstance_ObjectSemantics/Scope FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::_environment0_Function_ConstructedInstance_ObjectSemantics
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2c2b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2c2e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c31
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_ConstructedInstance_ObjectSemantics/Scope FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::_environment0_Function_ConstructedInstance_ObjectSemantics
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor::__js_call__(class Modules.Function_ConstructedInstance_ObjectSemantics/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c4a
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_ConstructedInstance_ObjectSemantics/Scope FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::_environment0_Function_ConstructedInstance_ObjectSemantics
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor::__js_call__(class Modules.Function_ConstructedInstance_ObjectSemantics/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c5f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor::ConstructCore
-
-} // end of class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_BFB5006D_makeConstructor
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionExpression_9C50FAD2_L48C12
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/Scope _environment1_makeConstructor
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c6e
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/Scope FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionExpression_9C50FAD2_L48C12::_environment1_makeConstructor
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionExpression_9C50FAD2_L48C12::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_9C50FAD2_L48C12::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2c84
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9C50FAD2_L48C12::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2c87
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9C50FAD2_L48C12::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c8a
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionExpression_9C50FAD2_L48C12::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionExpression_L48C11::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_9C50FAD2_L48C12::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ca3
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionExpression_9C50FAD2_L48C12::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Function_ConstructedInstance_ObjectSemantics/makeConstructor/FunctionExpression_L48C11::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_9C50FAD2_L48C12::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cb8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_9C50FAD2_L48C12::ConstructCore
-
-} // end of class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionExpression_9C50FAD2_L48C12
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionExpression_23475292_L61C18
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2cc7
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_23475292_L61C18::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2ccf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_23475292_L61C18::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2cd2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_23475292_L61C18::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cd5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_23475292_L61C18::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cdd
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_23475292_L61C18::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cf0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Function_ConstructedInstance_ObjectSemantics/'<>DynamicFunction_L61C17'::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_23475292_L61C18::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cff
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_23475292_L61C18::ConstructCore
-
-} // end of class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionExpression_23475292_L61C18
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2d0e
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2d16
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2d19
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d1c
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Function_ConstructedInstance_ObjectSemantics/PrimitivePrototype::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d28
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Function_ConstructedInstance_ObjectSemantics/PrimitivePrototype::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d30
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype::ConstructCore
-
-} // end of class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_E8D4B04C_PrimitivePrototype
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_9DD67922_NullPrototype
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2d3f
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_9DD67922_NullPrototype::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2d47
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9DD67922_NullPrototype::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2d4a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9DD67922_NullPrototype::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d4d
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Function_ConstructedInstance_ObjectSemantics/NullPrototype::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_9DD67922_NullPrototype::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d59
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Function_ConstructedInstance_ObjectSemantics/NullPrototype::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_9DD67922_NullPrototype::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d61
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9DD67922_NullPrototype::ConstructCore
-
-} // end of class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_FunctionDeclaration_9DD67922_NullPrototype
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_ClassConstructor_3BB98598_PointReader
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d70
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_ClassConstructor_3BB98598_PointReader::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_3BB98598_PointReader::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2d7f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_3BB98598_PointReader::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2d82
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_3BB98598_PointReader::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d85
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_3BB98598_PointReader::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d91
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_3BB98598_PointReader::ConstructCore
-
-} // end of class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_ClassConstructor_3BB98598_PointReader
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_ClassStaticMethod_94C5E765_PointReader_read
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2d9d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassStaticMethod_94C5E765_PointReader_read::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2da5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassStaticMethod_94C5E765_PointReader_read::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2da8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassStaticMethod_94C5E765_PointReader_read::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2dab
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.2
-		IL_0001: ldc.i4.0
-		IL_0002: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0007: call object Modules.Function_ConstructedInstance_ObjectSemantics/PointReader::read(object)
-		IL_000c: ret
-	} // end of method FunctionObject_ClassStaticMethod_94C5E765_PointReader_read::CallCore
-
-} // end of class FunctionObjects.Function_ConstructedInstance_ObjectSemantics_DC5CBADE.FunctionObject_ClassStaticMethod_94C5E765_PointReader_read
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_Call_Length_Name.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_Call_Length_Name.verified.txt
@@ -31,6 +31,128 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A064FBB8_L3C14
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x214c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_A064FBB8_L3C14::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2154
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A064FBB8_L3C14::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2157
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A064FBB8_L3C14::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x215a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_A064FBB8_L3C14::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2162
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Function_Constructor_Call_Length_Name/'<>DynamicFunction_L3C13'::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionExpression_A064FBB8_L3C14::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x217c
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Function_Constructor_Call_Length_Name/'<>DynamicFunction_L3C13'::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionExpression_A064FBB8_L3C14::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2192
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_A064FBB8_L3C14::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_A064FBB8_L3C14
+
 
 		// Methods
 		.method public hidebysig static 
@@ -98,7 +220,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Constructor_Call_Length_Name/Scope,
-			[1] class FunctionObjects.Function_Constructor_Call_Length_Name_6D50EF12.FunctionObject_FunctionExpression_A064FBB8_L3C14,
+			[1] class Modules.Function_Constructor_Call_Length_Name/'<>DynamicFunction_L3C13'/FunctionObject_FunctionExpression_A064FBB8_L3C14,
 			[2] object[],
 			[3] object,
 			[4] object
@@ -114,13 +236,13 @@
 		IL_000f: ldloc.0
 		IL_0010: stelem.ref
 		IL_0011: stloc.2
-		IL_0012: newobj instance void FunctionObjects.Function_Constructor_Call_Length_Name_6D50EF12.FunctionObject_FunctionExpression_A064FBB8_L3C14::.ctor()
+		IL_0012: newobj instance void Modules.Function_Constructor_Call_Length_Name/'<>DynamicFunction_L3C13'/FunctionObject_FunctionExpression_A064FBB8_L3C14::.ctor()
 		IL_0017: ldc.i4.2
 		IL_0018: conv.r8
 		IL_0019: ldstr ""
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.0
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Constructor_Call_Length_Name_6D50EF12.FunctionObject_FunctionExpression_A064FBB8_L3C14>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Constructor_Call_Length_Name/'<>DynamicFunction_L3C13'/FunctionObject_FunctionExpression_A064FBB8_L3C14>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldstr "console"
 		IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
@@ -171,128 +293,6 @@
 	} // end of method Function_Constructor_Call_Length_Name::__js_module_init__
 
 } // end of class Modules.Function_Constructor_Call_Length_Name
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Constructor_Call_Length_Name_6D50EF12.FunctionObject_FunctionExpression_A064FBB8_L3C14
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x214c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_A064FBB8_L3C14::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2154
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A064FBB8_L3C14::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2157
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A064FBB8_L3C14::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x215a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_A064FBB8_L3C14::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2162
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Function_Constructor_Call_Length_Name/'<>DynamicFunction_L3C13'::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_A064FBB8_L3C14::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x217c
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Function_Constructor_Call_Length_Name/'<>DynamicFunction_L3C13'::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_A064FBB8_L3C14::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2192
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A064FBB8_L3C14::ConstructCore
-
-} // end of class FunctionObjects.Function_Constructor_Call_Length_Name_6D50EF12.FunctionObject_FunctionExpression_A064FBB8_L3C14
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_GlobalScope_NoClosure.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_GlobalScope_NoClosure.verified.txt
@@ -35,6 +35,116 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5C71ED13_L9C16
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x21c5
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_5C71ED13_L9C16::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x21cd
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_5C71ED13_L9C16::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x21d0
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_5C71ED13_L9C16::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object ResolveThisArgumentCore (
+						object thisArgument
+					) cil managed 
+				{
+					// Method begins at RVA 0x21d3
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_5C71ED13_L9C16::ResolveThisArgumentCore
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x21db
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: call object Modules.Function_Constructor_GlobalScope_NoClosure/outer/'<>DynamicFunction_L9C15'::__js_call__(object)
+					IL_000a: ret
+				} // end of method FunctionObject_FunctionExpression_5C71ED13_L9C16::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x21e7
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: call object Modules.Function_Constructor_GlobalScope_NoClosure/outer/'<>DynamicFunction_L9C15'::__js_call__(object)
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_5C71ED13_L9C16::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x21ef
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_5C71ED13_L9C16::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_5C71ED13_L9C16
+
 
 			// Methods
 			.method public hidebysig static 
@@ -100,6 +210,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1B6CABDD_outer
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2194
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_1B6CABDD_outer::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x219c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1B6CABDD_outer::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x219f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1B6CABDD_outer::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21a2
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Function_Constructor_GlobalScope_NoClosure/outer::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_1B6CABDD_outer::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21ae
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Function_Constructor_GlobalScope_NoClosure/outer::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_1B6CABDD_outer::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21b6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_1B6CABDD_outer::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_1B6CABDD_outer
+
 
 		// Methods
 		.method public hidebysig static 
@@ -117,7 +322,7 @@
 			.locals init (
 				[0] class Modules.Function_Constructor_GlobalScope_NoClosure/outer/Scope,
 				[1] float64,
-				[2] class FunctionObjects.Function_Constructor_GlobalScope_NoClosure_C772D853.FunctionObject_FunctionExpression_5C71ED13_L9C16,
+				[2] class Modules.Function_Constructor_GlobalScope_NoClosure/outer/'<>DynamicFunction_L9C15'/FunctionObject_FunctionExpression_5C71ED13_L9C16,
 				[3] object[],
 				[4] object,
 				[5] object
@@ -136,13 +341,13 @@
 			IL_002e: pop
 			IL_002f: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_0034: stloc.3
-			IL_0035: newobj instance void FunctionObjects.Function_Constructor_GlobalScope_NoClosure_C772D853.FunctionObject_FunctionExpression_5C71ED13_L9C16::.ctor()
+			IL_0035: newobj instance void Modules.Function_Constructor_GlobalScope_NoClosure/outer/'<>DynamicFunction_L9C15'/FunctionObject_FunctionExpression_5C71ED13_L9C16::.ctor()
 			IL_003a: ldc.i4.0
 			IL_003b: conv.r8
 			IL_003c: ldstr ""
 			IL_0041: ldc.i4.0
 			IL_0042: ldc.i4.0
-			IL_0043: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Constructor_GlobalScope_NoClosure_C772D853.FunctionObject_FunctionExpression_5C71ED13_L9C16>(!!0, float64, string, bool, bool)
+			IL_0043: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Constructor_GlobalScope_NoClosure/outer/'<>DynamicFunction_L9C15'/FunctionObject_FunctionExpression_5C71ED13_L9C16>(!!0, float64, string, bool, bool)
 			IL_0048: stloc.2
 			IL_0049: ldstr "console"
 			IL_004e: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
@@ -207,7 +412,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Constructor_GlobalScope_NoClosure/Scope,
-			[1] class FunctionObjects.Function_Constructor_GlobalScope_NoClosure_C772D853.FunctionObject_FunctionDeclaration_1B6CABDD_outer,
+			[1] class Modules.Function_Constructor_GlobalScope_NoClosure/outer/FunctionObject_FunctionDeclaration_1B6CABDD_outer,
 			[2] float64,
 			[3] object[]
 		)
@@ -221,13 +426,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.Function_Constructor_GlobalScope_NoClosure_C772D853.FunctionObject_FunctionDeclaration_1B6CABDD_outer::.ctor()
+		IL_0011: newobj instance void Modules.Function_Constructor_GlobalScope_NoClosure/outer/FunctionObject_FunctionDeclaration_1B6CABDD_outer::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "outer"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Constructor_GlobalScope_NoClosure_C772D853.FunctionObject_FunctionDeclaration_1B6CABDD_outer>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Constructor_GlobalScope_NoClosure/outer/FunctionObject_FunctionDeclaration_1B6CABDD_outer>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: ldc.r8 10
@@ -241,211 +446,6 @@
 	} // end of method Function_Constructor_GlobalScope_NoClosure::__js_module_init__
 
 } // end of class Modules.Function_Constructor_GlobalScope_NoClosure
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Constructor_GlobalScope_NoClosure_C772D853.FunctionObject_FunctionDeclaration_1B6CABDD_outer
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2194
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_1B6CABDD_outer::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x219c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1B6CABDD_outer::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x219f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1B6CABDD_outer::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21a2
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Function_Constructor_GlobalScope_NoClosure/outer::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_1B6CABDD_outer::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ae
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Function_Constructor_GlobalScope_NoClosure/outer::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_1B6CABDD_outer::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21b6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_1B6CABDD_outer::ConstructCore
-
-} // end of class FunctionObjects.Function_Constructor_GlobalScope_NoClosure_C772D853.FunctionObject_FunctionDeclaration_1B6CABDD_outer
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Constructor_GlobalScope_NoClosure_C772D853.FunctionObject_FunctionExpression_5C71ED13_L9C16
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21c5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_5C71ED13_L9C16::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21cd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5C71ED13_L9C16::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21d0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5C71ED13_L9C16::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x21d3
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_5C71ED13_L9C16::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21db
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Function_Constructor_GlobalScope_NoClosure/outer/'<>DynamicFunction_L9C15'::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_5C71ED13_L9C16::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21e7
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Function_Constructor_GlobalScope_NoClosure/outer/'<>DynamicFunction_L9C15'::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_5C71ED13_L9C16::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ef
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5C71ED13_L9C16::ConstructCore
-
-} // end of class FunctionObjects.Function_Constructor_GlobalScope_NoClosure_C772D853.FunctionObject_FunctionExpression_5C71ED13_L9C16
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_New_ConstantString_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_New_ConstantString_Basic.verified.txt
@@ -31,6 +31,118 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_717FBDDC_L3C12
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2121
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_717FBDDC_L3C12::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2129
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_717FBDDC_L3C12::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x212c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_717FBDDC_L3C12::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x212f
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_717FBDDC_L3C12::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2137
+				// Header size: 1
+				// Code size: 16 (0x10)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call float64 Modules.Function_Constructor_New_ConstantString_Basic/'<>DynamicFunction_L3C11'::__js_call__(object)
+				IL_000a: box [System.Runtime]System.Double
+				IL_000f: ret
+			} // end of method FunctionObject_FunctionExpression_717FBDDC_L3C12::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2148
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call float64 Modules.Function_Constructor_New_ConstantString_Basic/'<>DynamicFunction_L3C11'::__js_call__(object)
+				IL_0006: box [System.Runtime]System.Double
+				IL_000b: ret
+			} // end of method FunctionObject_FunctionExpression_717FBDDC_L3C12::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2155
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_717FBDDC_L3C12::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_717FBDDC_L3C12
+
 
 		// Methods
 		.method public hidebysig static 
@@ -89,7 +201,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Constructor_New_ConstantString_Basic/Scope,
-			[1] class FunctionObjects.Function_Constructor_New_ConstantString_Basic_3C3F899C.FunctionObject_FunctionExpression_717FBDDC_L3C12,
+			[1] class Modules.Function_Constructor_New_ConstantString_Basic/'<>DynamicFunction_L3C11'/FunctionObject_FunctionExpression_717FBDDC_L3C12,
 			[2] object[],
 			[3] object,
 			[4] object
@@ -105,13 +217,13 @@
 		IL_000f: ldloc.0
 		IL_0010: stelem.ref
 		IL_0011: stloc.2
-		IL_0012: newobj instance void FunctionObjects.Function_Constructor_New_ConstantString_Basic_3C3F899C.FunctionObject_FunctionExpression_717FBDDC_L3C12::.ctor()
+		IL_0012: newobj instance void Modules.Function_Constructor_New_ConstantString_Basic/'<>DynamicFunction_L3C11'/FunctionObject_FunctionExpression_717FBDDC_L3C12::.ctor()
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr ""
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.0
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Constructor_New_ConstantString_Basic_3C3F899C.FunctionObject_FunctionExpression_717FBDDC_L3C12>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Constructor_New_ConstantString_Basic/'<>DynamicFunction_L3C11'/FunctionObject_FunctionExpression_717FBDDC_L3C12>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldstr "console"
 		IL_002b: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
@@ -156,118 +268,6 @@
 	} // end of method Function_Constructor_New_ConstantString_Basic::__js_module_init__
 
 } // end of class Modules.Function_Constructor_New_ConstantString_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Constructor_New_ConstantString_Basic_3C3F899C.FunctionObject_FunctionExpression_717FBDDC_L3C12
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2121
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_717FBDDC_L3C12::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2129
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_717FBDDC_L3C12::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x212c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_717FBDDC_L3C12::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x212f
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_717FBDDC_L3C12::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2137
-		// Header size: 1
-		// Code size: 16 (0x10)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call float64 Modules.Function_Constructor_New_ConstantString_Basic/'<>DynamicFunction_L3C11'::__js_call__(object)
-		IL_000a: box [System.Runtime]System.Double
-		IL_000f: ret
-	} // end of method FunctionObject_FunctionExpression_717FBDDC_L3C12::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2148
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call float64 Modules.Function_Constructor_New_ConstantString_Basic/'<>DynamicFunction_L3C11'::__js_call__(object)
-		IL_0006: box [System.Runtime]System.Double
-		IL_000b: ret
-	} // end of method FunctionObject_FunctionExpression_717FBDDC_L3C12::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2155
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_717FBDDC_L3C12::ConstructCore
-
-} // end of class FunctionObjects.Function_Constructor_New_ConstantString_Basic_3C3F899C.FunctionObject_FunctionExpression_717FBDDC_L3C12
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_New_ShadowedLocal_NoSyntaxError.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Constructor_New_ShadowedLocal_NoSyntaxError.verified.txt
@@ -51,6 +51,89 @@
 
 		} // end of class Scope_ctor
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_8DAADD44_ClassExpression_L3C16
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2116
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Function_Constructor_New_ShadowedLocal_NoSyntaxError/ClassExpression_L3C16/FunctionObject_ClassConstructor_8DAADD44_ClassExpression_L3C16::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_8DAADD44_ClassExpression_L3C16::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2125
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_8DAADD44_ClassExpression_L3C16::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2128
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_8DAADD44_ClassExpression_L3C16::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x212b
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_8DAADD44_ClassExpression_L3C16::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2137
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_8DAADD44_ClassExpression_L3C16::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_8DAADD44_ClassExpression_L3C16
+
 
 		// Fields
 		.field public object source
@@ -175,89 +258,6 @@
 	} // end of method Function_Constructor_New_ShadowedLocal_NoSyntaxError::__js_module_init__
 
 } // end of class Modules.Function_Constructor_New_ShadowedLocal_NoSyntaxError
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Constructor_New_ShadowedLocal_NoSyntaxError_681E68F1.FunctionObject_ClassConstructor_8DAADD44_ClassExpression_L3C16
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2116
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Function_Constructor_New_ShadowedLocal_NoSyntaxError_681E68F1.FunctionObject_ClassConstructor_8DAADD44_ClassExpression_L3C16::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_8DAADD44_ClassExpression_L3C16::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2125
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_8DAADD44_ClassExpression_L3C16::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2128
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_8DAADD44_ClassExpression_L3C16::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x212b
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_8DAADD44_ClassExpression_L3C16::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2137
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_8DAADD44_ClassExpression_L3C16::ConstructCore
-
-} // end of class FunctionObjects.Function_Constructor_New_ShadowedLocal_NoSyntaxError_681E68F1.FunctionObject_ClassConstructor_8DAADD44_ClassExpression_L3C16
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_DefaultParameterExpression.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_DefaultParameterExpression.verified.txt
@@ -53,6 +53,121 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_87C4B4A9_calculate
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2175
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_87C4B4A9_calculate::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x217d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_87C4B4A9_calculate::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2180
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_87C4B4A9_calculate::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2183
+				// Header size: 1
+				// Code size: 37 (0x25)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: ldarg.2
+				IL_0019: ldc.i4.2
+				IL_001a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001f: call object Modules.Function_DefaultParameterExpression/calculate::__js_call__(object, float64, object, object)
+				IL_0024: ret
+			} // end of method FunctionObject_FunctionDeclaration_87C4B4A9_calculate::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21a9
+				// Header size: 1
+				// Code size: 33 (0x21)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: ldarg.2
+				IL_0015: ldc.i4.2
+				IL_0016: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001b: call object Modules.Function_DefaultParameterExpression/calculate::__js_call__(object, float64, object, object)
+				IL_0020: ret
+			} // end of method FunctionObject_FunctionDeclaration_87C4B4A9_calculate::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21cb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_87C4B4A9_calculate::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_87C4B4A9_calculate
+
 
 		// Methods
 		.method public hidebysig static 
@@ -156,7 +271,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_DefaultParameterExpression/Scope,
-			[1] class FunctionObjects.Function_DefaultParameterExpression_52DC052C.FunctionObject_FunctionDeclaration_87C4B4A9_calculate,
+			[1] class Modules.Function_DefaultParameterExpression/calculate/FunctionObject_FunctionDeclaration_87C4B4A9_calculate,
 			[2] object[]
 		)
 
@@ -169,13 +284,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.Function_DefaultParameterExpression_52DC052C.FunctionObject_FunctionDeclaration_87C4B4A9_calculate::.ctor()
+		IL_0011: newobj instance void Modules.Function_DefaultParameterExpression/calculate/FunctionObject_FunctionDeclaration_87C4B4A9_calculate::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "calculate"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_DefaultParameterExpression_52DC052C.FunctionObject_FunctionDeclaration_87C4B4A9_calculate>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_DefaultParameterExpression/calculate/FunctionObject_FunctionDeclaration_87C4B4A9_calculate>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -213,121 +328,6 @@
 	} // end of method Function_DefaultParameterExpression::__js_module_init__
 
 } // end of class Modules.Function_DefaultParameterExpression
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_DefaultParameterExpression_52DC052C.FunctionObject_FunctionDeclaration_87C4B4A9_calculate
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2175
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_87C4B4A9_calculate::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x217d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_87C4B4A9_calculate::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2180
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_87C4B4A9_calculate::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2183
-		// Header size: 1
-		// Code size: 37 (0x25)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: ldarg.2
-		IL_0019: ldc.i4.2
-		IL_001a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001f: call object Modules.Function_DefaultParameterExpression/calculate::__js_call__(object, float64, object, object)
-		IL_0024: ret
-	} // end of method FunctionObject_FunctionDeclaration_87C4B4A9_calculate::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21a9
-		// Header size: 1
-		// Code size: 33 (0x21)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: ldarg.2
-		IL_0015: ldc.i4.2
-		IL_0016: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001b: call object Modules.Function_DefaultParameterExpression/calculate::__js_call__(object, float64, object, object)
-		IL_0020: ret
-	} // end of method FunctionObject_FunctionDeclaration_87C4B4A9_calculate::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21cb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_87C4B4A9_calculate::ConstructCore
-
-} // end of class FunctionObjects.Function_DefaultParameterExpression_52DC052C.FunctionObject_FunctionDeclaration_87C4B4A9_calculate
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_DefaultParameterValue.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_DefaultParameterValue.verified.txt
@@ -53,6 +53,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4C80C787_greet
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x231a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_4C80C787_greet::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2322
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4C80C787_greet::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2325
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4C80C787_greet::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2328
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Function_DefaultParameterValue/greet::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_4C80C787_greet::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x233b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Function_DefaultParameterValue/greet::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4C80C787_greet::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x234a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4C80C787_greet::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_4C80C787_greet
+
 
 		// Methods
 		.method public hidebysig static 
@@ -143,6 +244,115 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A99DB459_add
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2359
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_A99DB459_add::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2361
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A99DB459_add::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2364
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A99DB459_add::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2367
+				// Header size: 1
+				// Code size: 30 (0x1e)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call object Modules.Function_DefaultParameterValue/'add'::__js_call__(object, float64, object)
+				IL_001d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A99DB459_add::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2386
+				// Header size: 1
+				// Code size: 26 (0x1a)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call object Modules.Function_DefaultParameterValue/'add'::__js_call__(object, float64, object)
+				IL_0019: ret
+			} // end of method FunctionObject_FunctionDeclaration_A99DB459_add::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23a1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A99DB459_add::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_A99DB459_add
 
 
 		// Methods
@@ -236,6 +446,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4C0D3643_multi
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x23b0
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_4C0D3643_multi::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x23b8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4C0D3643_multi::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x23bb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4C0D3643_multi::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x23be
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.2
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.Function_DefaultParameterValue/multi::__js_call__(object, object, object, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionDeclaration_4C0D3643_multi::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23df
+				// Header size: 1
+				// Code size: 28 (0x1c)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: ldarg.2
+				IL_0010: ldc.i4.2
+				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0016: call object Modules.Function_DefaultParameterValue/multi::__js_call__(object, object, object, object)
+				IL_001b: ret
+			} // end of method FunctionObject_FunctionDeclaration_4C0D3643_multi::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23fc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4C0D3643_multi::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_4C0D3643_multi
 
 
 		// Methods
@@ -353,9 +676,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_DefaultParameterValue/Scope,
-			[1] class FunctionObjects.Function_DefaultParameterValue_3EFC752F.FunctionObject_FunctionDeclaration_4C80C787_greet,
-			[2] class FunctionObjects.Function_DefaultParameterValue_3EFC752F.FunctionObject_FunctionDeclaration_A99DB459_add,
-			[3] class FunctionObjects.Function_DefaultParameterValue_3EFC752F.FunctionObject_FunctionDeclaration_4C0D3643_multi,
+			[1] class Modules.Function_DefaultParameterValue/greet/FunctionObject_FunctionDeclaration_4C80C787_greet,
+			[2] class Modules.Function_DefaultParameterValue/'add'/FunctionObject_FunctionDeclaration_A99DB459_add,
+			[3] class Modules.Function_DefaultParameterValue/multi/FunctionObject_FunctionDeclaration_4C0D3643_multi,
 			[4] object[]
 		)
 
@@ -368,13 +691,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 4
-		IL_0012: newobj instance void FunctionObjects.Function_DefaultParameterValue_3EFC752F.FunctionObject_FunctionDeclaration_4C80C787_greet::.ctor()
+		IL_0012: newobj instance void Modules.Function_DefaultParameterValue/greet/FunctionObject_FunctionDeclaration_4C80C787_greet::.ctor()
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "greet"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_DefaultParameterValue_3EFC752F.FunctionObject_FunctionDeclaration_4C80C787_greet>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_DefaultParameterValue/greet/FunctionObject_FunctionDeclaration_4C80C787_greet>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -383,13 +706,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 4
-		IL_0032: newobj instance void FunctionObjects.Function_DefaultParameterValue_3EFC752F.FunctionObject_FunctionDeclaration_A99DB459_add::.ctor()
+		IL_0032: newobj instance void Modules.Function_DefaultParameterValue/'add'/FunctionObject_FunctionDeclaration_A99DB459_add::.ctor()
 		IL_0037: ldc.i4.1
 		IL_0038: conv.r8
 		IL_0039: ldstr "add"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_DefaultParameterValue_3EFC752F.FunctionObject_FunctionDeclaration_A99DB459_add>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_DefaultParameterValue/'add'/FunctionObject_FunctionDeclaration_A99DB459_add>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -398,13 +721,13 @@
 		IL_004e: ldloc.0
 		IL_004f: stelem.ref
 		IL_0050: stloc.s 4
-		IL_0052: newobj instance void FunctionObjects.Function_DefaultParameterValue_3EFC752F.FunctionObject_FunctionDeclaration_4C0D3643_multi::.ctor()
+		IL_0052: newobj instance void Modules.Function_DefaultParameterValue/multi/FunctionObject_FunctionDeclaration_4C0D3643_multi::.ctor()
 		IL_0057: ldc.i4.0
 		IL_0058: conv.r8
 		IL_0059: ldstr "multi"
 		IL_005e: ldc.i4.0
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_DefaultParameterValue_3EFC752F.FunctionObject_FunctionDeclaration_4C0D3643_multi>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_DefaultParameterValue/multi/FunctionObject_FunctionDeclaration_4C0D3643_multi>(!!0, float64, string, bool, bool)
 		IL_0065: stloc.3
 		IL_0066: nop
 		IL_0067: nop
@@ -477,329 +800,6 @@
 	} // end of method Function_DefaultParameterValue::__js_module_init__
 
 } // end of class Modules.Function_DefaultParameterValue
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_DefaultParameterValue_3EFC752F.FunctionObject_FunctionDeclaration_4C80C787_greet
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x231a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_4C80C787_greet::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2322
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4C80C787_greet::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2325
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4C80C787_greet::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2328
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Function_DefaultParameterValue/greet::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_4C80C787_greet::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x233b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Function_DefaultParameterValue/greet::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4C80C787_greet::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x234a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4C80C787_greet::ConstructCore
-
-} // end of class FunctionObjects.Function_DefaultParameterValue_3EFC752F.FunctionObject_FunctionDeclaration_4C80C787_greet
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_DefaultParameterValue_3EFC752F.FunctionObject_FunctionDeclaration_A99DB459_add
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2359
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_A99DB459_add::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2361
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A99DB459_add::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2364
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A99DB459_add::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2367
-		// Header size: 1
-		// Code size: 30 (0x1e)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call object Modules.Function_DefaultParameterValue/'add'::__js_call__(object, float64, object)
-		IL_001d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A99DB459_add::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2386
-		// Header size: 1
-		// Code size: 26 (0x1a)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call object Modules.Function_DefaultParameterValue/'add'::__js_call__(object, float64, object)
-		IL_0019: ret
-	} // end of method FunctionObject_FunctionDeclaration_A99DB459_add::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23a1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A99DB459_add::ConstructCore
-
-} // end of class FunctionObjects.Function_DefaultParameterValue_3EFC752F.FunctionObject_FunctionDeclaration_A99DB459_add
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_DefaultParameterValue_3EFC752F.FunctionObject_FunctionDeclaration_4C0D3643_multi
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x23b0
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_4C0D3643_multi::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23b8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4C0D3643_multi::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23bb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4C0D3643_multi::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23be
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.2
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.Function_DefaultParameterValue/multi::__js_call__(object, object, object, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionDeclaration_4C0D3643_multi::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23df
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: ldarg.2
-		IL_0010: ldc.i4.2
-		IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0016: call object Modules.Function_DefaultParameterValue/multi::__js_call__(object, object, object, object)
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionDeclaration_4C0D3643_multi::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23fc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4C0D3643_multi::ConstructCore
-
-} // end of class FunctionObjects.Function_DefaultParameterValue_3EFC752F.FunctionObject_FunctionDeclaration_4C0D3643_multi
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter.verified.txt
@@ -35,6 +35,124 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_CBDAF3AF_L9C26
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/Scope _environment1_makeOffsetMapper
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x21fd
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/Scope Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionExpression_L9C25/FunctionObject_FunctionExpression_CBDAF3AF_L9C26::_environment1_makeOffsetMapper
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionExpression_L9C25/FunctionObject_FunctionExpression_CBDAF3AF_L9C26::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionExpression_CBDAF3AF_L9C26::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2213
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_CBDAF3AF_L9C26::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2216
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_CBDAF3AF_L9C26::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2219
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionExpression_L9C25/FunctionObject_FunctionExpression_CBDAF3AF_L9C26::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionExpression_L9C25::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_CBDAF3AF_L9C26::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2232
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionExpression_L9C25/FunctionObject_FunctionExpression_CBDAF3AF_L9C26::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionExpression_L9C25::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_CBDAF3AF_L9C26::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2247
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_CBDAF3AF_L9C26::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_CBDAF3AF_L9C26
+
 
 			// Methods
 			.method public hidebysig static 
@@ -99,6 +217,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope _environment0_Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21ab
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::_environment0_Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21ba
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21bd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21c0
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::_environment0_Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper::__js_call__(class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21d9
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::_environment0_Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper::__js_call__(class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21ee
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper
+
 
 		// Methods
 		.method public hidebysig static 
@@ -121,7 +352,7 @@
 				[0] class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/Scope,
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[2] object[],
-				[3] class FunctionObjects.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter_7F55A461.FunctionObject_FunctionExpression_CBDAF3AF_L9C26,
+				[3] class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionExpression_L9C25/FunctionObject_FunctionExpression_CBDAF3AF_L9C26,
 				[4] string
 			)
 
@@ -158,13 +389,13 @@
 			IL_0052: ldelem.ref
 			IL_0053: castclass Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/Scope
 			IL_0058: ldloc.2
-			IL_0059: newobj instance void FunctionObjects.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter_7F55A461.FunctionObject_FunctionExpression_CBDAF3AF_L9C26::.ctor(class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/Scope, object[])
+			IL_0059: newobj instance void Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionExpression_L9C25/FunctionObject_FunctionExpression_CBDAF3AF_L9C26::.ctor(class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/Scope, object[])
 			IL_005e: ldc.i4.1
 			IL_005f: conv.r8
 			IL_0060: ldstr ""
 			IL_0065: ldc.i4.0
 			IL_0066: ldc.i4.1
-			IL_0067: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter_7F55A461.FunctionObject_FunctionExpression_CBDAF3AF_L9C26>(!!0, float64, string, bool, bool)
+			IL_0067: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionExpression_L9C25/FunctionObject_FunctionExpression_CBDAF3AF_L9C26>(!!0, float64, string, bool, bool)
 			IL_006c: stloc.3
 			IL_006d: ldloc.1
 			IL_006e: ldc.i4.1
@@ -235,7 +466,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope,
-			[1] class FunctionObjects.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter_7F55A461.FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper,
+			[1] class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper,
 			[2] object[],
 			[3] object,
 			[4] object
@@ -254,13 +485,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope
-		IL_0019: newobj instance void FunctionObjects.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter_7F55A461.FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::.ctor(class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope)
+		IL_0019: newobj instance void Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::.ctor(class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope)
 		IL_001e: ldc.i4.1
 		IL_001f: conv.r8
 		IL_0020: ldstr "makeOffsetMapper"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter_7F55A461.FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
@@ -285,237 +516,6 @@
 	} // end of method Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter::__js_module_init__
 
 } // end of class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter_7F55A461.FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope _environment0_Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ab
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope FunctionObjects.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter_7F55A461.FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::_environment0_Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21ba
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21bd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21c0
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope FunctionObjects.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter_7F55A461.FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::_environment0_Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper::__js_call__(class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21d9
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope FunctionObjects.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter_7F55A461.FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::_environment0_Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper::__js_call__(class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ee
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper::ConstructCore
-
-} // end of class FunctionObjects.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter_7F55A461.FunctionObject_FunctionDeclaration_6980DA54_makeOffsetMapper
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter_7F55A461.FunctionObject_FunctionExpression_CBDAF3AF_L9C26
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/Scope _environment1_makeOffsetMapper
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x21fd
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/Scope FunctionObjects.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter_7F55A461.FunctionObject_FunctionExpression_CBDAF3AF_L9C26::_environment1_makeOffsetMapper
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter_7F55A461.FunctionObject_FunctionExpression_CBDAF3AF_L9C26::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_CBDAF3AF_L9C26::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2213
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_CBDAF3AF_L9C26::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2216
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_CBDAF3AF_L9C26::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2219
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter_7F55A461.FunctionObject_FunctionExpression_CBDAF3AF_L9C26::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionExpression_L9C25::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_CBDAF3AF_L9C26::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2232
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter_7F55A461.FunctionObject_FunctionExpression_CBDAF3AF_L9C26::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter/makeOffsetMapper/FunctionExpression_L9C25::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_CBDAF3AF_L9C26::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2247
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_CBDAF3AF_L9C26::ConstructCore
-
-} // end of class FunctionObjects.Function_FunctionExpression_AsExpression_ArrayMapCapturesOuter_7F55A461.FunctionObject_FunctionExpression_CBDAF3AF_L9C26
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GeneratedConstruction_Semantics.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GeneratedConstruction_Semantics.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0A22665E_Receiver
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2bcb
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_0A22665E_Receiver::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2bd3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0A22665E_Receiver::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2bd6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0A22665E_Receiver::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bd9
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Function_GeneratedConstruction_Semantics/Receiver::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_0A22665E_Receiver::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bec
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Function_GeneratedConstruction_Semantics/Receiver::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0A22665E_Receiver::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bfb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0A22665E_Receiver::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_0A22665E_Receiver
+
 
 		// Methods
 		.method public hidebysig static 
@@ -96,6 +197,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_73B6C30F_Alternate
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2c0a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_73B6C30F_Alternate::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2c12
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_73B6C30F_Alternate::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2c15
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_73B6C30F_Alternate::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c18
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Function_GeneratedConstruction_Semantics/Alternate::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_73B6C30F_Alternate::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c24
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Function_GeneratedConstruction_Semantics/Alternate::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_73B6C30F_Alternate::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c2c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_73B6C30F_Alternate::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_73B6C30F_Alternate
+
 
 		// Methods
 		.method public hidebysig static 
@@ -140,6 +336,103 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2c3b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2c43
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2c46
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c49
+				// Header size: 1
+				// Code size: 16 (0x10)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call float64 Modules.Function_GeneratedConstruction_Semantics/ReturnsPrimitive::__js_call__(object)
+				IL_000a: box [System.Runtime]System.Double
+				IL_000f: ret
+			} // end of method FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c5a
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call float64 Modules.Function_GeneratedConstruction_Semantics/ReturnsPrimitive::__js_call__(object)
+				IL_0006: box [System.Runtime]System.Double
+				IL_000b: ret
+			} // end of method FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c67
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive
 
 
 		// Methods
@@ -192,6 +485,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_GeneratedConstruction_Semantics/Scope _environment0_Function_GeneratedConstruction_Semantics
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_GeneratedConstruction_Semantics/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c76
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_GeneratedConstruction_Semantics/Scope Modules.Function_GeneratedConstruction_Semantics/ReturnsObject/FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::_environment0_Function_GeneratedConstruction_Semantics
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2c85
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2c88
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c8b
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_GeneratedConstruction_Semantics/Scope Modules.Function_GeneratedConstruction_Semantics/ReturnsObject/FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::_environment0_Function_GeneratedConstruction_Semantics
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_GeneratedConstruction_Semantics/ReturnsObject::__js_call__(class Modules.Function_GeneratedConstruction_Semantics/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c9d
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_GeneratedConstruction_Semantics/Scope Modules.Function_GeneratedConstruction_Semantics/ReturnsObject/FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::_environment0_Function_GeneratedConstruction_Semantics
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_GeneratedConstruction_Semantics/ReturnsObject::__js_call__(class Modules.Function_GeneratedConstruction_Semantics/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2cab
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject
 
 
 		// Methods
@@ -251,6 +651,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_60D679A4_BoundTarget
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2d2b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_60D679A4_BoundTarget::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2d33
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_60D679A4_BoundTarget::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2d36
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_60D679A4_BoundTarget::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d39
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Function_GeneratedConstruction_Semantics/BoundTarget::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_60D679A4_BoundTarget::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d4c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Function_GeneratedConstruction_Semantics/BoundTarget::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_60D679A4_BoundTarget::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d5b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_60D679A4_BoundTarget::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_60D679A4_BoundTarget
 
 
 		// Methods
@@ -421,6 +922,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2A9B4B11_L96C24
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2d80
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_2A9B4B11_L96C24::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2d88
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_2A9B4B11_L96C24::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2d8b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_2A9B4B11_L96C24::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d8e
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_holder::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_2A9B4B11_L96C24::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d9a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_holder::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_2A9B4B11_L96C24::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2da2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_2A9B4B11_L96C24::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_2A9B4B11_L96C24
+
 
 		// Methods
 		.method public hidebysig static 
@@ -465,6 +1061,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A05B3306_L69C33
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_GeneratedConstruction_Semantics/Scope _environment0_Function_GeneratedConstruction_Semantics
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_GeneratedConstruction_Semantics/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ce7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_GeneratedConstruction_Semantics/Scope Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject_FunctionExpression_A05B3306_L69C33::_environment0_Function_GeneratedConstruction_Semantics
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_A05B3306_L69C33::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2cf6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A05B3306_L69C33::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2cf9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A05B3306_L69C33::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2cfc
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_GeneratedConstruction_Semantics/Scope Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject_FunctionExpression_A05B3306_L69C33::_environment0_Function_GeneratedConstruction_Semantics
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32::__js_call__(class Modules.Function_GeneratedConstruction_Semantics/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_A05B3306_L69C33::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d0e
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_GeneratedConstruction_Semantics/Scope Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject_FunctionExpression_A05B3306_L69C33::_environment0_Function_GeneratedConstruction_Semantics
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32::__js_call__(class Modules.Function_GeneratedConstruction_Semantics/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_A05B3306_L69C33::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d1c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_A05B3306_L69C33::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_A05B3306_L69C33
 
 
 		// Methods
@@ -530,6 +1233,89 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_479B7F3D_DerivedFromObject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2cba
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Function_GeneratedConstruction_Semantics/DerivedFromObject/FunctionObject_ClassConstructor_479B7F3D_DerivedFromObject::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_479B7F3D_DerivedFromObject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2cc9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_479B7F3D_DerivedFromObject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2ccc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_479B7F3D_DerivedFromObject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ccf
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_479B7F3D_DerivedFromObject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2cdb
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_479B7F3D_DerivedFromObject::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_479B7F3D_DerivedFromObject
+
 
 		// Fields
 		.field private object[] _scopes
@@ -549,7 +1335,7 @@
 			.maxstack 8
 			.locals init (
 				[0] object[],
-				[1] class FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionExpression_A05B3306_L69C33
+				[1] class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject_FunctionExpression_A05B3306_L69C33
 			)
 
 			IL_0000: ldc.i4.1
@@ -565,13 +1351,13 @@
 			IL_000e: ldc.i4.0
 			IL_000f: ldelem.ref
 			IL_0010: castclass Modules.Function_GeneratedConstruction_Semantics/Scope
-			IL_0015: newobj instance void FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionExpression_A05B3306_L69C33::.ctor(class Modules.Function_GeneratedConstruction_Semantics/Scope)
+			IL_0015: newobj instance void Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject_FunctionExpression_A05B3306_L69C33::.ctor(class Modules.Function_GeneratedConstruction_Semantics/Scope)
 			IL_001a: ldc.i4.0
 			IL_001b: conv.r8
 			IL_001c: ldstr ""
 			IL_0021: ldc.i4.1
 			IL_0022: ldc.i4.1
-			IL_0023: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionExpression_A05B3306_L69C33>(!!0, float64, string, bool, bool)
+			IL_0023: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject_FunctionExpression_A05B3306_L69C33>(!!0, float64, string, bool, bool)
 			IL_0028: stloc.1
 			IL_0029: ldarg.0
 			IL_002a: ldloc.1
@@ -788,11 +1574,11 @@
 		.maxstack 10
 		.locals init (
 			[0] class Modules.Function_GeneratedConstruction_Semantics/Scope,
-			[1] class FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionDeclaration_0A22665E_Receiver,
-			[2] class FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionDeclaration_73B6C30F_Alternate,
-			[3] class FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive,
-			[4] class FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject,
-			[5] class FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionDeclaration_60D679A4_BoundTarget,
+			[1] class Modules.Function_GeneratedConstruction_Semantics/Receiver/FunctionObject_FunctionDeclaration_0A22665E_Receiver,
+			[2] class Modules.Function_GeneratedConstruction_Semantics/Alternate/FunctionObject_FunctionDeclaration_73B6C30F_Alternate,
+			[3] class Modules.Function_GeneratedConstruction_Semantics/ReturnsPrimitive/FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive,
+			[4] class Modules.Function_GeneratedConstruction_Semantics/ReturnsObject/FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject,
+			[5] class Modules.Function_GeneratedConstruction_Semantics/BoundTarget/FunctionObject_FunctionDeclaration_60D679A4_BoundTarget,
 			[6] object,
 			[7] object,
 			[8] object,
@@ -827,7 +1613,7 @@
 			[37] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[38] object,
 			[39] class [System.Runtime]System.Type,
-			[40] class FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionExpression_A05B3306_L69C33,
+			[40] class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject_FunctionExpression_A05B3306_L69C33,
 			[41] class Modules.Function_GeneratedConstruction_Semantics/ArrowFunction_L95C15/FunctionObject,
 			[42] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
 			[43] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -844,13 +1630,13 @@
 		IL_0013: ldloc.0
 		IL_0014: stelem.ref
 		IL_0015: stloc.s 28
-		IL_0017: newobj instance void FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionDeclaration_0A22665E_Receiver::.ctor()
+		IL_0017: newobj instance void Modules.Function_GeneratedConstruction_Semantics/Receiver/FunctionObject_FunctionDeclaration_0A22665E_Receiver::.ctor()
 		IL_001c: ldc.i4.1
 		IL_001d: conv.r8
 		IL_001e: ldstr "Receiver"
 		IL_0023: ldc.i4.1
 		IL_0024: ldc.i4.1
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionDeclaration_0A22665E_Receiver>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/Receiver/FunctionObject_FunctionDeclaration_0A22665E_Receiver>(!!0, float64, string, bool, bool)
 		IL_002a: stloc.1
 		IL_002b: ldc.i4.1
 		IL_002c: newarr [System.Runtime]System.Object
@@ -859,13 +1645,13 @@
 		IL_0033: ldloc.0
 		IL_0034: stelem.ref
 		IL_0035: stloc.s 28
-		IL_0037: newobj instance void FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionDeclaration_73B6C30F_Alternate::.ctor()
+		IL_0037: newobj instance void Modules.Function_GeneratedConstruction_Semantics/Alternate/FunctionObject_FunctionDeclaration_73B6C30F_Alternate::.ctor()
 		IL_003c: ldc.i4.0
 		IL_003d: conv.r8
 		IL_003e: ldstr "Alternate"
 		IL_0043: ldc.i4.0
 		IL_0044: ldc.i4.1
-		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionDeclaration_73B6C30F_Alternate>(!!0, float64, string, bool, bool)
+		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/Alternate/FunctionObject_FunctionDeclaration_73B6C30F_Alternate>(!!0, float64, string, bool, bool)
 		IL_004a: stloc.2
 		IL_004b: ldc.i4.1
 		IL_004c: newarr [System.Runtime]System.Object
@@ -874,13 +1660,13 @@
 		IL_0053: ldloc.0
 		IL_0054: stelem.ref
 		IL_0055: stloc.s 28
-		IL_0057: newobj instance void FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive::.ctor()
+		IL_0057: newobj instance void Modules.Function_GeneratedConstruction_Semantics/ReturnsPrimitive/FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive::.ctor()
 		IL_005c: ldc.i4.0
 		IL_005d: conv.r8
 		IL_005e: ldstr "ReturnsPrimitive"
 		IL_0063: ldc.i4.1
 		IL_0064: ldc.i4.1
-		IL_0065: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive>(!!0, float64, string, bool, bool)
+		IL_0065: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/ReturnsPrimitive/FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive>(!!0, float64, string, bool, bool)
 		IL_006a: stloc.3
 		IL_006b: ldc.i4.1
 		IL_006c: newarr [System.Runtime]System.Object
@@ -893,13 +1679,13 @@
 		IL_0079: ldc.i4.0
 		IL_007a: ldelem.ref
 		IL_007b: castclass Modules.Function_GeneratedConstruction_Semantics/Scope
-		IL_0080: newobj instance void FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::.ctor(class Modules.Function_GeneratedConstruction_Semantics/Scope)
+		IL_0080: newobj instance void Modules.Function_GeneratedConstruction_Semantics/ReturnsObject/FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::.ctor(class Modules.Function_GeneratedConstruction_Semantics/Scope)
 		IL_0085: ldc.i4.0
 		IL_0086: conv.r8
 		IL_0087: ldstr "ReturnsObject"
 		IL_008c: ldc.i4.1
 		IL_008d: ldc.i4.1
-		IL_008e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject>(!!0, float64, string, bool, bool)
+		IL_008e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/ReturnsObject/FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject>(!!0, float64, string, bool, bool)
 		IL_0093: stloc.s 4
 		IL_0095: ldc.i4.1
 		IL_0096: newarr [System.Runtime]System.Object
@@ -908,13 +1694,13 @@
 		IL_009d: ldloc.0
 		IL_009e: stelem.ref
 		IL_009f: stloc.s 28
-		IL_00a1: newobj instance void FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionDeclaration_60D679A4_BoundTarget::.ctor()
+		IL_00a1: newobj instance void Modules.Function_GeneratedConstruction_Semantics/BoundTarget/FunctionObject_FunctionDeclaration_60D679A4_BoundTarget::.ctor()
 		IL_00a6: ldc.i4.1
 		IL_00a7: conv.r8
 		IL_00a8: ldstr "BoundTarget"
 		IL_00ad: ldc.i4.1
 		IL_00ae: ldc.i4.1
-		IL_00af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionDeclaration_60D679A4_BoundTarget>(!!0, float64, string, bool, bool)
+		IL_00af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/BoundTarget/FunctionObject_FunctionDeclaration_60D679A4_BoundTarget>(!!0, float64, string, bool, bool)
 		IL_00b4: stloc.s 5
 		IL_00b6: nop
 		IL_00b7: nop
@@ -1365,13 +2151,13 @@
 		IL_059c: ldc.i4.0
 		IL_059d: ldelem.ref
 		IL_059e: castclass Modules.Function_GeneratedConstruction_Semantics/Scope
-		IL_05a3: newobj instance void FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionExpression_A05B3306_L69C33::.ctor(class Modules.Function_GeneratedConstruction_Semantics/Scope)
+		IL_05a3: newobj instance void Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject_FunctionExpression_A05B3306_L69C33::.ctor(class Modules.Function_GeneratedConstruction_Semantics/Scope)
 		IL_05a8: ldc.i4.0
 		IL_05a9: conv.r8
 		IL_05aa: ldstr ""
 		IL_05af: ldc.i4.1
 		IL_05b0: ldc.i4.1
-		IL_05b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionExpression_A05B3306_L69C33>(!!0, float64, string, bool, bool)
+		IL_05b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32/FunctionObject_FunctionExpression_A05B3306_L69C33>(!!0, float64, string, bool, bool)
 		IL_05b6: stloc.s 40
 		IL_05b8: ldloc.s 29
 		IL_05ba: ldloc.s 40
@@ -1719,792 +2505,6 @@
 	} // end of method Function_GeneratedConstruction_Semantics::__js_module_init__
 
 } // end of class Modules.Function_GeneratedConstruction_Semantics
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionDeclaration_0A22665E_Receiver
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2bcb
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_0A22665E_Receiver::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2bd3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0A22665E_Receiver::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2bd6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0A22665E_Receiver::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bd9
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Function_GeneratedConstruction_Semantics/Receiver::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_0A22665E_Receiver::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bec
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Function_GeneratedConstruction_Semantics/Receiver::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0A22665E_Receiver::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bfb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0A22665E_Receiver::ConstructCore
-
-} // end of class FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionDeclaration_0A22665E_Receiver
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionDeclaration_73B6C30F_Alternate
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2c0a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_73B6C30F_Alternate::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2c12
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_73B6C30F_Alternate::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2c15
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_73B6C30F_Alternate::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c18
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Function_GeneratedConstruction_Semantics/Alternate::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_73B6C30F_Alternate::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c24
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Function_GeneratedConstruction_Semantics/Alternate::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_73B6C30F_Alternate::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c2c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_73B6C30F_Alternate::ConstructCore
-
-} // end of class FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionDeclaration_73B6C30F_Alternate
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2c3b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2c43
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2c46
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c49
-		// Header size: 1
-		// Code size: 16 (0x10)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call float64 Modules.Function_GeneratedConstruction_Semantics/ReturnsPrimitive::__js_call__(object)
-		IL_000a: box [System.Runtime]System.Double
-		IL_000f: ret
-	} // end of method FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c5a
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call float64 Modules.Function_GeneratedConstruction_Semantics/ReturnsPrimitive::__js_call__(object)
-		IL_0006: box [System.Runtime]System.Double
-		IL_000b: ret
-	} // end of method FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c67
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive::ConstructCore
-
-} // end of class FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionDeclaration_6C45D523_ReturnsPrimitive
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_GeneratedConstruction_Semantics/Scope _environment0_Function_GeneratedConstruction_Semantics
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_GeneratedConstruction_Semantics/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c76
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_GeneratedConstruction_Semantics/Scope FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::_environment0_Function_GeneratedConstruction_Semantics
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2c85
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2c88
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c8b
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_GeneratedConstruction_Semantics/Scope FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::_environment0_Function_GeneratedConstruction_Semantics
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_GeneratedConstruction_Semantics/ReturnsObject::__js_call__(class Modules.Function_GeneratedConstruction_Semantics/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c9d
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_GeneratedConstruction_Semantics/Scope FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::_environment0_Function_GeneratedConstruction_Semantics
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_GeneratedConstruction_Semantics/ReturnsObject::__js_call__(class Modules.Function_GeneratedConstruction_Semantics/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cab
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject::ConstructCore
-
-} // end of class FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionDeclaration_B6B6D69D_ReturnsObject
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_ClassConstructor_479B7F3D_DerivedFromObject
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cba
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_ClassConstructor_479B7F3D_DerivedFromObject::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_479B7F3D_DerivedFromObject::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2cc9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_479B7F3D_DerivedFromObject::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2ccc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_479B7F3D_DerivedFromObject::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ccf
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_479B7F3D_DerivedFromObject::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cdb
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_479B7F3D_DerivedFromObject::ConstructCore
-
-} // end of class FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_ClassConstructor_479B7F3D_DerivedFromObject
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionExpression_A05B3306_L69C33
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_GeneratedConstruction_Semantics/Scope _environment0_Function_GeneratedConstruction_Semantics
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_GeneratedConstruction_Semantics/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ce7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_GeneratedConstruction_Semantics/Scope FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionExpression_A05B3306_L69C33::_environment0_Function_GeneratedConstruction_Semantics
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A05B3306_L69C33::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2cf6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A05B3306_L69C33::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2cf9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A05B3306_L69C33::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cfc
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_GeneratedConstruction_Semantics/Scope FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionExpression_A05B3306_L69C33::_environment0_Function_GeneratedConstruction_Semantics
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32::__js_call__(class Modules.Function_GeneratedConstruction_Semantics/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_A05B3306_L69C33::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d0e
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_GeneratedConstruction_Semantics/Scope FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionExpression_A05B3306_L69C33::_environment0_Function_GeneratedConstruction_Semantics
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_L69C32::__js_call__(class Modules.Function_GeneratedConstruction_Semantics/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_A05B3306_L69C33::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d1c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A05B3306_L69C33::ConstructCore
-
-} // end of class FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionExpression_A05B3306_L69C33
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionDeclaration_60D679A4_BoundTarget
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2d2b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_60D679A4_BoundTarget::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2d33
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_60D679A4_BoundTarget::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2d36
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_60D679A4_BoundTarget::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d39
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Function_GeneratedConstruction_Semantics/BoundTarget::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_60D679A4_BoundTarget::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d4c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Function_GeneratedConstruction_Semantics/BoundTarget::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_60D679A4_BoundTarget::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d5b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_60D679A4_BoundTarget::ConstructCore
-
-} // end of class FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionDeclaration_60D679A4_BoundTarget
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionExpression_2A9B4B11_L96C24
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2d80
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_2A9B4B11_L96C24::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2d88
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2A9B4B11_L96C24::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2d8b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2A9B4B11_L96C24::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d8e
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_holder::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_2A9B4B11_L96C24::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d9a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Function_GeneratedConstruction_Semantics/FunctionExpression_holder::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_2A9B4B11_L96C24::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2da2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2A9B4B11_L96C24::ConstructCore
-
-} // end of class FunctionObjects.Function_GeneratedConstruction_Semantics_8F3626F4.FunctionObject_FunctionExpression_2A9B4B11_L96C24
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionCallsGlobalFunction.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionCallsGlobalFunction.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope _environment0_Function_GlobalFunctionCallsGlobalFunction
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x218e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorldProxy/FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::_environment0_Function_GlobalFunctionCallsGlobalFunction
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x219d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21a0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21a3
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorldProxy/FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::_environment0_Function_GlobalFunctionCallsGlobalFunction
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorldProxy::__js_call__(class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21b5
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorldProxy/FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::_environment0_Function_GlobalFunctionCallsGlobalFunction
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorldProxy::__js_call__(class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21c3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy
+
 
 		// Methods
 		.method public hidebysig static 
@@ -102,6 +209,101 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_ED3CD900_helloWorld
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21d2
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_ED3CD900_helloWorld::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21da
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_ED3CD900_helloWorld::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21dd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_ED3CD900_helloWorld::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21e0
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorld::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_ED3CD900_helloWorld::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21ec
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorld::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_ED3CD900_helloWorld::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_ED3CD900_helloWorld::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_ED3CD900_helloWorld
 
 
 		// Methods
@@ -181,9 +383,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope,
-			[1] class FunctionObjects.Function_GlobalFunctionCallsGlobalFunction_D96879A1.FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy,
+			[1] class Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorldProxy/FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy,
 			[2] object[],
-			[3] class FunctionObjects.Function_GlobalFunctionCallsGlobalFunction_D96879A1.FunctionObject_FunctionDeclaration_ED3CD900_helloWorld
+			[3] class Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorld/FunctionObject_FunctionDeclaration_ED3CD900_helloWorld
 		)
 
 		IL_0000: newobj instance void Modules.Function_GlobalFunctionCallsGlobalFunction/Scope::.ctor()
@@ -199,13 +401,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_GlobalFunctionCallsGlobalFunction/Scope
-		IL_0019: newobj instance void FunctionObjects.Function_GlobalFunctionCallsGlobalFunction_D96879A1.FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::.ctor(class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope)
+		IL_0019: newobj instance void Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorldProxy/FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::.ctor(class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "helloWorldProxy"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_GlobalFunctionCallsGlobalFunction_D96879A1.FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorldProxy/FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: ldc.i4.1
 		IL_002e: newarr [System.Runtime]System.Object
@@ -214,13 +416,13 @@
 		IL_0035: ldloc.0
 		IL_0036: stelem.ref
 		IL_0037: stloc.2
-		IL_0038: newobj instance void FunctionObjects.Function_GlobalFunctionCallsGlobalFunction_D96879A1.FunctionObject_FunctionDeclaration_ED3CD900_helloWorld::.ctor()
+		IL_0038: newobj instance void Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorld/FunctionObject_FunctionDeclaration_ED3CD900_helloWorld::.ctor()
 		IL_003d: ldc.i4.0
 		IL_003e: conv.r8
 		IL_003f: ldstr "helloWorld"
 		IL_0044: ldc.i4.0
 		IL_0045: ldc.i4.1
-		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_GlobalFunctionCallsGlobalFunction_D96879A1.FunctionObject_FunctionDeclaration_ED3CD900_helloWorld>(!!0, float64, string, bool, bool)
+		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorld/FunctionObject_FunctionDeclaration_ED3CD900_helloWorld>(!!0, float64, string, bool, bool)
 		IL_004b: stloc.3
 		IL_004c: ldloc.0
 		IL_004d: ldloc.3
@@ -246,208 +448,6 @@
 	} // end of method Function_GlobalFunctionCallsGlobalFunction::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionCallsGlobalFunction
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_GlobalFunctionCallsGlobalFunction_D96879A1.FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope _environment0_Function_GlobalFunctionCallsGlobalFunction
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x218e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope FunctionObjects.Function_GlobalFunctionCallsGlobalFunction_D96879A1.FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::_environment0_Function_GlobalFunctionCallsGlobalFunction
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x219d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21a0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21a3
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope FunctionObjects.Function_GlobalFunctionCallsGlobalFunction_D96879A1.FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::_environment0_Function_GlobalFunctionCallsGlobalFunction
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorldProxy::__js_call__(class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21b5
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope FunctionObjects.Function_GlobalFunctionCallsGlobalFunction_D96879A1.FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::_environment0_Function_GlobalFunctionCallsGlobalFunction
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorldProxy::__js_call__(class Modules.Function_GlobalFunctionCallsGlobalFunction/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21c3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy::ConstructCore
-
-} // end of class FunctionObjects.Function_GlobalFunctionCallsGlobalFunction_D96879A1.FunctionObject_FunctionDeclaration_F57B81B0_helloWorldProxy
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_GlobalFunctionCallsGlobalFunction_D96879A1.FunctionObject_FunctionDeclaration_ED3CD900_helloWorld
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21d2
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_ED3CD900_helloWorld::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21da
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_ED3CD900_helloWorld::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21dd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_ED3CD900_helloWorld::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21e0
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorld::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_ED3CD900_helloWorld::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ec
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Function_GlobalFunctionCallsGlobalFunction/helloWorld::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_ED3CD900_helloWorld::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_ED3CD900_helloWorld::ConstructCore
-
-} // end of class FunctionObjects.Function_GlobalFunctionCallsGlobalFunction_D96879A1.FunctionObject_FunctionDeclaration_ED3CD900_helloWorld
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionChangesGlobalVariableValue.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionChangesGlobalVariableValue.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope _environment0_Function_GlobalFunctionChangesGlobalVariableValue
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2229
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope Modules.Function_GlobalFunctionChangesGlobalVariableValue/changeGlobalValues/FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::_environment0_Function_GlobalFunctionChangesGlobalVariableValue
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2238
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x223b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x223e
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope Modules.Function_GlobalFunctionChangesGlobalVariableValue/changeGlobalValues/FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::_environment0_Function_GlobalFunctionChangesGlobalVariableValue
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_GlobalFunctionChangesGlobalVariableValue/changeGlobalValues::__js_call__(class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2250
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope Modules.Function_GlobalFunctionChangesGlobalVariableValue/changeGlobalValues/FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::_environment0_Function_GlobalFunctionChangesGlobalVariableValue
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_GlobalFunctionChangesGlobalVariableValue/changeGlobalValues::__js_call__(class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x225e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues
+
 
 		// Methods
 		.method public hidebysig static 
@@ -188,7 +295,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope,
-			[1] class FunctionObjects.Function_GlobalFunctionChangesGlobalVariableValue_3AA92506.FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues,
+			[1] class Modules.Function_GlobalFunctionChangesGlobalVariableValue/changeGlobalValues/FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues,
 			[2] object[],
 			[3] object,
 			[4] object,
@@ -208,13 +315,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope
-		IL_0019: newobj instance void FunctionObjects.Function_GlobalFunctionChangesGlobalVariableValue_3AA92506.FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::.ctor(class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope)
+		IL_0019: newobj instance void Modules.Function_GlobalFunctionChangesGlobalVariableValue/changeGlobalValues/FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::.ctor(class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "changeGlobalValues"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_GlobalFunctionChangesGlobalVariableValue_3AA92506.FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionChangesGlobalVariableValue/changeGlobalValues/FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldloc.0
@@ -297,113 +404,6 @@
 	} // end of method Function_GlobalFunctionChangesGlobalVariableValue::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionChangesGlobalVariableValue
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_GlobalFunctionChangesGlobalVariableValue_3AA92506.FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope _environment0_Function_GlobalFunctionChangesGlobalVariableValue
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2229
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope FunctionObjects.Function_GlobalFunctionChangesGlobalVariableValue_3AA92506.FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::_environment0_Function_GlobalFunctionChangesGlobalVariableValue
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2238
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x223b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x223e
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope FunctionObjects.Function_GlobalFunctionChangesGlobalVariableValue_3AA92506.FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::_environment0_Function_GlobalFunctionChangesGlobalVariableValue
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_GlobalFunctionChangesGlobalVariableValue/changeGlobalValues::__js_call__(class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2250
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope FunctionObjects.Function_GlobalFunctionChangesGlobalVariableValue_3AA92506.FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::_environment0_Function_GlobalFunctionChangesGlobalVariableValue
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_GlobalFunctionChangesGlobalVariableValue/changeGlobalValues::__js_call__(class Modules.Function_GlobalFunctionChangesGlobalVariableValue/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x225e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues::ConstructCore
-
-} // end of class FunctionObjects.Function_GlobalFunctionChangesGlobalVariableValue_3AA92506.FunctionObject_FunctionDeclaration_F85FF87C_changeGlobalValues
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionDeclaresAndCallsNestedFunction.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionDeclaresAndCallsNestedFunction.verified.txt
@@ -35,6 +35,101 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C398478A_innerFunction
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x21ff
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionDeclaration_C398478A_innerFunction::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2207
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_C398478A_innerFunction::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x220a
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_C398478A_innerFunction::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x220d
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: call object Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/innerFunction::__js_call__(object)
+					IL_000a: ret
+				} // end of method FunctionObject_FunctionDeclaration_C398478A_innerFunction::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2219
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: call object Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/innerFunction::__js_call__(object)
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionDeclaration_C398478A_innerFunction::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2221
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionDeclaration_C398478A_innerFunction::ConstructCore
+
+			} // end of class FunctionObject_FunctionDeclaration_C398478A_innerFunction
+
 
 			// Methods
 			.method public hidebysig static 
@@ -91,6 +186,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_55A149C5_outerFunction
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21ce
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_55A149C5_outerFunction::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21d6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_55A149C5_outerFunction::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21d9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_55A149C5_outerFunction::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21dc
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_55A149C5_outerFunction::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21e8
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_55A149C5_outerFunction::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_55A149C5_outerFunction::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_55A149C5_outerFunction
+
 
 		// Methods
 		.method public hidebysig static 
@@ -107,7 +297,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/Scope,
-				[1] class FunctionObjects.Function_GlobalFunctionDeclaresAndCallsNestedFunction_612A9F8F.FunctionObject_FunctionDeclaration_C398478A_innerFunction,
+				[1] class Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/innerFunction/FunctionObject_FunctionDeclaration_C398478A_innerFunction,
 				[2] object,
 				[3] object[]
 			)
@@ -116,13 +306,13 @@
 			IL_0005: stloc.0
 			IL_0006: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_000b: stloc.3
-			IL_000c: newobj instance void FunctionObjects.Function_GlobalFunctionDeclaresAndCallsNestedFunction_612A9F8F.FunctionObject_FunctionDeclaration_C398478A_innerFunction::.ctor()
+			IL_000c: newobj instance void Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/innerFunction/FunctionObject_FunctionDeclaration_C398478A_innerFunction::.ctor()
 			IL_0011: ldc.i4.0
 			IL_0012: conv.r8
 			IL_0013: ldstr "innerFunction"
 			IL_0018: ldc.i4.0
 			IL_0019: ldc.i4.1
-			IL_001a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_GlobalFunctionDeclaresAndCallsNestedFunction_612A9F8F.FunctionObject_FunctionDeclaration_C398478A_innerFunction>(!!0, float64, string, bool, bool)
+			IL_001a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/innerFunction/FunctionObject_FunctionDeclaration_C398478A_innerFunction>(!!0, float64, string, bool, bool)
 			IL_001f: stloc.1
 			IL_0020: ldstr "console"
 			IL_0025: call object [JavaScriptRuntime]JavaScriptRuntime.ObjectRuntime::GetGlobalBindingValue(string)
@@ -202,7 +392,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/Scope,
-			[1] class FunctionObjects.Function_GlobalFunctionDeclaresAndCallsNestedFunction_612A9F8F.FunctionObject_FunctionDeclaration_55A149C5_outerFunction,
+			[1] class Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/FunctionObject_FunctionDeclaration_55A149C5_outerFunction,
 			[2] object,
 			[3] object[]
 		)
@@ -216,13 +406,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.Function_GlobalFunctionDeclaresAndCallsNestedFunction_612A9F8F.FunctionObject_FunctionDeclaration_55A149C5_outerFunction::.ctor()
+		IL_0011: newobj instance void Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/FunctionObject_FunctionDeclaration_55A149C5_outerFunction::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "outerFunction"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_GlobalFunctionDeclaresAndCallsNestedFunction_612A9F8F.FunctionObject_FunctionDeclaration_55A149C5_outerFunction>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/FunctionObject_FunctionDeclaration_55A149C5_outerFunction>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -256,196 +446,6 @@
 	} // end of method Function_GlobalFunctionDeclaresAndCallsNestedFunction::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_GlobalFunctionDeclaresAndCallsNestedFunction_612A9F8F.FunctionObject_FunctionDeclaration_55A149C5_outerFunction
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21ce
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_55A149C5_outerFunction::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21d6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_55A149C5_outerFunction::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21d9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_55A149C5_outerFunction::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21dc
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_55A149C5_outerFunction::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21e8
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_55A149C5_outerFunction::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_55A149C5_outerFunction::ConstructCore
-
-} // end of class FunctionObjects.Function_GlobalFunctionDeclaresAndCallsNestedFunction_612A9F8F.FunctionObject_FunctionDeclaration_55A149C5_outerFunction
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_GlobalFunctionDeclaresAndCallsNestedFunction_612A9F8F.FunctionObject_FunctionDeclaration_C398478A_innerFunction
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21ff
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_C398478A_innerFunction::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2207
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C398478A_innerFunction::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x220a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C398478A_innerFunction::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x220d
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/innerFunction::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_C398478A_innerFunction::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2219
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Function_GlobalFunctionDeclaresAndCallsNestedFunction/outerFunction/innerFunction::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_C398478A_innerFunction::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2221
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C398478A_innerFunction::ConstructCore
-
-} // end of class FunctionObjects.Function_GlobalFunctionDeclaresAndCallsNestedFunction_612A9F8F.FunctionObject_FunctionDeclaration_C398478A_innerFunction
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionLogsGlobalVariable.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionLogsGlobalVariable.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope _environment0_Function_GlobalFunctionLogsGlobalVariable
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x212a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope Modules.Function_GlobalFunctionLogsGlobalVariable/logGlobalValues/FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::_environment0_Function_GlobalFunctionLogsGlobalVariable
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2139
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x213c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x213f
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope Modules.Function_GlobalFunctionLogsGlobalVariable/logGlobalValues/FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::_environment0_Function_GlobalFunctionLogsGlobalVariable
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_GlobalFunctionLogsGlobalVariable/logGlobalValues::__js_call__(class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2151
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope Modules.Function_GlobalFunctionLogsGlobalVariable/logGlobalValues/FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::_environment0_Function_GlobalFunctionLogsGlobalVariable
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_GlobalFunctionLogsGlobalVariable/logGlobalValues::__js_call__(class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x215f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues
+
 
 		// Methods
 		.method public hidebysig static 
@@ -136,7 +243,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope,
-			[1] class FunctionObjects.Function_GlobalFunctionLogsGlobalVariable_61136835.FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues,
+			[1] class Modules.Function_GlobalFunctionLogsGlobalVariable/logGlobalValues/FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues,
 			[2] object[]
 		)
 
@@ -153,13 +260,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_GlobalFunctionLogsGlobalVariable/Scope
-		IL_0019: newobj instance void FunctionObjects.Function_GlobalFunctionLogsGlobalVariable_61136835.FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::.ctor(class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope)
+		IL_0019: newobj instance void Modules.Function_GlobalFunctionLogsGlobalVariable/logGlobalValues/FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::.ctor(class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "logGlobalValues"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_GlobalFunctionLogsGlobalVariable_61136835.FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionLogsGlobalVariable/logGlobalValues/FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldloc.0
@@ -178,113 +285,6 @@
 	} // end of method Function_GlobalFunctionLogsGlobalVariable::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionLogsGlobalVariable
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_GlobalFunctionLogsGlobalVariable_61136835.FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope _environment0_Function_GlobalFunctionLogsGlobalVariable
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x212a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope FunctionObjects.Function_GlobalFunctionLogsGlobalVariable_61136835.FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::_environment0_Function_GlobalFunctionLogsGlobalVariable
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2139
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x213c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x213f
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope FunctionObjects.Function_GlobalFunctionLogsGlobalVariable_61136835.FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::_environment0_Function_GlobalFunctionLogsGlobalVariable
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_GlobalFunctionLogsGlobalVariable/logGlobalValues::__js_call__(class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2151
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope FunctionObjects.Function_GlobalFunctionLogsGlobalVariable_61136835.FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::_environment0_Function_GlobalFunctionLogsGlobalVariable
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_GlobalFunctionLogsGlobalVariable/logGlobalValues::__js_call__(class Modules.Function_GlobalFunctionLogsGlobalVariable/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x215f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues::ConstructCore
-
-} // end of class FunctionObjects.Function_GlobalFunctionLogsGlobalVariable_61136835.FunctionObject_FunctionDeclaration_B5AE0A7B_logGlobalValues
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal.verified.txt
@@ -35,6 +35,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope _environment0_Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
+				.field private initonly class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope _environment1_createFunction
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope capture0,
+						class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2260
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction/FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::_environment0_Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction/FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::_environment1_createFunction
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction/FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x227d
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2280
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2283
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction/FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2295
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction/FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x22a3
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::ConstructCore
+
+			} // end of class FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction
+
 
 			// Methods
 			.method public hidebysig static 
@@ -149,6 +266,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9067EF51_createFunction
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope _environment0_Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x220e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/FunctionObject_FunctionDeclaration_9067EF51_createFunction::_environment0_Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9067EF51_createFunction::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x221d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9067EF51_createFunction::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2220
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9067EF51_createFunction::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2223
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/FunctionObject_FunctionDeclaration_9067EF51_createFunction::_environment0_Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction::__js_call__(class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_9067EF51_createFunction::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x223c
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/FunctionObject_FunctionDeclaration_9067EF51_createFunction::_environment0_Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction::__js_call__(class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_9067EF51_createFunction::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2251
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9067EF51_createFunction::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9067EF51_createFunction
+
 
 		// Methods
 		.method public hidebysig static 
@@ -169,7 +399,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope,
-				[1] class FunctionObjects.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal_56D65E06.FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction,
+				[1] class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction/FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction,
 				[2] object[]
 			)
 
@@ -198,13 +428,13 @@
 			IL_0026: ldelem.ref
 			IL_0027: castclass Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope
 			IL_002c: ldloc.2
-			IL_002d: newobj instance void FunctionObjects.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal_56D65E06.FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::.ctor(class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope, class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope, object[])
+			IL_002d: newobj instance void Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction/FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::.ctor(class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope, class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope, object[])
 			IL_0032: ldc.i4.0
 			IL_0033: conv.r8
 			IL_0034: ldstr "nestedFunction"
 			IL_0039: ldc.i4.0
 			IL_003a: ldc.i4.1
-			IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal_56D65E06.FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction>(!!0, float64, string, bool, bool)
+			IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction/FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction>(!!0, float64, string, bool, bool)
 			IL_0040: stloc.1
 			IL_0041: nop
 			IL_0042: ldloc.1
@@ -260,7 +490,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope,
-			[1] class FunctionObjects.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal_56D65E06.FunctionObject_FunctionDeclaration_9067EF51_createFunction,
+			[1] class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/FunctionObject_FunctionDeclaration_9067EF51_createFunction,
 			[2] object,
 			[3] object,
 			[4] object[]
@@ -279,13 +509,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope
-		IL_001b: newobj instance void FunctionObjects.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal_56D65E06.FunctionObject_FunctionDeclaration_9067EF51_createFunction::.ctor(class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope)
+		IL_001b: newobj instance void Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/FunctionObject_FunctionDeclaration_9067EF51_createFunction::.ctor(class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope)
 		IL_0020: ldc.i4.1
 		IL_0021: conv.r8
 		IL_0022: ldstr "createFunction"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal_56D65E06.FunctionObject_FunctionDeclaration_9067EF51_createFunction>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/FunctionObject_FunctionDeclaration_9067EF51_createFunction>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: nop
 		IL_0030: ldloc.0
@@ -317,236 +547,6 @@
 	} // end of method Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal_56D65E06.FunctionObject_FunctionDeclaration_9067EF51_createFunction
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope _environment0_Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x220e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope FunctionObjects.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal_56D65E06.FunctionObject_FunctionDeclaration_9067EF51_createFunction::_environment0_Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9067EF51_createFunction::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x221d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9067EF51_createFunction::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2220
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9067EF51_createFunction::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2223
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope FunctionObjects.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal_56D65E06.FunctionObject_FunctionDeclaration_9067EF51_createFunction::_environment0_Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction::__js_call__(class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_9067EF51_createFunction::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x223c
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope FunctionObjects.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal_56D65E06.FunctionObject_FunctionDeclaration_9067EF51_createFunction::_environment0_Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction::__js_call__(class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_9067EF51_createFunction::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2251
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9067EF51_createFunction::ConstructCore
-
-} // end of class FunctionObjects.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal_56D65E06.FunctionObject_FunctionDeclaration_9067EF51_createFunction
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal_56D65E06.FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope _environment0_Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
-	.field private initonly class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope _environment1_createFunction
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope capture0,
-			class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2260
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/Scope FunctionObjects.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal_56D65E06.FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::_environment0_Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/Scope FunctionObjects.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal_56D65E06.FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::_environment1_createFunction
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal_56D65E06.FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x227d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2280
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2283
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal_56D65E06.FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2295
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal_56D65E06.FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal/createFunction/nestedFunction::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22a3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction::ConstructCore
-
-} // end of class FunctionObjects.Function_GlobalFunctionReturnsNestedFunction_LogsParamAndGlobal_56D65E06.FunctionObject_FunctionDeclaration_9F7D53E5_nestedFunction
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithArrayIteration.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithArrayIteration.verified.txt
@@ -53,6 +53,109 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_88106FB6_processArray
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2193
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_88106FB6_processArray::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x219b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_88106FB6_processArray::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x219e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_88106FB6_processArray::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21a1
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0011: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_GlobalFunctionWithArrayIteration/processArray::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_88106FB6_processArray::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21b9
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_GlobalFunctionWithArrayIteration/processArray::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_88106FB6_processArray::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21cd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_88106FB6_processArray::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_88106FB6_processArray
+
 
 		// Methods
 		.method public hidebysig static 
@@ -164,7 +267,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionWithArrayIteration/Scope,
-			[1] class FunctionObjects.Function_GlobalFunctionWithArrayIteration_CD578465.FunctionObject_FunctionDeclaration_88106FB6_processArray,
+			[1] class Modules.Function_GlobalFunctionWithArrayIteration/processArray/FunctionObject_FunctionDeclaration_88106FB6_processArray,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] object,
 			[4] object[],
@@ -181,13 +284,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 4
-		IL_0012: newobj instance void FunctionObjects.Function_GlobalFunctionWithArrayIteration_CD578465.FunctionObject_FunctionDeclaration_88106FB6_processArray::.ctor()
+		IL_0012: newobj instance void Modules.Function_GlobalFunctionWithArrayIteration/processArray/FunctionObject_FunctionDeclaration_88106FB6_processArray::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "processArray"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_GlobalFunctionWithArrayIteration_CD578465.FunctionObject_FunctionDeclaration_88106FB6_processArray>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionWithArrayIteration/processArray/FunctionObject_FunctionDeclaration_88106FB6_processArray>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: nop
@@ -230,109 +333,6 @@
 	} // end of method Function_GlobalFunctionWithArrayIteration::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionWithArrayIteration
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_GlobalFunctionWithArrayIteration_CD578465.FunctionObject_FunctionDeclaration_88106FB6_processArray
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2193
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_88106FB6_processArray::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x219b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_88106FB6_processArray::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x219e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_88106FB6_processArray::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21a1
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0011: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_GlobalFunctionWithArrayIteration/processArray::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_88106FB6_processArray::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21b9
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_GlobalFunctionWithArrayIteration/processArray::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_88106FB6_processArray::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21cd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_88106FB6_processArray::ConstructCore
-
-} // end of class FunctionObjects.Function_GlobalFunctionWithArrayIteration_CD578465.FunctionObject_FunctionDeclaration_88106FB6_processArray
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithMultipleParameters.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithMultipleParameters.verified.txt
@@ -31,6 +31,109 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E2574271_f1
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2541
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_E2574271_f1::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2549
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E2574271_f1::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x254c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E2574271_f1::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x254f
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: call object Modules.Function_GlobalFunctionWithMultipleParameters/f1::__js_call__(object, float64)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_E2574271_f1::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2567
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: call object Modules.Function_GlobalFunctionWithMultipleParameters/f1::__js_call__(object, float64)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_E2574271_f1::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x257b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E2574271_f1::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E2574271_f1
+
 
 		// Methods
 		.method public hidebysig static 
@@ -85,6 +188,117 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DF573DB8_f2
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x258a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_DF573DB8_f2::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2592
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DF573DB8_f2::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2595
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DF573DB8_f2::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2598
+				// Header size: 1
+				// Code size: 35 (0x23)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001d: call object Modules.Function_GlobalFunctionWithMultipleParameters/f2::__js_call__(object, float64, float64)
+				IL_0022: ret
+			} // end of method FunctionObject_FunctionDeclaration_DF573DB8_f2::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25bc
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0019: call object Modules.Function_GlobalFunctionWithMultipleParameters/f2::__js_call__(object, float64, float64)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_DF573DB8_f2::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25dc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DF573DB8_f2::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_DF573DB8_f2
 
 
 		// Methods
@@ -143,6 +357,125 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E0573F4B_f3
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x25eb
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_E0573F4B_f3::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x25f3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E0573F4B_f3::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x25f6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E0573F4B_f3::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x25f9
+				// Header size: 1
+				// Code size: 47 (0x2f)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001d: ldarg.2
+				IL_001e: ldc.i4.2
+				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0029: call object Modules.Function_GlobalFunctionWithMultipleParameters/f3::__js_call__(object, float64, float64, float64)
+				IL_002e: ret
+			} // end of method FunctionObject_FunctionDeclaration_E0573F4B_f3::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2629
+				// Header size: 1
+				// Code size: 43 (0x2b)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0025: call object Modules.Function_GlobalFunctionWithMultipleParameters/f3::__js_call__(object, float64, float64, float64)
+				IL_002a: ret
+			} // end of method FunctionObject_FunctionDeclaration_E0573F4B_f3::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2655
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E0573F4B_f3::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E0573F4B_f3
 
 
 		// Methods
@@ -218,6 +551,133 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E557472A_f4
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2664
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_E557472A_f4::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x266c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E557472A_f4::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x266f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E557472A_f4::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2672
+				// Header size: 1
+				// Code size: 59 (0x3b)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001d: ldarg.2
+				IL_001e: ldc.i4.2
+				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0029: ldarg.2
+				IL_002a: ldc.i4.3
+				IL_002b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0035: call object Modules.Function_GlobalFunctionWithMultipleParameters/f4::__js_call__(object, float64, float64, float64, float64)
+				IL_003a: ret
+			} // end of method FunctionObject_FunctionDeclaration_E557472A_f4::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26ae
+				// Header size: 1
+				// Code size: 55 (0x37)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0025: ldarg.2
+				IL_0026: ldc.i4.3
+				IL_0027: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_002c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0031: call object Modules.Function_GlobalFunctionWithMultipleParameters/f4::__js_call__(object, float64, float64, float64, float64)
+				IL_0036: ret
+			} // end of method FunctionObject_FunctionDeclaration_E557472A_f4::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26e6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E557472A_f4::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E557472A_f4
 
 
 		// Methods
@@ -299,6 +759,141 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E65748BD_f5
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x26f5
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_E65748BD_f5::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x26fd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E65748BD_f5::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2700
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E65748BD_f5::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2704
+				// Header size: 12
+				// Code size: 71 (0x47)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001d: ldarg.2
+				IL_001e: ldc.i4.2
+				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0029: ldarg.2
+				IL_002a: ldc.i4.3
+				IL_002b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0035: ldarg.2
+				IL_0036: ldc.i4.4
+				IL_0037: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_003c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0041: call object Modules.Function_GlobalFunctionWithMultipleParameters/f5::__js_call__(object, float64, float64, float64, float64, float64)
+				IL_0046: ret
+			} // end of method FunctionObject_FunctionDeclaration_E65748BD_f5::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2758
+				// Header size: 12
+				// Code size: 67 (0x43)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0025: ldarg.2
+				IL_0026: ldc.i4.3
+				IL_0027: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_002c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0031: ldarg.2
+				IL_0032: ldc.i4.4
+				IL_0033: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0038: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_003d: call object Modules.Function_GlobalFunctionWithMultipleParameters/f5::__js_call__(object, float64, float64, float64, float64, float64)
+				IL_0042: ret
+			} // end of method FunctionObject_FunctionDeclaration_E65748BD_f5::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x27a7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E65748BD_f5::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E65748BD_f5
 
 
 		// Methods
@@ -386,6 +981,149 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E3574404_f6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x27b6
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_E3574404_f6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x27be
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E3574404_f6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x27c1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E3574404_f6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x27c4
+				// Header size: 12
+				// Code size: 83 (0x53)
+				.maxstack 9
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001d: ldarg.2
+				IL_001e: ldc.i4.2
+				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0029: ldarg.2
+				IL_002a: ldc.i4.3
+				IL_002b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0035: ldarg.2
+				IL_0036: ldc.i4.4
+				IL_0037: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_003c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0041: ldarg.2
+				IL_0042: ldc.i4.5
+				IL_0043: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0048: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_004d: call object Modules.Function_GlobalFunctionWithMultipleParameters/f6::__js_call__(object, float64, float64, float64, float64, float64, float64)
+				IL_0052: ret
+			} // end of method FunctionObject_FunctionDeclaration_E3574404_f6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2824
+				// Header size: 12
+				// Code size: 79 (0x4f)
+				.maxstack 9
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0025: ldarg.2
+				IL_0026: ldc.i4.3
+				IL_0027: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_002c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0031: ldarg.2
+				IL_0032: ldc.i4.4
+				IL_0033: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0038: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_003d: ldarg.2
+				IL_003e: ldc.i4.5
+				IL_003f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0044: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0049: call object Modules.Function_GlobalFunctionWithMultipleParameters/f6::__js_call__(object, float64, float64, float64, float64, float64, float64)
+				IL_004e: ret
+			} // end of method FunctionObject_FunctionDeclaration_E3574404_f6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x287f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E3574404_f6::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E3574404_f6
 
 
 		// Methods
@@ -522,12 +1260,12 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionWithMultipleParameters/Scope,
-			[1] class FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_E2574271_f1,
-			[2] class FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_DF573DB8_f2,
-			[3] class FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_E0573F4B_f3,
-			[4] class FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_E557472A_f4,
-			[5] class FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_E65748BD_f5,
-			[6] class FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_E3574404_f6,
+			[1] class Modules.Function_GlobalFunctionWithMultipleParameters/f1/FunctionObject_FunctionDeclaration_E2574271_f1,
+			[2] class Modules.Function_GlobalFunctionWithMultipleParameters/f2/FunctionObject_FunctionDeclaration_DF573DB8_f2,
+			[3] class Modules.Function_GlobalFunctionWithMultipleParameters/f3/FunctionObject_FunctionDeclaration_E0573F4B_f3,
+			[4] class Modules.Function_GlobalFunctionWithMultipleParameters/f4/FunctionObject_FunctionDeclaration_E557472A_f4,
+			[5] class Modules.Function_GlobalFunctionWithMultipleParameters/f5/FunctionObject_FunctionDeclaration_E65748BD_f5,
+			[6] class Modules.Function_GlobalFunctionWithMultipleParameters/f6/FunctionObject_FunctionDeclaration_E3574404_f6,
 			[7] object[]
 		)
 
@@ -540,13 +1278,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 7
-		IL_0012: newobj instance void FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_E2574271_f1::.ctor()
+		IL_0012: newobj instance void Modules.Function_GlobalFunctionWithMultipleParameters/f1/FunctionObject_FunctionDeclaration_E2574271_f1::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "f1"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_E2574271_f1>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionWithMultipleParameters/f1/FunctionObject_FunctionDeclaration_E2574271_f1>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -555,13 +1293,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 7
-		IL_0032: newobj instance void FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_DF573DB8_f2::.ctor()
+		IL_0032: newobj instance void Modules.Function_GlobalFunctionWithMultipleParameters/f2/FunctionObject_FunctionDeclaration_DF573DB8_f2::.ctor()
 		IL_0037: ldc.i4.2
 		IL_0038: conv.r8
 		IL_0039: ldstr "f2"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_DF573DB8_f2>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionWithMultipleParameters/f2/FunctionObject_FunctionDeclaration_DF573DB8_f2>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -570,13 +1308,13 @@
 		IL_004e: ldloc.0
 		IL_004f: stelem.ref
 		IL_0050: stloc.s 7
-		IL_0052: newobj instance void FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_E0573F4B_f3::.ctor()
+		IL_0052: newobj instance void Modules.Function_GlobalFunctionWithMultipleParameters/f3/FunctionObject_FunctionDeclaration_E0573F4B_f3::.ctor()
 		IL_0057: ldc.i4.3
 		IL_0058: conv.r8
 		IL_0059: ldstr "f3"
 		IL_005e: ldc.i4.0
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_E0573F4B_f3>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionWithMultipleParameters/f3/FunctionObject_FunctionDeclaration_E0573F4B_f3>(!!0, float64, string, bool, bool)
 		IL_0065: stloc.3
 		IL_0066: ldc.i4.1
 		IL_0067: newarr [System.Runtime]System.Object
@@ -585,13 +1323,13 @@
 		IL_006e: ldloc.0
 		IL_006f: stelem.ref
 		IL_0070: stloc.s 7
-		IL_0072: newobj instance void FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_E557472A_f4::.ctor()
+		IL_0072: newobj instance void Modules.Function_GlobalFunctionWithMultipleParameters/f4/FunctionObject_FunctionDeclaration_E557472A_f4::.ctor()
 		IL_0077: ldc.i4.4
 		IL_0078: conv.r8
 		IL_0079: ldstr "f4"
 		IL_007e: ldc.i4.0
 		IL_007f: ldc.i4.1
-		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_E557472A_f4>(!!0, float64, string, bool, bool)
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionWithMultipleParameters/f4/FunctionObject_FunctionDeclaration_E557472A_f4>(!!0, float64, string, bool, bool)
 		IL_0085: stloc.s 4
 		IL_0087: ldc.i4.1
 		IL_0088: newarr [System.Runtime]System.Object
@@ -600,13 +1338,13 @@
 		IL_008f: ldloc.0
 		IL_0090: stelem.ref
 		IL_0091: stloc.s 7
-		IL_0093: newobj instance void FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_E65748BD_f5::.ctor()
+		IL_0093: newobj instance void Modules.Function_GlobalFunctionWithMultipleParameters/f5/FunctionObject_FunctionDeclaration_E65748BD_f5::.ctor()
 		IL_0098: ldc.i4.5
 		IL_0099: conv.r8
 		IL_009a: ldstr "f5"
 		IL_009f: ldc.i4.0
 		IL_00a0: ldc.i4.1
-		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_E65748BD_f5>(!!0, float64, string, bool, bool)
+		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionWithMultipleParameters/f5/FunctionObject_FunctionDeclaration_E65748BD_f5>(!!0, float64, string, bool, bool)
 		IL_00a6: stloc.s 5
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -615,13 +1353,13 @@
 		IL_00b0: ldloc.0
 		IL_00b1: stelem.ref
 		IL_00b2: stloc.s 7
-		IL_00b4: newobj instance void FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_E3574404_f6::.ctor()
+		IL_00b4: newobj instance void Modules.Function_GlobalFunctionWithMultipleParameters/f6/FunctionObject_FunctionDeclaration_E3574404_f6::.ctor()
 		IL_00b9: ldc.i4.6
 		IL_00ba: conv.r8
 		IL_00bb: ldstr "f6"
 		IL_00c0: ldc.i4.0
 		IL_00c1: ldc.i4.1
-		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_E3574404_f6>(!!0, float64, string, bool, bool)
+		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionWithMultipleParameters/f6/FunctionObject_FunctionDeclaration_E3574404_f6>(!!0, float64, string, bool, bool)
 		IL_00c7: stloc.s 6
 		IL_00c9: nop
 		IL_00ca: nop
@@ -763,744 +1501,6 @@
 	} // end of method Function_GlobalFunctionWithMultipleParameters::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionWithMultipleParameters
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_E2574271_f1
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2541
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_E2574271_f1::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2549
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E2574271_f1::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x254c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E2574271_f1::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x254f
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: call object Modules.Function_GlobalFunctionWithMultipleParameters/f1::__js_call__(object, float64)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_E2574271_f1::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2567
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: call object Modules.Function_GlobalFunctionWithMultipleParameters/f1::__js_call__(object, float64)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_E2574271_f1::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x257b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E2574271_f1::ConstructCore
-
-} // end of class FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_E2574271_f1
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_DF573DB8_f2
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x258a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_DF573DB8_f2::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2592
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DF573DB8_f2::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2595
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DF573DB8_f2::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2598
-		// Header size: 1
-		// Code size: 35 (0x23)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001d: call object Modules.Function_GlobalFunctionWithMultipleParameters/f2::__js_call__(object, float64, float64)
-		IL_0022: ret
-	} // end of method FunctionObject_FunctionDeclaration_DF573DB8_f2::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25bc
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0019: call object Modules.Function_GlobalFunctionWithMultipleParameters/f2::__js_call__(object, float64, float64)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_DF573DB8_f2::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25dc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DF573DB8_f2::ConstructCore
-
-} // end of class FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_DF573DB8_f2
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_E0573F4B_f3
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x25eb
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_E0573F4B_f3::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x25f3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E0573F4B_f3::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x25f6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E0573F4B_f3::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x25f9
-		// Header size: 1
-		// Code size: 47 (0x2f)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001d: ldarg.2
-		IL_001e: ldc.i4.2
-		IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0029: call object Modules.Function_GlobalFunctionWithMultipleParameters/f3::__js_call__(object, float64, float64, float64)
-		IL_002e: ret
-	} // end of method FunctionObject_FunctionDeclaration_E0573F4B_f3::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2629
-		// Header size: 1
-		// Code size: 43 (0x2b)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0025: call object Modules.Function_GlobalFunctionWithMultipleParameters/f3::__js_call__(object, float64, float64, float64)
-		IL_002a: ret
-	} // end of method FunctionObject_FunctionDeclaration_E0573F4B_f3::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2655
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E0573F4B_f3::ConstructCore
-
-} // end of class FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_E0573F4B_f3
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_E557472A_f4
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2664
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_E557472A_f4::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x266c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E557472A_f4::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x266f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E557472A_f4::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2672
-		// Header size: 1
-		// Code size: 59 (0x3b)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001d: ldarg.2
-		IL_001e: ldc.i4.2
-		IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0029: ldarg.2
-		IL_002a: ldc.i4.3
-		IL_002b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0035: call object Modules.Function_GlobalFunctionWithMultipleParameters/f4::__js_call__(object, float64, float64, float64, float64)
-		IL_003a: ret
-	} // end of method FunctionObject_FunctionDeclaration_E557472A_f4::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26ae
-		// Header size: 1
-		// Code size: 55 (0x37)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0025: ldarg.2
-		IL_0026: ldc.i4.3
-		IL_0027: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_002c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0031: call object Modules.Function_GlobalFunctionWithMultipleParameters/f4::__js_call__(object, float64, float64, float64, float64)
-		IL_0036: ret
-	} // end of method FunctionObject_FunctionDeclaration_E557472A_f4::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26e6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E557472A_f4::ConstructCore
-
-} // end of class FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_E557472A_f4
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_E65748BD_f5
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x26f5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_E65748BD_f5::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x26fd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E65748BD_f5::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2700
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E65748BD_f5::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2704
-		// Header size: 12
-		// Code size: 71 (0x47)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001d: ldarg.2
-		IL_001e: ldc.i4.2
-		IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0029: ldarg.2
-		IL_002a: ldc.i4.3
-		IL_002b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0035: ldarg.2
-		IL_0036: ldc.i4.4
-		IL_0037: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_003c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0041: call object Modules.Function_GlobalFunctionWithMultipleParameters/f5::__js_call__(object, float64, float64, float64, float64, float64)
-		IL_0046: ret
-	} // end of method FunctionObject_FunctionDeclaration_E65748BD_f5::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2758
-		// Header size: 12
-		// Code size: 67 (0x43)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0025: ldarg.2
-		IL_0026: ldc.i4.3
-		IL_0027: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_002c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0031: ldarg.2
-		IL_0032: ldc.i4.4
-		IL_0033: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0038: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_003d: call object Modules.Function_GlobalFunctionWithMultipleParameters/f5::__js_call__(object, float64, float64, float64, float64, float64)
-		IL_0042: ret
-	} // end of method FunctionObject_FunctionDeclaration_E65748BD_f5::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27a7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E65748BD_f5::ConstructCore
-
-} // end of class FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_E65748BD_f5
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_E3574404_f6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x27b6
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_E3574404_f6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x27be
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E3574404_f6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x27c1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E3574404_f6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x27c4
-		// Header size: 12
-		// Code size: 83 (0x53)
-		.maxstack 9
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001d: ldarg.2
-		IL_001e: ldc.i4.2
-		IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0029: ldarg.2
-		IL_002a: ldc.i4.3
-		IL_002b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0035: ldarg.2
-		IL_0036: ldc.i4.4
-		IL_0037: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_003c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0041: ldarg.2
-		IL_0042: ldc.i4.5
-		IL_0043: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0048: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_004d: call object Modules.Function_GlobalFunctionWithMultipleParameters/f6::__js_call__(object, float64, float64, float64, float64, float64, float64)
-		IL_0052: ret
-	} // end of method FunctionObject_FunctionDeclaration_E3574404_f6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2824
-		// Header size: 12
-		// Code size: 79 (0x4f)
-		.maxstack 9
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0025: ldarg.2
-		IL_0026: ldc.i4.3
-		IL_0027: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_002c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0031: ldarg.2
-		IL_0032: ldc.i4.4
-		IL_0033: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0038: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_003d: ldarg.2
-		IL_003e: ldc.i4.5
-		IL_003f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0044: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0049: call object Modules.Function_GlobalFunctionWithMultipleParameters/f6::__js_call__(object, float64, float64, float64, float64, float64, float64)
-		IL_004e: ret
-	} // end of method FunctionObject_FunctionDeclaration_E3574404_f6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x287f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E3574404_f6::ConstructCore
-
-} // end of class FunctionObjects.Function_GlobalFunctionWithMultipleParameters_2A8D0445.FunctionObject_FunctionDeclaration_E3574404_f6
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithParameter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_GlobalFunctionWithParameter.verified.txt
@@ -31,6 +31,109 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D266391D_printMessage
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x20cc
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_D266391D_printMessage::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x20d4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D266391D_printMessage::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x20d7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D266391D_printMessage::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x20da
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0011: call object Modules.Function_GlobalFunctionWithParameter/printMessage::__js_call__(object, string)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_D266391D_printMessage::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x20f2
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: call object Modules.Function_GlobalFunctionWithParameter/printMessage::__js_call__(object, string)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_D266391D_printMessage::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2106
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D266391D_printMessage::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_D266391D_printMessage
+
 
 		// Methods
 		.method public hidebysig static 
@@ -106,7 +209,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_GlobalFunctionWithParameter/Scope,
-			[1] class FunctionObjects.Function_GlobalFunctionWithParameter_A7956660.FunctionObject_FunctionDeclaration_D266391D_printMessage,
+			[1] class Modules.Function_GlobalFunctionWithParameter/printMessage/FunctionObject_FunctionDeclaration_D266391D_printMessage,
 			[2] object[]
 		)
 
@@ -119,13 +222,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.Function_GlobalFunctionWithParameter_A7956660.FunctionObject_FunctionDeclaration_D266391D_printMessage::.ctor()
+		IL_0011: newobj instance void Modules.Function_GlobalFunctionWithParameter/printMessage/FunctionObject_FunctionDeclaration_D266391D_printMessage::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "printMessage"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_GlobalFunctionWithParameter_A7956660.FunctionObject_FunctionDeclaration_D266391D_printMessage>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_GlobalFunctionWithParameter/printMessage/FunctionObject_FunctionDeclaration_D266391D_printMessage>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -140,109 +243,6 @@
 	} // end of method Function_GlobalFunctionWithParameter::__js_module_init__
 
 } // end of class Modules.Function_GlobalFunctionWithParameter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_GlobalFunctionWithParameter_A7956660.FunctionObject_FunctionDeclaration_D266391D_printMessage
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x20cc
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_D266391D_printMessage::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x20d4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D266391D_printMessage::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x20d7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D266391D_printMessage::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x20da
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0011: call object Modules.Function_GlobalFunctionWithParameter/printMessage::__js_call__(object, string)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_D266391D_printMessage::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x20f2
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_000d: call object Modules.Function_GlobalFunctionWithParameter/printMessage::__js_call__(object, string)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_D266391D_printMessage::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2106
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D266391D_printMessage::ConstructCore
-
-} // end of class FunctionObjects.Function_GlobalFunctionWithParameter_A7956660.FunctionObject_FunctionDeclaration_D266391D_printMessage
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_HelloWorld.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_HelloWorld.verified.txt
@@ -31,6 +31,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9A002B81_helloWorld
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x20c4
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A002B81_helloWorld::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x20cc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A002B81_helloWorld::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x20cf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A002B81_helloWorld::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x20d2
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Function_HelloWorld/helloWorld::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A002B81_helloWorld::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x20de
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Function_HelloWorld/helloWorld::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A002B81_helloWorld::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x20e6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A002B81_helloWorld::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9A002B81_helloWorld
+
 
 		// Methods
 		.method public hidebysig static 
@@ -104,7 +199,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_HelloWorld/Scope,
-			[1] class FunctionObjects.Function_HelloWorld_337CB4D6.FunctionObject_FunctionDeclaration_9A002B81_helloWorld,
+			[1] class Modules.Function_HelloWorld/helloWorld/FunctionObject_FunctionDeclaration_9A002B81_helloWorld,
 			[2] object[]
 		)
 
@@ -117,13 +212,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.Function_HelloWorld_337CB4D6.FunctionObject_FunctionDeclaration_9A002B81_helloWorld::.ctor()
+		IL_0011: newobj instance void Modules.Function_HelloWorld/helloWorld/FunctionObject_FunctionDeclaration_9A002B81_helloWorld::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "helloWorld"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_HelloWorld_337CB4D6.FunctionObject_FunctionDeclaration_9A002B81_helloWorld>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_HelloWorld/helloWorld/FunctionObject_FunctionDeclaration_9A002B81_helloWorld>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -135,101 +230,6 @@
 	} // end of method Function_HelloWorld::__js_module_init__
 
 } // end of class Modules.Function_HelloWorld
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_HelloWorld_337CB4D6.FunctionObject_FunctionDeclaration_9A002B81_helloWorld
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x20c4
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A002B81_helloWorld::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x20cc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A002B81_helloWorld::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x20cf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A002B81_helloWorld::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x20d2
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Function_HelloWorld/helloWorld::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A002B81_helloWorld::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x20de
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Function_HelloWorld/helloWorld::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A002B81_helloWorld::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x20e6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A002B81_helloWorld::ConstructCore
-
-} // end of class FunctionObjects.Function_HelloWorld_337CB4D6.FunctionObject_FunctionDeclaration_9A002B81_helloWorld
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_IIFE_Classic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_IIFE_Classic.verified.txt
@@ -31,6 +31,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DC85BFED_L3C2
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x20cb
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_DC85BFED_L3C2::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x20d3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_DC85BFED_L3C2::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x20d6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_DC85BFED_L3C2::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x20d9
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Function_IIFE_Classic/FunctionExpression_L3C1::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_DC85BFED_L3C2::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x20e5
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Function_IIFE_Classic/FunctionExpression_L3C1::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_DC85BFED_L3C2::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x20ed
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_DC85BFED_L3C2::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_DC85BFED_L3C2
+
 
 		// Methods
 		.method public hidebysig static 
@@ -97,7 +192,7 @@
 		.locals init (
 			[0] class Modules.Function_IIFE_Classic/Scope,
 			[1] object[],
-			[2] class FunctionObjects.Function_IIFE_Classic_2C40DE5A.FunctionObject_FunctionExpression_DC85BFED_L3C2
+			[2] class Modules.Function_IIFE_Classic/FunctionExpression_L3C1/FunctionObject_FunctionExpression_DC85BFED_L3C2
 		)
 
 		IL_0000: newobj instance void Modules.Function_IIFE_Classic/Scope::.ctor()
@@ -110,13 +205,13 @@
 		IL_000f: ldloc.0
 		IL_0010: stelem.ref
 		IL_0011: stloc.1
-		IL_0012: newobj instance void FunctionObjects.Function_IIFE_Classic_2C40DE5A.FunctionObject_FunctionExpression_DC85BFED_L3C2::.ctor()
+		IL_0012: newobj instance void Modules.Function_IIFE_Classic/FunctionExpression_L3C1/FunctionObject_FunctionExpression_DC85BFED_L3C2::.ctor()
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr ""
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_IIFE_Classic_2C40DE5A.FunctionObject_FunctionExpression_DC85BFED_L3C2>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_IIFE_Classic/FunctionExpression_L3C1/FunctionObject_FunctionExpression_DC85BFED_L3C2>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.2
 		IL_0026: ldc.i4.0
 		IL_0027: newarr [System.Runtime]System.Object
@@ -130,101 +225,6 @@
 	} // end of method Function_IIFE_Classic::__js_module_init__
 
 } // end of class Modules.Function_IIFE_Classic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_IIFE_Classic_2C40DE5A.FunctionObject_FunctionExpression_DC85BFED_L3C2
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x20cb
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_DC85BFED_L3C2::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x20d3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DC85BFED_L3C2::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x20d6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DC85BFED_L3C2::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x20d9
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Function_IIFE_Classic/FunctionExpression_L3C1::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_DC85BFED_L3C2::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x20e5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Function_IIFE_Classic/FunctionExpression_L3C1::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_DC85BFED_L3C2::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x20ed
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DC85BFED_L3C2::ConstructCore
-
-} // end of class FunctionObjects.Function_IIFE_Classic_2C40DE5A.FunctionObject_FunctionExpression_DC85BFED_L3C2
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_IIFE_Recursive.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_IIFE_Recursive.verified.txt
@@ -80,6 +80,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F39F0734_walk
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2259
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_F39F0734_walk::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2261
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F39F0734_walk::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2264
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F39F0734_walk::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2267
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Function_IIFE_Recursive/walk::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionExpression_F39F0734_walk::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2281
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Function_IIFE_Recursive/walk::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionExpression_F39F0734_walk::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2297
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_F39F0734_walk::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_F39F0734_walk
+
 
 		// Methods
 		.method public hidebysig static 
@@ -225,7 +332,7 @@
 		.locals init (
 			[0] class Modules.Function_IIFE_Recursive/Scope,
 			[1] object[],
-			[2] class FunctionObjects.Function_IIFE_Recursive_C02B9FB2.FunctionObject_FunctionExpression_F39F0734_walk
+			[2] class Modules.Function_IIFE_Recursive/walk/FunctionObject_FunctionExpression_F39F0734_walk
 		)
 
 		IL_0000: newobj instance void Modules.Function_IIFE_Recursive/Scope::.ctor()
@@ -238,13 +345,13 @@
 		IL_000f: ldloc.0
 		IL_0010: stelem.ref
 		IL_0011: stloc.1
-		IL_0012: newobj instance void FunctionObjects.Function_IIFE_Recursive_C02B9FB2.FunctionObject_FunctionExpression_F39F0734_walk::.ctor()
+		IL_0012: newobj instance void Modules.Function_IIFE_Recursive/walk/FunctionObject_FunctionExpression_F39F0734_walk::.ctor()
 		IL_0017: ldc.i4.2
 		IL_0018: conv.r8
 		IL_0019: ldstr "walk"
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_IIFE_Recursive_C02B9FB2.FunctionObject_FunctionExpression_F39F0734_walk>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_IIFE_Recursive/walk/FunctionObject_FunctionExpression_F39F0734_walk>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.2
 		IL_0026: ldc.i4.2
 		IL_0027: newarr [System.Runtime]System.Object
@@ -312,113 +419,6 @@
 	} // end of method Function_IIFE_Recursive::__js_module_init__
 
 } // end of class Modules.Function_IIFE_Recursive
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_IIFE_Recursive_C02B9FB2.FunctionObject_FunctionExpression_F39F0734_walk
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2259
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_F39F0734_walk::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2261
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F39F0734_walk::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2264
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F39F0734_walk::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2267
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Function_IIFE_Recursive/walk::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_F39F0734_walk::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2281
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Function_IIFE_Recursive/walk::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_F39F0734_walk::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2297
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F39F0734_walk::ConstructCore
-
-} // end of class FunctionObjects.Function_IIFE_Recursive_C02B9FB2.FunctionObject_FunctionExpression_F39F0734_walk
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Instance_Length_Name_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Instance_Length_Name_Basic.verified.txt
@@ -31,6 +31,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_74B1D4A4_add3
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21ac
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_74B1D4A4_add3::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21b4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_74B1D4A4_add3::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21b7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_74B1D4A4_add3::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21ba
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.2
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.Function_Instance_Length_Name_Basic/add3::__js_call__(object, object, object, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionDeclaration_74B1D4A4_add3::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21db
+				// Header size: 1
+				// Code size: 28 (0x1c)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: ldarg.2
+				IL_0010: ldc.i4.2
+				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0016: call object Modules.Function_Instance_Length_Name_Basic/add3::__js_call__(object, object, object, object)
+				IL_001b: ret
+			} // end of method FunctionObject_FunctionDeclaration_74B1D4A4_add3::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_74B1D4A4_add3::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_74B1D4A4_add3
+
 
 		// Methods
 		.method public hidebysig static 
@@ -110,7 +223,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Instance_Length_Name_Basic/Scope,
-			[1] class FunctionObjects.Function_Instance_Length_Name_Basic_3DB9A4B1.FunctionObject_FunctionDeclaration_74B1D4A4_add3,
+			[1] class Modules.Function_Instance_Length_Name_Basic/add3/FunctionObject_FunctionDeclaration_74B1D4A4_add3,
 			[2] object[],
 			[3] object,
 			[4] object,
@@ -128,13 +241,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.Function_Instance_Length_Name_Basic_3DB9A4B1.FunctionObject_FunctionDeclaration_74B1D4A4_add3::.ctor()
+		IL_0011: newobj instance void Modules.Function_Instance_Length_Name_Basic/add3/FunctionObject_FunctionDeclaration_74B1D4A4_add3::.ctor()
 		IL_0016: ldc.i4.3
 		IL_0017: conv.r8
 		IL_0018: ldstr "add3"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Instance_Length_Name_Basic_3DB9A4B1.FunctionObject_FunctionDeclaration_74B1D4A4_add3>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Instance_Length_Name_Basic/add3/FunctionObject_FunctionDeclaration_74B1D4A4_add3>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -215,119 +328,6 @@
 	} // end of method Function_Instance_Length_Name_Basic::__js_module_init__
 
 } // end of class Modules.Function_Instance_Length_Name_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Instance_Length_Name_Basic_3DB9A4B1.FunctionObject_FunctionDeclaration_74B1D4A4_add3
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21ac
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_74B1D4A4_add3::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21b4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_74B1D4A4_add3::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21b7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_74B1D4A4_add3::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ba
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.2
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.Function_Instance_Length_Name_Basic/add3::__js_call__(object, object, object, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionDeclaration_74B1D4A4_add3::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21db
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: ldarg.2
-		IL_0010: ldc.i4.2
-		IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0016: call object Modules.Function_Instance_Length_Name_Basic/add3::__js_call__(object, object, object, object)
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionDeclaration_74B1D4A4_add3::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_74B1D4A4_add3::ConstructCore
-
-} // end of class FunctionObjects.Function_Instance_Length_Name_Basic_3DB9A4B1.FunctionObject_FunctionDeclaration_74B1D4A4_add3
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Instance_Length_Name_DescriptorOwnProperties.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Instance_Length_Name_DescriptorOwnProperties.verified.txt
@@ -31,6 +31,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7702B128_namedAdd
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x26d9
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_7702B128_namedAdd::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x26e1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7702B128_namedAdd::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x26e4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7702B128_namedAdd::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x26e7
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.2
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.Function_Instance_Length_Name_DescriptorOwnProperties/namedAdd::__js_call__(object, object, object, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionDeclaration_7702B128_namedAdd::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2708
+				// Header size: 1
+				// Code size: 28 (0x1c)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: ldarg.2
+				IL_0010: ldc.i4.2
+				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0016: call object Modules.Function_Instance_Length_Name_DescriptorOwnProperties/namedAdd::__js_call__(object, object, object, object)
+				IL_001b: ret
+			} // end of method FunctionObject_FunctionDeclaration_7702B128_namedAdd::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2725
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_7702B128_namedAdd::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_7702B128_namedAdd
+
 
 		// Methods
 		.method public hidebysig static 
@@ -89,6 +202,128 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D4A5687D_L18C21
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2734
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_D4A5687D_L18C21::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x273c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D4A5687D_L18C21::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x273f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D4A5687D_L18C21::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2742
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_D4A5687D_L18C21::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x274a
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Function_Instance_Length_Name_DescriptorOwnProperties/'<>DynamicFunction_L18C20'::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionExpression_D4A5687D_L18C21::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2764
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Function_Instance_Length_Name_DescriptorOwnProperties/'<>DynamicFunction_L18C20'::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionExpression_D4A5687D_L18C21::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x277a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_D4A5687D_L18C21::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_D4A5687D_L18C21
 
 
 		// Methods
@@ -164,10 +399,10 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Instance_Length_Name_DescriptorOwnProperties/Scope,
-			[1] class FunctionObjects.Function_Instance_Length_Name_DescriptorOwnProperties_6E788A01.FunctionObject_FunctionDeclaration_7702B128_namedAdd,
+			[1] class Modules.Function_Instance_Length_Name_DescriptorOwnProperties/namedAdd/FunctionObject_FunctionDeclaration_7702B128_namedAdd,
 			[2] object,
 			[3] object,
-			[4] class FunctionObjects.Function_Instance_Length_Name_DescriptorOwnProperties_6E788A01.FunctionObject_FunctionExpression_D4A5687D_L18C21,
+			[4] class Modules.Function_Instance_Length_Name_DescriptorOwnProperties/'<>DynamicFunction_L18C20'/FunctionObject_FunctionExpression_D4A5687D_L18C21,
 			[5] object,
 			[6] object,
 			[7] object[],
@@ -192,13 +427,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 7
-		IL_0012: newobj instance void FunctionObjects.Function_Instance_Length_Name_DescriptorOwnProperties_6E788A01.FunctionObject_FunctionDeclaration_7702B128_namedAdd::.ctor()
+		IL_0012: newobj instance void Modules.Function_Instance_Length_Name_DescriptorOwnProperties/namedAdd/FunctionObject_FunctionDeclaration_7702B128_namedAdd::.ctor()
 		IL_0017: ldc.i4.3
 		IL_0018: conv.r8
 		IL_0019: ldstr "namedAdd"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Instance_Length_Name_DescriptorOwnProperties_6E788A01.FunctionObject_FunctionDeclaration_7702B128_namedAdd>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Instance_Length_Name_DescriptorOwnProperties/namedAdd/FunctionObject_FunctionDeclaration_7702B128_namedAdd>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: nop
@@ -468,13 +703,13 @@
 		IL_0383: ldloc.0
 		IL_0384: stelem.ref
 		IL_0385: stloc.s 7
-		IL_0387: newobj instance void FunctionObjects.Function_Instance_Length_Name_DescriptorOwnProperties_6E788A01.FunctionObject_FunctionExpression_D4A5687D_L18C21::.ctor()
+		IL_0387: newobj instance void Modules.Function_Instance_Length_Name_DescriptorOwnProperties/'<>DynamicFunction_L18C20'/FunctionObject_FunctionExpression_D4A5687D_L18C21::.ctor()
 		IL_038c: ldc.i4.2
 		IL_038d: conv.r8
 		IL_038e: ldstr ""
 		IL_0393: ldc.i4.0
 		IL_0394: ldc.i4.0
-		IL_0395: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Instance_Length_Name_DescriptorOwnProperties_6E788A01.FunctionObject_FunctionExpression_D4A5687D_L18C21>(!!0, float64, string, bool, bool)
+		IL_0395: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Instance_Length_Name_DescriptorOwnProperties/'<>DynamicFunction_L18C20'/FunctionObject_FunctionExpression_D4A5687D_L18C21>(!!0, float64, string, bool, bool)
 		IL_039a: stloc.s 4
 		IL_039c: ldloc.s 4
 		IL_039e: ldstr "length"
@@ -681,241 +916,6 @@
 	} // end of method Function_Instance_Length_Name_DescriptorOwnProperties::__js_module_init__
 
 } // end of class Modules.Function_Instance_Length_Name_DescriptorOwnProperties
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Instance_Length_Name_DescriptorOwnProperties_6E788A01.FunctionObject_FunctionDeclaration_7702B128_namedAdd
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x26d9
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_7702B128_namedAdd::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x26e1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7702B128_namedAdd::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x26e4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7702B128_namedAdd::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x26e7
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.2
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.Function_Instance_Length_Name_DescriptorOwnProperties/namedAdd::__js_call__(object, object, object, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionDeclaration_7702B128_namedAdd::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2708
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: ldarg.2
-		IL_0010: ldc.i4.2
-		IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0016: call object Modules.Function_Instance_Length_Name_DescriptorOwnProperties/namedAdd::__js_call__(object, object, object, object)
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionDeclaration_7702B128_namedAdd::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2725
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_7702B128_namedAdd::ConstructCore
-
-} // end of class FunctionObjects.Function_Instance_Length_Name_DescriptorOwnProperties_6E788A01.FunctionObject_FunctionDeclaration_7702B128_namedAdd
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Instance_Length_Name_DescriptorOwnProperties_6E788A01.FunctionObject_FunctionExpression_D4A5687D_L18C21
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2734
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_D4A5687D_L18C21::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x273c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D4A5687D_L18C21::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x273f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D4A5687D_L18C21::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2742
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_D4A5687D_L18C21::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x274a
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Function_Instance_Length_Name_DescriptorOwnProperties/'<>DynamicFunction_L18C20'::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_D4A5687D_L18C21::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2764
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Function_Instance_Length_Name_DescriptorOwnProperties/'<>DynamicFunction_L18C20'::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_D4A5687D_L18C21::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x277a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D4A5687D_L18C21::ConstructCore
-
-} // end of class FunctionObjects.Function_Instance_Length_Name_DescriptorOwnProperties_6E788A01.FunctionObject_FunctionExpression_D4A5687D_L18C21
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous.verified.txt
@@ -31,6 +31,103 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x212d
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2135
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2138
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x213b
+				// Header size: 1
+				// Code size: 16 (0x10)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call float64 Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous/DynamicFunction_L12C34::__js_call__(object)
+				IL_000a: box [System.Runtime]System.Double
+				IL_000f: ret
+			} // end of method FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x214c
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call float64 Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous/DynamicFunction_L12C34::__js_call__(object)
+				IL_0006: box [System.Runtime]System.Double
+				IL_000b: ret
+			} // end of method FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2159
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34
+
 
 		// Methods
 		.method public hidebysig static 
@@ -98,7 +195,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous/Scope,
-			[1] class FunctionObjects.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous_7D2A153F.FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34,
+			[1] class Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous/DynamicFunction_L12C34/FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34,
 			[2] object[],
 			[3] object,
 			[4] object,
@@ -115,13 +212,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous_7D2A153F.FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34::.ctor()
+		IL_0011: newobj instance void Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous/DynamicFunction_L12C34/FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "DynamicFunction_L12C34"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous_7D2A153F.FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous/DynamicFunction_L12C34/FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -171,103 +268,6 @@
 	} // end of method Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous::__js_module_init__
 
 } // end of class Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous_7D2A153F.FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x212d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2135
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2138
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x213b
-		// Header size: 1
-		// Code size: 16 (0x10)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call float64 Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous/DynamicFunction_L12C34::__js_call__(object)
-		IL_000a: box [System.Runtime]System.Double
-		IL_000f: ret
-	} // end of method FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x214c
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call float64 Modules.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous/DynamicFunction_L12C34::__js_call__(object)
-		IL_0006: box [System.Runtime]System.Double
-		IL_000b: ret
-	} // end of method FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2159
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34::ConstructCore
-
-} // end of class FunctionObjects.Function_Instance_Name_DynamicFunctionLineColumnPattern_NoFalseAnonymous_7D2A153F.FunctionObject_FunctionDeclaration_B056D0AB_DynamicFunction_L12C34
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_IsEven_CompareResultToTrue.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_IsEven_CompareResultToTrue.verified.txt
@@ -31,6 +31,109 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_24CC1E21_isEven
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2106
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_24CC1E21_isEven::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x210e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_24CC1E21_isEven::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2111
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_24CC1E21_isEven::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2114
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: call object Modules.Function_IsEven_CompareResultToTrue/isEven::__js_call__(object, float64)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_24CC1E21_isEven::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x212c
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: call object Modules.Function_IsEven_CompareResultToTrue/isEven::__js_call__(object, float64)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_24CC1E21_isEven::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2140
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_24CC1E21_isEven::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_24CC1E21_isEven
+
 
 		// Methods
 		.method public hidebysig static 
@@ -102,7 +205,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_IsEven_CompareResultToTrue/Scope,
-			[1] class FunctionObjects.Function_IsEven_CompareResultToTrue_29CC3236.FunctionObject_FunctionDeclaration_24CC1E21_isEven,
+			[1] class Modules.Function_IsEven_CompareResultToTrue/isEven/FunctionObject_FunctionDeclaration_24CC1E21_isEven,
 			[2] object[],
 			[3] object,
 			[4] object,
@@ -119,13 +222,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.Function_IsEven_CompareResultToTrue_29CC3236.FunctionObject_FunctionDeclaration_24CC1E21_isEven::.ctor()
+		IL_0011: newobj instance void Modules.Function_IsEven_CompareResultToTrue/isEven/FunctionObject_FunctionDeclaration_24CC1E21_isEven::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "isEven"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_IsEven_CompareResultToTrue_29CC3236.FunctionObject_FunctionDeclaration_24CC1E21_isEven>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_IsEven_CompareResultToTrue/isEven/FunctionObject_FunctionDeclaration_24CC1E21_isEven>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -158,109 +261,6 @@
 	} // end of method Function_IsEven_CompareResultToTrue::__js_module_init__
 
 } // end of class Modules.Function_IsEven_CompareResultToTrue
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_IsEven_CompareResultToTrue_29CC3236.FunctionObject_FunctionDeclaration_24CC1E21_isEven
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2106
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_24CC1E21_isEven::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x210e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_24CC1E21_isEven::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2111
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_24CC1E21_isEven::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2114
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: call object Modules.Function_IsEven_CompareResultToTrue/isEven::__js_call__(object, float64)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_24CC1E21_isEven::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x212c
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: call object Modules.Function_IsEven_CompareResultToTrue/isEven::__js_call__(object, float64)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_24CC1E21_isEven::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2140
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_24CC1E21_isEven::ConstructCore
-
-} // end of class FunctionObjects.Function_IsEven_CompareResultToTrue_29CC3236.FunctionObject_FunctionDeclaration_24CC1E21_isEven
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_MaxParameters_16.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_MaxParameters_16.verified.txt
@@ -31,6 +31,197 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E2B5C791_f
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21e6
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_E2B5C791_f::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21ee
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E2B5C791_f::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21f1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E2B5C791_f::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f4
+				// Header size: 12
+				// Code size: 130 (0x82)
+				.maxstack 19
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.2
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: ldarg.2
+				IL_001b: ldc.i4.3
+				IL_001c: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0021: ldarg.2
+				IL_0022: ldc.i4.4
+				IL_0023: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0028: ldarg.2
+				IL_0029: ldc.i4.5
+				IL_002a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_002f: ldarg.2
+				IL_0030: ldc.i4.6
+				IL_0031: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0036: ldarg.2
+				IL_0037: ldc.i4.7
+				IL_0038: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_003d: ldarg.2
+				IL_003e: ldc.i4.8
+				IL_003f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0044: ldarg.2
+				IL_0045: ldc.i4.s 9
+				IL_0047: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_004c: ldarg.2
+				IL_004d: ldc.i4.s 10
+				IL_004f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0054: ldarg.2
+				IL_0055: ldc.i4.s 11
+				IL_0057: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_005c: ldarg.2
+				IL_005d: ldc.i4.s 12
+				IL_005f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0064: ldarg.2
+				IL_0065: ldc.i4.s 13
+				IL_0067: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_006c: ldarg.2
+				IL_006d: ldc.i4.s 14
+				IL_006f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0074: ldarg.2
+				IL_0075: ldc.i4.s 15
+				IL_0077: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_007c: call object Modules.Function_MaxParameters_16/f::__js_call__(object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object)
+				IL_0081: ret
+			} // end of method FunctionObject_FunctionDeclaration_E2B5C791_f::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2284
+				// Header size: 12
+				// Code size: 126 (0x7e)
+				.maxstack 19
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: ldarg.2
+				IL_0010: ldc.i4.2
+				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0016: ldarg.2
+				IL_0017: ldc.i4.3
+				IL_0018: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001d: ldarg.2
+				IL_001e: ldc.i4.4
+				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0024: ldarg.2
+				IL_0025: ldc.i4.5
+				IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_002b: ldarg.2
+				IL_002c: ldc.i4.6
+				IL_002d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0032: ldarg.2
+				IL_0033: ldc.i4.7
+				IL_0034: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0039: ldarg.2
+				IL_003a: ldc.i4.8
+				IL_003b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0040: ldarg.2
+				IL_0041: ldc.i4.s 9
+				IL_0043: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0048: ldarg.2
+				IL_0049: ldc.i4.s 10
+				IL_004b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0050: ldarg.2
+				IL_0051: ldc.i4.s 11
+				IL_0053: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0058: ldarg.2
+				IL_0059: ldc.i4.s 12
+				IL_005b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0060: ldarg.2
+				IL_0061: ldc.i4.s 13
+				IL_0063: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0068: ldarg.2
+				IL_0069: ldc.i4.s 14
+				IL_006b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0070: ldarg.2
+				IL_0071: ldc.i4.s 15
+				IL_0073: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0078: call object Modules.Function_MaxParameters_16/f::__js_call__(object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object)
+				IL_007d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E2B5C791_f::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x230e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E2B5C791_f::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E2B5C791_f
+
 
 		// Methods
 		.method public hidebysig static 
@@ -111,7 +302,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_MaxParameters_16/Scope,
-			[1] class FunctionObjects.Function_MaxParameters_16_4312A94E.FunctionObject_FunctionDeclaration_E2B5C791_f,
+			[1] class Modules.Function_MaxParameters_16/f/FunctionObject_FunctionDeclaration_E2B5C791_f,
 			[2] object[],
 			[3] object,
 			[4] object
@@ -126,13 +317,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.Function_MaxParameters_16_4312A94E.FunctionObject_FunctionDeclaration_E2B5C791_f::.ctor()
+		IL_0011: newobj instance void Modules.Function_MaxParameters_16/f/FunctionObject_FunctionDeclaration_E2B5C791_f::.ctor()
 		IL_0016: ldc.i4.s 16
 		IL_0018: conv.r8
 		IL_0019: ldstr "f"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_MaxParameters_16_4312A94E.FunctionObject_FunctionDeclaration_E2B5C791_f>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_MaxParameters_16/f/FunctionObject_FunctionDeclaration_E2B5C791_f>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: nop
@@ -237,197 +428,6 @@
 	} // end of method Function_MaxParameters_16::__js_module_init__
 
 } // end of class Modules.Function_MaxParameters_16
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_MaxParameters_16_4312A94E.FunctionObject_FunctionDeclaration_E2B5C791_f
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21e6
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_E2B5C791_f::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21ee
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E2B5C791_f::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21f1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E2B5C791_f::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f4
-		// Header size: 12
-		// Code size: 130 (0x82)
-		.maxstack 19
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.2
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: ldarg.2
-		IL_001b: ldc.i4.3
-		IL_001c: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0021: ldarg.2
-		IL_0022: ldc.i4.4
-		IL_0023: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0028: ldarg.2
-		IL_0029: ldc.i4.5
-		IL_002a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_002f: ldarg.2
-		IL_0030: ldc.i4.6
-		IL_0031: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0036: ldarg.2
-		IL_0037: ldc.i4.7
-		IL_0038: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_003d: ldarg.2
-		IL_003e: ldc.i4.8
-		IL_003f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0044: ldarg.2
-		IL_0045: ldc.i4.s 9
-		IL_0047: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_004c: ldarg.2
-		IL_004d: ldc.i4.s 10
-		IL_004f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0054: ldarg.2
-		IL_0055: ldc.i4.s 11
-		IL_0057: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_005c: ldarg.2
-		IL_005d: ldc.i4.s 12
-		IL_005f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0064: ldarg.2
-		IL_0065: ldc.i4.s 13
-		IL_0067: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_006c: ldarg.2
-		IL_006d: ldc.i4.s 14
-		IL_006f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0074: ldarg.2
-		IL_0075: ldc.i4.s 15
-		IL_0077: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_007c: call object Modules.Function_MaxParameters_16/f::__js_call__(object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object)
-		IL_0081: ret
-	} // end of method FunctionObject_FunctionDeclaration_E2B5C791_f::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2284
-		// Header size: 12
-		// Code size: 126 (0x7e)
-		.maxstack 19
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: ldarg.2
-		IL_0010: ldc.i4.2
-		IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0016: ldarg.2
-		IL_0017: ldc.i4.3
-		IL_0018: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001d: ldarg.2
-		IL_001e: ldc.i4.4
-		IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0024: ldarg.2
-		IL_0025: ldc.i4.5
-		IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_002b: ldarg.2
-		IL_002c: ldc.i4.6
-		IL_002d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0032: ldarg.2
-		IL_0033: ldc.i4.7
-		IL_0034: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0039: ldarg.2
-		IL_003a: ldc.i4.8
-		IL_003b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0040: ldarg.2
-		IL_0041: ldc.i4.s 9
-		IL_0043: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0048: ldarg.2
-		IL_0049: ldc.i4.s 10
-		IL_004b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0050: ldarg.2
-		IL_0051: ldc.i4.s 11
-		IL_0053: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0058: ldarg.2
-		IL_0059: ldc.i4.s 12
-		IL_005b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0060: ldarg.2
-		IL_0061: ldc.i4.s 13
-		IL_0063: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0068: ldarg.2
-		IL_0069: ldc.i4.s 14
-		IL_006b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0070: ldarg.2
-		IL_0071: ldc.i4.s 15
-		IL_0073: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0078: call object Modules.Function_MaxParameters_16/f::__js_call__(object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object)
-		IL_007d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E2B5C791_f::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x230e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E2B5C791_f::ConstructCore
-
-} // end of class FunctionObjects.Function_MaxParameters_16_4312A94E.FunctionObject_FunctionDeclaration_E2B5C791_f
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_MaxParameters_32_CallViaVariable.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_MaxParameters_32_CallViaVariable.verified.txt
@@ -31,6 +31,293 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5DEE3A80_f
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x230a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_5DEE3A80_f::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2312
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5DEE3A80_f::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2315
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5DEE3A80_f::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2318
+				// Header size: 12
+				// Code size: 258 (0x102)
+				.maxstack 35
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.2
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: ldarg.2
+				IL_001b: ldc.i4.3
+				IL_001c: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0021: ldarg.2
+				IL_0022: ldc.i4.4
+				IL_0023: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0028: ldarg.2
+				IL_0029: ldc.i4.5
+				IL_002a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_002f: ldarg.2
+				IL_0030: ldc.i4.6
+				IL_0031: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0036: ldarg.2
+				IL_0037: ldc.i4.7
+				IL_0038: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_003d: ldarg.2
+				IL_003e: ldc.i4.8
+				IL_003f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0044: ldarg.2
+				IL_0045: ldc.i4.s 9
+				IL_0047: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_004c: ldarg.2
+				IL_004d: ldc.i4.s 10
+				IL_004f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0054: ldarg.2
+				IL_0055: ldc.i4.s 11
+				IL_0057: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_005c: ldarg.2
+				IL_005d: ldc.i4.s 12
+				IL_005f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0064: ldarg.2
+				IL_0065: ldc.i4.s 13
+				IL_0067: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_006c: ldarg.2
+				IL_006d: ldc.i4.s 14
+				IL_006f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0074: ldarg.2
+				IL_0075: ldc.i4.s 15
+				IL_0077: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_007c: ldarg.2
+				IL_007d: ldc.i4.s 16
+				IL_007f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0084: ldarg.2
+				IL_0085: ldc.i4.s 17
+				IL_0087: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_008c: ldarg.2
+				IL_008d: ldc.i4.s 18
+				IL_008f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0094: ldarg.2
+				IL_0095: ldc.i4.s 19
+				IL_0097: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_009c: ldarg.2
+				IL_009d: ldc.i4.s 20
+				IL_009f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00a4: ldarg.2
+				IL_00a5: ldc.i4.s 21
+				IL_00a7: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00ac: ldarg.2
+				IL_00ad: ldc.i4.s 22
+				IL_00af: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00b4: ldarg.2
+				IL_00b5: ldc.i4.s 23
+				IL_00b7: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00bc: ldarg.2
+				IL_00bd: ldc.i4.s 24
+				IL_00bf: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00c4: ldarg.2
+				IL_00c5: ldc.i4.s 25
+				IL_00c7: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00cc: ldarg.2
+				IL_00cd: ldc.i4.s 26
+				IL_00cf: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00d4: ldarg.2
+				IL_00d5: ldc.i4.s 27
+				IL_00d7: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00dc: ldarg.2
+				IL_00dd: ldc.i4.s 28
+				IL_00df: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00e4: ldarg.2
+				IL_00e5: ldc.i4.s 29
+				IL_00e7: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00ec: ldarg.2
+				IL_00ed: ldc.i4.s 30
+				IL_00ef: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00f4: ldarg.2
+				IL_00f5: ldc.i4.s 31
+				IL_00f7: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00fc: call object Modules.Function_MaxParameters_32_CallViaVariable/f::__js_call__(object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object)
+				IL_0101: ret
+			} // end of method FunctionObject_FunctionDeclaration_5DEE3A80_f::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2428
+				// Header size: 12
+				// Code size: 254 (0xfe)
+				.maxstack 35
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: ldarg.2
+				IL_0010: ldc.i4.2
+				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0016: ldarg.2
+				IL_0017: ldc.i4.3
+				IL_0018: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001d: ldarg.2
+				IL_001e: ldc.i4.4
+				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0024: ldarg.2
+				IL_0025: ldc.i4.5
+				IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_002b: ldarg.2
+				IL_002c: ldc.i4.6
+				IL_002d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0032: ldarg.2
+				IL_0033: ldc.i4.7
+				IL_0034: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0039: ldarg.2
+				IL_003a: ldc.i4.8
+				IL_003b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0040: ldarg.2
+				IL_0041: ldc.i4.s 9
+				IL_0043: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0048: ldarg.2
+				IL_0049: ldc.i4.s 10
+				IL_004b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0050: ldarg.2
+				IL_0051: ldc.i4.s 11
+				IL_0053: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0058: ldarg.2
+				IL_0059: ldc.i4.s 12
+				IL_005b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0060: ldarg.2
+				IL_0061: ldc.i4.s 13
+				IL_0063: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0068: ldarg.2
+				IL_0069: ldc.i4.s 14
+				IL_006b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0070: ldarg.2
+				IL_0071: ldc.i4.s 15
+				IL_0073: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0078: ldarg.2
+				IL_0079: ldc.i4.s 16
+				IL_007b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0080: ldarg.2
+				IL_0081: ldc.i4.s 17
+				IL_0083: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0088: ldarg.2
+				IL_0089: ldc.i4.s 18
+				IL_008b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0090: ldarg.2
+				IL_0091: ldc.i4.s 19
+				IL_0093: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0098: ldarg.2
+				IL_0099: ldc.i4.s 20
+				IL_009b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00a0: ldarg.2
+				IL_00a1: ldc.i4.s 21
+				IL_00a3: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00a8: ldarg.2
+				IL_00a9: ldc.i4.s 22
+				IL_00ab: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00b0: ldarg.2
+				IL_00b1: ldc.i4.s 23
+				IL_00b3: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00b8: ldarg.2
+				IL_00b9: ldc.i4.s 24
+				IL_00bb: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00c0: ldarg.2
+				IL_00c1: ldc.i4.s 25
+				IL_00c3: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00c8: ldarg.2
+				IL_00c9: ldc.i4.s 26
+				IL_00cb: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00d0: ldarg.2
+				IL_00d1: ldc.i4.s 27
+				IL_00d3: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00d8: ldarg.2
+				IL_00d9: ldc.i4.s 28
+				IL_00db: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00e0: ldarg.2
+				IL_00e1: ldc.i4.s 29
+				IL_00e3: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00e8: ldarg.2
+				IL_00e9: ldc.i4.s 30
+				IL_00eb: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00f0: ldarg.2
+				IL_00f1: ldc.i4.s 31
+				IL_00f3: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_00f8: call object Modules.Function_MaxParameters_32_CallViaVariable/f::__js_call__(object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object)
+				IL_00fd: ret
+			} // end of method FunctionObject_FunctionDeclaration_5DEE3A80_f::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2532
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5DEE3A80_f::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_5DEE3A80_f
+
 
 		// Methods
 		.method public hidebysig static 
@@ -127,8 +414,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_MaxParameters_32_CallViaVariable/Scope,
-			[1] class FunctionObjects.Function_MaxParameters_32_CallViaVariable_A9F96153.FunctionObject_FunctionDeclaration_5DEE3A80_f,
-			[2] class FunctionObjects.Function_MaxParameters_32_CallViaVariable_A9F96153.FunctionObject_FunctionDeclaration_5DEE3A80_f,
+			[1] class Modules.Function_MaxParameters_32_CallViaVariable/f/FunctionObject_FunctionDeclaration_5DEE3A80_f,
+			[2] class Modules.Function_MaxParameters_32_CallViaVariable/f/FunctionObject_FunctionDeclaration_5DEE3A80_f,
 			[3] object[],
 			[4] object,
 			[5] object
@@ -143,13 +430,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.Function_MaxParameters_32_CallViaVariable_A9F96153.FunctionObject_FunctionDeclaration_5DEE3A80_f::.ctor()
+		IL_0011: newobj instance void Modules.Function_MaxParameters_32_CallViaVariable/f/FunctionObject_FunctionDeclaration_5DEE3A80_f::.ctor()
 		IL_0016: ldc.i4.s 32
 		IL_0018: conv.r8
 		IL_0019: ldstr "f"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_MaxParameters_32_CallViaVariable_A9F96153.FunctionObject_FunctionDeclaration_5DEE3A80_f>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_MaxParameters_32_CallViaVariable/f/FunctionObject_FunctionDeclaration_5DEE3A80_f>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: nop
@@ -336,293 +623,6 @@
 	} // end of method Function_MaxParameters_32_CallViaVariable::__js_module_init__
 
 } // end of class Modules.Function_MaxParameters_32_CallViaVariable
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_MaxParameters_32_CallViaVariable_A9F96153.FunctionObject_FunctionDeclaration_5DEE3A80_f
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x230a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_5DEE3A80_f::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2312
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5DEE3A80_f::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2315
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5DEE3A80_f::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2318
-		// Header size: 12
-		// Code size: 258 (0x102)
-		.maxstack 35
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.2
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: ldarg.2
-		IL_001b: ldc.i4.3
-		IL_001c: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0021: ldarg.2
-		IL_0022: ldc.i4.4
-		IL_0023: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0028: ldarg.2
-		IL_0029: ldc.i4.5
-		IL_002a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_002f: ldarg.2
-		IL_0030: ldc.i4.6
-		IL_0031: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0036: ldarg.2
-		IL_0037: ldc.i4.7
-		IL_0038: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_003d: ldarg.2
-		IL_003e: ldc.i4.8
-		IL_003f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0044: ldarg.2
-		IL_0045: ldc.i4.s 9
-		IL_0047: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_004c: ldarg.2
-		IL_004d: ldc.i4.s 10
-		IL_004f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0054: ldarg.2
-		IL_0055: ldc.i4.s 11
-		IL_0057: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_005c: ldarg.2
-		IL_005d: ldc.i4.s 12
-		IL_005f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0064: ldarg.2
-		IL_0065: ldc.i4.s 13
-		IL_0067: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_006c: ldarg.2
-		IL_006d: ldc.i4.s 14
-		IL_006f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0074: ldarg.2
-		IL_0075: ldc.i4.s 15
-		IL_0077: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_007c: ldarg.2
-		IL_007d: ldc.i4.s 16
-		IL_007f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0084: ldarg.2
-		IL_0085: ldc.i4.s 17
-		IL_0087: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_008c: ldarg.2
-		IL_008d: ldc.i4.s 18
-		IL_008f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0094: ldarg.2
-		IL_0095: ldc.i4.s 19
-		IL_0097: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_009c: ldarg.2
-		IL_009d: ldc.i4.s 20
-		IL_009f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00a4: ldarg.2
-		IL_00a5: ldc.i4.s 21
-		IL_00a7: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00ac: ldarg.2
-		IL_00ad: ldc.i4.s 22
-		IL_00af: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00b4: ldarg.2
-		IL_00b5: ldc.i4.s 23
-		IL_00b7: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00bc: ldarg.2
-		IL_00bd: ldc.i4.s 24
-		IL_00bf: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00c4: ldarg.2
-		IL_00c5: ldc.i4.s 25
-		IL_00c7: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00cc: ldarg.2
-		IL_00cd: ldc.i4.s 26
-		IL_00cf: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00d4: ldarg.2
-		IL_00d5: ldc.i4.s 27
-		IL_00d7: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00dc: ldarg.2
-		IL_00dd: ldc.i4.s 28
-		IL_00df: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00e4: ldarg.2
-		IL_00e5: ldc.i4.s 29
-		IL_00e7: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00ec: ldarg.2
-		IL_00ed: ldc.i4.s 30
-		IL_00ef: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00f4: ldarg.2
-		IL_00f5: ldc.i4.s 31
-		IL_00f7: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00fc: call object Modules.Function_MaxParameters_32_CallViaVariable/f::__js_call__(object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object)
-		IL_0101: ret
-	} // end of method FunctionObject_FunctionDeclaration_5DEE3A80_f::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2428
-		// Header size: 12
-		// Code size: 254 (0xfe)
-		.maxstack 35
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: ldarg.2
-		IL_0010: ldc.i4.2
-		IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0016: ldarg.2
-		IL_0017: ldc.i4.3
-		IL_0018: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001d: ldarg.2
-		IL_001e: ldc.i4.4
-		IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0024: ldarg.2
-		IL_0025: ldc.i4.5
-		IL_0026: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_002b: ldarg.2
-		IL_002c: ldc.i4.6
-		IL_002d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0032: ldarg.2
-		IL_0033: ldc.i4.7
-		IL_0034: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0039: ldarg.2
-		IL_003a: ldc.i4.8
-		IL_003b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0040: ldarg.2
-		IL_0041: ldc.i4.s 9
-		IL_0043: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0048: ldarg.2
-		IL_0049: ldc.i4.s 10
-		IL_004b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0050: ldarg.2
-		IL_0051: ldc.i4.s 11
-		IL_0053: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0058: ldarg.2
-		IL_0059: ldc.i4.s 12
-		IL_005b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0060: ldarg.2
-		IL_0061: ldc.i4.s 13
-		IL_0063: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0068: ldarg.2
-		IL_0069: ldc.i4.s 14
-		IL_006b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0070: ldarg.2
-		IL_0071: ldc.i4.s 15
-		IL_0073: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0078: ldarg.2
-		IL_0079: ldc.i4.s 16
-		IL_007b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0080: ldarg.2
-		IL_0081: ldc.i4.s 17
-		IL_0083: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0088: ldarg.2
-		IL_0089: ldc.i4.s 18
-		IL_008b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0090: ldarg.2
-		IL_0091: ldc.i4.s 19
-		IL_0093: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0098: ldarg.2
-		IL_0099: ldc.i4.s 20
-		IL_009b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00a0: ldarg.2
-		IL_00a1: ldc.i4.s 21
-		IL_00a3: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00a8: ldarg.2
-		IL_00a9: ldc.i4.s 22
-		IL_00ab: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00b0: ldarg.2
-		IL_00b1: ldc.i4.s 23
-		IL_00b3: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00b8: ldarg.2
-		IL_00b9: ldc.i4.s 24
-		IL_00bb: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00c0: ldarg.2
-		IL_00c1: ldc.i4.s 25
-		IL_00c3: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00c8: ldarg.2
-		IL_00c9: ldc.i4.s 26
-		IL_00cb: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00d0: ldarg.2
-		IL_00d1: ldc.i4.s 27
-		IL_00d3: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00d8: ldarg.2
-		IL_00d9: ldc.i4.s 28
-		IL_00db: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00e0: ldarg.2
-		IL_00e1: ldc.i4.s 29
-		IL_00e3: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00e8: ldarg.2
-		IL_00e9: ldc.i4.s 30
-		IL_00eb: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00f0: ldarg.2
-		IL_00f1: ldc.i4.s 31
-		IL_00f3: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_00f8: call object Modules.Function_MaxParameters_32_CallViaVariable/f::__js_call__(object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object, object)
-		IL_00fd: ret
-	} // end of method FunctionObject_FunctionDeclaration_5DEE3A80_f::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2532
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5DEE3A80_f::ConstructCore
-
-} // end of class FunctionObjects.Function_MaxParameters_32_CallViaVariable_A9F96153.FunctionObject_FunctionDeclaration_5DEE3A80_f
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NestedFunctionAccessesMultipleScopes.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NestedFunctionAccessesMultipleScopes.verified.txt
@@ -35,6 +35,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope _environment0_Function_NestedFunctionAccessesMultipleScopes
+				.field private initonly class Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/Scope _environment1_testFunction
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope capture0,
+						class Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x21ff
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction/FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::_environment0_Function_NestedFunctionAccessesMultipleScopes
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/Scope Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction/FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::_environment1_testFunction
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction/FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x221c
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x221f
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2222
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction/FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2234
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction/FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2242
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::ConstructCore
+
+			} // end of class FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction
+
 
 			// Methods
 			.method public hidebysig static 
@@ -134,6 +251,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B1D31301_testFunction
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope _environment0_Function_NestedFunctionAccessesMultipleScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21bb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/FunctionObject_FunctionDeclaration_B1D31301_testFunction::_environment0_Function_NestedFunctionAccessesMultipleScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B1D31301_testFunction::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21ca
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B1D31301_testFunction::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21cd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B1D31301_testFunction::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21d0
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/FunctionObject_FunctionDeclaration_B1D31301_testFunction::_environment0_Function_NestedFunctionAccessesMultipleScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction::__js_call__(class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_B1D31301_testFunction::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21e2
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/FunctionObject_FunctionDeclaration_B1D31301_testFunction::_environment0_Function_NestedFunctionAccessesMultipleScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction::__js_call__(class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_B1D31301_testFunction::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B1D31301_testFunction::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_B1D31301_testFunction
+
 
 		// Methods
 		.method public hidebysig static 
@@ -153,7 +377,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/Scope,
-				[1] class FunctionObjects.Function_NestedFunctionAccessesMultipleScopes_AC96F27E.FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction,
+				[1] class Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction/FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction,
 				[2] object[]
 			)
 
@@ -179,13 +403,13 @@
 			IL_001f: ldelem.ref
 			IL_0020: castclass Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/Scope
 			IL_0025: ldloc.2
-			IL_0026: newobj instance void FunctionObjects.Function_NestedFunctionAccessesMultipleScopes_AC96F27E.FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::.ctor(class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope, class Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/Scope, object[])
+			IL_0026: newobj instance void Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction/FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::.ctor(class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope, class Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/Scope, object[])
 			IL_002b: ldc.i4.0
 			IL_002c: conv.r8
 			IL_002d: ldstr "innerFunction"
 			IL_0032: ldc.i4.0
 			IL_0033: ldc.i4.1
-			IL_0034: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_NestedFunctionAccessesMultipleScopes_AC96F27E.FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction>(!!0, float64, string, bool, bool)
+			IL_0034: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction/FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction>(!!0, float64, string, bool, bool)
 			IL_0039: stloc.1
 			IL_003a: ldloc.0
 			IL_003b: ldstr "I am outer"
@@ -253,7 +477,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope,
-			[1] class FunctionObjects.Function_NestedFunctionAccessesMultipleScopes_AC96F27E.FunctionObject_FunctionDeclaration_B1D31301_testFunction,
+			[1] class Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/FunctionObject_FunctionDeclaration_B1D31301_testFunction,
 			[2] object[]
 		)
 
@@ -270,13 +494,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_NestedFunctionAccessesMultipleScopes/Scope
-		IL_0019: newobj instance void FunctionObjects.Function_NestedFunctionAccessesMultipleScopes_AC96F27E.FunctionObject_FunctionDeclaration_B1D31301_testFunction::.ctor(class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope)
+		IL_0019: newobj instance void Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/FunctionObject_FunctionDeclaration_B1D31301_testFunction::.ctor(class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "testFunction"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_NestedFunctionAccessesMultipleScopes_AC96F27E.FunctionObject_FunctionDeclaration_B1D31301_testFunction>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/FunctionObject_FunctionDeclaration_B1D31301_testFunction>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldloc.0
@@ -291,230 +515,6 @@
 	} // end of method Function_NestedFunctionAccessesMultipleScopes::__js_module_init__
 
 } // end of class Modules.Function_NestedFunctionAccessesMultipleScopes
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_NestedFunctionAccessesMultipleScopes_AC96F27E.FunctionObject_FunctionDeclaration_B1D31301_testFunction
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope _environment0_Function_NestedFunctionAccessesMultipleScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21bb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope FunctionObjects.Function_NestedFunctionAccessesMultipleScopes_AC96F27E.FunctionObject_FunctionDeclaration_B1D31301_testFunction::_environment0_Function_NestedFunctionAccessesMultipleScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B1D31301_testFunction::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21ca
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B1D31301_testFunction::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21cd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B1D31301_testFunction::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21d0
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope FunctionObjects.Function_NestedFunctionAccessesMultipleScopes_AC96F27E.FunctionObject_FunctionDeclaration_B1D31301_testFunction::_environment0_Function_NestedFunctionAccessesMultipleScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction::__js_call__(class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_B1D31301_testFunction::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21e2
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope FunctionObjects.Function_NestedFunctionAccessesMultipleScopes_AC96F27E.FunctionObject_FunctionDeclaration_B1D31301_testFunction::_environment0_Function_NestedFunctionAccessesMultipleScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction::__js_call__(class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_B1D31301_testFunction::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B1D31301_testFunction::ConstructCore
-
-} // end of class FunctionObjects.Function_NestedFunctionAccessesMultipleScopes_AC96F27E.FunctionObject_FunctionDeclaration_B1D31301_testFunction
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_NestedFunctionAccessesMultipleScopes_AC96F27E.FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope _environment0_Function_NestedFunctionAccessesMultipleScopes
-	.field private initonly class Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/Scope _environment1_testFunction
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope capture0,
-			class Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ff
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_NestedFunctionAccessesMultipleScopes/Scope FunctionObjects.Function_NestedFunctionAccessesMultipleScopes_AC96F27E.FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::_environment0_Function_NestedFunctionAccessesMultipleScopes
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/Scope FunctionObjects.Function_NestedFunctionAccessesMultipleScopes_AC96F27E.FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::_environment1_testFunction
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Function_NestedFunctionAccessesMultipleScopes_AC96F27E.FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x221c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x221f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2222
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Function_NestedFunctionAccessesMultipleScopes_AC96F27E.FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2234
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Function_NestedFunctionAccessesMultipleScopes_AC96F27E.FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_NestedFunctionAccessesMultipleScopes/testFunction/innerFunction::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2242
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction::ConstructCore
-
-} // end of class FunctionObjects.Function_NestedFunctionAccessesMultipleScopes_AC96F27E.FunctionObject_FunctionDeclaration_9DB41BFE_innerFunction
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NestedFunctionLogsOuterParameter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NestedFunctionLogsOuterParameter.verified.txt
@@ -35,6 +35,124 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/Scope _environment1_outerFunction
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x21c7
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/Scope Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/innerFunction/FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::_environment1_outerFunction
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/innerFunction/FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x21dd
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x21e0
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x21e3
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/innerFunction/FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/innerFunction::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x21fc
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/innerFunction/FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/innerFunction::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2211
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::ConstructCore
+
+			} // end of class FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction
+
 
 			// Methods
 			.method public hidebysig static 
@@ -116,6 +234,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0C23077A_outerFunction
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_NestedFunctionLogsOuterParameter/Scope _environment0_Function_NestedFunctionLogsOuterParameter
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_NestedFunctionLogsOuterParameter/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2175
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_NestedFunctionLogsOuterParameter/Scope Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/FunctionObject_FunctionDeclaration_0C23077A_outerFunction::_environment0_Function_NestedFunctionLogsOuterParameter
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0C23077A_outerFunction::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2184
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0C23077A_outerFunction::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2187
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0C23077A_outerFunction::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x218a
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_NestedFunctionLogsOuterParameter/Scope Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/FunctionObject_FunctionDeclaration_0C23077A_outerFunction::_environment0_Function_NestedFunctionLogsOuterParameter
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Function_NestedFunctionLogsOuterParameter/outerFunction::__js_call__(class Modules.Function_NestedFunctionLogsOuterParameter/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_0C23077A_outerFunction::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21a3
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_NestedFunctionLogsOuterParameter/Scope Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/FunctionObject_FunctionDeclaration_0C23077A_outerFunction::_environment0_Function_NestedFunctionLogsOuterParameter
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Function_NestedFunctionLogsOuterParameter/outerFunction::__js_call__(class Modules.Function_NestedFunctionLogsOuterParameter/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_0C23077A_outerFunction::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21b8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0C23077A_outerFunction::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_0C23077A_outerFunction
+
 
 		// Methods
 		.method public hidebysig static 
@@ -136,7 +367,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/Scope,
-				[1] class FunctionObjects.Function_NestedFunctionLogsOuterParameter_8340F31C.FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction,
+				[1] class Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/innerFunction/FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction,
 				[2] object[]
 			)
 
@@ -161,13 +392,13 @@
 			IL_001e: ldelem.ref
 			IL_001f: castclass Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/Scope
 			IL_0024: ldloc.2
-			IL_0025: newobj instance void FunctionObjects.Function_NestedFunctionLogsOuterParameter_8340F31C.FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::.ctor(class Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/Scope, object[])
+			IL_0025: newobj instance void Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/innerFunction/FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::.ctor(class Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/Scope, object[])
 			IL_002a: ldc.i4.1
 			IL_002b: conv.r8
 			IL_002c: ldstr "innerFunction"
 			IL_0031: ldc.i4.0
 			IL_0032: ldc.i4.1
-			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_NestedFunctionLogsOuterParameter_8340F31C.FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction>(!!0, float64, string, bool, bool)
+			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/innerFunction/FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction>(!!0, float64, string, bool, bool)
 			IL_0038: stloc.1
 			IL_0039: nop
 			IL_003a: ldloc.1
@@ -221,7 +452,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_NestedFunctionLogsOuterParameter/Scope,
-			[1] class FunctionObjects.Function_NestedFunctionLogsOuterParameter_8340F31C.FunctionObject_FunctionDeclaration_0C23077A_outerFunction,
+			[1] class Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/FunctionObject_FunctionDeclaration_0C23077A_outerFunction,
 			[2] object,
 			[3] object[]
 		)
@@ -239,13 +470,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_NestedFunctionLogsOuterParameter/Scope
-		IL_0019: newobj instance void FunctionObjects.Function_NestedFunctionLogsOuterParameter_8340F31C.FunctionObject_FunctionDeclaration_0C23077A_outerFunction::.ctor(class Modules.Function_NestedFunctionLogsOuterParameter/Scope)
+		IL_0019: newobj instance void Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/FunctionObject_FunctionDeclaration_0C23077A_outerFunction::.ctor(class Modules.Function_NestedFunctionLogsOuterParameter/Scope)
 		IL_001e: ldc.i4.1
 		IL_001f: conv.r8
 		IL_0020: ldstr "outerFunction"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_NestedFunctionLogsOuterParameter_8340F31C.FunctionObject_FunctionDeclaration_0C23077A_outerFunction>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/FunctionObject_FunctionDeclaration_0C23077A_outerFunction>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
@@ -267,237 +498,6 @@
 	} // end of method Function_NestedFunctionLogsOuterParameter::__js_module_init__
 
 } // end of class Modules.Function_NestedFunctionLogsOuterParameter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_NestedFunctionLogsOuterParameter_8340F31C.FunctionObject_FunctionDeclaration_0C23077A_outerFunction
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_NestedFunctionLogsOuterParameter/Scope _environment0_Function_NestedFunctionLogsOuterParameter
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_NestedFunctionLogsOuterParameter/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2175
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_NestedFunctionLogsOuterParameter/Scope FunctionObjects.Function_NestedFunctionLogsOuterParameter_8340F31C.FunctionObject_FunctionDeclaration_0C23077A_outerFunction::_environment0_Function_NestedFunctionLogsOuterParameter
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0C23077A_outerFunction::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2184
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0C23077A_outerFunction::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2187
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0C23077A_outerFunction::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x218a
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_NestedFunctionLogsOuterParameter/Scope FunctionObjects.Function_NestedFunctionLogsOuterParameter_8340F31C.FunctionObject_FunctionDeclaration_0C23077A_outerFunction::_environment0_Function_NestedFunctionLogsOuterParameter
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Function_NestedFunctionLogsOuterParameter/outerFunction::__js_call__(class Modules.Function_NestedFunctionLogsOuterParameter/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_0C23077A_outerFunction::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21a3
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_NestedFunctionLogsOuterParameter/Scope FunctionObjects.Function_NestedFunctionLogsOuterParameter_8340F31C.FunctionObject_FunctionDeclaration_0C23077A_outerFunction::_environment0_Function_NestedFunctionLogsOuterParameter
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Function_NestedFunctionLogsOuterParameter/outerFunction::__js_call__(class Modules.Function_NestedFunctionLogsOuterParameter/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_0C23077A_outerFunction::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21b8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0C23077A_outerFunction::ConstructCore
-
-} // end of class FunctionObjects.Function_NestedFunctionLogsOuterParameter_8340F31C.FunctionObject_FunctionDeclaration_0C23077A_outerFunction
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_NestedFunctionLogsOuterParameter_8340F31C.FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/Scope _environment1_outerFunction
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x21c7
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/Scope FunctionObjects.Function_NestedFunctionLogsOuterParameter_8340F31C.FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::_environment1_outerFunction
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Function_NestedFunctionLogsOuterParameter_8340F31C.FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21dd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21e0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21e3
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Function_NestedFunctionLogsOuterParameter_8340F31C.FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/innerFunction::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21fc
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Function_NestedFunctionLogsOuterParameter_8340F31C.FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Function_NestedFunctionLogsOuterParameter/outerFunction/innerFunction::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2211
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction::ConstructCore
-
-} // end of class FunctionObjects.Function_NestedFunctionLogsOuterParameter_8340F31C.FunctionObject_FunctionDeclaration_F8FBF66D_innerFunction
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewExpression_CapturesOuterCtor.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewExpression_CapturesOuterCtor.verified.txt
@@ -35,6 +35,101 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6D849243_L7C16
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2205
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_6D849243_L7C16::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x220d
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_6D849243_L7C16::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2210
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_6D849243_L7C16::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2213
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: call object Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionExpression_Ctor::__js_call__(object)
+					IL_000a: ret
+				} // end of method FunctionObject_FunctionExpression_6D849243_L7C16::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x221f
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: call object Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionExpression_Ctor::__js_call__(object)
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_6D849243_L7C16::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2227
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_6D849243_L7C16::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_6D849243_L7C16
+
 
 			// Methods
 			.method public hidebysig static 
@@ -86,6 +181,118 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_56210BE4_inner
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Function_NewExpression_CapturesOuterCtor/outer/Scope _environment1_outer
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Function_NewExpression_CapturesOuterCtor/outer/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x2236
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Function_NewExpression_CapturesOuterCtor/outer/Scope Modules.Function_NewExpression_CapturesOuterCtor/outer/inner/FunctionObject_FunctionDeclaration_56210BE4_inner::_environment1_outer
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Function_NewExpression_CapturesOuterCtor/outer/inner/FunctionObject_FunctionDeclaration_56210BE4_inner::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionDeclaration_56210BE4_inner::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x224c
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_56210BE4_inner::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x224f
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_56210BE4_inner::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2252
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Function_NewExpression_CapturesOuterCtor/outer/inner/FunctionObject_FunctionDeclaration_56210BE4_inner::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Function_NewExpression_CapturesOuterCtor/outer/inner::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionDeclaration_56210BE4_inner::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2264
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Function_NewExpression_CapturesOuterCtor/outer/inner/FunctionObject_FunctionDeclaration_56210BE4_inner::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Function_NewExpression_CapturesOuterCtor/outer/inner::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionDeclaration_56210BE4_inner::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2272
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionDeclaration_56210BE4_inner::ConstructCore
+
+			} // end of class FunctionObject_FunctionDeclaration_56210BE4_inner
 
 
 			// Methods
@@ -157,6 +364,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_93D08467_outer
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_NewExpression_CapturesOuterCtor/Scope _environment0_Function_NewExpression_CapturesOuterCtor
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_NewExpression_CapturesOuterCtor/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21c1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_NewExpression_CapturesOuterCtor/Scope Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionObject_FunctionDeclaration_93D08467_outer::_environment0_Function_NewExpression_CapturesOuterCtor
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_93D08467_outer::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21d0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_93D08467_outer::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21d3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_93D08467_outer::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21d6
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_NewExpression_CapturesOuterCtor/Scope Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionObject_FunctionDeclaration_93D08467_outer::_environment0_Function_NewExpression_CapturesOuterCtor
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_NewExpression_CapturesOuterCtor/outer::__js_call__(class Modules.Function_NewExpression_CapturesOuterCtor/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_93D08467_outer::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21e8
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_NewExpression_CapturesOuterCtor/Scope Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionObject_FunctionDeclaration_93D08467_outer::_environment0_Function_NewExpression_CapturesOuterCtor
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_NewExpression_CapturesOuterCtor/outer::__js_call__(class Modules.Function_NewExpression_CapturesOuterCtor/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_93D08467_outer::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_93D08467_outer::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_93D08467_outer
+
 
 		// Methods
 		.method public hidebysig static 
@@ -176,9 +490,9 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_NewExpression_CapturesOuterCtor/outer/Scope,
-				[1] class FunctionObjects.Function_NewExpression_CapturesOuterCtor_C5F9C589.FunctionObject_FunctionDeclaration_56210BE4_inner,
+				[1] class Modules.Function_NewExpression_CapturesOuterCtor/outer/inner/FunctionObject_FunctionDeclaration_56210BE4_inner,
 				[2] object[],
-				[3] class FunctionObjects.Function_NewExpression_CapturesOuterCtor_C5F9C589.FunctionObject_FunctionExpression_6D849243_L7C16,
+				[3] class Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionExpression_Ctor/FunctionObject_FunctionExpression_6D849243_L7C16,
 				[4] object
 			)
 
@@ -200,13 +514,13 @@
 			IL_0017: ldelem.ref
 			IL_0018: castclass Modules.Function_NewExpression_CapturesOuterCtor/outer/Scope
 			IL_001d: ldloc.2
-			IL_001e: newobj instance void FunctionObjects.Function_NewExpression_CapturesOuterCtor_C5F9C589.FunctionObject_FunctionDeclaration_56210BE4_inner::.ctor(class Modules.Function_NewExpression_CapturesOuterCtor/outer/Scope, object[])
+			IL_001e: newobj instance void Modules.Function_NewExpression_CapturesOuterCtor/outer/inner/FunctionObject_FunctionDeclaration_56210BE4_inner::.ctor(class Modules.Function_NewExpression_CapturesOuterCtor/outer/Scope, object[])
 			IL_0023: ldc.i4.0
 			IL_0024: conv.r8
 			IL_0025: ldstr "inner"
 			IL_002a: ldc.i4.0
 			IL_002b: ldc.i4.1
-			IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_NewExpression_CapturesOuterCtor_C5F9C589.FunctionObject_FunctionDeclaration_56210BE4_inner>(!!0, float64, string, bool, bool)
+			IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NewExpression_CapturesOuterCtor/outer/inner/FunctionObject_FunctionDeclaration_56210BE4_inner>(!!0, float64, string, bool, bool)
 			IL_0031: stloc.1
 			IL_0032: ldc.i4.1
 			IL_0033: newarr [System.Runtime]System.Object
@@ -215,13 +529,13 @@
 			IL_003a: ldarg.0
 			IL_003b: stelem.ref
 			IL_003c: stloc.2
-			IL_003d: newobj instance void FunctionObjects.Function_NewExpression_CapturesOuterCtor_C5F9C589.FunctionObject_FunctionExpression_6D849243_L7C16::.ctor()
+			IL_003d: newobj instance void Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionExpression_Ctor/FunctionObject_FunctionExpression_6D849243_L7C16::.ctor()
 			IL_0042: ldc.i4.0
 			IL_0043: conv.r8
 			IL_0044: ldstr ""
 			IL_0049: ldc.i4.1
 			IL_004a: ldc.i4.1
-			IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_NewExpression_CapturesOuterCtor_C5F9C589.FunctionObject_FunctionExpression_6D849243_L7C16>(!!0, float64, string, bool, bool)
+			IL_004b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionExpression_Ctor/FunctionObject_FunctionExpression_6D849243_L7C16>(!!0, float64, string, bool, bool)
 			IL_0050: stloc.3
 			IL_0051: ldloc.3
 			IL_0052: ldstr "Ctor"
@@ -298,7 +612,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_NewExpression_CapturesOuterCtor/Scope,
-			[1] class FunctionObjects.Function_NewExpression_CapturesOuterCtor_C5F9C589.FunctionObject_FunctionDeclaration_93D08467_outer,
+			[1] class Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionObject_FunctionDeclaration_93D08467_outer,
 			[2] object[],
 			[3] object,
 			[4] object
@@ -317,13 +631,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_NewExpression_CapturesOuterCtor/Scope
-		IL_0019: newobj instance void FunctionObjects.Function_NewExpression_CapturesOuterCtor_C5F9C589.FunctionObject_FunctionDeclaration_93D08467_outer::.ctor(class Modules.Function_NewExpression_CapturesOuterCtor/Scope)
+		IL_0019: newobj instance void Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionObject_FunctionDeclaration_93D08467_outer::.ctor(class Modules.Function_NewExpression_CapturesOuterCtor/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "outer"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_NewExpression_CapturesOuterCtor_C5F9C589.FunctionObject_FunctionDeclaration_93D08467_outer>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionObject_FunctionDeclaration_93D08467_outer>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
@@ -344,320 +658,6 @@
 	} // end of method Function_NewExpression_CapturesOuterCtor::__js_module_init__
 
 } // end of class Modules.Function_NewExpression_CapturesOuterCtor
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_NewExpression_CapturesOuterCtor_C5F9C589.FunctionObject_FunctionDeclaration_93D08467_outer
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_NewExpression_CapturesOuterCtor/Scope _environment0_Function_NewExpression_CapturesOuterCtor
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_NewExpression_CapturesOuterCtor/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21c1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_NewExpression_CapturesOuterCtor/Scope FunctionObjects.Function_NewExpression_CapturesOuterCtor_C5F9C589.FunctionObject_FunctionDeclaration_93D08467_outer::_environment0_Function_NewExpression_CapturesOuterCtor
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_93D08467_outer::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21d0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_93D08467_outer::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21d3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_93D08467_outer::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21d6
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_NewExpression_CapturesOuterCtor/Scope FunctionObjects.Function_NewExpression_CapturesOuterCtor_C5F9C589.FunctionObject_FunctionDeclaration_93D08467_outer::_environment0_Function_NewExpression_CapturesOuterCtor
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_NewExpression_CapturesOuterCtor/outer::__js_call__(class Modules.Function_NewExpression_CapturesOuterCtor/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_93D08467_outer::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21e8
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_NewExpression_CapturesOuterCtor/Scope FunctionObjects.Function_NewExpression_CapturesOuterCtor_C5F9C589.FunctionObject_FunctionDeclaration_93D08467_outer::_environment0_Function_NewExpression_CapturesOuterCtor
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_NewExpression_CapturesOuterCtor/outer::__js_call__(class Modules.Function_NewExpression_CapturesOuterCtor/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_93D08467_outer::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_93D08467_outer::ConstructCore
-
-} // end of class FunctionObjects.Function_NewExpression_CapturesOuterCtor_C5F9C589.FunctionObject_FunctionDeclaration_93D08467_outer
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_NewExpression_CapturesOuterCtor_C5F9C589.FunctionObject_FunctionExpression_6D849243_L7C16
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2205
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_6D849243_L7C16::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x220d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6D849243_L7C16::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2210
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6D849243_L7C16::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2213
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionExpression_Ctor::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_6D849243_L7C16::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x221f
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Function_NewExpression_CapturesOuterCtor/outer/FunctionExpression_Ctor::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_6D849243_L7C16::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2227
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_6D849243_L7C16::ConstructCore
-
-} // end of class FunctionObjects.Function_NewExpression_CapturesOuterCtor_C5F9C589.FunctionObject_FunctionExpression_6D849243_L7C16
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_NewExpression_CapturesOuterCtor_C5F9C589.FunctionObject_FunctionDeclaration_56210BE4_inner
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_NewExpression_CapturesOuterCtor/outer/Scope _environment1_outer
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_NewExpression_CapturesOuterCtor/outer/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x2236
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_NewExpression_CapturesOuterCtor/outer/Scope FunctionObjects.Function_NewExpression_CapturesOuterCtor_C5F9C589.FunctionObject_FunctionDeclaration_56210BE4_inner::_environment1_outer
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Function_NewExpression_CapturesOuterCtor_C5F9C589.FunctionObject_FunctionDeclaration_56210BE4_inner::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_56210BE4_inner::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x224c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_56210BE4_inner::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x224f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_56210BE4_inner::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2252
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Function_NewExpression_CapturesOuterCtor_C5F9C589.FunctionObject_FunctionDeclaration_56210BE4_inner::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_NewExpression_CapturesOuterCtor/outer/inner::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_56210BE4_inner::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2264
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Function_NewExpression_CapturesOuterCtor_C5F9C589.FunctionObject_FunctionDeclaration_56210BE4_inner::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_NewExpression_CapturesOuterCtor/outer/inner::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_56210BE4_inner::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2272
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_56210BE4_inner::ConstructCore
-
-} // end of class FunctionObjects.Function_NewExpression_CapturesOuterCtor_C5F9C589.FunctionObject_FunctionDeclaration_56210BE4_inner
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewExpression_MemberCallee_Compiles.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewExpression_MemberCallee_Compiles.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E3E2CDFC_L4C11
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x219c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_E3E2CDFC_L4C11::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21a4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E3E2CDFC_L4C11::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21a7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E3E2CDFC_L4C11::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21aa
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_impl::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_E3E2CDFC_L4C11::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21bd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_impl::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E3E2CDFC_L4C11::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21cc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E3E2CDFC_L4C11::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_E3E2CDFC_L4C11
+
 
 		// Methods
 		.method public hidebysig static 
@@ -80,6 +181,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_63DFE404_L11C20
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_NewExpression_MemberCallee_Compiles/Scope _environment0_Function_NewExpression_MemberCallee_Compiles
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_NewExpression_MemberCallee_Compiles/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21db
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_NewExpression_MemberCallee_Compiles/Scope Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_createWindow/FunctionObject_FunctionExpression_63DFE404_L11C20::_environment0_Function_NewExpression_MemberCallee_Compiles
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_63DFE404_L11C20::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21ea
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_63DFE404_L11C20::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21ed
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_63DFE404_L11C20::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f0
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_NewExpression_MemberCallee_Compiles/Scope Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_createWindow/FunctionObject_FunctionExpression_63DFE404_L11C20::_environment0_Function_NewExpression_MemberCallee_Compiles
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_createWindow::__js_call__(class Modules.Function_NewExpression_MemberCallee_Compiles/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_63DFE404_L11C20::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2209
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_NewExpression_MemberCallee_Compiles/Scope Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_createWindow/FunctionObject_FunctionExpression_63DFE404_L11C20::_environment0_Function_NewExpression_MemberCallee_Compiles
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_createWindow::__js_call__(class Modules.Function_NewExpression_MemberCallee_Compiles/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_63DFE404_L11C20::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x221e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_63DFE404_L11C20::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_63DFE404_L11C20
 
 
 		// Methods
@@ -236,9 +450,9 @@
 			[0] class Modules.Function_NewExpression_MemberCallee_Compiles/Scope,
 			[1] object,
 			[2] object[],
-			[3] class FunctionObjects.Function_NewExpression_MemberCallee_Compiles_86DE90F2.FunctionObject_FunctionExpression_E3E2CDFC_L4C11,
+			[3] class Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_impl/FunctionObject_FunctionExpression_E3E2CDFC_L4C11,
 			[4] class Modules.Function_NewExpression_MemberCallee_Compiles/ObjectLiterals/L3C12_impl,
-			[5] class FunctionObjects.Function_NewExpression_MemberCallee_Compiles_86DE90F2.FunctionObject_FunctionExpression_63DFE404_L11C20,
+			[5] class Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_createWindow/FunctionObject_FunctionExpression_63DFE404_L11C20,
 			[6] object,
 			[7] object
 		)
@@ -253,13 +467,13 @@
 		IL_000f: ldloc.0
 		IL_0010: stelem.ref
 		IL_0011: stloc.2
-		IL_0012: newobj instance void FunctionObjects.Function_NewExpression_MemberCallee_Compiles_86DE90F2.FunctionObject_FunctionExpression_E3E2CDFC_L4C11::.ctor()
+		IL_0012: newobj instance void Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_impl/FunctionObject_FunctionExpression_E3E2CDFC_L4C11::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr ""
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_NewExpression_MemberCallee_Compiles_86DE90F2.FunctionObject_FunctionExpression_E3E2CDFC_L4C11>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_impl/FunctionObject_FunctionExpression_E3E2CDFC_L4C11>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.3
 		IL_0026: newobj instance void Modules.Function_NewExpression_MemberCallee_Compiles/ObjectLiterals/L3C12_impl::.ctor()
 		IL_002b: stloc.s 4
@@ -280,13 +494,13 @@
 		IL_0049: ldc.i4.0
 		IL_004a: ldelem.ref
 		IL_004b: castclass Modules.Function_NewExpression_MemberCallee_Compiles/Scope
-		IL_0050: newobj instance void FunctionObjects.Function_NewExpression_MemberCallee_Compiles_86DE90F2.FunctionObject_FunctionExpression_63DFE404_L11C20::.ctor(class Modules.Function_NewExpression_MemberCallee_Compiles/Scope)
+		IL_0050: newobj instance void Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_createWindow/FunctionObject_FunctionExpression_63DFE404_L11C20::.ctor(class Modules.Function_NewExpression_MemberCallee_Compiles/Scope)
 		IL_0055: ldc.i4.1
 		IL_0056: conv.r8
 		IL_0057: ldstr ""
 		IL_005c: ldc.i4.0
 		IL_005d: ldc.i4.1
-		IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_NewExpression_MemberCallee_Compiles_86DE90F2.FunctionObject_FunctionExpression_63DFE404_L11C20>(!!0, float64, string, bool, bool)
+		IL_005e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_createWindow/FunctionObject_FunctionExpression_63DFE404_L11C20>(!!0, float64, string, bool, bool)
 		IL_0063: stloc.s 5
 		IL_0065: ldloc.s 5
 		IL_0067: ldstr "createWindow"
@@ -313,220 +527,6 @@
 	} // end of method Function_NewExpression_MemberCallee_Compiles::__js_module_init__
 
 } // end of class Modules.Function_NewExpression_MemberCallee_Compiles
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_NewExpression_MemberCallee_Compiles_86DE90F2.FunctionObject_FunctionExpression_E3E2CDFC_L4C11
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x219c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_E3E2CDFC_L4C11::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21a4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E3E2CDFC_L4C11::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21a7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E3E2CDFC_L4C11::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21aa
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_impl::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_E3E2CDFC_L4C11::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21bd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_impl::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E3E2CDFC_L4C11::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21cc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E3E2CDFC_L4C11::ConstructCore
-
-} // end of class FunctionObjects.Function_NewExpression_MemberCallee_Compiles_86DE90F2.FunctionObject_FunctionExpression_E3E2CDFC_L4C11
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_NewExpression_MemberCallee_Compiles_86DE90F2.FunctionObject_FunctionExpression_63DFE404_L11C20
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_NewExpression_MemberCallee_Compiles/Scope _environment0_Function_NewExpression_MemberCallee_Compiles
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_NewExpression_MemberCallee_Compiles/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21db
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_NewExpression_MemberCallee_Compiles/Scope FunctionObjects.Function_NewExpression_MemberCallee_Compiles_86DE90F2.FunctionObject_FunctionExpression_63DFE404_L11C20::_environment0_Function_NewExpression_MemberCallee_Compiles
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_63DFE404_L11C20::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21ea
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_63DFE404_L11C20::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21ed
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_63DFE404_L11C20::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f0
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_NewExpression_MemberCallee_Compiles/Scope FunctionObjects.Function_NewExpression_MemberCallee_Compiles_86DE90F2.FunctionObject_FunctionExpression_63DFE404_L11C20::_environment0_Function_NewExpression_MemberCallee_Compiles
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_createWindow::__js_call__(class Modules.Function_NewExpression_MemberCallee_Compiles/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_63DFE404_L11C20::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2209
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_NewExpression_MemberCallee_Compiles/Scope FunctionObjects.Function_NewExpression_MemberCallee_Compiles_86DE90F2.FunctionObject_FunctionExpression_63DFE404_L11C20::_environment0_Function_NewExpression_MemberCallee_Compiles
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Function_NewExpression_MemberCallee_Compiles/FunctionExpression_createWindow::__js_call__(class Modules.Function_NewExpression_MemberCallee_Compiles/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_63DFE404_L11C20::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x221e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_63DFE404_L11C20::ConstructCore
-
-} // end of class FunctionObjects.Function_NewExpression_MemberCallee_Compiles_86DE90F2.FunctionObject_FunctionExpression_63DFE404_L11C20
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewTarget_Arrow_Inherits.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewTarget_Arrow_Inherits.verified.txt
@@ -201,6 +201,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B41BFF0E_Outer
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_NewTarget_Arrow_Inherits/Scope _environment0_Function_NewTarget_Arrow_Inherits
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_NewTarget_Arrow_Inherits/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x218b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_NewTarget_Arrow_Inherits/Scope Modules.Function_NewTarget_Arrow_Inherits/Outer/FunctionObject_FunctionDeclaration_B41BFF0E_Outer::_environment0_Function_NewTarget_Arrow_Inherits
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B41BFF0E_Outer::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x219a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B41BFF0E_Outer::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x219d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B41BFF0E_Outer::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21a0
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_NewTarget_Arrow_Inherits/Scope Modules.Function_NewTarget_Arrow_Inherits/Outer/FunctionObject_FunctionDeclaration_B41BFF0E_Outer::_environment0_Function_NewTarget_Arrow_Inherits
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_NewTarget_Arrow_Inherits/Outer::__js_call__(class Modules.Function_NewTarget_Arrow_Inherits/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_B41BFF0E_Outer::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21b2
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_NewTarget_Arrow_Inherits/Scope Modules.Function_NewTarget_Arrow_Inherits/Outer/FunctionObject_FunctionDeclaration_B41BFF0E_Outer::_environment0_Function_NewTarget_Arrow_Inherits
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_NewTarget_Arrow_Inherits/Outer::__js_call__(class Modules.Function_NewTarget_Arrow_Inherits/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_B41BFF0E_Outer::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21c0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B41BFF0E_Outer::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_B41BFF0E_Outer
+
 
 		// Methods
 		.method public hidebysig static 
@@ -317,7 +424,7 @@
 		.locals init (
 			[0] class Modules.Function_NewTarget_Arrow_Inherits/Scope,
 			[1] object[],
-			[2] class FunctionObjects.Function_NewTarget_Arrow_Inherits_B5B38874.FunctionObject_FunctionDeclaration_B41BFF0E_Outer,
+			[2] class Modules.Function_NewTarget_Arrow_Inherits/Outer/FunctionObject_FunctionDeclaration_B41BFF0E_Outer,
 			[3] object
 		)
 
@@ -334,13 +441,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_NewTarget_Arrow_Inherits/Scope
-		IL_0019: newobj instance void FunctionObjects.Function_NewTarget_Arrow_Inherits_B5B38874.FunctionObject_FunctionDeclaration_B41BFF0E_Outer::.ctor(class Modules.Function_NewTarget_Arrow_Inherits/Scope)
+		IL_0019: newobj instance void Modules.Function_NewTarget_Arrow_Inherits/Outer/FunctionObject_FunctionDeclaration_B41BFF0E_Outer::.ctor(class Modules.Function_NewTarget_Arrow_Inherits/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "Outer"
 		IL_0025: ldc.i4.1
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_NewTarget_Arrow_Inherits_B5B38874.FunctionObject_FunctionDeclaration_B41BFF0E_Outer>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NewTarget_Arrow_Inherits/Outer/FunctionObject_FunctionDeclaration_B41BFF0E_Outer>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.2
 		IL_002d: ldloc.0
 		IL_002e: ldloc.2
@@ -366,113 +473,6 @@
 	} // end of method Function_NewTarget_Arrow_Inherits::__js_module_init__
 
 } // end of class Modules.Function_NewTarget_Arrow_Inherits
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_NewTarget_Arrow_Inherits_B5B38874.FunctionObject_FunctionDeclaration_B41BFF0E_Outer
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_NewTarget_Arrow_Inherits/Scope _environment0_Function_NewTarget_Arrow_Inherits
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_NewTarget_Arrow_Inherits/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x218b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_NewTarget_Arrow_Inherits/Scope FunctionObjects.Function_NewTarget_Arrow_Inherits_B5B38874.FunctionObject_FunctionDeclaration_B41BFF0E_Outer::_environment0_Function_NewTarget_Arrow_Inherits
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B41BFF0E_Outer::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x219a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B41BFF0E_Outer::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x219d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B41BFF0E_Outer::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21a0
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_NewTarget_Arrow_Inherits/Scope FunctionObjects.Function_NewTarget_Arrow_Inherits_B5B38874.FunctionObject_FunctionDeclaration_B41BFF0E_Outer::_environment0_Function_NewTarget_Arrow_Inherits
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_NewTarget_Arrow_Inherits/Outer::__js_call__(class Modules.Function_NewTarget_Arrow_Inherits/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_B41BFF0E_Outer::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21b2
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_NewTarget_Arrow_Inherits/Scope FunctionObjects.Function_NewTarget_Arrow_Inherits_B5B38874.FunctionObject_FunctionDeclaration_B41BFF0E_Outer::_environment0_Function_NewTarget_Arrow_Inherits
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_NewTarget_Arrow_Inherits/Outer::__js_call__(class Modules.Function_NewTarget_Arrow_Inherits/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_B41BFF0E_Outer::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21c0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B41BFF0E_Outer::ConstructCore
-
-} // end of class FunctionObjects.Function_NewTarget_Arrow_Inherits_B5B38874.FunctionObject_FunctionDeclaration_B41BFF0E_Outer
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewTarget_NewVsCall.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NewTarget_NewVsCall.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2CD84AA7_C
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_NewTarget_NewVsCall/Scope _environment0_Function_NewTarget_NewVsCall
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_NewTarget_NewVsCall/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x215a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_NewTarget_NewVsCall/Scope Modules.Function_NewTarget_NewVsCall/C/FunctionObject_FunctionDeclaration_2CD84AA7_C::_environment0_Function_NewTarget_NewVsCall
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_2CD84AA7_C::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2169
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2CD84AA7_C::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x216c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2CD84AA7_C::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x216f
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_NewTarget_NewVsCall/Scope Modules.Function_NewTarget_NewVsCall/C/FunctionObject_FunctionDeclaration_2CD84AA7_C::_environment0_Function_NewTarget_NewVsCall
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_NewTarget_NewVsCall/C::__js_call__(class Modules.Function_NewTarget_NewVsCall/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_2CD84AA7_C::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2181
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_NewTarget_NewVsCall/Scope Modules.Function_NewTarget_NewVsCall/C/FunctionObject_FunctionDeclaration_2CD84AA7_C::_environment0_Function_NewTarget_NewVsCall
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_NewTarget_NewVsCall/C::__js_call__(class Modules.Function_NewTarget_NewVsCall/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_2CD84AA7_C::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x218f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_2CD84AA7_C::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_2CD84AA7_C
+
 
 		// Methods
 		.method public hidebysig static 
@@ -154,7 +261,7 @@
 		.locals init (
 			[0] class Modules.Function_NewTarget_NewVsCall/Scope,
 			[1] object[],
-			[2] class FunctionObjects.Function_NewTarget_NewVsCall_883623FB.FunctionObject_FunctionDeclaration_2CD84AA7_C,
+			[2] class Modules.Function_NewTarget_NewVsCall/C/FunctionObject_FunctionDeclaration_2CD84AA7_C,
 			[3] object
 		)
 
@@ -171,13 +278,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_NewTarget_NewVsCall/Scope
-		IL_0019: newobj instance void FunctionObjects.Function_NewTarget_NewVsCall_883623FB.FunctionObject_FunctionDeclaration_2CD84AA7_C::.ctor(class Modules.Function_NewTarget_NewVsCall/Scope)
+		IL_0019: newobj instance void Modules.Function_NewTarget_NewVsCall/C/FunctionObject_FunctionDeclaration_2CD84AA7_C::.ctor(class Modules.Function_NewTarget_NewVsCall/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "C"
 		IL_0025: ldc.i4.1
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_NewTarget_NewVsCall_883623FB.FunctionObject_FunctionDeclaration_2CD84AA7_C>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NewTarget_NewVsCall/C/FunctionObject_FunctionDeclaration_2CD84AA7_C>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.2
 		IL_002d: ldloc.0
 		IL_002e: ldloc.2
@@ -203,113 +310,6 @@
 	} // end of method Function_NewTarget_NewVsCall::__js_module_init__
 
 } // end of class Modules.Function_NewTarget_NewVsCall
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_NewTarget_NewVsCall_883623FB.FunctionObject_FunctionDeclaration_2CD84AA7_C
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_NewTarget_NewVsCall/Scope _environment0_Function_NewTarget_NewVsCall
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_NewTarget_NewVsCall/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x215a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_NewTarget_NewVsCall/Scope FunctionObjects.Function_NewTarget_NewVsCall_883623FB.FunctionObject_FunctionDeclaration_2CD84AA7_C::_environment0_Function_NewTarget_NewVsCall
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_2CD84AA7_C::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2169
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2CD84AA7_C::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x216c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2CD84AA7_C::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x216f
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_NewTarget_NewVsCall/Scope FunctionObjects.Function_NewTarget_NewVsCall_883623FB.FunctionObject_FunctionDeclaration_2CD84AA7_C::_environment0_Function_NewTarget_NewVsCall
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_NewTarget_NewVsCall/C::__js_call__(class Modules.Function_NewTarget_NewVsCall/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_2CD84AA7_C::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2181
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_NewTarget_NewVsCall/Scope FunctionObjects.Function_NewTarget_NewVsCall_883623FB.FunctionObject_FunctionDeclaration_2CD84AA7_C::_environment0_Function_NewTarget_NewVsCall
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_NewTarget_NewVsCall/C::__js_call__(class Modules.Function_NewTarget_NewVsCall/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_2CD84AA7_C::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x218f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_2CD84AA7_C::ConstructCore
-
-} // end of class FunctionObjects.Function_NewTarget_NewVsCall_883623FB.FunctionObject_FunctionDeclaration_2CD84AA7_C
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NoCapture_NoScopesParameter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_NoCapture_NoScopesParameter.verified.txt
@@ -31,6 +31,117 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_979E7041_add
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x20e9
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_979E7041_add::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x20f1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_979E7041_add::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x20f4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_979E7041_add::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x20f7
+				// Header size: 1
+				// Code size: 35 (0x23)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001d: call object Modules.Function_NoCapture_NoScopesParameter/'add'::__js_call__(object, float64, float64)
+				IL_0022: ret
+			} // end of method FunctionObject_FunctionDeclaration_979E7041_add::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x211b
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0019: call object Modules.Function_NoCapture_NoScopesParameter/'add'::__js_call__(object, float64, float64)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_979E7041_add::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x213b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_979E7041_add::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_979E7041_add
+
 
 		// Methods
 		.method public hidebysig static 
@@ -101,7 +212,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_NoCapture_NoScopesParameter/Scope,
-			[1] class FunctionObjects.Function_NoCapture_NoScopesParameter_4836B897.FunctionObject_FunctionDeclaration_979E7041_add,
+			[1] class Modules.Function_NoCapture_NoScopesParameter/'add'/FunctionObject_FunctionDeclaration_979E7041_add,
 			[2] object[],
 			[3] object,
 			[4] object
@@ -116,13 +227,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.Function_NoCapture_NoScopesParameter_4836B897.FunctionObject_FunctionDeclaration_979E7041_add::.ctor()
+		IL_0011: newobj instance void Modules.Function_NoCapture_NoScopesParameter/'add'/FunctionObject_FunctionDeclaration_979E7041_add::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "add"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_NoCapture_NoScopesParameter_4836B897.FunctionObject_FunctionDeclaration_979E7041_add>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_NoCapture_NoScopesParameter/'add'/FunctionObject_FunctionDeclaration_979E7041_add>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -149,117 +260,6 @@
 	} // end of method Function_NoCapture_NoScopesParameter::__js_module_init__
 
 } // end of class Modules.Function_NoCapture_NoScopesParameter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_NoCapture_NoScopesParameter_4836B897.FunctionObject_FunctionDeclaration_979E7041_add
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x20e9
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_979E7041_add::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x20f1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_979E7041_add::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x20f4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_979E7041_add::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x20f7
-		// Header size: 1
-		// Code size: 35 (0x23)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001d: call object Modules.Function_NoCapture_NoScopesParameter/'add'::__js_call__(object, float64, float64)
-		IL_0022: ret
-	} // end of method FunctionObject_FunctionDeclaration_979E7041_add::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x211b
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0019: call object Modules.Function_NoCapture_NoScopesParameter/'add'::__js_call__(object, float64, float64)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_979E7041_add::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x213b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_979E7041_add::ConstructCore
-
-} // end of class FunctionObjects.Function_NoCapture_NoScopesParameter_4836B897.FunctionObject_FunctionDeclaration_979E7041_add
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ObjectLiteralMethod_ThisBinding.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ObjectLiteralMethod_ThisBinding.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_810AD7A8_L5C13
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x211d
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_810AD7A8_L5C13::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2125
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_810AD7A8_L5C13::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2128
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_810AD7A8_L5C13::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x212b
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Function_ObjectLiteralMethod_ThisBinding/FunctionExpression_obj::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_810AD7A8_L5C13::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x213e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Function_ObjectLiteralMethod_ThisBinding/FunctionExpression_obj::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_810AD7A8_L5C13::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x214d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_810AD7A8_L5C13::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_810AD7A8_L5C13
+
 
 		// Methods
 		.method public hidebysig static 
@@ -105,7 +206,7 @@
 			[0] class Modules.Function_ObjectLiteralMethod_ThisBinding/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[2] object[],
-			[3] class FunctionObjects.Function_ObjectLiteralMethod_ThisBinding_CE78C8F7.FunctionObject_FunctionExpression_810AD7A8_L5C13,
+			[3] class Modules.Function_ObjectLiteralMethod_ThisBinding/FunctionExpression_obj/FunctionObject_FunctionExpression_810AD7A8_L5C13,
 			[4] object,
 			[5] object
 		)
@@ -120,13 +221,13 @@
 		IL_000f: ldloc.0
 		IL_0010: stelem.ref
 		IL_0011: stloc.2
-		IL_0012: newobj instance void FunctionObjects.Function_ObjectLiteralMethod_ThisBinding_CE78C8F7.FunctionObject_FunctionExpression_810AD7A8_L5C13::.ctor()
+		IL_0012: newobj instance void Modules.Function_ObjectLiteralMethod_ThisBinding/FunctionExpression_obj/FunctionObject_FunctionExpression_810AD7A8_L5C13::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr ""
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_ObjectLiteralMethod_ThisBinding_CE78C8F7.FunctionObject_FunctionExpression_810AD7A8_L5C13>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ObjectLiteralMethod_ThisBinding/FunctionExpression_obj/FunctionObject_FunctionExpression_810AD7A8_L5C13>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.3
 		IL_0026: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_002b: dup
@@ -157,107 +258,6 @@
 	} // end of method Function_ObjectLiteralMethod_ThisBinding::__js_module_init__
 
 } // end of class Modules.Function_ObjectLiteralMethod_ThisBinding
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ObjectLiteralMethod_ThisBinding_CE78C8F7.FunctionObject_FunctionExpression_810AD7A8_L5C13
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x211d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_810AD7A8_L5C13::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2125
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_810AD7A8_L5C13::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2128
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_810AD7A8_L5C13::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x212b
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Function_ObjectLiteralMethod_ThisBinding/FunctionExpression_obj::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_810AD7A8_L5C13::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x213e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Function_ObjectLiteralMethod_ThisBinding/FunctionExpression_obj::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_810AD7A8_L5C13::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x214d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_810AD7A8_L5C13::ConstructCore
-
-} // end of class FunctionObjects.Function_ObjectLiteralMethod_ThisBinding_CE78C8F7.FunctionObject_FunctionExpression_810AD7A8_L5C13
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ObjectLiteralValueFunction_ForEachCapturesOuter.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ObjectLiteralValueFunction_ForEachCapturesOuter.verified.txt
@@ -35,6 +35,124 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B6BA9BE7_L7C37
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/Scope _environment1_FunctionExpression_DocumentLike
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x22c8
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/Scope Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionExpression_DocumentLike/FunctionObject_FunctionExpression_B6BA9BE7_L7C37::_environment1_FunctionExpression_DocumentLike
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionExpression_DocumentLike/FunctionObject_FunctionExpression_B6BA9BE7_L7C37::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionExpression_B6BA9BE7_L7C37::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x22de
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_B6BA9BE7_L7C37::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x22e1
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_B6BA9BE7_L7C37::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x22e4
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionExpression_DocumentLike/FunctionObject_FunctionExpression_B6BA9BE7_L7C37::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionExpression_DocumentLike::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_B6BA9BE7_L7C37::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x22fd
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionExpression_DocumentLike/FunctionObject_FunctionExpression_B6BA9BE7_L7C37::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionExpression_DocumentLike::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_B6BA9BE7_L7C37::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2312
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_B6BA9BE7_L7C37::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_B6BA9BE7_L7C37
+
 
 			// Methods
 			.method public hidebysig static 
@@ -126,6 +244,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3A7F94BC_L5C12
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/Scope _environment0_Function_ObjectLiteralValueFunction_ForEachCapturesOuter
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2276
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/Scope Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionObject_FunctionExpression_3A7F94BC_L5C12::_environment0_Function_ObjectLiteralValueFunction_ForEachCapturesOuter
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_3A7F94BC_L5C12::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2285
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_3A7F94BC_L5C12::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2288
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_3A7F94BC_L5C12::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x228b
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/Scope Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionObject_FunctionExpression_3A7F94BC_L5C12::_environment0_Function_ObjectLiteralValueFunction_ForEachCapturesOuter
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike::__js_call__(class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_3A7F94BC_L5C12::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22a4
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/Scope Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionObject_FunctionExpression_3A7F94BC_L5C12::_environment0_Function_ObjectLiteralValueFunction_ForEachCapturesOuter
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike::__js_call__(class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_3A7F94BC_L5C12::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22b9
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_3A7F94BC_L5C12::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_3A7F94BC_L5C12
+
 
 		// Methods
 		.method public hidebysig static 
@@ -149,7 +380,7 @@
 				[1] object,
 				[2] bool,
 				[3] object[],
-				[4] class FunctionObjects.Function_ObjectLiteralValueFunction_ForEachCapturesOuter_A835375E.FunctionObject_FunctionExpression_B6BA9BE7_L7C37
+				[4] class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionExpression_DocumentLike/FunctionObject_FunctionExpression_B6BA9BE7_L7C37
 			)
 
 			IL_0000: newobj instance void Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/Scope::.ctor()
@@ -192,13 +423,13 @@
 			IL_005c: ldelem.ref
 			IL_005d: castclass Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/Scope
 			IL_0062: ldloc.3
-			IL_0063: newobj instance void FunctionObjects.Function_ObjectLiteralValueFunction_ForEachCapturesOuter_A835375E.FunctionObject_FunctionExpression_B6BA9BE7_L7C37::.ctor(class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/Scope, object[])
+			IL_0063: newobj instance void Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionExpression_DocumentLike/FunctionObject_FunctionExpression_B6BA9BE7_L7C37::.ctor(class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/Scope, object[])
 			IL_0068: ldc.i4.1
 			IL_0069: conv.r8
 			IL_006a: ldstr ""
 			IL_006f: ldc.i4.0
 			IL_0070: ldc.i4.1
-			IL_0071: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_ObjectLiteralValueFunction_ForEachCapturesOuter_A835375E.FunctionObject_FunctionExpression_B6BA9BE7_L7C37>(!!0, float64, string, bool, bool)
+			IL_0071: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionExpression_DocumentLike/FunctionObject_FunctionExpression_B6BA9BE7_L7C37>(!!0, float64, string, bool, bool)
 			IL_0076: stloc.s 4
 			IL_0078: ldloc.1
 			IL_0079: ldstr "forEach"
@@ -235,6 +466,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FDB19B37_L16C15
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2321
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_FDB19B37_L16C15::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2329
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_FDB19B37_L16C15::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x232c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_FDB19B37_L16C15::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x232f
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_iterator::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_FDB19B37_L16C15::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2342
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_iterator::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_FDB19B37_L16C15::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2351
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_FDB19B37_L16C15::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_FDB19B37_L16C15
 
 
 		// Methods
@@ -368,9 +700,9 @@
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[4] object[],
-			[5] class FunctionObjects.Function_ObjectLiteralValueFunction_ForEachCapturesOuter_A835375E.FunctionObject_FunctionExpression_3A7F94BC_L5C12,
+			[5] class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionObject_FunctionExpression_3A7F94BC_L5C12,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[7] class FunctionObjects.Function_ObjectLiteralValueFunction_ForEachCapturesOuter_A835375E.FunctionObject_FunctionExpression_FDB19B37_L16C15,
+			[7] class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_iterator/FunctionObject_FunctionExpression_FDB19B37_L16C15,
 			[8] object
 		)
 
@@ -388,13 +720,13 @@
 		IL_0015: ldc.i4.0
 		IL_0016: ldelem.ref
 		IL_0017: castclass Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/Scope
-		IL_001c: newobj instance void FunctionObjects.Function_ObjectLiteralValueFunction_ForEachCapturesOuter_A835375E.FunctionObject_FunctionExpression_3A7F94BC_L5C12::.ctor(class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/Scope)
+		IL_001c: newobj instance void Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionObject_FunctionExpression_3A7F94BC_L5C12::.ctor(class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/Scope)
 		IL_0021: ldc.i4.1
 		IL_0022: conv.r8
 		IL_0023: ldstr ""
 		IL_0028: ldc.i4.1
 		IL_0029: ldc.i4.1
-		IL_002a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_ObjectLiteralValueFunction_ForEachCapturesOuter_A835375E.FunctionObject_FunctionExpression_3A7F94BC_L5C12>(!!0, float64, string, bool, bool)
+		IL_002a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionObject_FunctionExpression_3A7F94BC_L5C12>(!!0, float64, string, bool, bool)
 		IL_002f: stloc.s 5
 		IL_0031: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0036: dup
@@ -414,13 +746,13 @@
 		IL_005b: ldloc.0
 		IL_005c: stelem.ref
 		IL_005d: stloc.s 4
-		IL_005f: newobj instance void FunctionObjects.Function_ObjectLiteralValueFunction_ForEachCapturesOuter_A835375E.FunctionObject_FunctionExpression_FDB19B37_L16C15::.ctor()
+		IL_005f: newobj instance void Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_iterator/FunctionObject_FunctionExpression_FDB19B37_L16C15::.ctor()
 		IL_0064: ldc.i4.1
 		IL_0065: conv.r8
 		IL_0066: ldstr ""
 		IL_006b: ldc.i4.0
 		IL_006c: ldc.i4.1
-		IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_ObjectLiteralValueFunction_ForEachCapturesOuter_A835375E.FunctionObject_FunctionExpression_FDB19B37_L16C15>(!!0, float64, string, bool, bool)
+		IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_iterator/FunctionObject_FunctionExpression_FDB19B37_L16C15>(!!0, float64, string, bool, bool)
 		IL_0072: stloc.s 7
 		IL_0074: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0079: dup
@@ -458,338 +790,6 @@
 	} // end of method Function_ObjectLiteralValueFunction_ForEachCapturesOuter::__js_module_init__
 
 } // end of class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ObjectLiteralValueFunction_ForEachCapturesOuter_A835375E.FunctionObject_FunctionExpression_3A7F94BC_L5C12
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/Scope _environment0_Function_ObjectLiteralValueFunction_ForEachCapturesOuter
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2276
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/Scope FunctionObjects.Function_ObjectLiteralValueFunction_ForEachCapturesOuter_A835375E.FunctionObject_FunctionExpression_3A7F94BC_L5C12::_environment0_Function_ObjectLiteralValueFunction_ForEachCapturesOuter
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3A7F94BC_L5C12::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2285
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3A7F94BC_L5C12::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2288
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3A7F94BC_L5C12::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x228b
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/Scope FunctionObjects.Function_ObjectLiteralValueFunction_ForEachCapturesOuter_A835375E.FunctionObject_FunctionExpression_3A7F94BC_L5C12::_environment0_Function_ObjectLiteralValueFunction_ForEachCapturesOuter
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike::__js_call__(class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_3A7F94BC_L5C12::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22a4
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/Scope FunctionObjects.Function_ObjectLiteralValueFunction_ForEachCapturesOuter_A835375E.FunctionObject_FunctionExpression_3A7F94BC_L5C12::_environment0_Function_ObjectLiteralValueFunction_ForEachCapturesOuter
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike::__js_call__(class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_3A7F94BC_L5C12::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22b9
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3A7F94BC_L5C12::ConstructCore
-
-} // end of class FunctionObjects.Function_ObjectLiteralValueFunction_ForEachCapturesOuter_A835375E.FunctionObject_FunctionExpression_3A7F94BC_L5C12
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ObjectLiteralValueFunction_ForEachCapturesOuter_A835375E.FunctionObject_FunctionExpression_B6BA9BE7_L7C37
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/Scope _environment1_FunctionExpression_DocumentLike
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x22c8
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/Scope FunctionObjects.Function_ObjectLiteralValueFunction_ForEachCapturesOuter_A835375E.FunctionObject_FunctionExpression_B6BA9BE7_L7C37::_environment1_FunctionExpression_DocumentLike
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Function_ObjectLiteralValueFunction_ForEachCapturesOuter_A835375E.FunctionObject_FunctionExpression_B6BA9BE7_L7C37::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_B6BA9BE7_L7C37::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22de
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_B6BA9BE7_L7C37::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22e1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_B6BA9BE7_L7C37::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22e4
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Function_ObjectLiteralValueFunction_ForEachCapturesOuter_A835375E.FunctionObject_FunctionExpression_B6BA9BE7_L7C37::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionExpression_DocumentLike::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_B6BA9BE7_L7C37::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22fd
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Function_ObjectLiteralValueFunction_ForEachCapturesOuter_A835375E.FunctionObject_FunctionExpression_B6BA9BE7_L7C37::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_DocumentLike/FunctionExpression_DocumentLike::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_B6BA9BE7_L7C37::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2312
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_B6BA9BE7_L7C37::ConstructCore
-
-} // end of class FunctionObjects.Function_ObjectLiteralValueFunction_ForEachCapturesOuter_A835375E.FunctionObject_FunctionExpression_B6BA9BE7_L7C37
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ObjectLiteralValueFunction_ForEachCapturesOuter_A835375E.FunctionObject_FunctionExpression_FDB19B37_L16C15
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2321
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_FDB19B37_L16C15::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2329
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FDB19B37_L16C15::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x232c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FDB19B37_L16C15::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x232f
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_iterator::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_FDB19B37_L16C15::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2342
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Function_ObjectLiteralValueFunction_ForEachCapturesOuter/FunctionExpression_iterator::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_FDB19B37_L16C15::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2351
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_FDB19B37_L16C15::ConstructCore
-
-} // end of class FunctionObjects.Function_ObjectLiteralValueFunction_ForEachCapturesOuter_A835375E.FunctionObject_FunctionExpression_FDB19B37_L16C15
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterDestructuring_Object.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterDestructuring_Object.verified.txt
@@ -39,6 +39,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_149977FC_show
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x22f4
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_149977FC_show::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22fc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_149977FC_show::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22ff
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_149977FC_show::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2302
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Function_ParameterDestructuring_Object/show::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_149977FC_show::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2315
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Function_ParameterDestructuring_Object/show::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_149977FC_show::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2324
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_149977FC_show::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_149977FC_show
+
 
 		// Methods
 		.method public hidebysig static 
@@ -149,6 +250,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_984BBA87_config
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2333
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_984BBA87_config::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x233b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_984BBA87_config::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x233e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_984BBA87_config::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2341
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Function_ParameterDestructuring_Object/config::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_984BBA87_config::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2354
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Function_ParameterDestructuring_Object/config::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_984BBA87_config::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2363
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_984BBA87_config::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_984BBA87_config
 
 
 		// Methods
@@ -319,8 +521,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ParameterDestructuring_Object/Scope,
-			[1] class FunctionObjects.Function_ParameterDestructuring_Object_22BFC8D6.FunctionObject_FunctionDeclaration_149977FC_show,
-			[2] class FunctionObjects.Function_ParameterDestructuring_Object_22BFC8D6.FunctionObject_FunctionDeclaration_984BBA87_config,
+			[1] class Modules.Function_ParameterDestructuring_Object/show/FunctionObject_FunctionDeclaration_149977FC_show,
+			[2] class Modules.Function_ParameterDestructuring_Object/config/FunctionObject_FunctionDeclaration_984BBA87_config,
 			[3] object[],
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
@@ -334,13 +536,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.Function_ParameterDestructuring_Object_22BFC8D6.FunctionObject_FunctionDeclaration_149977FC_show::.ctor()
+		IL_0011: newobj instance void Modules.Function_ParameterDestructuring_Object/show/FunctionObject_FunctionDeclaration_149977FC_show::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "show"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_ParameterDestructuring_Object_22BFC8D6.FunctionObject_FunctionDeclaration_149977FC_show>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ParameterDestructuring_Object/show/FunctionObject_FunctionDeclaration_149977FC_show>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: ldc.i4.1
 		IL_0026: newarr [System.Runtime]System.Object
@@ -349,13 +551,13 @@
 		IL_002d: ldloc.0
 		IL_002e: stelem.ref
 		IL_002f: stloc.3
-		IL_0030: newobj instance void FunctionObjects.Function_ParameterDestructuring_Object_22BFC8D6.FunctionObject_FunctionDeclaration_984BBA87_config::.ctor()
+		IL_0030: newobj instance void Modules.Function_ParameterDestructuring_Object/config/FunctionObject_FunctionDeclaration_984BBA87_config::.ctor()
 		IL_0035: ldc.i4.1
 		IL_0036: conv.r8
 		IL_0037: ldstr "config"
 		IL_003c: ldc.i4.0
 		IL_003d: ldc.i4.1
-		IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_ParameterDestructuring_Object_22BFC8D6.FunctionObject_FunctionDeclaration_984BBA87_config>(!!0, float64, string, bool, bool)
+		IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ParameterDestructuring_Object/config/FunctionObject_FunctionDeclaration_984BBA87_config>(!!0, float64, string, bool, bool)
 		IL_0043: stloc.2
 		IL_0044: nop
 		IL_0045: nop
@@ -424,208 +626,6 @@
 	} // end of method Function_ParameterDestructuring_Object::__js_module_init__
 
 } // end of class Modules.Function_ParameterDestructuring_Object
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ParameterDestructuring_Object_22BFC8D6.FunctionObject_FunctionDeclaration_149977FC_show
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x22f4
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_149977FC_show::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22fc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_149977FC_show::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22ff
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_149977FC_show::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2302
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Function_ParameterDestructuring_Object/show::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_149977FC_show::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2315
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Function_ParameterDestructuring_Object/show::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_149977FC_show::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2324
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_149977FC_show::ConstructCore
-
-} // end of class FunctionObjects.Function_ParameterDestructuring_Object_22BFC8D6.FunctionObject_FunctionDeclaration_149977FC_show
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ParameterDestructuring_Object_22BFC8D6.FunctionObject_FunctionDeclaration_984BBA87_config
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2333
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_984BBA87_config::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x233b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_984BBA87_config::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x233e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_984BBA87_config::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2341
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Function_ParameterDestructuring_Object/config::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_984BBA87_config::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2354
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Function_ParameterDestructuring_Object/config::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_984BBA87_config::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2363
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_984BBA87_config::ConstructCore
-
-} // end of class FunctionObjects.Function_ParameterDestructuring_Object_22BFC8D6.FunctionObject_FunctionDeclaration_984BBA87_config
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterTypeInference_BinaryArguments.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterTypeInference_BinaryArguments.verified.txt
@@ -31,6 +31,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_125FB85F_value
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2a75
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_125FB85F_value::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2a7d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_125FB85F_value::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2a80
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_125FB85F_value::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a83
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Function_ParameterTypeInference_BinaryArguments/'value'::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_125FB85F_value::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a8f
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Function_ParameterTypeInference_BinaryArguments/'value'::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_125FB85F_value::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a97
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_125FB85F_value::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_125FB85F_value
+
 
 		// Methods
 		.method public hidebysig static 
@@ -443,6 +538,977 @@
 			} // end of method Scope_run::.ctor
 
 		} // end of class Scope_run
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_0F0D7DBD_BinaryReceiver
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2846
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver/FunctionObject_ClassConstructor_0F0D7DBD_BinaryReceiver::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_0F0D7DBD_BinaryReceiver::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2855
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_0F0D7DBD_BinaryReceiver::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2858
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_0F0D7DBD_BinaryReceiver::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x285b
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_0F0D7DBD_BinaryReceiver::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2867
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_0F0D7DBD_BinaryReceiver::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_0F0D7DBD_BinaryReceiver
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_19915569_BinaryReceiver_add
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2873
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_19915569_BinaryReceiver_add::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x287b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_19915569_BinaryReceiver_add::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x287e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_19915569_BinaryReceiver_add::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2881
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0012: call instance float64 Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::'add'(float64)
+				IL_0017: box [System.Runtime]System.Double
+				IL_001c: ret
+			} // end of method FunctionObject_ClassMethod_19915569_BinaryReceiver_add::CallCore
+
+		} // end of class FunctionObject_ClassMethod_19915569_BinaryReceiver_add
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_C89F94A2_BinaryReceiver_multiply
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x289f
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_C89F94A2_BinaryReceiver_multiply::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x28a7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_C89F94A2_BinaryReceiver_multiply::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x28aa
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_C89F94A2_BinaryReceiver_multiply::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x28ad
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0012: call instance float64 Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::multiply(float64)
+				IL_0017: box [System.Runtime]System.Double
+				IL_001c: ret
+			} // end of method FunctionObject_ClassMethod_C89F94A2_BinaryReceiver_multiply::CallCore
+
+		} // end of class FunctionObject_ClassMethod_C89F94A2_BinaryReceiver_multiply
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_0942BEAA_BinaryReceiver_shift
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x28cb
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_0942BEAA_BinaryReceiver_shift::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x28d3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_0942BEAA_BinaryReceiver_shift::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x28d6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_0942BEAA_BinaryReceiver_shift::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x28d9
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0012: call instance float64 Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::shift(float64)
+				IL_0017: box [System.Runtime]System.Double
+				IL_001c: ret
+			} // end of method FunctionObject_ClassMethod_0942BEAA_BinaryReceiver_shift::CallCore
+
+		} // end of class FunctionObject_ClassMethod_0942BEAA_BinaryReceiver_shift
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_A00A558B_BinaryReceiver_increment
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x28f7
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_A00A558B_BinaryReceiver_increment::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x28ff
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_A00A558B_BinaryReceiver_increment::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2902
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_A00A558B_BinaryReceiver_increment::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2905
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0012: call instance float64 Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::increment(float64)
+				IL_0017: box [System.Runtime]System.Double
+				IL_001c: ret
+			} // end of method FunctionObject_ClassMethod_A00A558B_BinaryReceiver_increment::CallCore
+
+		} // end of class FunctionObject_ClassMethod_A00A558B_BinaryReceiver_increment
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_46A1F899_BinaryReceiver_incrementBoolean
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2923
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_46A1F899_BinaryReceiver_incrementBoolean::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x292b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_46A1F899_BinaryReceiver_incrementBoolean::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x292e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_46A1F899_BinaryReceiver_incrementBoolean::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2931
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance float64 Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::incrementBoolean(object)
+				IL_0012: box [System.Runtime]System.Double
+				IL_0017: ret
+			} // end of method FunctionObject_ClassMethod_46A1F899_BinaryReceiver_incrementBoolean::CallCore
+
+		} // end of class FunctionObject_ClassMethod_46A1F899_BinaryReceiver_incrementBoolean
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_79F89F2A_BinaryReceiver_dynamicAdd
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x294a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_79F89F2A_BinaryReceiver_dynamicAdd::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2952
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_79F89F2A_BinaryReceiver_dynamicAdd::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2955
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_79F89F2A_BinaryReceiver_dynamicAdd::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2958
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::dynamicAdd(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassMethod_79F89F2A_BinaryReceiver_dynamicAdd::CallCore
+
+		} // end of class FunctionObject_ClassMethod_79F89F2A_BinaryReceiver_dynamicAdd
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_0A9F6F8D_BinaryReceiver_bigint
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x296c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_0A9F6F8D_BinaryReceiver_bigint::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2974
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_0A9F6F8D_BinaryReceiver_bigint::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2977
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_0A9F6F8D_BinaryReceiver_bigint::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x297a
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::bigint(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassMethod_0A9F6F8D_BinaryReceiver_bigint::CallCore
+
+		} // end of class FunctionObject_ClassMethod_0A9F6F8D_BinaryReceiver_bigint
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_B38BD446_BinaryReceiver_destructure
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x298e
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_B38BD446_BinaryReceiver_destructure::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2996
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_B38BD446_BinaryReceiver_destructure::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2999
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_B38BD446_BinaryReceiver_destructure::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x299c
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::destructure(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassMethod_B38BD446_BinaryReceiver_destructure::CallCore
+
+		} // end of class FunctionObject_ClassMethod_B38BD446_BinaryReceiver_destructure
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_09673A3C_BinaryReceiver_iterate
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x29b0
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_09673A3C_BinaryReceiver_iterate::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x29b8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_09673A3C_BinaryReceiver_iterate::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x29bb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_09673A3C_BinaryReceiver_iterate::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x29be
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::iterate(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassMethod_09673A3C_BinaryReceiver_iterate::CallCore
+
+		} // end of class FunctionObject_ClassMethod_09673A3C_BinaryReceiver_iterate
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_AE05B70D_BinaryReceiver_iterateVar
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x29d2
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_AE05B70D_BinaryReceiver_iterateVar::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x29da
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_AE05B70D_BinaryReceiver_iterateVar::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x29dd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_AE05B70D_BinaryReceiver_iterateVar::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x29e0
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::iterateVar(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassMethod_AE05B70D_BinaryReceiver_iterateVar::CallCore
+
+		} // end of class FunctionObject_ClassMethod_AE05B70D_BinaryReceiver_iterateVar
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_F6371A46_BinaryReceiver_iterateVarIn
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x29f4
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_F6371A46_BinaryReceiver_iterateVarIn::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x29fc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_F6371A46_BinaryReceiver_iterateVarIn::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x29ff
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_F6371A46_BinaryReceiver_iterateVarIn::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a02
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::iterateVarIn(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassMethod_F6371A46_BinaryReceiver_iterateVarIn::CallCore
+
+		} // end of class FunctionObject_ClassMethod_F6371A46_BinaryReceiver_iterateVarIn
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_12AA8A1B_BinaryReceiver_redeclare
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2a16
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_12AA8A1B_BinaryReceiver_redeclare::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2a1e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_12AA8A1B_BinaryReceiver_redeclare::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2a21
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_12AA8A1B_BinaryReceiver_redeclare::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a24
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::redeclare(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassMethod_12AA8A1B_BinaryReceiver_redeclare::CallCore
+
+		} // end of class FunctionObject_ClassMethod_12AA8A1B_BinaryReceiver_redeclare
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_2F3C6E2F_BinaryReceiver_functionRedeclare
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2a38
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_2F3C6E2F_BinaryReceiver_functionRedeclare::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2a40
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_2F3C6E2F_BinaryReceiver_functionRedeclare::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2a43
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_2F3C6E2F_BinaryReceiver_functionRedeclare::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a46
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::functionRedeclare(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassMethod_2F3C6E2F_BinaryReceiver_functionRedeclare::CallCore
+
+		} // end of class FunctionObject_ClassMethod_2F3C6E2F_BinaryReceiver_functionRedeclare
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_EC78B053_BinaryReceiver_run
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2a5a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_EC78B053_BinaryReceiver_run::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2a62
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_EC78B053_BinaryReceiver_run::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2a65
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_EC78B053_BinaryReceiver_run::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a68
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
+				IL_0006: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::run()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_EC78B053_BinaryReceiver_run::CallCore
+
+		} // end of class FunctionObject_ClassMethod_EC78B053_BinaryReceiver_run
 
 
 		// Fields
@@ -1040,7 +2106,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver/Scope_functionRedeclare,
-				[1] class FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_FunctionDeclaration_125FB85F_value,
+				[1] class Modules.Function_ParameterTypeInference_BinaryArguments/'value'/FunctionObject_FunctionDeclaration_125FB85F_value,
 				[2] object[],
 				[3] float64,
 				[4] object,
@@ -1051,13 +2117,13 @@
 			IL_0005: stloc.0
 			IL_0006: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_000b: stloc.2
-			IL_000c: newobj instance void FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_FunctionDeclaration_125FB85F_value::.ctor()
+			IL_000c: newobj instance void Modules.Function_ParameterTypeInference_BinaryArguments/'value'/FunctionObject_FunctionDeclaration_125FB85F_value::.ctor()
 			IL_0011: ldc.i4.0
 			IL_0012: conv.r8
 			IL_0013: ldstr "value"
 			IL_0018: ldc.i4.0
 			IL_0019: ldc.i4.1
-			IL_001a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_FunctionDeclaration_125FB85F_value>(!!0, float64, string, bool, bool)
+			IL_001a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ParameterTypeInference_BinaryArguments/'value'/FunctionObject_FunctionDeclaration_125FB85F_value>(!!0, float64, string, bool, bool)
 			IL_001f: stloc.1
 			IL_0020: nop
 			IL_0021: ldarg.1
@@ -1429,1072 +2495,6 @@
 	} // end of method Function_ParameterTypeInference_BinaryArguments::__js_module_init__
 
 } // end of class Modules.Function_ParameterTypeInference_BinaryArguments
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassConstructor_0F0D7DBD_BinaryReceiver
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2846
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassConstructor_0F0D7DBD_BinaryReceiver::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_0F0D7DBD_BinaryReceiver::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2855
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_0F0D7DBD_BinaryReceiver::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2858
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_0F0D7DBD_BinaryReceiver::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x285b
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_0F0D7DBD_BinaryReceiver::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2867
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_0F0D7DBD_BinaryReceiver::ConstructCore
-
-} // end of class FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassConstructor_0F0D7DBD_BinaryReceiver
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassMethod_19915569_BinaryReceiver_add
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2873
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_19915569_BinaryReceiver_add::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x287b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_19915569_BinaryReceiver_add::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x287e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_19915569_BinaryReceiver_add::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2881
-		// Header size: 1
-		// Code size: 29 (0x1d)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0012: call instance float64 Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::'add'(float64)
-		IL_0017: box [System.Runtime]System.Double
-		IL_001c: ret
-	} // end of method FunctionObject_ClassMethod_19915569_BinaryReceiver_add::CallCore
-
-} // end of class FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassMethod_19915569_BinaryReceiver_add
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassMethod_C89F94A2_BinaryReceiver_multiply
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x289f
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_C89F94A2_BinaryReceiver_multiply::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x28a7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_C89F94A2_BinaryReceiver_multiply::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x28aa
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_C89F94A2_BinaryReceiver_multiply::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x28ad
-		// Header size: 1
-		// Code size: 29 (0x1d)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0012: call instance float64 Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::multiply(float64)
-		IL_0017: box [System.Runtime]System.Double
-		IL_001c: ret
-	} // end of method FunctionObject_ClassMethod_C89F94A2_BinaryReceiver_multiply::CallCore
-
-} // end of class FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassMethod_C89F94A2_BinaryReceiver_multiply
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassMethod_0942BEAA_BinaryReceiver_shift
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x28cb
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_0942BEAA_BinaryReceiver_shift::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x28d3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_0942BEAA_BinaryReceiver_shift::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x28d6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_0942BEAA_BinaryReceiver_shift::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x28d9
-		// Header size: 1
-		// Code size: 29 (0x1d)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0012: call instance float64 Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::shift(float64)
-		IL_0017: box [System.Runtime]System.Double
-		IL_001c: ret
-	} // end of method FunctionObject_ClassMethod_0942BEAA_BinaryReceiver_shift::CallCore
-
-} // end of class FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassMethod_0942BEAA_BinaryReceiver_shift
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassMethod_A00A558B_BinaryReceiver_increment
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x28f7
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_A00A558B_BinaryReceiver_increment::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x28ff
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_A00A558B_BinaryReceiver_increment::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2902
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_A00A558B_BinaryReceiver_increment::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2905
-		// Header size: 1
-		// Code size: 29 (0x1d)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0012: call instance float64 Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::increment(float64)
-		IL_0017: box [System.Runtime]System.Double
-		IL_001c: ret
-	} // end of method FunctionObject_ClassMethod_A00A558B_BinaryReceiver_increment::CallCore
-
-} // end of class FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassMethod_A00A558B_BinaryReceiver_increment
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassMethod_46A1F899_BinaryReceiver_incrementBoolean
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2923
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_46A1F899_BinaryReceiver_incrementBoolean::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x292b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_46A1F899_BinaryReceiver_incrementBoolean::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x292e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_46A1F899_BinaryReceiver_incrementBoolean::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2931
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance float64 Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::incrementBoolean(object)
-		IL_0012: box [System.Runtime]System.Double
-		IL_0017: ret
-	} // end of method FunctionObject_ClassMethod_46A1F899_BinaryReceiver_incrementBoolean::CallCore
-
-} // end of class FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassMethod_46A1F899_BinaryReceiver_incrementBoolean
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassMethod_79F89F2A_BinaryReceiver_dynamicAdd
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x294a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_79F89F2A_BinaryReceiver_dynamicAdd::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2952
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_79F89F2A_BinaryReceiver_dynamicAdd::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2955
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_79F89F2A_BinaryReceiver_dynamicAdd::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2958
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::dynamicAdd(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassMethod_79F89F2A_BinaryReceiver_dynamicAdd::CallCore
-
-} // end of class FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassMethod_79F89F2A_BinaryReceiver_dynamicAdd
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassMethod_0A9F6F8D_BinaryReceiver_bigint
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x296c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_0A9F6F8D_BinaryReceiver_bigint::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2974
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_0A9F6F8D_BinaryReceiver_bigint::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2977
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_0A9F6F8D_BinaryReceiver_bigint::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x297a
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::bigint(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassMethod_0A9F6F8D_BinaryReceiver_bigint::CallCore
-
-} // end of class FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassMethod_0A9F6F8D_BinaryReceiver_bigint
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassMethod_B38BD446_BinaryReceiver_destructure
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x298e
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_B38BD446_BinaryReceiver_destructure::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2996
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_B38BD446_BinaryReceiver_destructure::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2999
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_B38BD446_BinaryReceiver_destructure::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x299c
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::destructure(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassMethod_B38BD446_BinaryReceiver_destructure::CallCore
-
-} // end of class FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassMethod_B38BD446_BinaryReceiver_destructure
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassMethod_09673A3C_BinaryReceiver_iterate
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x29b0
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_09673A3C_BinaryReceiver_iterate::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x29b8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_09673A3C_BinaryReceiver_iterate::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x29bb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_09673A3C_BinaryReceiver_iterate::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x29be
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::iterate(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassMethod_09673A3C_BinaryReceiver_iterate::CallCore
-
-} // end of class FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassMethod_09673A3C_BinaryReceiver_iterate
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassMethod_AE05B70D_BinaryReceiver_iterateVar
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x29d2
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_AE05B70D_BinaryReceiver_iterateVar::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x29da
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_AE05B70D_BinaryReceiver_iterateVar::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x29dd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_AE05B70D_BinaryReceiver_iterateVar::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x29e0
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::iterateVar(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassMethod_AE05B70D_BinaryReceiver_iterateVar::CallCore
-
-} // end of class FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassMethod_AE05B70D_BinaryReceiver_iterateVar
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassMethod_F6371A46_BinaryReceiver_iterateVarIn
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x29f4
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_F6371A46_BinaryReceiver_iterateVarIn::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x29fc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_F6371A46_BinaryReceiver_iterateVarIn::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x29ff
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_F6371A46_BinaryReceiver_iterateVarIn::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a02
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::iterateVarIn(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassMethod_F6371A46_BinaryReceiver_iterateVarIn::CallCore
-
-} // end of class FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassMethod_F6371A46_BinaryReceiver_iterateVarIn
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassMethod_12AA8A1B_BinaryReceiver_redeclare
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2a16
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_12AA8A1B_BinaryReceiver_redeclare::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a1e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_12AA8A1B_BinaryReceiver_redeclare::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a21
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_12AA8A1B_BinaryReceiver_redeclare::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a24
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::redeclare(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassMethod_12AA8A1B_BinaryReceiver_redeclare::CallCore
-
-} // end of class FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassMethod_12AA8A1B_BinaryReceiver_redeclare
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassMethod_2F3C6E2F_BinaryReceiver_functionRedeclare
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2a38
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_2F3C6E2F_BinaryReceiver_functionRedeclare::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a40
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_2F3C6E2F_BinaryReceiver_functionRedeclare::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a43
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_2F3C6E2F_BinaryReceiver_functionRedeclare::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a46
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::functionRedeclare(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassMethod_2F3C6E2F_BinaryReceiver_functionRedeclare::CallCore
-
-} // end of class FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassMethod_2F3C6E2F_BinaryReceiver_functionRedeclare
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassMethod_EC78B053_BinaryReceiver_run
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2a5a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_EC78B053_BinaryReceiver_run::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a62
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_EC78B053_BinaryReceiver_run::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a65
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_EC78B053_BinaryReceiver_run::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a68
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver
-		IL_0006: call instance object Modules.Function_ParameterTypeInference_BinaryArguments/BinaryReceiver::run()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_EC78B053_BinaryReceiver_run::CallCore
-
-} // end of class FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_ClassMethod_EC78B053_BinaryReceiver_run
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_FunctionDeclaration_125FB85F_value
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2a75
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_125FB85F_value::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a7d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_125FB85F_value::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a80
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_125FB85F_value::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a83
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Function_ParameterTypeInference_BinaryArguments/'value'::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_125FB85F_value::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a8f
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Function_ParameterTypeInference_BinaryArguments/'value'::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_125FB85F_value::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a97
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_125FB85F_value::ConstructCore
-
-} // end of class FunctionObjects.Function_ParameterTypeInference_BinaryArguments_6203558C.FunctionObject_FunctionDeclaration_125FB85F_value
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterTypeInference_DirectRotateArrayArgument.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterTypeInference_DirectRotateArrayArgument.verified.txt
@@ -31,6 +31,117 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9877C077_RotateX
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2401
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_9877C077_RotateX::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2409
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9877C077_RotateX::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x240c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9877C077_RotateX::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x240f
+				// Header size: 1
+				// Code size: 35 (0x23)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001d: call object Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateX::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
+				IL_0022: ret
+			} // end of method FunctionObject_FunctionDeclaration_9877C077_RotateX::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2433
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0019: call object Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateX::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_9877C077_RotateX::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2453
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9877C077_RotateX::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9877C077_RotateX
+
 
 		// Methods
 		.method public hidebysig static 
@@ -123,6 +234,117 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9777BEE4_RotateY
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2462
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_9777BEE4_RotateY::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x246a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9777BEE4_RotateY::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x246d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9777BEE4_RotateY::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2470
+				// Header size: 1
+				// Code size: 35 (0x23)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001d: call object Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateY::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
+				IL_0022: ret
+			} // end of method FunctionObject_FunctionDeclaration_9777BEE4_RotateY::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2494
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0019: call object Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateY::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_9777BEE4_RotateY::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24b4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9777BEE4_RotateY::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9777BEE4_RotateY
+
 
 		// Methods
 		.method public hidebysig static 
@@ -214,6 +436,117 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9A77C39D_RotateZ
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x24c3
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A77C39D_RotateZ::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24cb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A77C39D_RotateZ::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24ce
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A77C39D_RotateZ::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24d1
+				// Header size: 1
+				// Code size: 35 (0x23)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001d: call object Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateZ::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
+				IL_0022: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A77C39D_RotateZ::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24f5
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0019: call object Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateZ::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A77C39D_RotateZ::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2515
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A77C39D_RotateZ::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9A77C39D_RotateZ
 
 
 		// Methods
@@ -332,9 +665,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/Scope,
-			[1] class FunctionObjects.Function_ParameterTypeInference_DirectRotateArrayArgument_6301A653.FunctionObject_FunctionDeclaration_9877C077_RotateX,
-			[2] class FunctionObjects.Function_ParameterTypeInference_DirectRotateArrayArgument_6301A653.FunctionObject_FunctionDeclaration_9777BEE4_RotateY,
-			[3] class FunctionObjects.Function_ParameterTypeInference_DirectRotateArrayArgument_6301A653.FunctionObject_FunctionDeclaration_9A77C39D_RotateZ,
+			[1] class Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateX/FunctionObject_FunctionDeclaration_9877C077_RotateX,
+			[2] class Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateY/FunctionObject_FunctionDeclaration_9777BEE4_RotateY,
+			[3] class Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateZ/FunctionObject_FunctionDeclaration_9A77C39D_RotateZ,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[5] object[],
 			[6] object,
@@ -350,13 +683,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 5
-		IL_0012: newobj instance void FunctionObjects.Function_ParameterTypeInference_DirectRotateArrayArgument_6301A653.FunctionObject_FunctionDeclaration_9877C077_RotateX::.ctor()
+		IL_0012: newobj instance void Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateX/FunctionObject_FunctionDeclaration_9877C077_RotateX::.ctor()
 		IL_0017: ldc.i4.2
 		IL_0018: conv.r8
 		IL_0019: ldstr "RotateX"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_ParameterTypeInference_DirectRotateArrayArgument_6301A653.FunctionObject_FunctionDeclaration_9877C077_RotateX>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateX/FunctionObject_FunctionDeclaration_9877C077_RotateX>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -365,13 +698,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 5
-		IL_0032: newobj instance void FunctionObjects.Function_ParameterTypeInference_DirectRotateArrayArgument_6301A653.FunctionObject_FunctionDeclaration_9777BEE4_RotateY::.ctor()
+		IL_0032: newobj instance void Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateY/FunctionObject_FunctionDeclaration_9777BEE4_RotateY::.ctor()
 		IL_0037: ldc.i4.2
 		IL_0038: conv.r8
 		IL_0039: ldstr "RotateY"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_ParameterTypeInference_DirectRotateArrayArgument_6301A653.FunctionObject_FunctionDeclaration_9777BEE4_RotateY>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateY/FunctionObject_FunctionDeclaration_9777BEE4_RotateY>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -380,13 +713,13 @@
 		IL_004e: ldloc.0
 		IL_004f: stelem.ref
 		IL_0050: stloc.s 5
-		IL_0052: newobj instance void FunctionObjects.Function_ParameterTypeInference_DirectRotateArrayArgument_6301A653.FunctionObject_FunctionDeclaration_9A77C39D_RotateZ::.ctor()
+		IL_0052: newobj instance void Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateZ/FunctionObject_FunctionDeclaration_9A77C39D_RotateZ::.ctor()
 		IL_0057: ldc.i4.2
 		IL_0058: conv.r8
 		IL_0059: ldstr "RotateZ"
 		IL_005e: ldc.i4.0
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_ParameterTypeInference_DirectRotateArrayArgument_6301A653.FunctionObject_FunctionDeclaration_9A77C39D_RotateZ>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateZ/FunctionObject_FunctionDeclaration_9A77C39D_RotateZ>(!!0, float64, string, bool, bool)
 		IL_0065: stloc.3
 		IL_0066: nop
 		IL_0067: nop
@@ -473,339 +806,6 @@
 	} // end of method Function_ParameterTypeInference_DirectRotateArrayArgument::__js_module_init__
 
 } // end of class Modules.Function_ParameterTypeInference_DirectRotateArrayArgument
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ParameterTypeInference_DirectRotateArrayArgument_6301A653.FunctionObject_FunctionDeclaration_9877C077_RotateX
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2401
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_9877C077_RotateX::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2409
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9877C077_RotateX::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x240c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9877C077_RotateX::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x240f
-		// Header size: 1
-		// Code size: 35 (0x23)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001d: call object Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateX::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
-		IL_0022: ret
-	} // end of method FunctionObject_FunctionDeclaration_9877C077_RotateX::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2433
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0019: call object Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateX::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_9877C077_RotateX::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2453
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9877C077_RotateX::ConstructCore
-
-} // end of class FunctionObjects.Function_ParameterTypeInference_DirectRotateArrayArgument_6301A653.FunctionObject_FunctionDeclaration_9877C077_RotateX
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ParameterTypeInference_DirectRotateArrayArgument_6301A653.FunctionObject_FunctionDeclaration_9777BEE4_RotateY
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2462
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_9777BEE4_RotateY::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x246a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9777BEE4_RotateY::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x246d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9777BEE4_RotateY::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2470
-		// Header size: 1
-		// Code size: 35 (0x23)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001d: call object Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateY::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
-		IL_0022: ret
-	} // end of method FunctionObject_FunctionDeclaration_9777BEE4_RotateY::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2494
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0019: call object Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateY::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_9777BEE4_RotateY::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24b4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9777BEE4_RotateY::ConstructCore
-
-} // end of class FunctionObjects.Function_ParameterTypeInference_DirectRotateArrayArgument_6301A653.FunctionObject_FunctionDeclaration_9777BEE4_RotateY
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ParameterTypeInference_DirectRotateArrayArgument_6301A653.FunctionObject_FunctionDeclaration_9A77C39D_RotateZ
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x24c3
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A77C39D_RotateZ::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24cb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A77C39D_RotateZ::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24ce
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A77C39D_RotateZ::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24d1
-		// Header size: 1
-		// Code size: 35 (0x23)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001d: call object Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateZ::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
-		IL_0022: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A77C39D_RotateZ::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24f5
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0019: call object Modules.Function_ParameterTypeInference_DirectRotateArrayArgument/RotateZ::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A77C39D_RotateZ::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2515
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A77C39D_RotateZ::ConstructCore
-
-} // end of class FunctionObjects.Function_ParameterTypeInference_DirectRotateArrayArgument_6301A653.FunctionObject_FunctionDeclaration_9A77C39D_RotateZ
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_770551A8_add
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2104
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_770551A8_add::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x210c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_770551A8_add::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x210f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_770551A8_add::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2112
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/'add'::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_770551A8_add::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x212c
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/'add'::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_770551A8_add::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2142
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_770551A8_add::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_770551A8_add
+
 
 		// Methods
 		.method public hidebysig static 
@@ -105,7 +212,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/Scope,
-			[1] class FunctionObjects.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature_BC029EA2.FunctionObject_FunctionDeclaration_770551A8_add,
+			[1] class Modules.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/'add'/FunctionObject_FunctionDeclaration_770551A8_add,
 			[2] object[],
 			[3] object,
 			[4] object
@@ -120,13 +227,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature_BC029EA2.FunctionObject_FunctionDeclaration_770551A8_add::.ctor()
+		IL_0011: newobj instance void Modules.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/'add'/FunctionObject_FunctionDeclaration_770551A8_add::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "add"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature_BC029EA2.FunctionObject_FunctionDeclaration_770551A8_add>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/'add'/FunctionObject_FunctionDeclaration_770551A8_add>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -159,113 +266,6 @@
 	} // end of method Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature::__js_module_init__
 
 } // end of class Modules.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature_BC029EA2.FunctionObject_FunctionDeclaration_770551A8_add
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2104
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_770551A8_add::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x210c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_770551A8_add::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x210f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_770551A8_add::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2112
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/'add'::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_770551A8_add::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x212c
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature/'add'::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_770551A8_add::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2142
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_770551A8_add::ConstructCore
-
-} // end of class FunctionObjects.Function_ParameterTypeInference_EscapedFunction_KeepsObjectSignature_BC029EA2.FunctionObject_FunctionDeclaration_770551A8_add
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Prototype_Bind_PropertyExists.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Prototype_Bind_PropertyExists.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_30545E80_add
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2184
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_30545E80_add::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x218c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_30545E80_add::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x218f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_30545E80_add::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2192
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Function_Prototype_Bind_PropertyExists/'add'::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_30545E80_add::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21ac
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Function_Prototype_Bind_PropertyExists/'add'::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_30545E80_add::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21c2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_30545E80_add::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_30545E80_add
+
 
 		// Methods
 		.method public hidebysig static 
@@ -105,7 +212,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Prototype_Bind_PropertyExists/Scope,
-			[1] class FunctionObjects.Function_Prototype_Bind_PropertyExists_4700949A.FunctionObject_FunctionDeclaration_30545E80_add,
+			[1] class Modules.Function_Prototype_Bind_PropertyExists/'add'/FunctionObject_FunctionDeclaration_30545E80_add,
 			[2] object,
 			[3] object[],
 			[4] object,
@@ -122,13 +229,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.Function_Prototype_Bind_PropertyExists_4700949A.FunctionObject_FunctionDeclaration_30545E80_add::.ctor()
+		IL_0011: newobj instance void Modules.Function_Prototype_Bind_PropertyExists/'add'/FunctionObject_FunctionDeclaration_30545E80_add::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "add"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Prototype_Bind_PropertyExists_4700949A.FunctionObject_FunctionDeclaration_30545E80_add>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Prototype_Bind_PropertyExists/'add'/FunctionObject_FunctionDeclaration_30545E80_add>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: ldstr "console"
@@ -193,113 +300,6 @@
 	} // end of method Function_Prototype_Bind_PropertyExists::__js_module_init__
 
 } // end of class Modules.Function_Prototype_Bind_PropertyExists
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Prototype_Bind_PropertyExists_4700949A.FunctionObject_FunctionDeclaration_30545E80_add
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2184
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_30545E80_add::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x218c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_30545E80_add::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x218f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_30545E80_add::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2192
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Function_Prototype_Bind_PropertyExists/'add'::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_30545E80_add::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ac
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Function_Prototype_Bind_PropertyExists/'add'::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_30545E80_add::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21c2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_30545E80_add::ConstructCore
-
-} // end of class FunctionObjects.Function_Prototype_Bind_PropertyExists_4700949A.FunctionObject_FunctionDeclaration_30545E80_add
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Prototype_ObjectCreate_ObjectPrototype.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Prototype_ObjectCreate_ObjectPrototype.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21cb
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21d3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21d6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21d9
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Function_Prototype_ObjectCreate_ObjectPrototype/MyEvent::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21ec
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Function_Prototype_ObjectCreate_ObjectPrototype/MyEvent::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21fb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent
+
 
 		// Methods
 		.method public hidebysig static 
@@ -103,6 +204,101 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B6EC663B_dumpToConsole
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x220a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_B6EC663B_dumpToConsole::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2212
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_B6EC663B_dumpToConsole::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2215
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_B6EC663B_dumpToConsole::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2218
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Function_Prototype_ObjectCreate_ObjectPrototype/dumpToConsole::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_B6EC663B_dumpToConsole::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2224
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Function_Prototype_ObjectCreate_ObjectPrototype/dumpToConsole::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_B6EC663B_dumpToConsole::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x222c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_B6EC663B_dumpToConsole::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_B6EC663B_dumpToConsole
 
 
 		// Methods
@@ -192,11 +388,11 @@
 		.maxstack 12
 		.locals init (
 			[0] class Modules.Function_Prototype_ObjectCreate_ObjectPrototype/Scope,
-			[1] class FunctionObjects.Function_Prototype_ObjectCreate_ObjectPrototype_DCE93596.FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent,
+			[1] class Modules.Function_Prototype_ObjectCreate_ObjectPrototype/MyEvent/FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent,
 			[2] object,
 			[3] object[],
 			[4] object,
-			[5] class FunctionObjects.Function_Prototype_ObjectCreate_ObjectPrototype_DCE93596.FunctionObject_FunctionExpression_B6EC663B_dumpToConsole,
+			[5] class Modules.Function_Prototype_ObjectCreate_ObjectPrototype/dumpToConsole/FunctionObject_FunctionExpression_B6EC663B_dumpToConsole,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
 
@@ -209,13 +405,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.Function_Prototype_ObjectCreate_ObjectPrototype_DCE93596.FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent::.ctor()
+		IL_0011: newobj instance void Modules.Function_Prototype_ObjectCreate_ObjectPrototype/MyEvent/FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "MyEvent"
 		IL_001d: ldc.i4.1
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Prototype_ObjectCreate_ObjectPrototype_DCE93596.FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Prototype_ObjectCreate_ObjectPrototype/MyEvent/FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -231,13 +427,13 @@
 		IL_0045: ldloc.0
 		IL_0046: stelem.ref
 		IL_0047: stloc.3
-		IL_0048: newobj instance void FunctionObjects.Function_Prototype_ObjectCreate_ObjectPrototype_DCE93596.FunctionObject_FunctionExpression_B6EC663B_dumpToConsole::.ctor()
+		IL_0048: newobj instance void Modules.Function_Prototype_ObjectCreate_ObjectPrototype/dumpToConsole/FunctionObject_FunctionExpression_B6EC663B_dumpToConsole::.ctor()
 		IL_004d: ldc.i4.0
 		IL_004e: conv.r8
 		IL_004f: ldstr "dumpToConsole"
 		IL_0054: ldc.i4.1
 		IL_0055: ldc.i4.1
-		IL_0056: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Prototype_ObjectCreate_ObjectPrototype_DCE93596.FunctionObject_FunctionExpression_B6EC663B_dumpToConsole>(!!0, float64, string, bool, bool)
+		IL_0056: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Prototype_ObjectCreate_ObjectPrototype/dumpToConsole/FunctionObject_FunctionExpression_B6EC663B_dumpToConsole>(!!0, float64, string, bool, bool)
 		IL_005b: stloc.s 5
 		IL_005d: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0062: dup
@@ -279,202 +475,6 @@
 	} // end of method Function_Prototype_ObjectCreate_ObjectPrototype::__js_module_init__
 
 } // end of class Modules.Function_Prototype_ObjectCreate_ObjectPrototype
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Prototype_ObjectCreate_ObjectPrototype_DCE93596.FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21cb
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21d3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21d6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21d9
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Function_Prototype_ObjectCreate_ObjectPrototype/MyEvent::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ec
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Function_Prototype_ObjectCreate_ObjectPrototype/MyEvent::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21fb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent::ConstructCore
-
-} // end of class FunctionObjects.Function_Prototype_ObjectCreate_ObjectPrototype_DCE93596.FunctionObject_FunctionDeclaration_FBAE96E1_MyEvent
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Prototype_ObjectCreate_ObjectPrototype_DCE93596.FunctionObject_FunctionExpression_B6EC663B_dumpToConsole
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x220a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_B6EC663B_dumpToConsole::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2212
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_B6EC663B_dumpToConsole::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2215
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_B6EC663B_dumpToConsole::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2218
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Function_Prototype_ObjectCreate_ObjectPrototype/dumpToConsole::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_B6EC663B_dumpToConsole::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2224
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Function_Prototype_ObjectCreate_ObjectPrototype/dumpToConsole::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_B6EC663B_dumpToConsole::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x222c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_B6EC663B_dumpToConsole::ConstructCore
-
-} // end of class FunctionObjects.Function_Prototype_ObjectCreate_ObjectPrototype_DCE93596.FunctionObject_FunctionExpression_B6EC663B_dumpToConsole
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Prototype_ToString_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_Prototype_ToString_Basic.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_98182540_namedFn
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21bc
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_98182540_namedFn::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21c4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_98182540_namedFn::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21c7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_98182540_namedFn::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21ca
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Function_Prototype_ToString_Basic/namedFn::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_98182540_namedFn::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21e4
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Function_Prototype_ToString_Basic/namedFn::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_98182540_namedFn::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21fa
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_98182540_namedFn::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_98182540_namedFn
+
 
 		// Methods
 		.method public hidebysig static 
@@ -105,7 +212,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_Prototype_ToString_Basic/Scope,
-			[1] class FunctionObjects.Function_Prototype_ToString_Basic_615BB7F4.FunctionObject_FunctionDeclaration_98182540_namedFn,
+			[1] class Modules.Function_Prototype_ToString_Basic/namedFn/FunctionObject_FunctionDeclaration_98182540_namedFn,
 			[2] object,
 			[3] object[],
 			[4] object,
@@ -124,13 +231,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.Function_Prototype_ToString_Basic_615BB7F4.FunctionObject_FunctionDeclaration_98182540_namedFn::.ctor()
+		IL_0011: newobj instance void Modules.Function_Prototype_ToString_Basic/namedFn/FunctionObject_FunctionDeclaration_98182540_namedFn::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "namedFn"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_Prototype_ToString_Basic_615BB7F4.FunctionObject_FunctionDeclaration_98182540_namedFn>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_Prototype_ToString_Basic/namedFn/FunctionObject_FunctionDeclaration_98182540_namedFn>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -213,113 +320,6 @@
 	} // end of method Function_Prototype_ToString_Basic::__js_module_init__
 
 } // end of class Modules.Function_Prototype_ToString_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_Prototype_ToString_Basic_615BB7F4.FunctionObject_FunctionDeclaration_98182540_namedFn
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21bc
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_98182540_namedFn::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21c4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_98182540_namedFn::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21c7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_98182540_namedFn::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ca
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Function_Prototype_ToString_Basic/namedFn::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_98182540_namedFn::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21e4
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Function_Prototype_ToString_Basic/namedFn::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_98182540_namedFn::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21fa
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_98182540_namedFn::ConstructCore
-
-} // end of class FunctionObjects.Function_Prototype_ToString_Basic_615BB7F4.FunctionObject_FunctionDeclaration_98182540_namedFn
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_Basic.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_Basic.verified.txt
@@ -73,6 +73,113 @@
 
 		} // end of class Scope_For_L5C9
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9D72AA57_sum
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_RestParameters_Basic/Scope _environment0_Function_RestParameters_Basic
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_RestParameters_Basic/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_RestParameters_Basic/Scope Modules.Function_RestParameters_Basic/sum/FunctionObject_FunctionDeclaration_9D72AA57_sum::_environment0_Function_RestParameters_Basic
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9D72AA57_sum::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2200
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9D72AA57_sum::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2203
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9D72AA57_sum::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2206
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_RestParameters_Basic/Scope Modules.Function_RestParameters_Basic/sum/FunctionObject_FunctionDeclaration_9D72AA57_sum::_environment0_Function_RestParameters_Basic
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_RestParameters_Basic/sum::__js_call__(class Modules.Function_RestParameters_Basic/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_9D72AA57_sum::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2218
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_RestParameters_Basic/Scope Modules.Function_RestParameters_Basic/sum/FunctionObject_FunctionDeclaration_9D72AA57_sum::_environment0_Function_RestParameters_Basic
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_RestParameters_Basic/sum::__js_call__(class Modules.Function_RestParameters_Basic/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_9D72AA57_sum::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2226
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9D72AA57_sum::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9D72AA57_sum
+
 
 		// Methods
 		.method public hidebysig static 
@@ -189,7 +296,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_RestParameters_Basic/Scope,
-			[1] class FunctionObjects.Function_RestParameters_Basic_10EBE191.FunctionObject_FunctionDeclaration_9D72AA57_sum,
+			[1] class Modules.Function_RestParameters_Basic/sum/FunctionObject_FunctionDeclaration_9D72AA57_sum,
 			[2] object[],
 			[3] object,
 			[4] object
@@ -208,13 +315,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_RestParameters_Basic/Scope
-		IL_0019: newobj instance void FunctionObjects.Function_RestParameters_Basic_10EBE191.FunctionObject_FunctionDeclaration_9D72AA57_sum::.ctor(class Modules.Function_RestParameters_Basic/Scope)
+		IL_0019: newobj instance void Modules.Function_RestParameters_Basic/sum/FunctionObject_FunctionDeclaration_9D72AA57_sum::.ctor(class Modules.Function_RestParameters_Basic/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "sum"
 		IL_0025: ldc.i4.1
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_RestParameters_Basic_10EBE191.FunctionObject_FunctionDeclaration_9D72AA57_sum>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_RestParameters_Basic/sum/FunctionObject_FunctionDeclaration_9D72AA57_sum>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
@@ -275,113 +382,6 @@
 	} // end of method Function_RestParameters_Basic::__js_module_init__
 
 } // end of class Modules.Function_RestParameters_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_RestParameters_Basic_10EBE191.FunctionObject_FunctionDeclaration_9D72AA57_sum
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_RestParameters_Basic/Scope _environment0_Function_RestParameters_Basic
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_RestParameters_Basic/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_RestParameters_Basic/Scope FunctionObjects.Function_RestParameters_Basic_10EBE191.FunctionObject_FunctionDeclaration_9D72AA57_sum::_environment0_Function_RestParameters_Basic
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9D72AA57_sum::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2200
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9D72AA57_sum::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2203
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9D72AA57_sum::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2206
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_RestParameters_Basic/Scope FunctionObjects.Function_RestParameters_Basic_10EBE191.FunctionObject_FunctionDeclaration_9D72AA57_sum::_environment0_Function_RestParameters_Basic
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_RestParameters_Basic/sum::__js_call__(class Modules.Function_RestParameters_Basic/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_9D72AA57_sum::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2218
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_RestParameters_Basic/Scope FunctionObjects.Function_RestParameters_Basic_10EBE191.FunctionObject_FunctionDeclaration_9D72AA57_sum::_environment0_Function_RestParameters_Basic
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_RestParameters_Basic/sum::__js_call__(class Modules.Function_RestParameters_Basic/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_9D72AA57_sum::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2226
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9D72AA57_sum::ConstructCore
-
-} // end of class FunctionObjects.Function_RestParameters_Basic_10EBE191.FunctionObject_FunctionDeclaration_9D72AA57_sum
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_Empty.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_Empty.verified.txt
@@ -53,6 +53,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_15C1321C_logArgs
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x216a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_15C1321C_logArgs::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2172
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_15C1321C_logArgs::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2175
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_15C1321C_logArgs::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2178
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Function_RestParameters_Empty/logArgs::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_15C1321C_logArgs::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2184
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Function_RestParameters_Empty/logArgs::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_15C1321C_logArgs::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x218c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_15C1321C_logArgs::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_15C1321C_logArgs
+
 
 		// Methods
 		.method public hidebysig static 
@@ -157,7 +252,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_RestParameters_Empty/Scope,
-			[1] class FunctionObjects.Function_RestParameters_Empty_CC12CF3A.FunctionObject_FunctionDeclaration_15C1321C_logArgs,
+			[1] class Modules.Function_RestParameters_Empty/logArgs/FunctionObject_FunctionDeclaration_15C1321C_logArgs,
 			[2] object[]
 		)
 
@@ -170,13 +265,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.Function_RestParameters_Empty_CC12CF3A.FunctionObject_FunctionDeclaration_15C1321C_logArgs::.ctor()
+		IL_0011: newobj instance void Modules.Function_RestParameters_Empty/logArgs/FunctionObject_FunctionDeclaration_15C1321C_logArgs::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "logArgs"
 		IL_001d: ldc.i4.1
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_RestParameters_Empty_CC12CF3A.FunctionObject_FunctionDeclaration_15C1321C_logArgs>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_RestParameters_Empty/logArgs/FunctionObject_FunctionDeclaration_15C1321C_logArgs>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -204,101 +299,6 @@
 	} // end of method Function_RestParameters_Empty::__js_module_init__
 
 } // end of class Modules.Function_RestParameters_Empty
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_RestParameters_Empty_CC12CF3A.FunctionObject_FunctionDeclaration_15C1321C_logArgs
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x216a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_15C1321C_logArgs::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2172
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_15C1321C_logArgs::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2175
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_15C1321C_logArgs::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2178
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Function_RestParameters_Empty/logArgs::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_15C1321C_logArgs::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2184
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Function_RestParameters_Empty/logArgs::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_15C1321C_logArgs::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x218c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_15C1321C_logArgs::ConstructCore
-
-} // end of class FunctionObjects.Function_RestParameters_Empty_CC12CF3A.FunctionObject_FunctionDeclaration_15C1321C_logArgs
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_MultipleNamed.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_MultipleNamed.verified.txt
@@ -73,6 +73,125 @@
 
 		} // end of class Scope_For_L5C9
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5CDD99AA_format
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_RestParameters_MultipleNamed/Scope _environment0_Function_RestParameters_MultipleNamed
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_RestParameters_MultipleNamed/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_RestParameters_MultipleNamed/Scope Modules.Function_RestParameters_MultipleNamed/format/FunctionObject_FunctionDeclaration_5CDD99AA_format::_environment0_Function_RestParameters_MultipleNamed
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5CDD99AA_format::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2207
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5CDD99AA_format::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x220a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5CDD99AA_format::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x220d
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_RestParameters_MultipleNamed/Scope Modules.Function_RestParameters_MultipleNamed/format/FunctionObject_FunctionDeclaration_5CDD99AA_format::_environment0_Function_RestParameters_MultipleNamed
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Function_RestParameters_MultipleNamed/format::__js_call__(class Modules.Function_RestParameters_MultipleNamed/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_5CDD99AA_format::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x222d
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_RestParameters_MultipleNamed/Scope Modules.Function_RestParameters_MultipleNamed/format/FunctionObject_FunctionDeclaration_5CDD99AA_format::_environment0_Function_RestParameters_MultipleNamed
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Function_RestParameters_MultipleNamed/format::__js_call__(class Modules.Function_RestParameters_MultipleNamed/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_5CDD99AA_format::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2249
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5CDD99AA_format::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_5CDD99AA_format
+
 
 		// Methods
 		.method public hidebysig static 
@@ -198,7 +317,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_RestParameters_MultipleNamed/Scope,
-			[1] class FunctionObjects.Function_RestParameters_MultipleNamed_2DEE073E.FunctionObject_FunctionDeclaration_5CDD99AA_format,
+			[1] class Modules.Function_RestParameters_MultipleNamed/format/FunctionObject_FunctionDeclaration_5CDD99AA_format,
 			[2] object[],
 			[3] object,
 			[4] object
@@ -217,13 +336,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_RestParameters_MultipleNamed/Scope
-		IL_0019: newobj instance void FunctionObjects.Function_RestParameters_MultipleNamed_2DEE073E.FunctionObject_FunctionDeclaration_5CDD99AA_format::.ctor(class Modules.Function_RestParameters_MultipleNamed/Scope)
+		IL_0019: newobj instance void Modules.Function_RestParameters_MultipleNamed/format/FunctionObject_FunctionDeclaration_5CDD99AA_format::.ctor(class Modules.Function_RestParameters_MultipleNamed/Scope)
 		IL_001e: ldc.i4.2
 		IL_001f: conv.r8
 		IL_0020: ldstr "format"
 		IL_0025: ldc.i4.1
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_RestParameters_MultipleNamed_2DEE073E.FunctionObject_FunctionDeclaration_5CDD99AA_format>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_RestParameters_MultipleNamed/format/FunctionObject_FunctionDeclaration_5CDD99AA_format>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
@@ -303,125 +422,6 @@
 	} // end of method Function_RestParameters_MultipleNamed::__js_module_init__
 
 } // end of class Modules.Function_RestParameters_MultipleNamed
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_RestParameters_MultipleNamed_2DEE073E.FunctionObject_FunctionDeclaration_5CDD99AA_format
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_RestParameters_MultipleNamed/Scope _environment0_Function_RestParameters_MultipleNamed
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_RestParameters_MultipleNamed/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_RestParameters_MultipleNamed/Scope FunctionObjects.Function_RestParameters_MultipleNamed_2DEE073E.FunctionObject_FunctionDeclaration_5CDD99AA_format::_environment0_Function_RestParameters_MultipleNamed
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5CDD99AA_format::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2207
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5CDD99AA_format::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x220a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5CDD99AA_format::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x220d
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_RestParameters_MultipleNamed/Scope FunctionObjects.Function_RestParameters_MultipleNamed_2DEE073E.FunctionObject_FunctionDeclaration_5CDD99AA_format::_environment0_Function_RestParameters_MultipleNamed
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Function_RestParameters_MultipleNamed/format::__js_call__(class Modules.Function_RestParameters_MultipleNamed/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_5CDD99AA_format::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x222d
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_RestParameters_MultipleNamed/Scope FunctionObjects.Function_RestParameters_MultipleNamed_2DEE073E.FunctionObject_FunctionDeclaration_5CDD99AA_format::_environment0_Function_RestParameters_MultipleNamed
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Function_RestParameters_MultipleNamed/format::__js_call__(class Modules.Function_RestParameters_MultipleNamed/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_5CDD99AA_format::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2249
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5CDD99AA_format::ConstructCore
-
-} // end of class FunctionObjects.Function_RestParameters_MultipleNamed_2DEE073E.FunctionObject_FunctionDeclaration_5CDD99AA_format
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_WithNamedParams.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_RestParameters_WithNamedParams.verified.txt
@@ -95,6 +95,119 @@
 
 		} // end of class Scope_For_L5C9
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3E0DE254_combine
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_RestParameters_WithNamedParams/Scope _environment0_Function_RestParameters_WithNamedParams
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_RestParameters_WithNamedParams/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x220e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_RestParameters_WithNamedParams/Scope Modules.Function_RestParameters_WithNamedParams/combine/FunctionObject_FunctionDeclaration_3E0DE254_combine::_environment0_Function_RestParameters_WithNamedParams
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3E0DE254_combine::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x221d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3E0DE254_combine::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2220
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3E0DE254_combine::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2223
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_RestParameters_WithNamedParams/Scope Modules.Function_RestParameters_WithNamedParams/combine/FunctionObject_FunctionDeclaration_3E0DE254_combine::_environment0_Function_RestParameters_WithNamedParams
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Function_RestParameters_WithNamedParams/combine::__js_call__(class Modules.Function_RestParameters_WithNamedParams/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_3E0DE254_combine::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x223c
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_RestParameters_WithNamedParams/Scope Modules.Function_RestParameters_WithNamedParams/combine/FunctionObject_FunctionDeclaration_3E0DE254_combine::_environment0_Function_RestParameters_WithNamedParams
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Function_RestParameters_WithNamedParams/combine::__js_call__(class Modules.Function_RestParameters_WithNamedParams/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_3E0DE254_combine::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2251
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3E0DE254_combine::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_3E0DE254_combine
+
 
 		// Methods
 		.method public hidebysig static 
@@ -227,7 +340,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_RestParameters_WithNamedParams/Scope,
-			[1] class FunctionObjects.Function_RestParameters_WithNamedParams_343327BC.FunctionObject_FunctionDeclaration_3E0DE254_combine,
+			[1] class Modules.Function_RestParameters_WithNamedParams/combine/FunctionObject_FunctionDeclaration_3E0DE254_combine,
 			[2] object[],
 			[3] object,
 			[4] object
@@ -246,13 +359,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Function_RestParameters_WithNamedParams/Scope
-		IL_0019: newobj instance void FunctionObjects.Function_RestParameters_WithNamedParams_343327BC.FunctionObject_FunctionDeclaration_3E0DE254_combine::.ctor(class Modules.Function_RestParameters_WithNamedParams/Scope)
+		IL_0019: newobj instance void Modules.Function_RestParameters_WithNamedParams/combine/FunctionObject_FunctionDeclaration_3E0DE254_combine::.ctor(class Modules.Function_RestParameters_WithNamedParams/Scope)
 		IL_001e: ldc.i4.1
 		IL_001f: conv.r8
 		IL_0020: ldstr "combine"
 		IL_0025: ldc.i4.1
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_RestParameters_WithNamedParams_343327BC.FunctionObject_FunctionDeclaration_3E0DE254_combine>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_RestParameters_WithNamedParams/combine/FunctionObject_FunctionDeclaration_3E0DE254_combine>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
@@ -327,119 +440,6 @@
 	} // end of method Function_RestParameters_WithNamedParams::__js_module_init__
 
 } // end of class Modules.Function_RestParameters_WithNamedParams
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_RestParameters_WithNamedParams_343327BC.FunctionObject_FunctionDeclaration_3E0DE254_combine
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_RestParameters_WithNamedParams/Scope _environment0_Function_RestParameters_WithNamedParams
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_RestParameters_WithNamedParams/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x220e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_RestParameters_WithNamedParams/Scope FunctionObjects.Function_RestParameters_WithNamedParams_343327BC.FunctionObject_FunctionDeclaration_3E0DE254_combine::_environment0_Function_RestParameters_WithNamedParams
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3E0DE254_combine::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x221d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3E0DE254_combine::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2220
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3E0DE254_combine::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2223
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_RestParameters_WithNamedParams/Scope FunctionObjects.Function_RestParameters_WithNamedParams_343327BC.FunctionObject_FunctionDeclaration_3E0DE254_combine::_environment0_Function_RestParameters_WithNamedParams
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Function_RestParameters_WithNamedParams/combine::__js_call__(class Modules.Function_RestParameters_WithNamedParams/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_3E0DE254_combine::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x223c
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_RestParameters_WithNamedParams/Scope FunctionObjects.Function_RestParameters_WithNamedParams_343327BC.FunctionObject_FunctionDeclaration_3E0DE254_combine::_environment0_Function_RestParameters_WithNamedParams
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Function_RestParameters_WithNamedParams/combine::__js_call__(class Modules.Function_RestParameters_WithNamedParams/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_3E0DE254_combine::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2251
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3E0DE254_combine::ConstructCore
-
-} // end of class FunctionObjects.Function_RestParameters_WithNamedParams_343327BC.FunctionObject_FunctionDeclaration_3E0DE254_combine
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ReturnObjectWithClosure.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ReturnObjectWithClosure.verified.txt
@@ -35,6 +35,124 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_314E1964_multiply
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Function_ReturnObjectWithClosure/createCalculator/Scope _environment1_createCalculator
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Function_ReturnObjectWithClosure/createCalculator/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x2292
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Function_ReturnObjectWithClosure/createCalculator/Scope Modules.Function_ReturnObjectWithClosure/createCalculator/multiply/FunctionObject_FunctionDeclaration_314E1964_multiply::_environment1_createCalculator
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Function_ReturnObjectWithClosure/createCalculator/multiply/FunctionObject_FunctionDeclaration_314E1964_multiply::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionDeclaration_314E1964_multiply::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x22a8
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_314E1964_multiply::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x22ab
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_314E1964_multiply::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x22ae
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Function_ReturnObjectWithClosure/createCalculator/multiply/FunctionObject_FunctionDeclaration_314E1964_multiply::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Function_ReturnObjectWithClosure/createCalculator/multiply::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionDeclaration_314E1964_multiply::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x22c7
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Function_ReturnObjectWithClosure/createCalculator/multiply/FunctionObject_FunctionDeclaration_314E1964_multiply::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Function_ReturnObjectWithClosure/createCalculator/multiply::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionDeclaration_314E1964_multiply::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x22dc
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionDeclaration_314E1964_multiply::ConstructCore
+
+			} // end of class FunctionObject_FunctionDeclaration_314E1964_multiply
+
 
 			// Methods
 			.method public hidebysig static 
@@ -101,6 +219,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_ReturnObjectWithClosure/Scope _environment0_Function_ReturnObjectWithClosure
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_ReturnObjectWithClosure/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2240
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_ReturnObjectWithClosure/Scope Modules.Function_ReturnObjectWithClosure/createCalculator/FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::_environment0_Function_ReturnObjectWithClosure
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x224f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2252
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2255
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_ReturnObjectWithClosure/Scope Modules.Function_ReturnObjectWithClosure/createCalculator/FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::_environment0_Function_ReturnObjectWithClosure
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Function_ReturnObjectWithClosure/createCalculator::__js_call__(class Modules.Function_ReturnObjectWithClosure/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x226e
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_ReturnObjectWithClosure/Scope Modules.Function_ReturnObjectWithClosure/createCalculator/FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::_environment0_Function_ReturnObjectWithClosure
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Function_ReturnObjectWithClosure/createCalculator::__js_call__(class Modules.Function_ReturnObjectWithClosure/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2283
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator
+
 
 		// Methods
 		.method public hidebysig static 
@@ -121,7 +352,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Function_ReturnObjectWithClosure/createCalculator/Scope,
-				[1] class FunctionObjects.Function_ReturnObjectWithClosure_74AB32AC.FunctionObject_FunctionDeclaration_314E1964_multiply,
+				[1] class Modules.Function_ReturnObjectWithClosure/createCalculator/multiply/FunctionObject_FunctionDeclaration_314E1964_multiply,
 				[2] object[],
 				[3] object,
 				[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
@@ -148,13 +379,13 @@
 			IL_001e: ldelem.ref
 			IL_001f: castclass Modules.Function_ReturnObjectWithClosure/createCalculator/Scope
 			IL_0024: ldloc.2
-			IL_0025: newobj instance void FunctionObjects.Function_ReturnObjectWithClosure_74AB32AC.FunctionObject_FunctionDeclaration_314E1964_multiply::.ctor(class Modules.Function_ReturnObjectWithClosure/createCalculator/Scope, object[])
+			IL_0025: newobj instance void Modules.Function_ReturnObjectWithClosure/createCalculator/multiply/FunctionObject_FunctionDeclaration_314E1964_multiply::.ctor(class Modules.Function_ReturnObjectWithClosure/createCalculator/Scope, object[])
 			IL_002a: ldc.i4.1
 			IL_002b: conv.r8
 			IL_002c: ldstr "multiply"
 			IL_0031: ldc.i4.0
 			IL_0032: ldc.i4.1
-			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_ReturnObjectWithClosure_74AB32AC.FunctionObject_FunctionDeclaration_314E1964_multiply>(!!0, float64, string, bool, bool)
+			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ReturnObjectWithClosure/createCalculator/multiply/FunctionObject_FunctionDeclaration_314E1964_multiply>(!!0, float64, string, bool, bool)
 			IL_0038: stloc.1
 			IL_0039: nop
 			IL_003a: ldloc.0
@@ -221,7 +452,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ReturnObjectWithClosure/Scope,
-			[1] class FunctionObjects.Function_ReturnObjectWithClosure_74AB32AC.FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator,
+			[1] class Modules.Function_ReturnObjectWithClosure/createCalculator/FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator,
 			[2] object,
 			[3] object,
 			[4] object[],
@@ -242,13 +473,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Function_ReturnObjectWithClosure/Scope
-		IL_001b: newobj instance void FunctionObjects.Function_ReturnObjectWithClosure_74AB32AC.FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::.ctor(class Modules.Function_ReturnObjectWithClosure/Scope)
+		IL_001b: newobj instance void Modules.Function_ReturnObjectWithClosure/createCalculator/FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::.ctor(class Modules.Function_ReturnObjectWithClosure/Scope)
 		IL_0020: ldc.i4.1
 		IL_0021: conv.r8
 		IL_0022: ldstr "createCalculator"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_ReturnObjectWithClosure_74AB32AC.FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ReturnObjectWithClosure/createCalculator/FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: nop
 		IL_0030: nop
@@ -320,237 +551,6 @@
 	} // end of method Function_ReturnObjectWithClosure::__js_module_init__
 
 } // end of class Modules.Function_ReturnObjectWithClosure
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ReturnObjectWithClosure_74AB32AC.FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_ReturnObjectWithClosure/Scope _environment0_Function_ReturnObjectWithClosure
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_ReturnObjectWithClosure/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2240
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_ReturnObjectWithClosure/Scope FunctionObjects.Function_ReturnObjectWithClosure_74AB32AC.FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::_environment0_Function_ReturnObjectWithClosure
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x224f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2252
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2255
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_ReturnObjectWithClosure/Scope FunctionObjects.Function_ReturnObjectWithClosure_74AB32AC.FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::_environment0_Function_ReturnObjectWithClosure
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Function_ReturnObjectWithClosure/createCalculator::__js_call__(class Modules.Function_ReturnObjectWithClosure/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x226e
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_ReturnObjectWithClosure/Scope FunctionObjects.Function_ReturnObjectWithClosure_74AB32AC.FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::_environment0_Function_ReturnObjectWithClosure
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Function_ReturnObjectWithClosure/createCalculator::__js_call__(class Modules.Function_ReturnObjectWithClosure/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2283
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator::ConstructCore
-
-} // end of class FunctionObjects.Function_ReturnObjectWithClosure_74AB32AC.FunctionObject_FunctionDeclaration_F6A82D9B_createCalculator
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ReturnObjectWithClosure_74AB32AC.FunctionObject_FunctionDeclaration_314E1964_multiply
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_ReturnObjectWithClosure/createCalculator/Scope _environment1_createCalculator
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_ReturnObjectWithClosure/createCalculator/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x2292
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_ReturnObjectWithClosure/createCalculator/Scope FunctionObjects.Function_ReturnObjectWithClosure_74AB32AC.FunctionObject_FunctionDeclaration_314E1964_multiply::_environment1_createCalculator
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Function_ReturnObjectWithClosure_74AB32AC.FunctionObject_FunctionDeclaration_314E1964_multiply::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_314E1964_multiply::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22a8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_314E1964_multiply::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22ab
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_314E1964_multiply::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22ae
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Function_ReturnObjectWithClosure_74AB32AC.FunctionObject_FunctionDeclaration_314E1964_multiply::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Function_ReturnObjectWithClosure/createCalculator/multiply::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_314E1964_multiply::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22c7
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Function_ReturnObjectWithClosure_74AB32AC.FunctionObject_FunctionDeclaration_314E1964_multiply::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Function_ReturnObjectWithClosure/createCalculator/multiply::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_314E1964_multiply::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22dc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_314E1964_multiply::ConstructCore
-
-} // end of class FunctionObjects.Function_ReturnObjectWithClosure_74AB32AC.FunctionObject_FunctionDeclaration_314E1964_multiply
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ReturnsStaticValueAndLogs.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_ReturnsStaticValueAndLogs.verified.txt
@@ -31,6 +31,103 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_754F5DB8_returnsFive
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x20fe
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_754F5DB8_returnsFive::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2106
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_754F5DB8_returnsFive::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2109
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_754F5DB8_returnsFive::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x210c
+				// Header size: 1
+				// Code size: 16 (0x10)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call float64 Modules.Function_ReturnsStaticValueAndLogs/returnsFive::__js_call__(object)
+				IL_000a: box [System.Runtime]System.Double
+				IL_000f: ret
+			} // end of method FunctionObject_FunctionDeclaration_754F5DB8_returnsFive::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x211d
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call float64 Modules.Function_ReturnsStaticValueAndLogs/returnsFive::__js_call__(object)
+				IL_0006: box [System.Runtime]System.Double
+				IL_000b: ret
+			} // end of method FunctionObject_FunctionDeclaration_754F5DB8_returnsFive::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x212a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_754F5DB8_returnsFive::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_754F5DB8_returnsFive
+
 
 		// Methods
 		.method public hidebysig static 
@@ -104,7 +201,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_ReturnsStaticValueAndLogs/Scope,
-			[1] class FunctionObjects.Function_ReturnsStaticValueAndLogs_CCB2E1F2.FunctionObject_FunctionDeclaration_754F5DB8_returnsFive,
+			[1] class Modules.Function_ReturnsStaticValueAndLogs/returnsFive/FunctionObject_FunctionDeclaration_754F5DB8_returnsFive,
 			[2] float64,
 			[3] object[],
 			[4] object,
@@ -120,13 +217,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.Function_ReturnsStaticValueAndLogs_CCB2E1F2.FunctionObject_FunctionDeclaration_754F5DB8_returnsFive::.ctor()
+		IL_0011: newobj instance void Modules.Function_ReturnsStaticValueAndLogs/returnsFive/FunctionObject_FunctionDeclaration_754F5DB8_returnsFive::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "returnsFive"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_ReturnsStaticValueAndLogs_CCB2E1F2.FunctionObject_FunctionDeclaration_754F5DB8_returnsFive>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_ReturnsStaticValueAndLogs/returnsFive/FunctionObject_FunctionDeclaration_754F5DB8_returnsFive>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -152,103 +249,6 @@
 	} // end of method Function_ReturnsStaticValueAndLogs::__js_module_init__
 
 } // end of class Modules.Function_ReturnsStaticValueAndLogs
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_ReturnsStaticValueAndLogs_CCB2E1F2.FunctionObject_FunctionDeclaration_754F5DB8_returnsFive
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x20fe
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_754F5DB8_returnsFive::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2106
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_754F5DB8_returnsFive::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2109
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_754F5DB8_returnsFive::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x210c
-		// Header size: 1
-		// Code size: 16 (0x10)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call float64 Modules.Function_ReturnsStaticValueAndLogs/returnsFive::__js_call__(object)
-		IL_000a: box [System.Runtime]System.Double
-		IL_000f: ret
-	} // end of method FunctionObject_FunctionDeclaration_754F5DB8_returnsFive::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x211d
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call float64 Modules.Function_ReturnsStaticValueAndLogs/returnsFive::__js_call__(object)
-		IL_0006: box [System.Runtime]System.Double
-		IL_000b: ret
-	} // end of method FunctionObject_FunctionDeclaration_754F5DB8_returnsFive::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x212a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_754F5DB8_returnsFive::ConstructCore
-
-} // end of class FunctionObjects.Function_ReturnsStaticValueAndLogs_CCB2E1F2.FunctionObject_FunctionDeclaration_754F5DB8_returnsFive
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerCallResults.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerCallResults.verified.txt
@@ -31,6 +31,109 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6A061CB8_math
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x333d
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_6A061CB8_math::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3345
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6A061CB8_math::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3348
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6A061CB8_math::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x334b
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: call object Modules.Function_SchedulerCallResults/math::__js_call__(object, float64)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_6A061CB8_math::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3363
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: call object Modules.Function_SchedulerCallResults/math::__js_call__(object, float64)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_6A061CB8_math::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3377
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6A061CB8_math::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_6A061CB8_math
+
 
 		// Methods
 		.method public hidebysig static 
@@ -83,6 +186,109 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B2F496B1_nestedCall
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3386
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_B2F496B1_nestedCall::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x338e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B2F496B1_nestedCall::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3391
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B2F496B1_nestedCall::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3394
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: call object Modules.Function_SchedulerCallResults/nestedCall::__js_call__(object, float64)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_B2F496B1_nestedCall::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x33ac
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: call object Modules.Function_SchedulerCallResults/nestedCall::__js_call__(object, float64)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_B2F496B1_nestedCall::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x33c0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B2F496B1_nestedCall::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_B2F496B1_nestedCall
+
 
 		// Methods
 		.method public hidebysig static 
@@ -132,6 +338,117 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_29CCB5FD_compareCall
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x33cf
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_29CCB5FD_compareCall::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x33d7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_29CCB5FD_compareCall::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x33da
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_29CCB5FD_compareCall::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x33dd
+				// Header size: 1
+				// Code size: 35 (0x23)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001d: call object Modules.Function_SchedulerCallResults/compareCall::__js_call__(object, float64, float64)
+				IL_0022: ret
+			} // end of method FunctionObject_FunctionDeclaration_29CCB5FD_compareCall::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3401
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0019: call object Modules.Function_SchedulerCallResults/compareCall::__js_call__(object, float64, float64)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_29CCB5FD_compareCall::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3421
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_29CCB5FD_compareCall::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_29CCB5FD_compareCall
 
 
 		// Methods
@@ -185,6 +502,109 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6A57C981_argumentCall
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3430
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_6A57C981_argumentCall::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3438
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6A57C981_argumentCall::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x343b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6A57C981_argumentCall::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x343e
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: call object Modules.Function_SchedulerCallResults/argumentCall::__js_call__(object, float64)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_6A57C981_argumentCall::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3456
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: call object Modules.Function_SchedulerCallResults/argumentCall::__js_call__(object, float64)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_6A57C981_argumentCall::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x346a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6A57C981_argumentCall::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_6A57C981_argumentCall
 
 
 		// Methods
@@ -247,6 +667,125 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3479
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3481
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3484
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3487
+				// Header size: 1
+				// Code size: 47 (0x2f)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001d: ldarg.2
+				IL_001e: ldc.i4.2
+				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0029: call object Modules.Function_SchedulerCallResults/argumentDependency::__js_call__(object, float64, float64, float64)
+				IL_002e: ret
+			} // end of method FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x34b7
+				// Header size: 1
+				// Code size: 43 (0x2b)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0025: call object Modules.Function_SchedulerCallResults/argumentDependency::__js_call__(object, float64, float64, float64)
+				IL_002a: ret
+			} // end of method FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x34e3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency
 
 
 		// Methods
@@ -315,6 +854,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_35BAD19F_g
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_SchedulerCallResults/Scope _environment0_Function_SchedulerCallResults
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_SchedulerCallResults/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x34f2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/g/FunctionObject_FunctionDeclaration_35BAD19F_g::_environment0_Function_SchedulerCallResults
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_35BAD19F_g::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3501
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_35BAD19F_g::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3504
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_35BAD19F_g::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3507
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/g/FunctionObject_FunctionDeclaration_35BAD19F_g::_environment0_Function_SchedulerCallResults
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_SchedulerCallResults/g::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_35BAD19F_g::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3519
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/g/FunctionObject_FunctionDeclaration_35BAD19F_g::_environment0_Function_SchedulerCallResults
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_SchedulerCallResults/g::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_35BAD19F_g::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3527
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_35BAD19F_g::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_35BAD19F_g
+
 
 		// Methods
 		.method public hidebysig static 
@@ -378,6 +1024,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3ABAD97E_h
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_SchedulerCallResults/Scope _environment0_Function_SchedulerCallResults
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_SchedulerCallResults/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3536
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/h/FunctionObject_FunctionDeclaration_3ABAD97E_h::_environment0_Function_SchedulerCallResults
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3ABAD97E_h::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3545
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3ABAD97E_h::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3548
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3ABAD97E_h::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x354b
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/h/FunctionObject_FunctionDeclaration_3ABAD97E_h::_environment0_Function_SchedulerCallResults
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_SchedulerCallResults/h::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_3ABAD97E_h::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x355d
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/h/FunctionObject_FunctionDeclaration_3ABAD97E_h::_environment0_Function_SchedulerCallResults
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_SchedulerCallResults/h::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_3ABAD97E_h::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x356b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3ABAD97E_h::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_3ABAD97E_h
+
 
 		// Methods
 		.method public hidebysig static 
@@ -440,6 +1193,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_86C347EB_ordered
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_SchedulerCallResults/Scope _environment0_Function_SchedulerCallResults
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_SchedulerCallResults/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x357a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/ordered/FunctionObject_FunctionDeclaration_86C347EB_ordered::_environment0_Function_SchedulerCallResults
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_86C347EB_ordered::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3589
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_86C347EB_ordered::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x358c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_86C347EB_ordered::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x358f
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/ordered/FunctionObject_FunctionDeclaration_86C347EB_ordered::_environment0_Function_SchedulerCallResults
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_SchedulerCallResults/ordered::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_86C347EB_ordered::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x35a1
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/ordered/FunctionObject_FunctionDeclaration_86C347EB_ordered::_environment0_Function_SchedulerCallResults
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_SchedulerCallResults/ordered::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_86C347EB_ordered::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x35af
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_86C347EB_ordered::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_86C347EB_ordered
 
 
 		// Methods
@@ -731,6 +1591,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9A5CC64E_throwing
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_SchedulerCallResults/Scope _environment0_Function_SchedulerCallResults
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_SchedulerCallResults/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x35be
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/throwing/FunctionObject_FunctionDeclaration_9A5CC64E_throwing::_environment0_Function_SchedulerCallResults
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A5CC64E_throwing::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x35cd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A5CC64E_throwing::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x35d0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A5CC64E_throwing::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x35d3
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/throwing/FunctionObject_FunctionDeclaration_9A5CC64E_throwing::_environment0_Function_SchedulerCallResults
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_SchedulerCallResults/throwing::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A5CC64E_throwing::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x35e5
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/throwing/FunctionObject_FunctionDeclaration_9A5CC64E_throwing::_environment0_Function_SchedulerCallResults
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_SchedulerCallResults/throwing::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A5CC64E_throwing::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x35f3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A5CC64E_throwing::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9A5CC64E_throwing
+
 
 		// Methods
 		.method public hidebysig static 
@@ -892,6 +1859,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E0F2AA72_multiUse
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_SchedulerCallResults/Scope _environment0_Function_SchedulerCallResults
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_SchedulerCallResults/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x362c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/multiUse/FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::_environment0_Function_SchedulerCallResults
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x363b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x363e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3641
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/multiUse/FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::_environment0_Function_SchedulerCallResults
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_SchedulerCallResults/multiUse::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3653
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/multiUse/FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::_environment0_Function_SchedulerCallResults
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_SchedulerCallResults/multiUse::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3661
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E0F2AA72_multiUse
+
 
 		// Methods
 		.method public hidebysig static 
@@ -976,6 +2050,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_SchedulerCallResults/Scope _environment0_Function_SchedulerCallResults
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_SchedulerCallResults/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3825
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/fluentTypedCalls/FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::_environment0_Function_SchedulerCallResults
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3834
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3837
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x383a
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/fluentTypedCalls/FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::_environment0_Function_SchedulerCallResults
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_SchedulerCallResults/fluentTypedCalls::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x384c
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/fluentTypedCalls/FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::_environment0_Function_SchedulerCallResults
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_SchedulerCallResults/fluentTypedCalls::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x385a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls
 
 
 		// Methods
@@ -1064,6 +2245,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_SchedulerCallResults/Scope _environment0_Function_SchedulerCallResults
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_SchedulerCallResults/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3869
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/singleTypedCall/FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::_environment0_Function_SchedulerCallResults
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3878
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x387b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x387e
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/singleTypedCall/FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::_environment0_Function_SchedulerCallResults
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_SchedulerCallResults/singleTypedCall::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3890
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/singleTypedCall/FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::_environment0_Function_SchedulerCallResults
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_SchedulerCallResults/singleTypedCall::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x389e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall
 
 
 		// Methods
@@ -1171,6 +2459,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_SchedulerCallResults/Scope _environment0_Function_SchedulerCallResults
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_SchedulerCallResults/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x38ad
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/scheduledInlineCall/FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::_environment0_Function_SchedulerCallResults
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x38bc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x38bf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x38c2
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/scheduledInlineCall/FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::_environment0_Function_SchedulerCallResults
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_SchedulerCallResults/scheduledInlineCall::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x38d4
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/scheduledInlineCall/FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::_environment0_Function_SchedulerCallResults
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_SchedulerCallResults/scheduledInlineCall::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x38e2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1263,6 +2658,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_SchedulerCallResults/Scope _environment0_Function_SchedulerCallResults
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_SchedulerCallResults/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x38f1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/deepScheduledInlineCall/FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::_environment0_Function_SchedulerCallResults
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3900
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3903
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3906
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/deepScheduledInlineCall/FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::_environment0_Function_SchedulerCallResults
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_SchedulerCallResults/deepScheduledInlineCall::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3918
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/deepScheduledInlineCall/FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::_environment0_Function_SchedulerCallResults
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_SchedulerCallResults/deepScheduledInlineCall::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3926
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1351,6 +2853,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_SchedulerCallResults/Scope _environment0_Function_SchedulerCallResults
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_SchedulerCallResults/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3935
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/deepScheduledInlineCallWithCarriedResult/FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::_environment0_Function_SchedulerCallResults
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3944
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3947
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x394a
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/deepScheduledInlineCallWithCarriedResult/FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::_environment0_Function_SchedulerCallResults
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_SchedulerCallResults/deepScheduledInlineCallWithCarriedResult::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x395c
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope Modules.Function_SchedulerCallResults/deepScheduledInlineCallWithCarriedResult/FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::_environment0_Function_SchedulerCallResults
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_SchedulerCallResults/deepScheduledInlineCallWithCarriedResult::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x396a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult
 
 
 		// Methods
@@ -1640,6 +3249,672 @@
 			} // end of method Scope_maxSumWithFloor::.ctor
 
 		} // end of class Scope_maxSumWithFloor
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_AD25A3C2_Counter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3670
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Function_SchedulerCallResults/Counter/FunctionObject_ClassConstructor_AD25A3C2_Counter::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_AD25A3C2_Counter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x367f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_AD25A3C2_Counter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3682
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_AD25A3C2_Counter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3685
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_AD25A3C2_Counter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3691
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_AD25A3C2_Counter::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_AD25A3C2_Counter
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_3AF3677E_Counter_add
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x369d
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_3AF3677E_Counter_add::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x36a5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_3AF3677E_Counter_add::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x36a8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_3AF3677E_Counter_add::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x36ab
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Function_SchedulerCallResults/Counter
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance class Modules.Function_SchedulerCallResults/Counter Modules.Function_SchedulerCallResults/Counter::'add'(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassMethod_3AF3677E_Counter_add::CallCore
+
+		} // end of class FunctionObject_ClassMethod_3AF3677E_Counter_add
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_1144290A_Counter_getValue
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x36bf
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_1144290A_Counter_getValue::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x36c7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_1144290A_Counter_getValue::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x36ca
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_1144290A_Counter_getValue::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x36cd
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Function_SchedulerCallResults/Counter
+				IL_0006: call instance object Modules.Function_SchedulerCallResults/Counter::getValue()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_1144290A_Counter_getValue::CallCore
+
+		} // end of class FunctionObject_ClassMethod_1144290A_Counter_getValue
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_CA685DB0_Counter_chain
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x36da
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_CA685DB0_Counter_chain::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x36e2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_CA685DB0_Counter_chain::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x36e5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_CA685DB0_Counter_chain::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x36e8
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Function_SchedulerCallResults/Counter
+				IL_0006: call instance object Modules.Function_SchedulerCallResults/Counter::chain()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_CA685DB0_Counter_chain::CallCore
+
+		} // end of class FunctionObject_ClassMethod_CA685DB0_Counter_chain
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x36f5
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x36fd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3700
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3703
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Function_SchedulerCallResults/Counter
+				IL_0006: call instance object Modules.Function_SchedulerCallResults/Counter::addOnce()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce::CallCore
+
+		} // end of class FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_7D3B0342_Counter_next
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3710
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_7D3B0342_Counter_next::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3718
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_7D3B0342_Counter_next::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x371b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_7D3B0342_Counter_next::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x371e
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Function_SchedulerCallResults/Counter
+				IL_0006: call instance object Modules.Function_SchedulerCallResults/Counter::next()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_7D3B0342_Counter_next::CallCore
+
+		} // end of class FunctionObject_ClassMethod_7D3B0342_Counter_next
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_F11C223A_Counter_maxNext
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x372b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_F11C223A_Counter_maxNext::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3733
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_F11C223A_Counter_maxNext::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3736
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_F11C223A_Counter_maxNext::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3739
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Function_SchedulerCallResults/Counter
+				IL_0006: call instance float64 Modules.Function_SchedulerCallResults/Counter::maxNext()
+				IL_000b: box [System.Runtime]System.Double
+				IL_0010: ret
+			} // end of method FunctionObject_ClassMethod_F11C223A_Counter_maxNext::CallCore
+
+		} // end of class FunctionObject_ClassMethod_F11C223A_Counter_maxNext
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_2830FF5E_Counter_sum
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x374b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_2830FF5E_Counter_sum::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3753
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_2830FF5E_Counter_sum::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3756
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_2830FF5E_Counter_sum::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x375c
+				// Header size: 12
+				// Code size: 125 (0x7d)
+				.maxstack 12
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Function_SchedulerCallResults/Counter
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001e: ldarg.2
+				IL_001f: ldc.i4.2
+				IL_0020: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0025: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_002a: ldarg.2
+				IL_002b: ldc.i4.3
+				IL_002c: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0031: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0036: ldarg.2
+				IL_0037: ldc.i4.4
+				IL_0038: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_003d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0042: ldarg.2
+				IL_0043: ldc.i4.5
+				IL_0044: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0049: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_004e: ldarg.2
+				IL_004f: ldc.i4.6
+				IL_0050: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_005a: ldarg.2
+				IL_005b: ldc.i4.7
+				IL_005c: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0061: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0066: ldarg.2
+				IL_0067: ldc.i4.8
+				IL_0068: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_006d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0072: call instance float64 Modules.Function_SchedulerCallResults/Counter::sum(float64, float64, float64, float64, float64, float64, float64, float64, float64)
+				IL_0077: box [System.Runtime]System.Double
+				IL_007c: ret
+			} // end of method FunctionObject_ClassMethod_2830FF5E_Counter_sum::CallCore
+
+		} // end of class FunctionObject_ClassMethod_2830FF5E_Counter_sum
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_A75B52F6_Counter_maxSum
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x37e5
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_A75B52F6_Counter_maxSum::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x37ed
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_A75B52F6_Counter_maxSum::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x37f0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_A75B52F6_Counter_maxSum::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x37f3
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Function_SchedulerCallResults/Counter
+				IL_0006: call instance float64 Modules.Function_SchedulerCallResults/Counter::maxSum()
+				IL_000b: box [System.Runtime]System.Double
+				IL_0010: ret
+			} // end of method FunctionObject_ClassMethod_A75B52F6_Counter_maxSum::CallCore
+
+		} // end of class FunctionObject_ClassMethod_A75B52F6_Counter_maxSum
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3805
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x380d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3810
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3813
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Function_SchedulerCallResults/Counter
+				IL_0006: call instance float64 Modules.Function_SchedulerCallResults/Counter::maxSumWithFloor()
+				IL_000b: box [System.Runtime]System.Double
+				IL_0010: ret
+			} // end of method FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor::CallCore
+
+		} // end of class FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor
 
 
 		// Fields
@@ -2044,22 +4319,22 @@
 		.maxstack 13
 		.locals init (
 			[0] class Modules.Function_SchedulerCallResults/Scope,
-			[1] class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_6A061CB8_math,
-			[2] class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_B2F496B1_nestedCall,
-			[3] class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_29CCB5FD_compareCall,
-			[4] class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_6A57C981_argumentCall,
-			[5] class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency,
-			[6] class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_86C347EB_ordered,
-			[7] class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_9A5CC64E_throwing,
-			[8] class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_E0F2AA72_multiUse,
-			[9] class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls,
-			[10] class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall,
-			[11] class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall,
-			[12] class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall,
-			[13] class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult,
+			[1] class Modules.Function_SchedulerCallResults/math/FunctionObject_FunctionDeclaration_6A061CB8_math,
+			[2] class Modules.Function_SchedulerCallResults/nestedCall/FunctionObject_FunctionDeclaration_B2F496B1_nestedCall,
+			[3] class Modules.Function_SchedulerCallResults/compareCall/FunctionObject_FunctionDeclaration_29CCB5FD_compareCall,
+			[4] class Modules.Function_SchedulerCallResults/argumentCall/FunctionObject_FunctionDeclaration_6A57C981_argumentCall,
+			[5] class Modules.Function_SchedulerCallResults/argumentDependency/FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency,
+			[6] class Modules.Function_SchedulerCallResults/ordered/FunctionObject_FunctionDeclaration_86C347EB_ordered,
+			[7] class Modules.Function_SchedulerCallResults/throwing/FunctionObject_FunctionDeclaration_9A5CC64E_throwing,
+			[8] class Modules.Function_SchedulerCallResults/multiUse/FunctionObject_FunctionDeclaration_E0F2AA72_multiUse,
+			[9] class Modules.Function_SchedulerCallResults/fluentTypedCalls/FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls,
+			[10] class Modules.Function_SchedulerCallResults/singleTypedCall/FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall,
+			[11] class Modules.Function_SchedulerCallResults/scheduledInlineCall/FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall,
+			[12] class Modules.Function_SchedulerCallResults/deepScheduledInlineCall/FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall,
+			[13] class Modules.Function_SchedulerCallResults/deepScheduledInlineCallWithCarriedResult/FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult,
 			[14] object[],
-			[15] class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_35BAD19F_g,
-			[16] class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_3ABAD97E_h,
+			[15] class Modules.Function_SchedulerCallResults/g/FunctionObject_FunctionDeclaration_35BAD19F_g,
+			[16] class Modules.Function_SchedulerCallResults/h/FunctionObject_FunctionDeclaration_3ABAD97E_h,
 			[17] class [System.Runtime]System.Type,
 			[18] object,
 			[19] object,
@@ -2076,13 +4351,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 14
-		IL_0012: newobj instance void FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_6A061CB8_math::.ctor()
+		IL_0012: newobj instance void Modules.Function_SchedulerCallResults/math/FunctionObject_FunctionDeclaration_6A061CB8_math::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "math"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_6A061CB8_math>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/math/FunctionObject_FunctionDeclaration_6A061CB8_math>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -2091,13 +4366,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 14
-		IL_0032: newobj instance void FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_B2F496B1_nestedCall::.ctor()
+		IL_0032: newobj instance void Modules.Function_SchedulerCallResults/nestedCall/FunctionObject_FunctionDeclaration_B2F496B1_nestedCall::.ctor()
 		IL_0037: ldc.i4.1
 		IL_0038: conv.r8
 		IL_0039: ldstr "nestedCall"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_B2F496B1_nestedCall>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/nestedCall/FunctionObject_FunctionDeclaration_B2F496B1_nestedCall>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -2106,13 +4381,13 @@
 		IL_004e: ldloc.0
 		IL_004f: stelem.ref
 		IL_0050: stloc.s 14
-		IL_0052: newobj instance void FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_29CCB5FD_compareCall::.ctor()
+		IL_0052: newobj instance void Modules.Function_SchedulerCallResults/compareCall/FunctionObject_FunctionDeclaration_29CCB5FD_compareCall::.ctor()
 		IL_0057: ldc.i4.2
 		IL_0058: conv.r8
 		IL_0059: ldstr "compareCall"
 		IL_005e: ldc.i4.0
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_29CCB5FD_compareCall>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/compareCall/FunctionObject_FunctionDeclaration_29CCB5FD_compareCall>(!!0, float64, string, bool, bool)
 		IL_0065: stloc.3
 		IL_0066: ldc.i4.1
 		IL_0067: newarr [System.Runtime]System.Object
@@ -2121,13 +4396,13 @@
 		IL_006e: ldloc.0
 		IL_006f: stelem.ref
 		IL_0070: stloc.s 14
-		IL_0072: newobj instance void FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_6A57C981_argumentCall::.ctor()
+		IL_0072: newobj instance void Modules.Function_SchedulerCallResults/argumentCall/FunctionObject_FunctionDeclaration_6A57C981_argumentCall::.ctor()
 		IL_0077: ldc.i4.1
 		IL_0078: conv.r8
 		IL_0079: ldstr "argumentCall"
 		IL_007e: ldc.i4.0
 		IL_007f: ldc.i4.1
-		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_6A57C981_argumentCall>(!!0, float64, string, bool, bool)
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/argumentCall/FunctionObject_FunctionDeclaration_6A57C981_argumentCall>(!!0, float64, string, bool, bool)
 		IL_0085: stloc.s 4
 		IL_0087: ldc.i4.1
 		IL_0088: newarr [System.Runtime]System.Object
@@ -2136,13 +4411,13 @@
 		IL_008f: ldloc.0
 		IL_0090: stelem.ref
 		IL_0091: stloc.s 14
-		IL_0093: newobj instance void FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency::.ctor()
+		IL_0093: newobj instance void Modules.Function_SchedulerCallResults/argumentDependency/FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency::.ctor()
 		IL_0098: ldc.i4.3
 		IL_0099: conv.r8
 		IL_009a: ldstr "argumentDependency"
 		IL_009f: ldc.i4.0
 		IL_00a0: ldc.i4.1
-		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency>(!!0, float64, string, bool, bool)
+		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/argumentDependency/FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency>(!!0, float64, string, bool, bool)
 		IL_00a6: stloc.s 5
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -2155,13 +4430,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Function_SchedulerCallResults/Scope
-		IL_00bd: newobj instance void FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_35BAD19F_g::.ctor(class Modules.Function_SchedulerCallResults/Scope)
+		IL_00bd: newobj instance void Modules.Function_SchedulerCallResults/g/FunctionObject_FunctionDeclaration_35BAD19F_g::.ctor(class Modules.Function_SchedulerCallResults/Scope)
 		IL_00c2: ldc.i4.0
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "g"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_35BAD19F_g>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/g/FunctionObject_FunctionDeclaration_35BAD19F_g>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 15
 		IL_00d2: ldloc.0
 		IL_00d3: ldloc.s 15
@@ -2177,13 +4452,13 @@
 		IL_00e8: ldc.i4.0
 		IL_00e9: ldelem.ref
 		IL_00ea: castclass Modules.Function_SchedulerCallResults/Scope
-		IL_00ef: newobj instance void FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_3ABAD97E_h::.ctor(class Modules.Function_SchedulerCallResults/Scope)
+		IL_00ef: newobj instance void Modules.Function_SchedulerCallResults/h/FunctionObject_FunctionDeclaration_3ABAD97E_h::.ctor(class Modules.Function_SchedulerCallResults/Scope)
 		IL_00f4: ldc.i4.0
 		IL_00f5: conv.r8
 		IL_00f6: ldstr "h"
 		IL_00fb: ldc.i4.0
 		IL_00fc: ldc.i4.1
-		IL_00fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_3ABAD97E_h>(!!0, float64, string, bool, bool)
+		IL_00fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/h/FunctionObject_FunctionDeclaration_3ABAD97E_h>(!!0, float64, string, bool, bool)
 		IL_0102: stloc.s 16
 		IL_0104: ldloc.0
 		IL_0105: ldloc.s 16
@@ -2199,13 +4474,13 @@
 		IL_011a: ldc.i4.0
 		IL_011b: ldelem.ref
 		IL_011c: castclass Modules.Function_SchedulerCallResults/Scope
-		IL_0121: newobj instance void FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_86C347EB_ordered::.ctor(class Modules.Function_SchedulerCallResults/Scope)
+		IL_0121: newobj instance void Modules.Function_SchedulerCallResults/ordered/FunctionObject_FunctionDeclaration_86C347EB_ordered::.ctor(class Modules.Function_SchedulerCallResults/Scope)
 		IL_0126: ldc.i4.0
 		IL_0127: conv.r8
 		IL_0128: ldstr "ordered"
 		IL_012d: ldc.i4.0
 		IL_012e: ldc.i4.1
-		IL_012f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_86C347EB_ordered>(!!0, float64, string, bool, bool)
+		IL_012f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/ordered/FunctionObject_FunctionDeclaration_86C347EB_ordered>(!!0, float64, string, bool, bool)
 		IL_0134: stloc.s 6
 		IL_0136: ldc.i4.1
 		IL_0137: newarr [System.Runtime]System.Object
@@ -2218,13 +4493,13 @@
 		IL_0144: ldc.i4.0
 		IL_0145: ldelem.ref
 		IL_0146: castclass Modules.Function_SchedulerCallResults/Scope
-		IL_014b: newobj instance void FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_9A5CC64E_throwing::.ctor(class Modules.Function_SchedulerCallResults/Scope)
+		IL_014b: newobj instance void Modules.Function_SchedulerCallResults/throwing/FunctionObject_FunctionDeclaration_9A5CC64E_throwing::.ctor(class Modules.Function_SchedulerCallResults/Scope)
 		IL_0150: ldc.i4.0
 		IL_0151: conv.r8
 		IL_0152: ldstr "throwing"
 		IL_0157: ldc.i4.0
 		IL_0158: ldc.i4.1
-		IL_0159: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_9A5CC64E_throwing>(!!0, float64, string, bool, bool)
+		IL_0159: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/throwing/FunctionObject_FunctionDeclaration_9A5CC64E_throwing>(!!0, float64, string, bool, bool)
 		IL_015e: stloc.s 7
 		IL_0160: ldc.i4.1
 		IL_0161: newarr [System.Runtime]System.Object
@@ -2237,13 +4512,13 @@
 		IL_016e: ldc.i4.0
 		IL_016f: ldelem.ref
 		IL_0170: castclass Modules.Function_SchedulerCallResults/Scope
-		IL_0175: newobj instance void FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::.ctor(class Modules.Function_SchedulerCallResults/Scope)
+		IL_0175: newobj instance void Modules.Function_SchedulerCallResults/multiUse/FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::.ctor(class Modules.Function_SchedulerCallResults/Scope)
 		IL_017a: ldc.i4.0
 		IL_017b: conv.r8
 		IL_017c: ldstr "multiUse"
 		IL_0181: ldc.i4.0
 		IL_0182: ldc.i4.1
-		IL_0183: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_E0F2AA72_multiUse>(!!0, float64, string, bool, bool)
+		IL_0183: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/multiUse/FunctionObject_FunctionDeclaration_E0F2AA72_multiUse>(!!0, float64, string, bool, bool)
 		IL_0188: stloc.s 8
 		IL_018a: ldc.i4.1
 		IL_018b: newarr [System.Runtime]System.Object
@@ -2256,13 +4531,13 @@
 		IL_0198: ldc.i4.0
 		IL_0199: ldelem.ref
 		IL_019a: castclass Modules.Function_SchedulerCallResults/Scope
-		IL_019f: newobj instance void FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::.ctor(class Modules.Function_SchedulerCallResults/Scope)
+		IL_019f: newobj instance void Modules.Function_SchedulerCallResults/fluentTypedCalls/FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::.ctor(class Modules.Function_SchedulerCallResults/Scope)
 		IL_01a4: ldc.i4.0
 		IL_01a5: conv.r8
 		IL_01a6: ldstr "fluentTypedCalls"
 		IL_01ab: ldc.i4.0
 		IL_01ac: ldc.i4.1
-		IL_01ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls>(!!0, float64, string, bool, bool)
+		IL_01ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/fluentTypedCalls/FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls>(!!0, float64, string, bool, bool)
 		IL_01b2: stloc.s 9
 		IL_01b4: ldc.i4.1
 		IL_01b5: newarr [System.Runtime]System.Object
@@ -2275,13 +4550,13 @@
 		IL_01c2: ldc.i4.0
 		IL_01c3: ldelem.ref
 		IL_01c4: castclass Modules.Function_SchedulerCallResults/Scope
-		IL_01c9: newobj instance void FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::.ctor(class Modules.Function_SchedulerCallResults/Scope)
+		IL_01c9: newobj instance void Modules.Function_SchedulerCallResults/singleTypedCall/FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::.ctor(class Modules.Function_SchedulerCallResults/Scope)
 		IL_01ce: ldc.i4.0
 		IL_01cf: conv.r8
 		IL_01d0: ldstr "singleTypedCall"
 		IL_01d5: ldc.i4.0
 		IL_01d6: ldc.i4.1
-		IL_01d7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall>(!!0, float64, string, bool, bool)
+		IL_01d7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/singleTypedCall/FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall>(!!0, float64, string, bool, bool)
 		IL_01dc: stloc.s 10
 		IL_01de: ldc.i4.1
 		IL_01df: newarr [System.Runtime]System.Object
@@ -2294,13 +4569,13 @@
 		IL_01ec: ldc.i4.0
 		IL_01ed: ldelem.ref
 		IL_01ee: castclass Modules.Function_SchedulerCallResults/Scope
-		IL_01f3: newobj instance void FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::.ctor(class Modules.Function_SchedulerCallResults/Scope)
+		IL_01f3: newobj instance void Modules.Function_SchedulerCallResults/scheduledInlineCall/FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::.ctor(class Modules.Function_SchedulerCallResults/Scope)
 		IL_01f8: ldc.i4.0
 		IL_01f9: conv.r8
 		IL_01fa: ldstr "scheduledInlineCall"
 		IL_01ff: ldc.i4.0
 		IL_0200: ldc.i4.1
-		IL_0201: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall>(!!0, float64, string, bool, bool)
+		IL_0201: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/scheduledInlineCall/FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall>(!!0, float64, string, bool, bool)
 		IL_0206: stloc.s 11
 		IL_0208: ldc.i4.1
 		IL_0209: newarr [System.Runtime]System.Object
@@ -2313,13 +4588,13 @@
 		IL_0216: ldc.i4.0
 		IL_0217: ldelem.ref
 		IL_0218: castclass Modules.Function_SchedulerCallResults/Scope
-		IL_021d: newobj instance void FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::.ctor(class Modules.Function_SchedulerCallResults/Scope)
+		IL_021d: newobj instance void Modules.Function_SchedulerCallResults/deepScheduledInlineCall/FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::.ctor(class Modules.Function_SchedulerCallResults/Scope)
 		IL_0222: ldc.i4.0
 		IL_0223: conv.r8
 		IL_0224: ldstr "deepScheduledInlineCall"
 		IL_0229: ldc.i4.0
 		IL_022a: ldc.i4.1
-		IL_022b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall>(!!0, float64, string, bool, bool)
+		IL_022b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/deepScheduledInlineCall/FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall>(!!0, float64, string, bool, bool)
 		IL_0230: stloc.s 12
 		IL_0232: ldc.i4.1
 		IL_0233: newarr [System.Runtime]System.Object
@@ -2332,13 +4607,13 @@
 		IL_0240: ldc.i4.0
 		IL_0241: ldelem.ref
 		IL_0242: castclass Modules.Function_SchedulerCallResults/Scope
-		IL_0247: newobj instance void FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::.ctor(class Modules.Function_SchedulerCallResults/Scope)
+		IL_0247: newobj instance void Modules.Function_SchedulerCallResults/deepScheduledInlineCallWithCarriedResult/FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::.ctor(class Modules.Function_SchedulerCallResults/Scope)
 		IL_024c: ldc.i4.0
 		IL_024d: conv.r8
 		IL_024e: ldstr "deepScheduledInlineCallWithCarriedResult"
 		IL_0253: ldc.i4.0
 		IL_0254: ldc.i4.1
-		IL_0255: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult>(!!0, float64, string, bool, bool)
+		IL_0255: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerCallResults/deepScheduledInlineCallWithCarriedResult/FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult>(!!0, float64, string, bool, bool)
 		IL_025a: stloc.s 13
 		IL_025c: nop
 		IL_025d: nop
@@ -3032,2281 +5307,6 @@
 	} // end of method Function_SchedulerCallResults::__js_module_init__
 
 } // end of class Modules.Function_SchedulerCallResults
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_6A061CB8_math
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x333d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_6A061CB8_math::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3345
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6A061CB8_math::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3348
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6A061CB8_math::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x334b
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: call object Modules.Function_SchedulerCallResults/math::__js_call__(object, float64)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_6A061CB8_math::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3363
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: call object Modules.Function_SchedulerCallResults/math::__js_call__(object, float64)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_6A061CB8_math::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3377
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6A061CB8_math::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_6A061CB8_math
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_B2F496B1_nestedCall
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3386
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_B2F496B1_nestedCall::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x338e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B2F496B1_nestedCall::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3391
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B2F496B1_nestedCall::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3394
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: call object Modules.Function_SchedulerCallResults/nestedCall::__js_call__(object, float64)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_B2F496B1_nestedCall::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x33ac
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: call object Modules.Function_SchedulerCallResults/nestedCall::__js_call__(object, float64)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_B2F496B1_nestedCall::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x33c0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B2F496B1_nestedCall::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_B2F496B1_nestedCall
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_29CCB5FD_compareCall
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x33cf
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_29CCB5FD_compareCall::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x33d7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_29CCB5FD_compareCall::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x33da
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_29CCB5FD_compareCall::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x33dd
-		// Header size: 1
-		// Code size: 35 (0x23)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001d: call object Modules.Function_SchedulerCallResults/compareCall::__js_call__(object, float64, float64)
-		IL_0022: ret
-	} // end of method FunctionObject_FunctionDeclaration_29CCB5FD_compareCall::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3401
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0019: call object Modules.Function_SchedulerCallResults/compareCall::__js_call__(object, float64, float64)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_29CCB5FD_compareCall::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3421
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_29CCB5FD_compareCall::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_29CCB5FD_compareCall
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_6A57C981_argumentCall
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3430
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_6A57C981_argumentCall::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3438
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6A57C981_argumentCall::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x343b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6A57C981_argumentCall::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x343e
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: call object Modules.Function_SchedulerCallResults/argumentCall::__js_call__(object, float64)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_6A57C981_argumentCall::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3456
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: call object Modules.Function_SchedulerCallResults/argumentCall::__js_call__(object, float64)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_6A57C981_argumentCall::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x346a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6A57C981_argumentCall::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_6A57C981_argumentCall
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3479
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3481
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3484
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3487
-		// Header size: 1
-		// Code size: 47 (0x2f)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001d: ldarg.2
-		IL_001e: ldc.i4.2
-		IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0029: call object Modules.Function_SchedulerCallResults/argumentDependency::__js_call__(object, float64, float64, float64)
-		IL_002e: ret
-	} // end of method FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x34b7
-		// Header size: 1
-		// Code size: 43 (0x2b)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0025: call object Modules.Function_SchedulerCallResults/argumentDependency::__js_call__(object, float64, float64, float64)
-		IL_002a: ret
-	} // end of method FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x34e3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_F2E42C3C_argumentDependency
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_35BAD19F_g
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_SchedulerCallResults/Scope _environment0_Function_SchedulerCallResults
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_SchedulerCallResults/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x34f2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_35BAD19F_g::_environment0_Function_SchedulerCallResults
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_35BAD19F_g::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3501
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_35BAD19F_g::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3504
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_35BAD19F_g::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3507
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_35BAD19F_g::_environment0_Function_SchedulerCallResults
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_SchedulerCallResults/g::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_35BAD19F_g::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3519
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_35BAD19F_g::_environment0_Function_SchedulerCallResults
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_SchedulerCallResults/g::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_35BAD19F_g::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3527
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_35BAD19F_g::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_35BAD19F_g
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_3ABAD97E_h
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_SchedulerCallResults/Scope _environment0_Function_SchedulerCallResults
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_SchedulerCallResults/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3536
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_3ABAD97E_h::_environment0_Function_SchedulerCallResults
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3ABAD97E_h::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3545
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3ABAD97E_h::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3548
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3ABAD97E_h::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x354b
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_3ABAD97E_h::_environment0_Function_SchedulerCallResults
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_SchedulerCallResults/h::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_3ABAD97E_h::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x355d
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_3ABAD97E_h::_environment0_Function_SchedulerCallResults
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_SchedulerCallResults/h::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_3ABAD97E_h::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x356b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3ABAD97E_h::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_3ABAD97E_h
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_86C347EB_ordered
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_SchedulerCallResults/Scope _environment0_Function_SchedulerCallResults
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_SchedulerCallResults/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x357a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_86C347EB_ordered::_environment0_Function_SchedulerCallResults
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_86C347EB_ordered::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3589
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_86C347EB_ordered::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x358c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_86C347EB_ordered::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x358f
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_86C347EB_ordered::_environment0_Function_SchedulerCallResults
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_SchedulerCallResults/ordered::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_86C347EB_ordered::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x35a1
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_86C347EB_ordered::_environment0_Function_SchedulerCallResults
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_SchedulerCallResults/ordered::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_86C347EB_ordered::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x35af
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_86C347EB_ordered::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_86C347EB_ordered
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_9A5CC64E_throwing
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_SchedulerCallResults/Scope _environment0_Function_SchedulerCallResults
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_SchedulerCallResults/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x35be
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_9A5CC64E_throwing::_environment0_Function_SchedulerCallResults
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A5CC64E_throwing::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x35cd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A5CC64E_throwing::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x35d0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A5CC64E_throwing::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x35d3
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_9A5CC64E_throwing::_environment0_Function_SchedulerCallResults
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_SchedulerCallResults/throwing::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A5CC64E_throwing::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x35e5
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_9A5CC64E_throwing::_environment0_Function_SchedulerCallResults
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_SchedulerCallResults/throwing::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A5CC64E_throwing::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x35f3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A5CC64E_throwing::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_9A5CC64E_throwing
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_E0F2AA72_multiUse
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_SchedulerCallResults/Scope _environment0_Function_SchedulerCallResults
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_SchedulerCallResults/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x362c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::_environment0_Function_SchedulerCallResults
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x363b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x363e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3641
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::_environment0_Function_SchedulerCallResults
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_SchedulerCallResults/multiUse::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3653
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::_environment0_Function_SchedulerCallResults
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_SchedulerCallResults/multiUse::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3661
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E0F2AA72_multiUse::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_E0F2AA72_multiUse
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_ClassConstructor_AD25A3C2_Counter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3670
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_ClassConstructor_AD25A3C2_Counter::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_AD25A3C2_Counter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x367f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_AD25A3C2_Counter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3682
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_AD25A3C2_Counter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3685
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_AD25A3C2_Counter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3691
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_AD25A3C2_Counter::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_ClassConstructor_AD25A3C2_Counter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_ClassMethod_3AF3677E_Counter_add
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x369d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_3AF3677E_Counter_add::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x36a5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_3AF3677E_Counter_add::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x36a8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_3AF3677E_Counter_add::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x36ab
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Function_SchedulerCallResults/Counter
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance class Modules.Function_SchedulerCallResults/Counter Modules.Function_SchedulerCallResults/Counter::'add'(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassMethod_3AF3677E_Counter_add::CallCore
-
-} // end of class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_ClassMethod_3AF3677E_Counter_add
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_ClassMethod_1144290A_Counter_getValue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x36bf
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_1144290A_Counter_getValue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x36c7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_1144290A_Counter_getValue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x36ca
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_1144290A_Counter_getValue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x36cd
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Function_SchedulerCallResults/Counter
-		IL_0006: call instance object Modules.Function_SchedulerCallResults/Counter::getValue()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_1144290A_Counter_getValue::CallCore
-
-} // end of class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_ClassMethod_1144290A_Counter_getValue
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_ClassMethod_CA685DB0_Counter_chain
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x36da
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_CA685DB0_Counter_chain::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x36e2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_CA685DB0_Counter_chain::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x36e5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_CA685DB0_Counter_chain::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x36e8
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Function_SchedulerCallResults/Counter
-		IL_0006: call instance object Modules.Function_SchedulerCallResults/Counter::chain()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_CA685DB0_Counter_chain::CallCore
-
-} // end of class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_ClassMethod_CA685DB0_Counter_chain
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x36f5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x36fd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3700
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3703
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Function_SchedulerCallResults/Counter
-		IL_0006: call instance object Modules.Function_SchedulerCallResults/Counter::addOnce()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce::CallCore
-
-} // end of class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_ClassMethod_9A1C5F1B_Counter_addOnce
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_ClassMethod_7D3B0342_Counter_next
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3710
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_7D3B0342_Counter_next::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3718
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_7D3B0342_Counter_next::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x371b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_7D3B0342_Counter_next::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x371e
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Function_SchedulerCallResults/Counter
-		IL_0006: call instance object Modules.Function_SchedulerCallResults/Counter::next()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_7D3B0342_Counter_next::CallCore
-
-} // end of class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_ClassMethod_7D3B0342_Counter_next
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_ClassMethod_F11C223A_Counter_maxNext
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x372b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_F11C223A_Counter_maxNext::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3733
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_F11C223A_Counter_maxNext::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3736
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_F11C223A_Counter_maxNext::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3739
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Function_SchedulerCallResults/Counter
-		IL_0006: call instance float64 Modules.Function_SchedulerCallResults/Counter::maxNext()
-		IL_000b: box [System.Runtime]System.Double
-		IL_0010: ret
-	} // end of method FunctionObject_ClassMethod_F11C223A_Counter_maxNext::CallCore
-
-} // end of class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_ClassMethod_F11C223A_Counter_maxNext
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_ClassMethod_2830FF5E_Counter_sum
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x374b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_2830FF5E_Counter_sum::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3753
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_2830FF5E_Counter_sum::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3756
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_2830FF5E_Counter_sum::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x375c
-		// Header size: 12
-		// Code size: 125 (0x7d)
-		.maxstack 12
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Function_SchedulerCallResults/Counter
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001e: ldarg.2
-		IL_001f: ldc.i4.2
-		IL_0020: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0025: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_002a: ldarg.2
-		IL_002b: ldc.i4.3
-		IL_002c: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0031: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0036: ldarg.2
-		IL_0037: ldc.i4.4
-		IL_0038: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_003d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0042: ldarg.2
-		IL_0043: ldc.i4.5
-		IL_0044: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0049: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_004e: ldarg.2
-		IL_004f: ldc.i4.6
-		IL_0050: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0055: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_005a: ldarg.2
-		IL_005b: ldc.i4.7
-		IL_005c: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0061: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0066: ldarg.2
-		IL_0067: ldc.i4.8
-		IL_0068: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_006d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0072: call instance float64 Modules.Function_SchedulerCallResults/Counter::sum(float64, float64, float64, float64, float64, float64, float64, float64, float64)
-		IL_0077: box [System.Runtime]System.Double
-		IL_007c: ret
-	} // end of method FunctionObject_ClassMethod_2830FF5E_Counter_sum::CallCore
-
-} // end of class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_ClassMethod_2830FF5E_Counter_sum
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_ClassMethod_A75B52F6_Counter_maxSum
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x37e5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_A75B52F6_Counter_maxSum::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x37ed
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_A75B52F6_Counter_maxSum::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x37f0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_A75B52F6_Counter_maxSum::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x37f3
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Function_SchedulerCallResults/Counter
-		IL_0006: call instance float64 Modules.Function_SchedulerCallResults/Counter::maxSum()
-		IL_000b: box [System.Runtime]System.Double
-		IL_0010: ret
-	} // end of method FunctionObject_ClassMethod_A75B52F6_Counter_maxSum::CallCore
-
-} // end of class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_ClassMethod_A75B52F6_Counter_maxSum
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3805
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x380d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3810
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3813
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Function_SchedulerCallResults/Counter
-		IL_0006: call instance float64 Modules.Function_SchedulerCallResults/Counter::maxSumWithFloor()
-		IL_000b: box [System.Runtime]System.Double
-		IL_0010: ret
-	} // end of method FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor::CallCore
-
-} // end of class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_ClassMethod_DF0780BC_Counter_maxSumWithFloor
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_SchedulerCallResults/Scope _environment0_Function_SchedulerCallResults
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_SchedulerCallResults/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3825
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::_environment0_Function_SchedulerCallResults
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3834
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3837
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x383a
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::_environment0_Function_SchedulerCallResults
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_SchedulerCallResults/fluentTypedCalls::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x384c
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::_environment0_Function_SchedulerCallResults
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_SchedulerCallResults/fluentTypedCalls::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x385a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_105D0369_fluentTypedCalls
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_SchedulerCallResults/Scope _environment0_Function_SchedulerCallResults
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_SchedulerCallResults/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3869
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::_environment0_Function_SchedulerCallResults
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3878
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x387b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x387e
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::_environment0_Function_SchedulerCallResults
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_SchedulerCallResults/singleTypedCall::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3890
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::_environment0_Function_SchedulerCallResults
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_SchedulerCallResults/singleTypedCall::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x389e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_D74585DE_singleTypedCall
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_SchedulerCallResults/Scope _environment0_Function_SchedulerCallResults
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_SchedulerCallResults/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x38ad
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::_environment0_Function_SchedulerCallResults
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x38bc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x38bf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x38c2
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::_environment0_Function_SchedulerCallResults
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_SchedulerCallResults/scheduledInlineCall::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x38d4
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::_environment0_Function_SchedulerCallResults
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_SchedulerCallResults/scheduledInlineCall::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x38e2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_3B1B2BB8_scheduledInlineCall
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_SchedulerCallResults/Scope _environment0_Function_SchedulerCallResults
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_SchedulerCallResults/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x38f1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::_environment0_Function_SchedulerCallResults
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3900
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3903
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3906
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::_environment0_Function_SchedulerCallResults
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_SchedulerCallResults/deepScheduledInlineCall::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3918
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::_environment0_Function_SchedulerCallResults
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_SchedulerCallResults/deepScheduledInlineCall::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3926
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_B74D2966_deepScheduledInlineCall
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_SchedulerCallResults/Scope _environment0_Function_SchedulerCallResults
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_SchedulerCallResults/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3935
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::_environment0_Function_SchedulerCallResults
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3944
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3947
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x394a
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::_environment0_Function_SchedulerCallResults
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_SchedulerCallResults/deepScheduledInlineCallWithCarriedResult::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x395c
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerCallResults/Scope FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::_environment0_Function_SchedulerCallResults
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_SchedulerCallResults/deepScheduledInlineCallWithCarriedResult::__js_call__(class Modules.Function_SchedulerCallResults/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x396a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerCallResults_6428AB4F.FunctionObject_FunctionDeclaration_033115F9_deepScheduledInlineCallWithCarriedResult
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerConversionsStableLoads.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerConversionsStableLoads.verified.txt
@@ -31,6 +31,109 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_769438BB_concat
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2651
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_769438BB_concat::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2659
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_769438BB_concat::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x265c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_769438BB_concat::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x265f
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: call object Modules.Function_SchedulerConversionsStableLoads/concat::__js_call__(object, float64)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_769438BB_concat::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2677
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: call object Modules.Function_SchedulerConversionsStableLoads/concat::__js_call__(object, float64)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_769438BB_concat::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x268b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_769438BB_concat::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_769438BB_concat
+
 
 		// Methods
 		.method public hidebysig static 
@@ -89,6 +192,109 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F3B41092_stringLength
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x269a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_F3B41092_stringLength::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x26a2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F3B41092_stringLength::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x26a5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F3B41092_stringLength::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x26a8
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0011: call object Modules.Function_SchedulerConversionsStableLoads/stringLength::__js_call__(object, string)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_F3B41092_stringLength::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26c0
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: call object Modules.Function_SchedulerConversionsStableLoads/stringLength::__js_call__(object, string)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_F3B41092_stringLength::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26d4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F3B41092_stringLength::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_F3B41092_stringLength
+
 
 		// Methods
 		.method public hidebysig static 
@@ -140,6 +346,109 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3006B504_arrayLength
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x26e3
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_3006B504_arrayLength::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x26eb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3006B504_arrayLength::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x26ee
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3006B504_arrayLength::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x26f1
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0011: call object Modules.Function_SchedulerConversionsStableLoads/arrayLength::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_3006B504_arrayLength::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2709
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_000d: call object Modules.Function_SchedulerConversionsStableLoads/arrayLength::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_3006B504_arrayLength::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x271d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3006B504_arrayLength::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_3006B504_arrayLength
+
 
 		// Methods
 		.method public hidebysig static 
@@ -189,6 +498,109 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CF905D20_arrayElement
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x272c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_CF905D20_arrayElement::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2734
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CF905D20_arrayElement::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2737
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CF905D20_arrayElement::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x273a
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0011: call object Modules.Function_SchedulerConversionsStableLoads/arrayElement::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_CF905D20_arrayElement::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2752
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_000d: call object Modules.Function_SchedulerConversionsStableLoads/arrayElement::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_CF905D20_arrayElement::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2766
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_CF905D20_arrayElement::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_CF905D20_arrayElement
 
 
 		// Methods
@@ -247,6 +659,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C32D2A2E_typedArray
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2775
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_C32D2A2E_typedArray::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x277d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C32D2A2E_typedArray::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2780
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C32D2A2E_typedArray::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2783
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Function_SchedulerConversionsStableLoads/typedArray::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_C32D2A2E_typedArray::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2796
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Function_SchedulerConversionsStableLoads/typedArray::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C32D2A2E_typedArray::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x27a5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C32D2A2E_typedArray::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C32D2A2E_typedArray
 
 
 		// Methods
@@ -310,6 +823,109 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_30928FD8_postfix
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x27b4
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_30928FD8_postfix::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x27bc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_30928FD8_postfix::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x27bf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_30928FD8_postfix::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x27c2
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerConversionsStableLoads/postfix::__js_call__(object, float64)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_30928FD8_postfix::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x27da
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerConversionsStableLoads/postfix::__js_call__(object, float64)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_30928FD8_postfix::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x27ee
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_30928FD8_postfix::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_30928FD8_postfix
 
 
 		// Methods
@@ -384,6 +1000,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C5AABBA4_L29C10
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_SchedulerConversionsStableLoads/Scope _environment0_Function_SchedulerConversionsStableLoads
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_SchedulerConversionsStableLoads/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x27fd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_SchedulerConversionsStableLoads/Scope Modules.Function_SchedulerConversionsStableLoads/FunctionExpression_object/FunctionObject_FunctionExpression_C5AABBA4_L29C10::_environment0_Function_SchedulerConversionsStableLoads
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_C5AABBA4_L29C10::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x280c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C5AABBA4_L29C10::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x280f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C5AABBA4_L29C10::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2812
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerConversionsStableLoads/Scope Modules.Function_SchedulerConversionsStableLoads/FunctionExpression_object/FunctionObject_FunctionExpression_C5AABBA4_L29C10::_environment0_Function_SchedulerConversionsStableLoads
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_SchedulerConversionsStableLoads/FunctionExpression_object::__js_call__(class Modules.Function_SchedulerConversionsStableLoads/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_C5AABBA4_L29C10::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2824
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerConversionsStableLoads/Scope Modules.Function_SchedulerConversionsStableLoads/FunctionExpression_object/FunctionObject_FunctionExpression_C5AABBA4_L29C10::_environment0_Function_SchedulerConversionsStableLoads
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_SchedulerConversionsStableLoads/FunctionExpression_object::__js_call__(class Modules.Function_SchedulerConversionsStableLoads/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_C5AABBA4_L29C10::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2832
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_C5AABBA4_L29C10::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_C5AABBA4_L29C10
 
 
 		// Methods
@@ -528,12 +1251,12 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_SchedulerConversionsStableLoads/Scope,
-			[1] class FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_769438BB_concat,
-			[2] class FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_F3B41092_stringLength,
-			[3] class FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_3006B504_arrayLength,
-			[4] class FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_CF905D20_arrayElement,
-			[5] class FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_C32D2A2E_typedArray,
-			[6] class FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_30928FD8_postfix,
+			[1] class Modules.Function_SchedulerConversionsStableLoads/concat/FunctionObject_FunctionDeclaration_769438BB_concat,
+			[2] class Modules.Function_SchedulerConversionsStableLoads/stringLength/FunctionObject_FunctionDeclaration_F3B41092_stringLength,
+			[3] class Modules.Function_SchedulerConversionsStableLoads/arrayLength/FunctionObject_FunctionDeclaration_3006B504_arrayLength,
+			[4] class Modules.Function_SchedulerConversionsStableLoads/arrayElement/FunctionObject_FunctionDeclaration_CF905D20_arrayElement,
+			[5] class Modules.Function_SchedulerConversionsStableLoads/typedArray/FunctionObject_FunctionDeclaration_C32D2A2E_typedArray,
+			[6] class Modules.Function_SchedulerConversionsStableLoads/postfix/FunctionObject_FunctionDeclaration_30928FD8_postfix,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[8] class [System.Runtime]System.Exception,
 			[9] object,
@@ -542,7 +1265,7 @@
 			[12] object,
 			[13] object[],
 			[14] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[15] class FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionExpression_C5AABBA4_L29C10,
+			[15] class Modules.Function_SchedulerConversionsStableLoads/FunctionExpression_object/FunctionObject_FunctionExpression_C5AABBA4_L29C10,
 			[16] object,
 			[17] object,
 			[18] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -563,13 +1286,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 13
-		IL_0012: newobj instance void FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_769438BB_concat::.ctor()
+		IL_0012: newobj instance void Modules.Function_SchedulerConversionsStableLoads/concat/FunctionObject_FunctionDeclaration_769438BB_concat::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "concat"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_769438BB_concat>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerConversionsStableLoads/concat/FunctionObject_FunctionDeclaration_769438BB_concat>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -578,13 +1301,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 13
-		IL_0032: newobj instance void FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_F3B41092_stringLength::.ctor()
+		IL_0032: newobj instance void Modules.Function_SchedulerConversionsStableLoads/stringLength/FunctionObject_FunctionDeclaration_F3B41092_stringLength::.ctor()
 		IL_0037: ldc.i4.1
 		IL_0038: conv.r8
 		IL_0039: ldstr "stringLength"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_F3B41092_stringLength>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerConversionsStableLoads/stringLength/FunctionObject_FunctionDeclaration_F3B41092_stringLength>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -593,13 +1316,13 @@
 		IL_004e: ldloc.0
 		IL_004f: stelem.ref
 		IL_0050: stloc.s 13
-		IL_0052: newobj instance void FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_3006B504_arrayLength::.ctor()
+		IL_0052: newobj instance void Modules.Function_SchedulerConversionsStableLoads/arrayLength/FunctionObject_FunctionDeclaration_3006B504_arrayLength::.ctor()
 		IL_0057: ldc.i4.1
 		IL_0058: conv.r8
 		IL_0059: ldstr "arrayLength"
 		IL_005e: ldc.i4.0
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_3006B504_arrayLength>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerConversionsStableLoads/arrayLength/FunctionObject_FunctionDeclaration_3006B504_arrayLength>(!!0, float64, string, bool, bool)
 		IL_0065: stloc.3
 		IL_0066: ldc.i4.1
 		IL_0067: newarr [System.Runtime]System.Object
@@ -608,13 +1331,13 @@
 		IL_006e: ldloc.0
 		IL_006f: stelem.ref
 		IL_0070: stloc.s 13
-		IL_0072: newobj instance void FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_CF905D20_arrayElement::.ctor()
+		IL_0072: newobj instance void Modules.Function_SchedulerConversionsStableLoads/arrayElement/FunctionObject_FunctionDeclaration_CF905D20_arrayElement::.ctor()
 		IL_0077: ldc.i4.1
 		IL_0078: conv.r8
 		IL_0079: ldstr "arrayElement"
 		IL_007e: ldc.i4.0
 		IL_007f: ldc.i4.1
-		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_CF905D20_arrayElement>(!!0, float64, string, bool, bool)
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerConversionsStableLoads/arrayElement/FunctionObject_FunctionDeclaration_CF905D20_arrayElement>(!!0, float64, string, bool, bool)
 		IL_0085: stloc.s 4
 		IL_0087: ldc.i4.1
 		IL_0088: newarr [System.Runtime]System.Object
@@ -623,13 +1346,13 @@
 		IL_008f: ldloc.0
 		IL_0090: stelem.ref
 		IL_0091: stloc.s 13
-		IL_0093: newobj instance void FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_C32D2A2E_typedArray::.ctor()
+		IL_0093: newobj instance void Modules.Function_SchedulerConversionsStableLoads/typedArray/FunctionObject_FunctionDeclaration_C32D2A2E_typedArray::.ctor()
 		IL_0098: ldc.i4.1
 		IL_0099: conv.r8
 		IL_009a: ldstr "typedArray"
 		IL_009f: ldc.i4.0
 		IL_00a0: ldc.i4.1
-		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_C32D2A2E_typedArray>(!!0, float64, string, bool, bool)
+		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerConversionsStableLoads/typedArray/FunctionObject_FunctionDeclaration_C32D2A2E_typedArray>(!!0, float64, string, bool, bool)
 		IL_00a6: stloc.s 5
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -638,13 +1361,13 @@
 		IL_00b0: ldloc.0
 		IL_00b1: stelem.ref
 		IL_00b2: stloc.s 13
-		IL_00b4: newobj instance void FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_30928FD8_postfix::.ctor()
+		IL_00b4: newobj instance void Modules.Function_SchedulerConversionsStableLoads/postfix/FunctionObject_FunctionDeclaration_30928FD8_postfix::.ctor()
 		IL_00b9: ldc.i4.1
 		IL_00ba: conv.r8
 		IL_00bb: ldstr "postfix"
 		IL_00c0: ldc.i4.0
 		IL_00c1: ldc.i4.1
-		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_30928FD8_postfix>(!!0, float64, string, bool, bool)
+		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerConversionsStableLoads/postfix/FunctionObject_FunctionDeclaration_30928FD8_postfix>(!!0, float64, string, bool, bool)
 		IL_00c7: stloc.s 6
 		IL_00c9: nop
 		IL_00ca: nop
@@ -670,16 +1393,16 @@
 		IL_00f9: ldc.i4.0
 		IL_00fa: ldelem.ref
 		IL_00fb: castclass Modules.Function_SchedulerConversionsStableLoads/Scope
-		IL_0100: newobj instance void FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionExpression_C5AABBA4_L29C10::.ctor(class Modules.Function_SchedulerConversionsStableLoads/Scope)
+		IL_0100: newobj instance void Modules.Function_SchedulerConversionsStableLoads/FunctionExpression_object/FunctionObject_FunctionExpression_C5AABBA4_L29C10::.ctor(class Modules.Function_SchedulerConversionsStableLoads/Scope)
 		IL_0105: ldc.i4.0
 		IL_0106: conv.r8
 		IL_0107: ldstr ""
 		IL_010c: ldc.i4.0
 		IL_010d: ldc.i4.1
-		IL_010e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionExpression_C5AABBA4_L29C10>(!!0, float64, string, bool, bool)
+		IL_010e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerConversionsStableLoads/FunctionExpression_object/FunctionObject_FunctionExpression_C5AABBA4_L29C10>(!!0, float64, string, bool, bool)
 		IL_0113: stloc.s 15
 		IL_0115: ldloc.s 15
-		IL_0117: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionExpression_C5AABBA4_L29C10>(!!0)
+		IL_0117: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerConversionsStableLoads/FunctionExpression_object/FunctionObject_FunctionExpression_C5AABBA4_L29C10>(!!0)
 		IL_011c: stloc.s 15
 		IL_011e: ldloc.s 14
 		IL_0120: ldstr "x"
@@ -938,729 +1661,6 @@
 	} // end of method Function_SchedulerConversionsStableLoads::__js_module_init__
 
 } // end of class Modules.Function_SchedulerConversionsStableLoads
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_769438BB_concat
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2651
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_769438BB_concat::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2659
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_769438BB_concat::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x265c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_769438BB_concat::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x265f
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: call object Modules.Function_SchedulerConversionsStableLoads/concat::__js_call__(object, float64)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_769438BB_concat::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2677
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: call object Modules.Function_SchedulerConversionsStableLoads/concat::__js_call__(object, float64)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_769438BB_concat::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x268b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_769438BB_concat::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_769438BB_concat
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_F3B41092_stringLength
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x269a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_F3B41092_stringLength::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x26a2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F3B41092_stringLength::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x26a5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F3B41092_stringLength::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x26a8
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0011: call object Modules.Function_SchedulerConversionsStableLoads/stringLength::__js_call__(object, string)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_F3B41092_stringLength::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26c0
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_000d: call object Modules.Function_SchedulerConversionsStableLoads/stringLength::__js_call__(object, string)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_F3B41092_stringLength::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26d4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F3B41092_stringLength::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_F3B41092_stringLength
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_3006B504_arrayLength
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x26e3
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_3006B504_arrayLength::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x26eb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3006B504_arrayLength::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x26ee
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3006B504_arrayLength::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x26f1
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0011: call object Modules.Function_SchedulerConversionsStableLoads/arrayLength::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_3006B504_arrayLength::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2709
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_000d: call object Modules.Function_SchedulerConversionsStableLoads/arrayLength::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_3006B504_arrayLength::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x271d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3006B504_arrayLength::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_3006B504_arrayLength
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_CF905D20_arrayElement
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x272c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_CF905D20_arrayElement::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2734
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CF905D20_arrayElement::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2737
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CF905D20_arrayElement::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x273a
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0011: call object Modules.Function_SchedulerConversionsStableLoads/arrayElement::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_CF905D20_arrayElement::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2752
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_000d: call object Modules.Function_SchedulerConversionsStableLoads/arrayElement::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_CF905D20_arrayElement::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2766
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_CF905D20_arrayElement::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_CF905D20_arrayElement
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_C32D2A2E_typedArray
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2775
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_C32D2A2E_typedArray::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x277d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C32D2A2E_typedArray::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2780
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C32D2A2E_typedArray::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2783
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Function_SchedulerConversionsStableLoads/typedArray::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_C32D2A2E_typedArray::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2796
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Function_SchedulerConversionsStableLoads/typedArray::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C32D2A2E_typedArray::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27a5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C32D2A2E_typedArray::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_C32D2A2E_typedArray
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_30928FD8_postfix
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x27b4
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_30928FD8_postfix::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x27bc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_30928FD8_postfix::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x27bf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_30928FD8_postfix::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x27c2
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerConversionsStableLoads/postfix::__js_call__(object, float64)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_30928FD8_postfix::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27da
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerConversionsStableLoads/postfix::__js_call__(object, float64)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_30928FD8_postfix::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27ee
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_30928FD8_postfix::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionDeclaration_30928FD8_postfix
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionExpression_C5AABBA4_L29C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_SchedulerConversionsStableLoads/Scope _environment0_Function_SchedulerConversionsStableLoads
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_SchedulerConversionsStableLoads/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x27fd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_SchedulerConversionsStableLoads/Scope FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionExpression_C5AABBA4_L29C10::_environment0_Function_SchedulerConversionsStableLoads
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C5AABBA4_L29C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x280c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C5AABBA4_L29C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x280f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C5AABBA4_L29C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2812
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerConversionsStableLoads/Scope FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionExpression_C5AABBA4_L29C10::_environment0_Function_SchedulerConversionsStableLoads
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_SchedulerConversionsStableLoads/FunctionExpression_object::__js_call__(class Modules.Function_SchedulerConversionsStableLoads/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_C5AABBA4_L29C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2824
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerConversionsStableLoads/Scope FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionExpression_C5AABBA4_L29C10::_environment0_Function_SchedulerConversionsStableLoads
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_SchedulerConversionsStableLoads/FunctionExpression_object::__js_call__(class Modules.Function_SchedulerConversionsStableLoads/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_C5AABBA4_L29C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2832
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C5AABBA4_L29C10::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerConversionsStableLoads_6645F6FC.FunctionObject_FunctionExpression_C5AABBA4_L29C10
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerGeneralRegions.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerGeneralRegions.verified.txt
@@ -31,6 +31,133 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5F3B77EC_mixed
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x286d
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_5F3B77EC_mixed::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2875
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5F3B77EC_mixed::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2878
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5F3B77EC_mixed::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x287b
+				// Header size: 1
+				// Code size: 59 (0x3b)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001d: ldarg.2
+				IL_001e: ldc.i4.2
+				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0029: ldarg.2
+				IL_002a: ldc.i4.3
+				IL_002b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0035: call object Modules.Function_SchedulerGeneralRegions/mixed::__js_call__(object, float64, float64, float64, float64)
+				IL_003a: ret
+			} // end of method FunctionObject_FunctionDeclaration_5F3B77EC_mixed::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x28b7
+				// Header size: 1
+				// Code size: 55 (0x37)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0025: ldarg.2
+				IL_0026: ldc.i4.3
+				IL_0027: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_002c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0031: call object Modules.Function_SchedulerGeneralRegions/mixed::__js_call__(object, float64, float64, float64, float64)
+				IL_0036: ret
+			} // end of method FunctionObject_FunctionDeclaration_5F3B77EC_mixed::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x28ef
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5F3B77EC_mixed::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_5F3B77EC_mixed
+
 
 		// Methods
 		.method public hidebysig static 
@@ -104,6 +231,129 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_881E8806_nested
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_SchedulerGeneralRegions/Scope _environment0_Function_SchedulerGeneralRegions
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_SchedulerGeneralRegions/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x28fe
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/'nested'/FunctionObject_FunctionDeclaration_881E8806_nested::_environment0_Function_SchedulerGeneralRegions
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_881E8806_nested::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x290d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_881E8806_nested::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2910
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_881E8806_nested::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2913
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/'nested'/FunctionObject_FunctionDeclaration_881E8806_nested::_environment0_Function_SchedulerGeneralRegions
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: ldarg.2
+				IL_0018: ldc.i4.1
+				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0023: call object Modules.Function_SchedulerGeneralRegions/'nested'::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object, float64, float64)
+				IL_0028: ret
+			} // end of method FunctionObject_FunctionDeclaration_881E8806_nested::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x293d
+				// Header size: 1
+				// Code size: 37 (0x25)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/'nested'/FunctionObject_FunctionDeclaration_881E8806_nested::_environment0_Function_SchedulerGeneralRegions
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.1
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001f: call object Modules.Function_SchedulerGeneralRegions/'nested'::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object, float64, float64)
+				IL_0024: ret
+			} // end of method FunctionObject_FunctionDeclaration_881E8806_nested::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2963
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_881E8806_nested::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_881E8806_nested
 
 
 		// Methods
@@ -179,6 +429,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F97EF509_read
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_SchedulerGeneralRegions/Scope _environment0_Function_SchedulerGeneralRegions
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_SchedulerGeneralRegions/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2972
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/read/FunctionObject_FunctionDeclaration_F97EF509_read::_environment0_Function_SchedulerGeneralRegions
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F97EF509_read::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2981
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F97EF509_read::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2984
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F97EF509_read::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2987
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/read/FunctionObject_FunctionDeclaration_F97EF509_read::_environment0_Function_SchedulerGeneralRegions
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_SchedulerGeneralRegions/read::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_F97EF509_read::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2999
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/read/FunctionObject_FunctionDeclaration_F97EF509_read::_environment0_Function_SchedulerGeneralRegions
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_SchedulerGeneralRegions/read::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_F97EF509_read::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x29a7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F97EF509_read::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_F97EF509_read
+
 
 		// Methods
 		.method public hidebysig static 
@@ -241,6 +598,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C6E365D0_write
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_SchedulerGeneralRegions/Scope _environment0_Function_SchedulerGeneralRegions
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_SchedulerGeneralRegions/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x29b6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/write/FunctionObject_FunctionDeclaration_C6E365D0_write::_environment0_Function_SchedulerGeneralRegions
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C6E365D0_write::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x29c5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C6E365D0_write::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x29c8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C6E365D0_write::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x29cb
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/write/FunctionObject_FunctionDeclaration_C6E365D0_write::_environment0_Function_SchedulerGeneralRegions
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_SchedulerGeneralRegions/write::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_C6E365D0_write::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x29dd
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/write/FunctionObject_FunctionDeclaration_C6E365D0_write::_environment0_Function_SchedulerGeneralRegions
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_SchedulerGeneralRegions/write::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_C6E365D0_write::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x29eb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C6E365D0_write::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C6E365D0_write
 
 
 		// Methods
@@ -318,6 +782,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2D7AD0BA_ordered
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_SchedulerGeneralRegions/Scope _environment0_Function_SchedulerGeneralRegions
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_SchedulerGeneralRegions/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x29fa
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/ordered/FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::_environment0_Function_SchedulerGeneralRegions
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2a09
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2a0c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a0f
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/ordered/FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::_environment0_Function_SchedulerGeneralRegions
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_SchedulerGeneralRegions/ordered::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a21
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/ordered/FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::_environment0_Function_SchedulerGeneralRegions
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_SchedulerGeneralRegions/ordered::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a2f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_2D7AD0BA_ordered
 
 
 		// Methods
@@ -433,6 +1004,118 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2BB3E1E3_L39C14
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Function_SchedulerGeneralRegions/Scope _environment0_Function_SchedulerGeneralRegions
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Function_SchedulerGeneralRegions/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x2a9a
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object/FunctionObject_FunctionExpression_2BB3E1E3_L39C14::_environment0_Function_SchedulerGeneralRegions
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object/FunctionObject_FunctionExpression_2BB3E1E3_L39C14::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionExpression_2BB3E1E3_L39C14::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2ab0
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_2BB3E1E3_L39C14::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2ab3
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_2BB3E1E3_L39C14::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2ab6
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object/FunctionObject_FunctionExpression_2BB3E1E3_L39C14::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_2BB3E1E3_L39C14::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2ac8
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object/FunctionObject_FunctionExpression_2BB3E1E3_L39C14::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_2BB3E1E3_L39C14::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2ad6
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_2BB3E1E3_L39C14::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_2BB3E1E3_L39C14
+
 
 			// Methods
 			.method public hidebysig static 
@@ -504,6 +1187,124 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_17150E04_L43C14
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Function_SchedulerGeneralRegions/Scope _environment0_Function_SchedulerGeneralRegions
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Function_SchedulerGeneralRegions/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x2ae5
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14::_environment0_Function_SchedulerGeneralRegions
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionExpression_17150E04_L43C14::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2afb
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_17150E04_L43C14::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2afe
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_17150E04_L43C14::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2b01
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_17150E04_L43C14::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2b1a
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_17150E04_L43C14::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2b2f
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_17150E04_L43C14::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_17150E04_L43C14
+
 
 			// Methods
 			.method public hidebysig static 
@@ -574,6 +1375,121 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_61C2125E_getter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_SchedulerGeneralRegions/Scope _environment0_Function_SchedulerGeneralRegions
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_SchedulerGeneralRegions/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a3e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/getter/FunctionObject_FunctionDeclaration_61C2125E_getter::_environment0_Function_SchedulerGeneralRegions
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_61C2125E_getter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2a4d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_61C2125E_getter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2a50
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_61C2125E_getter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a53
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/getter/FunctionObject_FunctionDeclaration_61C2125E_getter::_environment0_Function_SchedulerGeneralRegions
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: call object Modules.Function_SchedulerGeneralRegions/getter::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object, float64)
+				IL_001c: ret
+			} // end of method FunctionObject_FunctionDeclaration_61C2125E_getter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a71
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/getter/FunctionObject_FunctionDeclaration_61C2125E_getter::_environment0_Function_SchedulerGeneralRegions
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0013: call object Modules.Function_SchedulerGeneralRegions/getter::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object, float64)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_61C2125E_getter::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a8b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_61C2125E_getter::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_61C2125E_getter
+
 
 		// Methods
 		.method public hidebysig static 
@@ -598,8 +1514,8 @@
 				[2] object,
 				[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[4] object[],
-				[5] class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionExpression_2BB3E1E3_L39C14,
-				[6] class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionExpression_17150E04_L43C14,
+				[5] class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object/FunctionObject_FunctionExpression_2BB3E1E3_L39C14,
+				[6] class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14,
 				[7] object,
 				[8] object,
 				[9] object
@@ -633,16 +1549,16 @@
 			IL_0037: ldelem.ref
 			IL_0038: castclass Modules.Function_SchedulerGeneralRegions/Scope
 			IL_003d: ldloc.s 4
-			IL_003f: newobj instance void FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionExpression_2BB3E1E3_L39C14::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope, object[])
+			IL_003f: newobj instance void Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object/FunctionObject_FunctionExpression_2BB3E1E3_L39C14::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope, object[])
 			IL_0044: ldc.i4.0
 			IL_0045: conv.r8
 			IL_0046: ldstr ""
 			IL_004b: ldc.i4.1
 			IL_004c: ldc.i4.1
-			IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionExpression_2BB3E1E3_L39C14>(!!0, float64, string, bool, bool)
+			IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object/FunctionObject_FunctionExpression_2BB3E1E3_L39C14>(!!0, float64, string, bool, bool)
 			IL_0052: stloc.s 5
 			IL_0054: ldloc.s 5
-			IL_0056: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionExpression_2BB3E1E3_L39C14>(!!0)
+			IL_0056: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object/FunctionObject_FunctionExpression_2BB3E1E3_L39C14>(!!0)
 			IL_005b: stloc.s 5
 			IL_005d: ldloc.3
 			IL_005e: ldstr "x"
@@ -666,16 +1582,16 @@
 			IL_007f: ldelem.ref
 			IL_0080: castclass Modules.Function_SchedulerGeneralRegions/Scope
 			IL_0085: ldloc.s 4
-			IL_0087: newobj instance void FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionExpression_17150E04_L43C14::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope, object[])
+			IL_0087: newobj instance void Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope, object[])
 			IL_008c: ldc.i4.1
 			IL_008d: conv.r8
 			IL_008e: ldstr ""
 			IL_0093: ldc.i4.1
 			IL_0094: ldc.i4.1
-			IL_0095: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionExpression_17150E04_L43C14>(!!0, float64, string, bool, bool)
+			IL_0095: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14>(!!0, float64, string, bool, bool)
 			IL_009a: stloc.s 6
 			IL_009c: ldloc.s 6
-			IL_009e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionExpression_17150E04_L43C14>(!!0)
+			IL_009e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13/FunctionObject_FunctionExpression_17150E04_L43C14>(!!0)
 			IL_00a3: stloc.s 6
 			IL_00a5: ldloc.3
 			IL_00a6: ldstr "x"
@@ -789,6 +1705,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_63E493E1_caught
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_SchedulerGeneralRegions/Scope _environment0_Function_SchedulerGeneralRegions
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_SchedulerGeneralRegions/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b3e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/caught/FunctionObject_FunctionDeclaration_63E493E1_caught::_environment0_Function_SchedulerGeneralRegions
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_63E493E1_caught::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2b4d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_63E493E1_caught::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2b50
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_63E493E1_caught::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b53
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/caught/FunctionObject_FunctionDeclaration_63E493E1_caught::_environment0_Function_SchedulerGeneralRegions
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_SchedulerGeneralRegions/caught::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_63E493E1_caught::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b65
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope Modules.Function_SchedulerGeneralRegions/caught/FunctionObject_FunctionDeclaration_63E493E1_caught::_environment0_Function_SchedulerGeneralRegions
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_SchedulerGeneralRegions/caught::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_63E493E1_caught::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b73
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_63E493E1_caught::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_63E493E1_caught
 
 
 		// Methods
@@ -974,15 +1997,15 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Function_SchedulerGeneralRegions/Scope,
-			[1] class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_5F3B77EC_mixed,
-			[2] class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_881E8806_nested,
-			[3] class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_2D7AD0BA_ordered,
-			[4] class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_61C2125E_getter,
-			[5] class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_63E493E1_caught,
+			[1] class Modules.Function_SchedulerGeneralRegions/mixed/FunctionObject_FunctionDeclaration_5F3B77EC_mixed,
+			[2] class Modules.Function_SchedulerGeneralRegions/'nested'/FunctionObject_FunctionDeclaration_881E8806_nested,
+			[3] class Modules.Function_SchedulerGeneralRegions/ordered/FunctionObject_FunctionDeclaration_2D7AD0BA_ordered,
+			[4] class Modules.Function_SchedulerGeneralRegions/getter/FunctionObject_FunctionDeclaration_61C2125E_getter,
+			[5] class Modules.Function_SchedulerGeneralRegions/caught/FunctionObject_FunctionDeclaration_63E493E1_caught,
 			[6] object,
 			[7] object[],
-			[8] class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_F97EF509_read,
-			[9] class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_C6E365D0_write,
+			[8] class Modules.Function_SchedulerGeneralRegions/read/FunctionObject_FunctionDeclaration_F97EF509_read,
+			[9] class Modules.Function_SchedulerGeneralRegions/write/FunctionObject_FunctionDeclaration_C6E365D0_write,
 			[10] object,
 			[11] object,
 			[12] object
@@ -997,13 +2020,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 7
-		IL_0012: newobj instance void FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_5F3B77EC_mixed::.ctor()
+		IL_0012: newobj instance void Modules.Function_SchedulerGeneralRegions/mixed/FunctionObject_FunctionDeclaration_5F3B77EC_mixed::.ctor()
 		IL_0017: ldc.i4.4
 		IL_0018: conv.r8
 		IL_0019: ldstr "mixed"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_5F3B77EC_mixed>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/mixed/FunctionObject_FunctionDeclaration_5F3B77EC_mixed>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -1016,13 +2039,13 @@
 		IL_0034: ldc.i4.0
 		IL_0035: ldelem.ref
 		IL_0036: castclass Modules.Function_SchedulerGeneralRegions/Scope
-		IL_003b: newobj instance void FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_881E8806_nested::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope)
+		IL_003b: newobj instance void Modules.Function_SchedulerGeneralRegions/'nested'/FunctionObject_FunctionDeclaration_881E8806_nested::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope)
 		IL_0040: ldc.i4.2
 		IL_0041: conv.r8
 		IL_0042: ldstr "nested"
 		IL_0047: ldc.i4.0
 		IL_0048: ldc.i4.1
-		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_881E8806_nested>(!!0, float64, string, bool, bool)
+		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/'nested'/FunctionObject_FunctionDeclaration_881E8806_nested>(!!0, float64, string, bool, bool)
 		IL_004e: stloc.2
 		IL_004f: ldc.i4.1
 		IL_0050: newarr [System.Runtime]System.Object
@@ -1035,13 +2058,13 @@
 		IL_005d: ldc.i4.0
 		IL_005e: ldelem.ref
 		IL_005f: castclass Modules.Function_SchedulerGeneralRegions/Scope
-		IL_0064: newobj instance void FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_F97EF509_read::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope)
+		IL_0064: newobj instance void Modules.Function_SchedulerGeneralRegions/read/FunctionObject_FunctionDeclaration_F97EF509_read::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope)
 		IL_0069: ldc.i4.0
 		IL_006a: conv.r8
 		IL_006b: ldstr "read"
 		IL_0070: ldc.i4.0
 		IL_0071: ldc.i4.1
-		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_F97EF509_read>(!!0, float64, string, bool, bool)
+		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/read/FunctionObject_FunctionDeclaration_F97EF509_read>(!!0, float64, string, bool, bool)
 		IL_0077: stloc.s 8
 		IL_0079: ldloc.0
 		IL_007a: ldloc.s 8
@@ -1057,13 +2080,13 @@
 		IL_008f: ldc.i4.0
 		IL_0090: ldelem.ref
 		IL_0091: castclass Modules.Function_SchedulerGeneralRegions/Scope
-		IL_0096: newobj instance void FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_C6E365D0_write::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope)
+		IL_0096: newobj instance void Modules.Function_SchedulerGeneralRegions/write/FunctionObject_FunctionDeclaration_C6E365D0_write::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope)
 		IL_009b: ldc.i4.0
 		IL_009c: conv.r8
 		IL_009d: ldstr "write"
 		IL_00a2: ldc.i4.0
 		IL_00a3: ldc.i4.1
-		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_C6E365D0_write>(!!0, float64, string, bool, bool)
+		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/write/FunctionObject_FunctionDeclaration_C6E365D0_write>(!!0, float64, string, bool, bool)
 		IL_00a9: stloc.s 9
 		IL_00ab: ldloc.0
 		IL_00ac: ldloc.s 9
@@ -1079,13 +2102,13 @@
 		IL_00c1: ldc.i4.0
 		IL_00c2: ldelem.ref
 		IL_00c3: castclass Modules.Function_SchedulerGeneralRegions/Scope
-		IL_00c8: newobj instance void FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope)
+		IL_00c8: newobj instance void Modules.Function_SchedulerGeneralRegions/ordered/FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope)
 		IL_00cd: ldc.i4.0
 		IL_00ce: conv.r8
 		IL_00cf: ldstr "ordered"
 		IL_00d4: ldc.i4.0
 		IL_00d5: ldc.i4.1
-		IL_00d6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_2D7AD0BA_ordered>(!!0, float64, string, bool, bool)
+		IL_00d6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/ordered/FunctionObject_FunctionDeclaration_2D7AD0BA_ordered>(!!0, float64, string, bool, bool)
 		IL_00db: stloc.3
 		IL_00dc: ldc.i4.1
 		IL_00dd: newarr [System.Runtime]System.Object
@@ -1098,13 +2121,13 @@
 		IL_00ea: ldc.i4.0
 		IL_00eb: ldelem.ref
 		IL_00ec: castclass Modules.Function_SchedulerGeneralRegions/Scope
-		IL_00f1: newobj instance void FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_61C2125E_getter::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope)
+		IL_00f1: newobj instance void Modules.Function_SchedulerGeneralRegions/getter/FunctionObject_FunctionDeclaration_61C2125E_getter::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope)
 		IL_00f6: ldc.i4.1
 		IL_00f7: conv.r8
 		IL_00f8: ldstr "getter"
 		IL_00fd: ldc.i4.0
 		IL_00fe: ldc.i4.1
-		IL_00ff: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_61C2125E_getter>(!!0, float64, string, bool, bool)
+		IL_00ff: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/getter/FunctionObject_FunctionDeclaration_61C2125E_getter>(!!0, float64, string, bool, bool)
 		IL_0104: stloc.s 4
 		IL_0106: ldc.i4.1
 		IL_0107: newarr [System.Runtime]System.Object
@@ -1117,13 +2140,13 @@
 		IL_0114: ldc.i4.0
 		IL_0115: ldelem.ref
 		IL_0116: castclass Modules.Function_SchedulerGeneralRegions/Scope
-		IL_011b: newobj instance void FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_63E493E1_caught::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope)
+		IL_011b: newobj instance void Modules.Function_SchedulerGeneralRegions/caught/FunctionObject_FunctionDeclaration_63E493E1_caught::.ctor(class Modules.Function_SchedulerGeneralRegions/Scope)
 		IL_0120: ldc.i4.0
 		IL_0121: conv.r8
 		IL_0122: ldstr "caught"
 		IL_0127: ldc.i4.0
 		IL_0128: ldc.i4.1
-		IL_0129: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_63E493E1_caught>(!!0, float64, string, bool, bool)
+		IL_0129: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerGeneralRegions/caught/FunctionObject_FunctionDeclaration_63E493E1_caught>(!!0, float64, string, bool, bool)
 		IL_012e: stloc.s 5
 		IL_0130: nop
 		IL_0131: nop
@@ -1265,1029 +2288,6 @@
 	} // end of method Function_SchedulerGeneralRegions::__js_module_init__
 
 } // end of class Modules.Function_SchedulerGeneralRegions
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_5F3B77EC_mixed
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x286d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_5F3B77EC_mixed::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2875
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5F3B77EC_mixed::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2878
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5F3B77EC_mixed::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x287b
-		// Header size: 1
-		// Code size: 59 (0x3b)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001d: ldarg.2
-		IL_001e: ldc.i4.2
-		IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0029: ldarg.2
-		IL_002a: ldc.i4.3
-		IL_002b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0035: call object Modules.Function_SchedulerGeneralRegions/mixed::__js_call__(object, float64, float64, float64, float64)
-		IL_003a: ret
-	} // end of method FunctionObject_FunctionDeclaration_5F3B77EC_mixed::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28b7
-		// Header size: 1
-		// Code size: 55 (0x37)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0025: ldarg.2
-		IL_0026: ldc.i4.3
-		IL_0027: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_002c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0031: call object Modules.Function_SchedulerGeneralRegions/mixed::__js_call__(object, float64, float64, float64, float64)
-		IL_0036: ret
-	} // end of method FunctionObject_FunctionDeclaration_5F3B77EC_mixed::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28ef
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5F3B77EC_mixed::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_5F3B77EC_mixed
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_881E8806_nested
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_SchedulerGeneralRegions/Scope _environment0_Function_SchedulerGeneralRegions
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_SchedulerGeneralRegions/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x28fe
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_881E8806_nested::_environment0_Function_SchedulerGeneralRegions
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_881E8806_nested::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x290d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_881E8806_nested::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2910
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_881E8806_nested::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2913
-		// Header size: 1
-		// Code size: 41 (0x29)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_881E8806_nested::_environment0_Function_SchedulerGeneralRegions
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0017: ldarg.2
-		IL_0018: ldc.i4.1
-		IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0023: call object Modules.Function_SchedulerGeneralRegions/'nested'::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object, float64, float64)
-		IL_0028: ret
-	} // end of method FunctionObject_FunctionDeclaration_881E8806_nested::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x293d
-		// Header size: 1
-		// Code size: 37 (0x25)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_881E8806_nested::_environment0_Function_SchedulerGeneralRegions
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.1
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001f: call object Modules.Function_SchedulerGeneralRegions/'nested'::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object, float64, float64)
-		IL_0024: ret
-	} // end of method FunctionObject_FunctionDeclaration_881E8806_nested::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2963
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_881E8806_nested::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_881E8806_nested
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_F97EF509_read
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_SchedulerGeneralRegions/Scope _environment0_Function_SchedulerGeneralRegions
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_SchedulerGeneralRegions/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2972
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_F97EF509_read::_environment0_Function_SchedulerGeneralRegions
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F97EF509_read::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2981
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F97EF509_read::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2984
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F97EF509_read::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2987
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_F97EF509_read::_environment0_Function_SchedulerGeneralRegions
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_SchedulerGeneralRegions/read::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_F97EF509_read::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2999
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_F97EF509_read::_environment0_Function_SchedulerGeneralRegions
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_SchedulerGeneralRegions/read::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_F97EF509_read::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29a7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F97EF509_read::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_F97EF509_read
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_C6E365D0_write
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_SchedulerGeneralRegions/Scope _environment0_Function_SchedulerGeneralRegions
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_SchedulerGeneralRegions/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x29b6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_C6E365D0_write::_environment0_Function_SchedulerGeneralRegions
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C6E365D0_write::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x29c5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C6E365D0_write::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x29c8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C6E365D0_write::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x29cb
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_C6E365D0_write::_environment0_Function_SchedulerGeneralRegions
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_SchedulerGeneralRegions/write::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_C6E365D0_write::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29dd
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_C6E365D0_write::_environment0_Function_SchedulerGeneralRegions
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_SchedulerGeneralRegions/write::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_C6E365D0_write::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29eb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C6E365D0_write::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_C6E365D0_write
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_2D7AD0BA_ordered
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_SchedulerGeneralRegions/Scope _environment0_Function_SchedulerGeneralRegions
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_SchedulerGeneralRegions/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x29fa
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::_environment0_Function_SchedulerGeneralRegions
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a09
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a0c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a0f
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::_environment0_Function_SchedulerGeneralRegions
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_SchedulerGeneralRegions/ordered::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a21
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::_environment0_Function_SchedulerGeneralRegions
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_SchedulerGeneralRegions/ordered::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a2f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_2D7AD0BA_ordered::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_2D7AD0BA_ordered
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_61C2125E_getter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_SchedulerGeneralRegions/Scope _environment0_Function_SchedulerGeneralRegions
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_SchedulerGeneralRegions/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a3e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_61C2125E_getter::_environment0_Function_SchedulerGeneralRegions
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_61C2125E_getter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a4d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_61C2125E_getter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a50
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_61C2125E_getter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a53
-		// Header size: 1
-		// Code size: 29 (0x1d)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_61C2125E_getter::_environment0_Function_SchedulerGeneralRegions
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0017: call object Modules.Function_SchedulerGeneralRegions/getter::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object, float64)
-		IL_001c: ret
-	} // end of method FunctionObject_FunctionDeclaration_61C2125E_getter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a71
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_61C2125E_getter::_environment0_Function_SchedulerGeneralRegions
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0013: call object Modules.Function_SchedulerGeneralRegions/getter::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object, float64)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_61C2125E_getter::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a8b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_61C2125E_getter::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_61C2125E_getter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionExpression_2BB3E1E3_L39C14
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_SchedulerGeneralRegions/Scope _environment0_Function_SchedulerGeneralRegions
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_SchedulerGeneralRegions/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a9a
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionExpression_2BB3E1E3_L39C14::_environment0_Function_SchedulerGeneralRegions
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionExpression_2BB3E1E3_L39C14::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_2BB3E1E3_L39C14::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2ab0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2BB3E1E3_L39C14::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2ab3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2BB3E1E3_L39C14::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ab6
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionExpression_2BB3E1E3_L39C14::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_2BB3E1E3_L39C14::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ac8
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionExpression_2BB3E1E3_L39C14::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_2BB3E1E3_L39C14::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ad6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2BB3E1E3_L39C14::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionExpression_2BB3E1E3_L39C14
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionExpression_17150E04_L43C14
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_SchedulerGeneralRegions/Scope _environment0_Function_SchedulerGeneralRegions
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_SchedulerGeneralRegions/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ae5
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionExpression_17150E04_L43C14::_environment0_Function_SchedulerGeneralRegions
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionExpression_17150E04_L43C14::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_17150E04_L43C14::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2afb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_17150E04_L43C14::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2afe
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_17150E04_L43C14::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b01
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionExpression_17150E04_L43C14::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_17150E04_L43C14::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b1a
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionExpression_17150E04_L43C14::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Function_SchedulerGeneralRegions/getter/FunctionExpression_object_L43C13::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_17150E04_L43C14::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b2f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_17150E04_L43C14::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionExpression_17150E04_L43C14
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_63E493E1_caught
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_SchedulerGeneralRegions/Scope _environment0_Function_SchedulerGeneralRegions
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_SchedulerGeneralRegions/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b3e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_SchedulerGeneralRegions/Scope FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_63E493E1_caught::_environment0_Function_SchedulerGeneralRegions
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_63E493E1_caught::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2b4d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_63E493E1_caught::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2b50
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_63E493E1_caught::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b53
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_63E493E1_caught::_environment0_Function_SchedulerGeneralRegions
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_SchedulerGeneralRegions/caught::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_63E493E1_caught::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b65
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerGeneralRegions/Scope FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_63E493E1_caught::_environment0_Function_SchedulerGeneralRegions
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_SchedulerGeneralRegions/caught::__js_call__(class Modules.Function_SchedulerGeneralRegions/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_63E493E1_caught::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b73
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_63E493E1_caught::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerGeneralRegions_296EA10A.FunctionObject_FunctionDeclaration_63E493E1_caught
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerLiteralArguments.verified.txt
+++ b/tests/Jroc.Tests/Function/Snapshots/GeneratorTests.Function_SchedulerLiteralArguments.verified.txt
@@ -31,6 +31,117 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3C021B3C_args
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2bd3
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_3C021B3C_args::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2bdb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3C021B3C_args::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2bde
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3C021B3C_args::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2be1
+				// Header size: 1
+				// Code size: 35 (0x23)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001d: call object Modules.Function_SchedulerLiteralArguments/args::__js_call__(object, float64, float64)
+				IL_0022: ret
+			} // end of method FunctionObject_FunctionDeclaration_3C021B3C_args::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c05
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0019: call object Modules.Function_SchedulerLiteralArguments/args::__js_call__(object, float64, float64)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_3C021B3C_args::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c25
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3C021B3C_args::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_3C021B3C_args
+
 
 		// Methods
 		.method public hidebysig static 
@@ -95,6 +206,117 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_82194727_arrayValue
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2c34
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_82194727_arrayValue::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2c3c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_82194727_arrayValue::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2c3f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_82194727_arrayValue::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c42
+				// Header size: 1
+				// Code size: 35 (0x23)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001d: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerLiteralArguments/arrayValue::__js_call__(object, float64, float64)
+				IL_0022: ret
+			} // end of method FunctionObject_FunctionDeclaration_82194727_arrayValue::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c66
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0019: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerLiteralArguments/arrayValue::__js_call__(object, float64, float64)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_82194727_arrayValue::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c86
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_82194727_arrayValue::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_82194727_arrayValue
+
 
 		// Methods
 		.method public hidebysig static 
@@ -152,6 +374,129 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B6660A63_objectValue
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_SchedulerLiteralArguments/Scope _environment0_Function_SchedulerLiteralArguments
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_SchedulerLiteralArguments/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c95
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/objectValue/FunctionObject_FunctionDeclaration_B6660A63_objectValue::_environment0_Function_SchedulerLiteralArguments
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B6660A63_objectValue::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2ca4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B6660A63_objectValue::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2ca7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B6660A63_objectValue::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2caa
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/objectValue/FunctionObject_FunctionDeclaration_B6660A63_objectValue::_environment0_Function_SchedulerLiteralArguments
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: ldarg.2
+				IL_0018: ldc.i4.1
+				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0023: call object Modules.Function_SchedulerLiteralArguments/objectValue::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, float64, float64)
+				IL_0028: ret
+			} // end of method FunctionObject_FunctionDeclaration_B6660A63_objectValue::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2cd4
+				// Header size: 1
+				// Code size: 37 (0x25)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/objectValue/FunctionObject_FunctionDeclaration_B6660A63_objectValue::_environment0_Function_SchedulerLiteralArguments
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.1
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001f: call object Modules.Function_SchedulerLiteralArguments/objectValue::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, float64, float64)
+				IL_0024: ret
+			} // end of method FunctionObject_FunctionDeclaration_B6660A63_objectValue::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2cfa
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B6660A63_objectValue::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_B6660A63_objectValue
 
 
 		// Methods
@@ -214,6 +559,129 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_93C38E4A_nested
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_SchedulerLiteralArguments/Scope _environment0_Function_SchedulerLiteralArguments
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_SchedulerLiteralArguments/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d09
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/'nested'/FunctionObject_FunctionDeclaration_93C38E4A_nested::_environment0_Function_SchedulerLiteralArguments
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_93C38E4A_nested::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2d18
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_93C38E4A_nested::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2d1b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_93C38E4A_nested::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d1e
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/'nested'/FunctionObject_FunctionDeclaration_93C38E4A_nested::_environment0_Function_SchedulerLiteralArguments
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: ldarg.2
+				IL_0018: ldc.i4.1
+				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0023: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerLiteralArguments/'nested'::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, float64, float64)
+				IL_0028: ret
+			} // end of method FunctionObject_FunctionDeclaration_93C38E4A_nested::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d48
+				// Header size: 1
+				// Code size: 37 (0x25)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/'nested'/FunctionObject_FunctionDeclaration_93C38E4A_nested::_environment0_Function_SchedulerLiteralArguments
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.1
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerLiteralArguments/'nested'::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, float64, float64)
+				IL_0024: ret
+			} // end of method FunctionObject_FunctionDeclaration_93C38E4A_nested::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d6e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_93C38E4A_nested::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_93C38E4A_nested
 
 
 		// Methods
@@ -283,6 +751,173 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3A5A524C_deepArray
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2d7d
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_3A5A524C_deepArray::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2d85
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3A5A524C_deepArray::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2d88
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3A5A524C_deepArray::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d8c
+				// Header size: 12
+				// Code size: 119 (0x77)
+				.maxstack 12
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001d: ldarg.2
+				IL_001e: ldc.i4.2
+				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0029: ldarg.2
+				IL_002a: ldc.i4.3
+				IL_002b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0035: ldarg.2
+				IL_0036: ldc.i4.4
+				IL_0037: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_003c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0041: ldarg.2
+				IL_0042: ldc.i4.5
+				IL_0043: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0048: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_004d: ldarg.2
+				IL_004e: ldc.i4.6
+				IL_004f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0054: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0059: ldarg.2
+				IL_005a: ldc.i4.7
+				IL_005b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0065: ldarg.2
+				IL_0066: ldc.i4.8
+				IL_0067: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_006c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0071: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerLiteralArguments/deepArray::__js_call__(object, float64, float64, float64, float64, float64, float64, float64, float64, float64)
+				IL_0076: ret
+			} // end of method FunctionObject_FunctionDeclaration_3A5A524C_deepArray::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e10
+				// Header size: 12
+				// Code size: 115 (0x73)
+				.maxstack 12
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0025: ldarg.2
+				IL_0026: ldc.i4.3
+				IL_0027: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_002c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0031: ldarg.2
+				IL_0032: ldc.i4.4
+				IL_0033: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0038: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_003d: ldarg.2
+				IL_003e: ldc.i4.5
+				IL_003f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0044: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0049: ldarg.2
+				IL_004a: ldc.i4.6
+				IL_004b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0050: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0055: ldarg.2
+				IL_0056: ldc.i4.7
+				IL_0057: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_005c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0061: ldarg.2
+				IL_0062: ldc.i4.8
+				IL_0063: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0068: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_006d: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerLiteralArguments/deepArray::__js_call__(object, float64, float64, float64, float64, float64, float64, float64, float64, float64)
+				IL_0072: ret
+			} // end of method FunctionObject_FunctionDeclaration_3A5A524C_deepArray::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e8f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3A5A524C_deepArray::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_3A5A524C_deepArray
 
 
 		// Methods
@@ -358,6 +993,121 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_48D60399_f
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_SchedulerLiteralArguments/Scope _environment0_Function_SchedulerLiteralArguments
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_SchedulerLiteralArguments/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e9e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/f/FunctionObject_FunctionDeclaration_48D60399_f::_environment0_Function_SchedulerLiteralArguments
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_48D60399_f::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2ead
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_48D60399_f::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2eb0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_48D60399_f::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2eb3
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/f/FunctionObject_FunctionDeclaration_48D60399_f::_environment0_Function_SchedulerLiteralArguments
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0017: call object Modules.Function_SchedulerLiteralArguments/f::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, string)
+				IL_001c: ret
+			} // end of method FunctionObject_FunctionDeclaration_48D60399_f::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ed1
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/f/FunctionObject_FunctionDeclaration_48D60399_f::_environment0_Function_SchedulerLiteralArguments
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0013: call object Modules.Function_SchedulerLiteralArguments/f::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, string)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_48D60399_f::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2eeb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_48D60399_f::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_48D60399_f
+
 
 		// Methods
 		.method public hidebysig static 
@@ -420,6 +1170,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_SchedulerLiteralArguments/Scope _environment0_Function_SchedulerLiteralArguments
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_SchedulerLiteralArguments/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2efa
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/arrayOrder/FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::_environment0_Function_SchedulerLiteralArguments
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2f09
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2f0c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f0f
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/arrayOrder/FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::_environment0_Function_SchedulerLiteralArguments
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_SchedulerLiteralArguments/arrayOrder::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f21
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/arrayOrder/FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::_environment0_Function_SchedulerLiteralArguments
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_SchedulerLiteralArguments/arrayOrder::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f2f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder
 
 
 		// Methods
@@ -564,6 +1421,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_46C14D52_objectOrder
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_SchedulerLiteralArguments/Scope _environment0_Function_SchedulerLiteralArguments
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_SchedulerLiteralArguments/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f3e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/objectOrder/FunctionObject_FunctionDeclaration_46C14D52_objectOrder::_environment0_Function_SchedulerLiteralArguments
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_46C14D52_objectOrder::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2f4d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_46C14D52_objectOrder::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2f50
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_46C14D52_objectOrder::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f53
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/objectOrder/FunctionObject_FunctionDeclaration_46C14D52_objectOrder::_environment0_Function_SchedulerLiteralArguments
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_SchedulerLiteralArguments/objectOrder::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_46C14D52_objectOrder::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f65
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/objectOrder/FunctionObject_FunctionDeclaration_46C14D52_objectOrder::_environment0_Function_SchedulerLiteralArguments
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_SchedulerLiteralArguments/objectOrder::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_46C14D52_objectOrder::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f73
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_46C14D52_objectOrder::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_46C14D52_objectOrder
+
 
 		// Methods
 		.method public hidebysig static 
@@ -693,6 +1657,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_082DF7FE_L42C22
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_SchedulerLiteralArguments/Scope _environment0_Function_SchedulerLiteralArguments
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_SchedulerLiteralArguments/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f82
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/FunctionExpression_spread/FunctionObject_FunctionExpression_082DF7FE_L42C22::_environment0_Function_SchedulerLiteralArguments
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_082DF7FE_L42C22::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2f91
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_082DF7FE_L42C22::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2f94
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_082DF7FE_L42C22::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f97
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/FunctionExpression_spread/FunctionObject_FunctionExpression_082DF7FE_L42C22::_environment0_Function_SchedulerLiteralArguments
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_SchedulerLiteralArguments/FunctionExpression_spread::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_082DF7FE_L42C22::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2fa9
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/FunctionExpression_spread/FunctionObject_FunctionExpression_082DF7FE_L42C22::_environment0_Function_SchedulerLiteralArguments
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_SchedulerLiteralArguments/FunctionExpression_spread::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_082DF7FE_L42C22::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2fb7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_082DF7FE_L42C22::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_082DF7FE_L42C22
+
 
 		// Methods
 		.method public hidebysig static 
@@ -763,6 +1834,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_SchedulerLiteralArguments/Scope _environment0_Function_SchedulerLiteralArguments
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_SchedulerLiteralArguments/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2fc6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/spreadOrder/FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::_environment0_Function_SchedulerLiteralArguments
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2fd5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2fd8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2fdb
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/spreadOrder/FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::_environment0_Function_SchedulerLiteralArguments
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_SchedulerLiteralArguments/spreadOrder::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2fed
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/spreadOrder/FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::_environment0_Function_SchedulerLiteralArguments
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_SchedulerLiteralArguments/spreadOrder::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ffb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder
 
 
 		// Methods
@@ -928,6 +2106,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_SchedulerLiteralArguments/Scope _environment0_Function_SchedulerLiteralArguments
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_SchedulerLiteralArguments/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x300a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/exceptionOrder/FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::_environment0_Function_SchedulerLiteralArguments
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3019
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x301c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x301f
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/exceptionOrder/FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::_environment0_Function_SchedulerLiteralArguments
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Function_SchedulerLiteralArguments/exceptionOrder::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3031
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/exceptionOrder/FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::_environment0_Function_SchedulerLiteralArguments
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Function_SchedulerLiteralArguments/exceptionOrder::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x303f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1068,6 +2353,121 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DC80D3A4_throwValue
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Function_SchedulerLiteralArguments/Scope _environment0_Function_SchedulerLiteralArguments
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Function_SchedulerLiteralArguments/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x304e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/throwValue/FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::_environment0_Function_SchedulerLiteralArguments
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x305d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3060
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3063
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/throwValue/FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::_environment0_Function_SchedulerLiteralArguments
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0017: call object Modules.Function_SchedulerLiteralArguments/throwValue::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, string)
+				IL_001c: ret
+			} // end of method FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3081
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope Modules.Function_SchedulerLiteralArguments/throwValue/FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::_environment0_Function_SchedulerLiteralArguments
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0013: call object Modules.Function_SchedulerLiteralArguments/throwValue::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, string)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x309b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_DC80D3A4_throwValue
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1188,20 +2588,20 @@
 		.maxstack 10
 		.locals init (
 			[0] class Modules.Function_SchedulerLiteralArguments/Scope,
-			[1] class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_3C021B3C_args,
-			[2] class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_82194727_arrayValue,
-			[3] class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_B6660A63_objectValue,
-			[4] class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_93C38E4A_nested,
-			[5] class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_3A5A524C_deepArray,
-			[6] class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder,
-			[7] class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_46C14D52_objectOrder,
-			[8] class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder,
-			[9] class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder,
+			[1] class Modules.Function_SchedulerLiteralArguments/args/FunctionObject_FunctionDeclaration_3C021B3C_args,
+			[2] class Modules.Function_SchedulerLiteralArguments/arrayValue/FunctionObject_FunctionDeclaration_82194727_arrayValue,
+			[3] class Modules.Function_SchedulerLiteralArguments/objectValue/FunctionObject_FunctionDeclaration_B6660A63_objectValue,
+			[4] class Modules.Function_SchedulerLiteralArguments/'nested'/FunctionObject_FunctionDeclaration_93C38E4A_nested,
+			[5] class Modules.Function_SchedulerLiteralArguments/deepArray/FunctionObject_FunctionDeclaration_3A5A524C_deepArray,
+			[6] class Modules.Function_SchedulerLiteralArguments/arrayOrder/FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder,
+			[7] class Modules.Function_SchedulerLiteralArguments/objectOrder/FunctionObject_FunctionDeclaration_46C14D52_objectOrder,
+			[8] class Modules.Function_SchedulerLiteralArguments/spreadOrder/FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder,
+			[9] class Modules.Function_SchedulerLiteralArguments/exceptionOrder/FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder,
 			[10] object,
 			[11] object,
 			[12] object[],
-			[13] class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_48D60399_f,
-			[14] class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_DC80D3A4_throwValue,
+			[13] class Modules.Function_SchedulerLiteralArguments/f/FunctionObject_FunctionDeclaration_48D60399_f,
+			[14] class Modules.Function_SchedulerLiteralArguments/throwValue/FunctionObject_FunctionDeclaration_DC80D3A4_throwValue,
 			[15] object,
 			[16] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
 			[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -1218,13 +2618,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 12
-		IL_0012: newobj instance void FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_3C021B3C_args::.ctor()
+		IL_0012: newobj instance void Modules.Function_SchedulerLiteralArguments/args/FunctionObject_FunctionDeclaration_3C021B3C_args::.ctor()
 		IL_0017: ldc.i4.2
 		IL_0018: conv.r8
 		IL_0019: ldstr "args"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_3C021B3C_args>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/args/FunctionObject_FunctionDeclaration_3C021B3C_args>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -1233,13 +2633,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 12
-		IL_0032: newobj instance void FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_82194727_arrayValue::.ctor()
+		IL_0032: newobj instance void Modules.Function_SchedulerLiteralArguments/arrayValue/FunctionObject_FunctionDeclaration_82194727_arrayValue::.ctor()
 		IL_0037: ldc.i4.2
 		IL_0038: conv.r8
 		IL_0039: ldstr "arrayValue"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_82194727_arrayValue>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/arrayValue/FunctionObject_FunctionDeclaration_82194727_arrayValue>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -1252,13 +2652,13 @@
 		IL_0054: ldc.i4.0
 		IL_0055: ldelem.ref
 		IL_0056: castclass Modules.Function_SchedulerLiteralArguments/Scope
-		IL_005b: newobj instance void FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_B6660A63_objectValue::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
+		IL_005b: newobj instance void Modules.Function_SchedulerLiteralArguments/objectValue/FunctionObject_FunctionDeclaration_B6660A63_objectValue::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
 		IL_0060: ldc.i4.2
 		IL_0061: conv.r8
 		IL_0062: ldstr "objectValue"
 		IL_0067: ldc.i4.0
 		IL_0068: ldc.i4.1
-		IL_0069: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_B6660A63_objectValue>(!!0, float64, string, bool, bool)
+		IL_0069: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/objectValue/FunctionObject_FunctionDeclaration_B6660A63_objectValue>(!!0, float64, string, bool, bool)
 		IL_006e: stloc.3
 		IL_006f: ldc.i4.1
 		IL_0070: newarr [System.Runtime]System.Object
@@ -1271,13 +2671,13 @@
 		IL_007d: ldc.i4.0
 		IL_007e: ldelem.ref
 		IL_007f: castclass Modules.Function_SchedulerLiteralArguments/Scope
-		IL_0084: newobj instance void FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_93C38E4A_nested::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
+		IL_0084: newobj instance void Modules.Function_SchedulerLiteralArguments/'nested'/FunctionObject_FunctionDeclaration_93C38E4A_nested::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
 		IL_0089: ldc.i4.2
 		IL_008a: conv.r8
 		IL_008b: ldstr "nested"
 		IL_0090: ldc.i4.0
 		IL_0091: ldc.i4.1
-		IL_0092: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_93C38E4A_nested>(!!0, float64, string, bool, bool)
+		IL_0092: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/'nested'/FunctionObject_FunctionDeclaration_93C38E4A_nested>(!!0, float64, string, bool, bool)
 		IL_0097: stloc.s 4
 		IL_0099: ldc.i4.1
 		IL_009a: newarr [System.Runtime]System.Object
@@ -1286,13 +2686,13 @@
 		IL_00a1: ldloc.0
 		IL_00a2: stelem.ref
 		IL_00a3: stloc.s 12
-		IL_00a5: newobj instance void FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_3A5A524C_deepArray::.ctor()
+		IL_00a5: newobj instance void Modules.Function_SchedulerLiteralArguments/deepArray/FunctionObject_FunctionDeclaration_3A5A524C_deepArray::.ctor()
 		IL_00aa: ldc.i4.s 9
 		IL_00ac: conv.r8
 		IL_00ad: ldstr "deepArray"
 		IL_00b2: ldc.i4.0
 		IL_00b3: ldc.i4.1
-		IL_00b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_3A5A524C_deepArray>(!!0, float64, string, bool, bool)
+		IL_00b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/deepArray/FunctionObject_FunctionDeclaration_3A5A524C_deepArray>(!!0, float64, string, bool, bool)
 		IL_00b9: stloc.s 5
 		IL_00bb: ldc.i4.1
 		IL_00bc: newarr [System.Runtime]System.Object
@@ -1305,13 +2705,13 @@
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldelem.ref
 		IL_00cb: castclass Modules.Function_SchedulerLiteralArguments/Scope
-		IL_00d0: newobj instance void FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_48D60399_f::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
+		IL_00d0: newobj instance void Modules.Function_SchedulerLiteralArguments/f/FunctionObject_FunctionDeclaration_48D60399_f::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
 		IL_00d5: ldc.i4.1
 		IL_00d6: conv.r8
 		IL_00d7: ldstr "f"
 		IL_00dc: ldc.i4.0
 		IL_00dd: ldc.i4.1
-		IL_00de: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_48D60399_f>(!!0, float64, string, bool, bool)
+		IL_00de: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/f/FunctionObject_FunctionDeclaration_48D60399_f>(!!0, float64, string, bool, bool)
 		IL_00e3: stloc.s 13
 		IL_00e5: ldloc.0
 		IL_00e6: ldloc.s 13
@@ -1327,13 +2727,13 @@
 		IL_00fb: ldc.i4.0
 		IL_00fc: ldelem.ref
 		IL_00fd: castclass Modules.Function_SchedulerLiteralArguments/Scope
-		IL_0102: newobj instance void FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
+		IL_0102: newobj instance void Modules.Function_SchedulerLiteralArguments/arrayOrder/FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
 		IL_0107: ldc.i4.0
 		IL_0108: conv.r8
 		IL_0109: ldstr "arrayOrder"
 		IL_010e: ldc.i4.0
 		IL_010f: ldc.i4.1
-		IL_0110: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder>(!!0, float64, string, bool, bool)
+		IL_0110: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/arrayOrder/FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder>(!!0, float64, string, bool, bool)
 		IL_0115: stloc.s 6
 		IL_0117: ldc.i4.1
 		IL_0118: newarr [System.Runtime]System.Object
@@ -1346,13 +2746,13 @@
 		IL_0125: ldc.i4.0
 		IL_0126: ldelem.ref
 		IL_0127: castclass Modules.Function_SchedulerLiteralArguments/Scope
-		IL_012c: newobj instance void FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_46C14D52_objectOrder::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
+		IL_012c: newobj instance void Modules.Function_SchedulerLiteralArguments/objectOrder/FunctionObject_FunctionDeclaration_46C14D52_objectOrder::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
 		IL_0131: ldc.i4.0
 		IL_0132: conv.r8
 		IL_0133: ldstr "objectOrder"
 		IL_0138: ldc.i4.0
 		IL_0139: ldc.i4.1
-		IL_013a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_46C14D52_objectOrder>(!!0, float64, string, bool, bool)
+		IL_013a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/objectOrder/FunctionObject_FunctionDeclaration_46C14D52_objectOrder>(!!0, float64, string, bool, bool)
 		IL_013f: stloc.s 7
 		IL_0141: ldc.i4.1
 		IL_0142: newarr [System.Runtime]System.Object
@@ -1365,13 +2765,13 @@
 		IL_014f: ldc.i4.0
 		IL_0150: ldelem.ref
 		IL_0151: castclass Modules.Function_SchedulerLiteralArguments/Scope
-		IL_0156: newobj instance void FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
+		IL_0156: newobj instance void Modules.Function_SchedulerLiteralArguments/spreadOrder/FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
 		IL_015b: ldc.i4.0
 		IL_015c: conv.r8
 		IL_015d: ldstr "spreadOrder"
 		IL_0162: ldc.i4.0
 		IL_0163: ldc.i4.1
-		IL_0164: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder>(!!0, float64, string, bool, bool)
+		IL_0164: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/spreadOrder/FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder>(!!0, float64, string, bool, bool)
 		IL_0169: stloc.s 8
 		IL_016b: ldc.i4.1
 		IL_016c: newarr [System.Runtime]System.Object
@@ -1384,13 +2784,13 @@
 		IL_0179: ldc.i4.0
 		IL_017a: ldelem.ref
 		IL_017b: castclass Modules.Function_SchedulerLiteralArguments/Scope
-		IL_0180: newobj instance void FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
+		IL_0180: newobj instance void Modules.Function_SchedulerLiteralArguments/exceptionOrder/FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
 		IL_0185: ldc.i4.0
 		IL_0186: conv.r8
 		IL_0187: ldstr "exceptionOrder"
 		IL_018c: ldc.i4.0
 		IL_018d: ldc.i4.1
-		IL_018e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder>(!!0, float64, string, bool, bool)
+		IL_018e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/exceptionOrder/FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder>(!!0, float64, string, bool, bool)
 		IL_0193: stloc.s 9
 		IL_0195: ldc.i4.1
 		IL_0196: newarr [System.Runtime]System.Object
@@ -1403,13 +2803,13 @@
 		IL_01a3: ldc.i4.0
 		IL_01a4: ldelem.ref
 		IL_01a5: castclass Modules.Function_SchedulerLiteralArguments/Scope
-		IL_01aa: newobj instance void FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
+		IL_01aa: newobj instance void Modules.Function_SchedulerLiteralArguments/throwValue/FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::.ctor(class Modules.Function_SchedulerLiteralArguments/Scope)
 		IL_01af: ldc.i4.1
 		IL_01b0: conv.r8
 		IL_01b1: ldstr "throwValue"
 		IL_01b6: ldc.i4.0
 		IL_01b7: ldc.i4.1
-		IL_01b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_DC80D3A4_throwValue>(!!0, float64, string, bool, bool)
+		IL_01b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Function_SchedulerLiteralArguments/throwValue/FunctionObject_FunctionDeclaration_DC80D3A4_throwValue>(!!0, float64, string, bool, bool)
 		IL_01bd: stloc.s 14
 		IL_01bf: ldloc.0
 		IL_01c0: ldloc.s 14
@@ -1713,1406 +3113,6 @@
 	} // end of method Function_SchedulerLiteralArguments::__js_module_init__
 
 } // end of class Modules.Function_SchedulerLiteralArguments
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_3C021B3C_args
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2bd3
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_3C021B3C_args::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2bdb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3C021B3C_args::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2bde
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3C021B3C_args::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2be1
-		// Header size: 1
-		// Code size: 35 (0x23)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001d: call object Modules.Function_SchedulerLiteralArguments/args::__js_call__(object, float64, float64)
-		IL_0022: ret
-	} // end of method FunctionObject_FunctionDeclaration_3C021B3C_args::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c05
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0019: call object Modules.Function_SchedulerLiteralArguments/args::__js_call__(object, float64, float64)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_3C021B3C_args::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c25
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3C021B3C_args::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_3C021B3C_args
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_82194727_arrayValue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2c34
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_82194727_arrayValue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2c3c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_82194727_arrayValue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2c3f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_82194727_arrayValue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c42
-		// Header size: 1
-		// Code size: 35 (0x23)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001d: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerLiteralArguments/arrayValue::__js_call__(object, float64, float64)
-		IL_0022: ret
-	} // end of method FunctionObject_FunctionDeclaration_82194727_arrayValue::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c66
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0019: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerLiteralArguments/arrayValue::__js_call__(object, float64, float64)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_82194727_arrayValue::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c86
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_82194727_arrayValue::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_82194727_arrayValue
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_B6660A63_objectValue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_SchedulerLiteralArguments/Scope _environment0_Function_SchedulerLiteralArguments
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_SchedulerLiteralArguments/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c95
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_B6660A63_objectValue::_environment0_Function_SchedulerLiteralArguments
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B6660A63_objectValue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2ca4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B6660A63_objectValue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2ca7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B6660A63_objectValue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2caa
-		// Header size: 1
-		// Code size: 41 (0x29)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_B6660A63_objectValue::_environment0_Function_SchedulerLiteralArguments
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0017: ldarg.2
-		IL_0018: ldc.i4.1
-		IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0023: call object Modules.Function_SchedulerLiteralArguments/objectValue::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, float64, float64)
-		IL_0028: ret
-	} // end of method FunctionObject_FunctionDeclaration_B6660A63_objectValue::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cd4
-		// Header size: 1
-		// Code size: 37 (0x25)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_B6660A63_objectValue::_environment0_Function_SchedulerLiteralArguments
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.1
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001f: call object Modules.Function_SchedulerLiteralArguments/objectValue::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, float64, float64)
-		IL_0024: ret
-	} // end of method FunctionObject_FunctionDeclaration_B6660A63_objectValue::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cfa
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B6660A63_objectValue::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_B6660A63_objectValue
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_93C38E4A_nested
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_SchedulerLiteralArguments/Scope _environment0_Function_SchedulerLiteralArguments
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_SchedulerLiteralArguments/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d09
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_93C38E4A_nested::_environment0_Function_SchedulerLiteralArguments
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_93C38E4A_nested::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2d18
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_93C38E4A_nested::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2d1b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_93C38E4A_nested::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d1e
-		// Header size: 1
-		// Code size: 41 (0x29)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_93C38E4A_nested::_environment0_Function_SchedulerLiteralArguments
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0017: ldarg.2
-		IL_0018: ldc.i4.1
-		IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0023: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerLiteralArguments/'nested'::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, float64, float64)
-		IL_0028: ret
-	} // end of method FunctionObject_FunctionDeclaration_93C38E4A_nested::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d48
-		// Header size: 1
-		// Code size: 37 (0x25)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_93C38E4A_nested::_environment0_Function_SchedulerLiteralArguments
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.1
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerLiteralArguments/'nested'::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, float64, float64)
-		IL_0024: ret
-	} // end of method FunctionObject_FunctionDeclaration_93C38E4A_nested::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d6e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_93C38E4A_nested::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_93C38E4A_nested
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_3A5A524C_deepArray
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2d7d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_3A5A524C_deepArray::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2d85
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3A5A524C_deepArray::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2d88
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3A5A524C_deepArray::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d8c
-		// Header size: 12
-		// Code size: 119 (0x77)
-		.maxstack 12
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001d: ldarg.2
-		IL_001e: ldc.i4.2
-		IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0029: ldarg.2
-		IL_002a: ldc.i4.3
-		IL_002b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0030: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0035: ldarg.2
-		IL_0036: ldc.i4.4
-		IL_0037: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_003c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0041: ldarg.2
-		IL_0042: ldc.i4.5
-		IL_0043: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0048: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_004d: ldarg.2
-		IL_004e: ldc.i4.6
-		IL_004f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0054: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0059: ldarg.2
-		IL_005a: ldc.i4.7
-		IL_005b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0060: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0065: ldarg.2
-		IL_0066: ldc.i4.8
-		IL_0067: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_006c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0071: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerLiteralArguments/deepArray::__js_call__(object, float64, float64, float64, float64, float64, float64, float64, float64, float64)
-		IL_0076: ret
-	} // end of method FunctionObject_FunctionDeclaration_3A5A524C_deepArray::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e10
-		// Header size: 12
-		// Code size: 115 (0x73)
-		.maxstack 12
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0025: ldarg.2
-		IL_0026: ldc.i4.3
-		IL_0027: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_002c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0031: ldarg.2
-		IL_0032: ldc.i4.4
-		IL_0033: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0038: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_003d: ldarg.2
-		IL_003e: ldc.i4.5
-		IL_003f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0044: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0049: ldarg.2
-		IL_004a: ldc.i4.6
-		IL_004b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0050: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0055: ldarg.2
-		IL_0056: ldc.i4.7
-		IL_0057: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_005c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0061: ldarg.2
-		IL_0062: ldc.i4.8
-		IL_0063: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0068: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_006d: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Function_SchedulerLiteralArguments/deepArray::__js_call__(object, float64, float64, float64, float64, float64, float64, float64, float64, float64)
-		IL_0072: ret
-	} // end of method FunctionObject_FunctionDeclaration_3A5A524C_deepArray::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e8f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3A5A524C_deepArray::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_3A5A524C_deepArray
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_48D60399_f
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_SchedulerLiteralArguments/Scope _environment0_Function_SchedulerLiteralArguments
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_SchedulerLiteralArguments/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e9e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_48D60399_f::_environment0_Function_SchedulerLiteralArguments
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_48D60399_f::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2ead
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_48D60399_f::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2eb0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_48D60399_f::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2eb3
-		// Header size: 1
-		// Code size: 29 (0x1d)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_48D60399_f::_environment0_Function_SchedulerLiteralArguments
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0017: call object Modules.Function_SchedulerLiteralArguments/f::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, string)
-		IL_001c: ret
-	} // end of method FunctionObject_FunctionDeclaration_48D60399_f::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ed1
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_48D60399_f::_environment0_Function_SchedulerLiteralArguments
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0013: call object Modules.Function_SchedulerLiteralArguments/f::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, string)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_48D60399_f::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2eeb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_48D60399_f::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_48D60399_f
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_SchedulerLiteralArguments/Scope _environment0_Function_SchedulerLiteralArguments
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_SchedulerLiteralArguments/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2efa
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::_environment0_Function_SchedulerLiteralArguments
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2f09
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2f0c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f0f
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::_environment0_Function_SchedulerLiteralArguments
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_SchedulerLiteralArguments/arrayOrder::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f21
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::_environment0_Function_SchedulerLiteralArguments
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_SchedulerLiteralArguments/arrayOrder::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f2f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_7CF570FE_arrayOrder
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_46C14D52_objectOrder
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_SchedulerLiteralArguments/Scope _environment0_Function_SchedulerLiteralArguments
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_SchedulerLiteralArguments/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f3e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_46C14D52_objectOrder::_environment0_Function_SchedulerLiteralArguments
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_46C14D52_objectOrder::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2f4d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_46C14D52_objectOrder::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2f50
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_46C14D52_objectOrder::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f53
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_46C14D52_objectOrder::_environment0_Function_SchedulerLiteralArguments
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_SchedulerLiteralArguments/objectOrder::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_46C14D52_objectOrder::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f65
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_46C14D52_objectOrder::_environment0_Function_SchedulerLiteralArguments
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_SchedulerLiteralArguments/objectOrder::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_46C14D52_objectOrder::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f73
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_46C14D52_objectOrder::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_46C14D52_objectOrder
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionExpression_082DF7FE_L42C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_SchedulerLiteralArguments/Scope _environment0_Function_SchedulerLiteralArguments
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_SchedulerLiteralArguments/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f82
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionExpression_082DF7FE_L42C22::_environment0_Function_SchedulerLiteralArguments
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_082DF7FE_L42C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2f91
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_082DF7FE_L42C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2f94
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_082DF7FE_L42C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f97
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionExpression_082DF7FE_L42C22::_environment0_Function_SchedulerLiteralArguments
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_SchedulerLiteralArguments/FunctionExpression_spread::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_082DF7FE_L42C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2fa9
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionExpression_082DF7FE_L42C22::_environment0_Function_SchedulerLiteralArguments
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_SchedulerLiteralArguments/FunctionExpression_spread::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_082DF7FE_L42C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2fb7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_082DF7FE_L42C22::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionExpression_082DF7FE_L42C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_SchedulerLiteralArguments/Scope _environment0_Function_SchedulerLiteralArguments
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_SchedulerLiteralArguments/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2fc6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::_environment0_Function_SchedulerLiteralArguments
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2fd5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2fd8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2fdb
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::_environment0_Function_SchedulerLiteralArguments
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_SchedulerLiteralArguments/spreadOrder::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2fed
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::_environment0_Function_SchedulerLiteralArguments
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_SchedulerLiteralArguments/spreadOrder::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ffb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_9AEA23E6_spreadOrder
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_SchedulerLiteralArguments/Scope _environment0_Function_SchedulerLiteralArguments
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_SchedulerLiteralArguments/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x300a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::_environment0_Function_SchedulerLiteralArguments
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3019
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x301c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x301f
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::_environment0_Function_SchedulerLiteralArguments
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Function_SchedulerLiteralArguments/exceptionOrder::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3031
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::_environment0_Function_SchedulerLiteralArguments
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Function_SchedulerLiteralArguments/exceptionOrder::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x303f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_6480C72E_exceptionOrder
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_DC80D3A4_throwValue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Function_SchedulerLiteralArguments/Scope _environment0_Function_SchedulerLiteralArguments
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Function_SchedulerLiteralArguments/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x304e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Function_SchedulerLiteralArguments/Scope FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::_environment0_Function_SchedulerLiteralArguments
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x305d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3060
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3063
-		// Header size: 1
-		// Code size: 29 (0x1d)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::_environment0_Function_SchedulerLiteralArguments
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0017: call object Modules.Function_SchedulerLiteralArguments/throwValue::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, string)
-		IL_001c: ret
-	} // end of method FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3081
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Function_SchedulerLiteralArguments/Scope FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::_environment0_Function_SchedulerLiteralArguments
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0013: call object Modules.Function_SchedulerLiteralArguments/throwValue::__js_call__(class Modules.Function_SchedulerLiteralArguments/Scope, object, string)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x309b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DC80D3A4_throwValue::ConstructCore
-
-} // end of class FunctionObjects.Function_SchedulerLiteralArguments_89510E16.FunctionObject_FunctionDeclaration_DC80D3A4_throwValue
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_BasicNext.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_BasicNext.verified.txt
@@ -37,6 +37,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_362D250E_g
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x245e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Generator_BasicNext/g/FunctionObject_FunctionDeclaration_362D250E_g::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_362D250E_g::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x246d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_362D250E_g::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2470
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_362D250E_g::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2473
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_BasicNext/g/FunctionObject_FunctionDeclaration_362D250E_g::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Generator_BasicNext/g::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_362D250E_g::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2485
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_BasicNext/g/FunctionObject_FunctionDeclaration_362D250E_g::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Generator_BasicNext/g::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_362D250E_g::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_362D250E_g
+
 
 		// Methods
 		.method public hidebysig static 
@@ -446,94 +534,6 @@
 	} // end of method Generator_BasicNext::__js_module_init__
 
 } // end of class Modules.Generator_BasicNext
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_BasicNext_4872927E.FunctionObject_FunctionDeclaration_362D250E_g
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x245e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Generator_BasicNext_4872927E.FunctionObject_FunctionDeclaration_362D250E_g::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_362D250E_g::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x246d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_362D250E_g::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2470
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_362D250E_g::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2473
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_BasicNext_4872927E.FunctionObject_FunctionDeclaration_362D250E_g::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Generator_BasicNext/g::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_362D250E_g::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2485
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_BasicNext_4872927E.FunctionObject_FunctionDeclaration_362D250E_g::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Generator_BasicNext/g::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_362D250E_g::ConstructBodyCore
-
-} // end of class FunctionObjects.Generator_BasicNext_4872927E.FunctionObject_FunctionDeclaration_362D250E_g
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_ClassMethod_SimpleYield.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_ClassMethod_SimpleYield.verified.txt
@@ -51,6 +51,149 @@
 
 		} // end of class Scope_values
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_55505B9D_Gen
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2430
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Generator_ClassMethod_SimpleYield/Gen/FunctionObject_ClassConstructor_55505B9D_Gen::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_55505B9D_Gen::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x243f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_55505B9D_Gen::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2442
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_55505B9D_Gen::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2445
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_55505B9D_Gen::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2451
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_55505B9D_Gen::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_55505B9D_Gen
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_8A90F746_Gen_values
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x245d
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_8A90F746_Gen_values::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2465
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_8A90F746_Gen_values::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2468
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_8A90F746_Gen_values::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x246b
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Generator_ClassMethod_SimpleYield/Gen
+				IL_0006: call instance object Modules.Generator_ClassMethod_SimpleYield/Gen::values(object[], object)
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_8A90F746_Gen_values::CallCore
+
+		} // end of class FunctionObject_ClassMethod_8A90F746_Gen_values
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -501,149 +644,6 @@
 	} // end of method Generator_ClassMethod_SimpleYield::__js_module_init__
 
 } // end of class Modules.Generator_ClassMethod_SimpleYield
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_ClassMethod_SimpleYield_EDE07868.FunctionObject_ClassConstructor_55505B9D_Gen
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2430
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Generator_ClassMethod_SimpleYield_EDE07868.FunctionObject_ClassConstructor_55505B9D_Gen::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_55505B9D_Gen::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x243f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_55505B9D_Gen::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2442
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_55505B9D_Gen::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2445
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_55505B9D_Gen::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2451
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_55505B9D_Gen::ConstructCore
-
-} // end of class FunctionObjects.Generator_ClassMethod_SimpleYield_EDE07868.FunctionObject_ClassConstructor_55505B9D_Gen
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_ClassMethod_SimpleYield_EDE07868.FunctionObject_ClassMethod_8A90F746_Gen_values
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x245d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_8A90F746_Gen_values::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2465
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_8A90F746_Gen_values::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2468
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_8A90F746_Gen_values::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x246b
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Generator_ClassMethod_SimpleYield/Gen
-		IL_0006: call instance object Modules.Generator_ClassMethod_SimpleYield/Gen::values(object[], object)
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_8A90F746_Gen_values::CallCore
-
-} // end of class FunctionObjects.Generator_ClassMethod_SimpleYield_EDE07868.FunctionObject_ClassMethod_8A90F746_Gen_values
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_ClassMethod_WithThis.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_ClassMethod_WithThis.verified.txt
@@ -71,6 +71,149 @@
 
 		} // end of class Scope_getCountLater
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_3DEBA3B4_Counter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2375
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Generator_ClassMethod_WithThis/Counter/FunctionObject_ClassConstructor_3DEBA3B4_Counter::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_3DEBA3B4_Counter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2384
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_3DEBA3B4_Counter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2387
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_3DEBA3B4_Counter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x238a
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_3DEBA3B4_Counter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2396
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_3DEBA3B4_Counter::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_3DEBA3B4_Counter
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_5CAB54E8_Counter_getCountLater
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x23a2
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_5CAB54E8_Counter_getCountLater::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x23aa
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_5CAB54E8_Counter_getCountLater::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x23ad
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_5CAB54E8_Counter_getCountLater::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x23b0
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Generator_ClassMethod_WithThis/Counter
+				IL_0006: call instance object Modules.Generator_ClassMethod_WithThis/Counter::getCountLater(object[], object)
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_5CAB54E8_Counter_getCountLater::CallCore
+
+		} // end of class FunctionObject_ClassMethod_5CAB54E8_Counter_getCountLater
+
 
 		// Fields
 		.field public float64 count
@@ -453,149 +596,6 @@
 	} // end of method Generator_ClassMethod_WithThis::__js_module_init__
 
 } // end of class Modules.Generator_ClassMethod_WithThis
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_ClassMethod_WithThis_EF482AC9.FunctionObject_ClassConstructor_3DEBA3B4_Counter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2375
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Generator_ClassMethod_WithThis_EF482AC9.FunctionObject_ClassConstructor_3DEBA3B4_Counter::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_3DEBA3B4_Counter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2384
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_3DEBA3B4_Counter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2387
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_3DEBA3B4_Counter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x238a
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_3DEBA3B4_Counter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2396
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_3DEBA3B4_Counter::ConstructCore
-
-} // end of class FunctionObjects.Generator_ClassMethod_WithThis_EF482AC9.FunctionObject_ClassConstructor_3DEBA3B4_Counter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_ClassMethod_WithThis_EF482AC9.FunctionObject_ClassMethod_5CAB54E8_Counter_getCountLater
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x23a2
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_5CAB54E8_Counter_getCountLater::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23aa
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_5CAB54E8_Counter_getCountLater::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23ad
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_5CAB54E8_Counter_getCountLater::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23b0
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Generator_ClassMethod_WithThis/Counter
-		IL_0006: call instance object Modules.Generator_ClassMethod_WithThis/Counter::getCountLater(object[], object)
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_5CAB54E8_Counter_getCountLater::CallCore
-
-} // end of class FunctionObjects.Generator_ClassMethod_WithThis_EF482AC9.FunctionObject_ClassMethod_5CAB54E8_Counter_getCountLater
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_ClassMethod_YieldAssign.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_ClassMethod_YieldAssign.verified.txt
@@ -51,6 +51,149 @@
 
 		} // end of class Scope_values
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_50C640BC_Gen
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2436
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Generator_ClassMethod_YieldAssign/Gen/FunctionObject_ClassConstructor_50C640BC_Gen::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_50C640BC_Gen::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2445
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_50C640BC_Gen::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2448
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_50C640BC_Gen::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x244b
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_50C640BC_Gen::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2457
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_50C640BC_Gen::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_50C640BC_Gen
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_764EBF87_Gen_values
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2463
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_764EBF87_Gen_values::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x246b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_764EBF87_Gen_values::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x246e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_764EBF87_Gen_values::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2471
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Generator_ClassMethod_YieldAssign/Gen
+				IL_0006: call instance object Modules.Generator_ClassMethod_YieldAssign/Gen::values(object[], object)
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_764EBF87_Gen_values::CallCore
+
+		} // end of class FunctionObject_ClassMethod_764EBF87_Gen_values
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -506,149 +649,6 @@
 	} // end of method Generator_ClassMethod_YieldAssign::__js_module_init__
 
 } // end of class Modules.Generator_ClassMethod_YieldAssign
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_ClassMethod_YieldAssign_3C0A8F0B.FunctionObject_ClassConstructor_50C640BC_Gen
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2436
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Generator_ClassMethod_YieldAssign_3C0A8F0B.FunctionObject_ClassConstructor_50C640BC_Gen::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_50C640BC_Gen::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2445
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_50C640BC_Gen::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2448
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_50C640BC_Gen::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x244b
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_50C640BC_Gen::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2457
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_50C640BC_Gen::ConstructCore
-
-} // end of class FunctionObjects.Generator_ClassMethod_YieldAssign_3C0A8F0B.FunctionObject_ClassConstructor_50C640BC_Gen
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_ClassMethod_YieldAssign_3C0A8F0B.FunctionObject_ClassMethod_764EBF87_Gen_values
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2463
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_764EBF87_Gen_values::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x246b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_764EBF87_Gen_values::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x246e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_764EBF87_Gen_values::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2471
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Generator_ClassMethod_YieldAssign/Gen
-		IL_0006: call instance object Modules.Generator_ClassMethod_YieldAssign/Gen::values(object[], object)
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_764EBF87_Gen_values::CallCore
-
-} // end of class FunctionObjects.Generator_ClassMethod_YieldAssign_3C0A8F0B.FunctionObject_ClassMethod_764EBF87_Gen_values
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_Inheritance_SuperIteratorMethod.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_Inheritance_SuperIteratorMethod.verified.txt
@@ -51,6 +51,149 @@
 
 		} // end of class Scope_values
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_DA8A3036_Base
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2469
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Generator_Inheritance_SuperIteratorMethod/Base/FunctionObject_ClassConstructor_DA8A3036_Base::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_DA8A3036_Base::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2478
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_DA8A3036_Base::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x247b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_DA8A3036_Base::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x247e
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_DA8A3036_Base::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x248a
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_DA8A3036_Base::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_DA8A3036_Base
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_C9EFEAA1_Base_values
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2496
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_C9EFEAA1_Base_values::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x249e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_C9EFEAA1_Base_values::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24a1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_C9EFEAA1_Base_values::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24a4
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Generator_Inheritance_SuperIteratorMethod/Base
+				IL_0006: call instance object Modules.Generator_Inheritance_SuperIteratorMethod/Base::values(object[], object)
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_C9EFEAA1_Base_values::CallCore
+
+		} // end of class FunctionObject_ClassMethod_C9EFEAA1_Base_values
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -261,6 +404,149 @@
 			} // end of method Scope_run::.ctor
 
 		} // end of class Scope_run
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_C29E0300_Derived
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x24b1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Generator_Inheritance_SuperIteratorMethod/Derived/FunctionObject_ClassConstructor_C29E0300_Derived::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_C29E0300_Derived::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24c0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_C29E0300_Derived::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24c3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_C29E0300_Derived::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24c6
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_C29E0300_Derived::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24d2
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_C29E0300_Derived::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_C29E0300_Derived
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_E8608C04_Derived_run
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x24de
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_E8608C04_Derived_run::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24e6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_E8608C04_Derived_run::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24e9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_E8608C04_Derived_run::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24ec
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Generator_Inheritance_SuperIteratorMethod/Derived
+				IL_0006: call instance object Modules.Generator_Inheritance_SuperIteratorMethod/Derived::run()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_E8608C04_Derived_run::CallCore
+
+		} // end of class FunctionObject_ClassMethod_E8608C04_Derived_run
 
 
 		// Methods
@@ -590,292 +876,6 @@
 	} // end of method Generator_Inheritance_SuperIteratorMethod::__js_module_init__
 
 } // end of class Modules.Generator_Inheritance_SuperIteratorMethod
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_Inheritance_SuperIteratorMethod_7C9BDB9A.FunctionObject_ClassConstructor_DA8A3036_Base
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2469
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Generator_Inheritance_SuperIteratorMethod_7C9BDB9A.FunctionObject_ClassConstructor_DA8A3036_Base::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_DA8A3036_Base::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2478
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_DA8A3036_Base::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x247b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_DA8A3036_Base::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x247e
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_DA8A3036_Base::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x248a
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_DA8A3036_Base::ConstructCore
-
-} // end of class FunctionObjects.Generator_Inheritance_SuperIteratorMethod_7C9BDB9A.FunctionObject_ClassConstructor_DA8A3036_Base
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_Inheritance_SuperIteratorMethod_7C9BDB9A.FunctionObject_ClassMethod_C9EFEAA1_Base_values
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2496
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_C9EFEAA1_Base_values::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x249e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_C9EFEAA1_Base_values::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24a1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_C9EFEAA1_Base_values::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24a4
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Generator_Inheritance_SuperIteratorMethod/Base
-		IL_0006: call instance object Modules.Generator_Inheritance_SuperIteratorMethod/Base::values(object[], object)
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_C9EFEAA1_Base_values::CallCore
-
-} // end of class FunctionObjects.Generator_Inheritance_SuperIteratorMethod_7C9BDB9A.FunctionObject_ClassMethod_C9EFEAA1_Base_values
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_Inheritance_SuperIteratorMethod_7C9BDB9A.FunctionObject_ClassConstructor_C29E0300_Derived
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x24b1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Generator_Inheritance_SuperIteratorMethod_7C9BDB9A.FunctionObject_ClassConstructor_C29E0300_Derived::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_C29E0300_Derived::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24c0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_C29E0300_Derived::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24c3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_C29E0300_Derived::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24c6
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_C29E0300_Derived::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24d2
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_C29E0300_Derived::ConstructCore
-
-} // end of class FunctionObjects.Generator_Inheritance_SuperIteratorMethod_7C9BDB9A.FunctionObject_ClassConstructor_C29E0300_Derived
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_Inheritance_SuperIteratorMethod_7C9BDB9A.FunctionObject_ClassMethod_E8608C04_Derived_run
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x24de
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_E8608C04_Derived_run::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24e6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_E8608C04_Derived_run::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24e9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_E8608C04_Derived_run::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24ec
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Generator_Inheritance_SuperIteratorMethod/Derived
-		IL_0006: call instance object Modules.Generator_Inheritance_SuperIteratorMethod/Derived::run()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_E8608C04_Derived_run::CallCore
-
-} // end of class FunctionObjects.Generator_Inheritance_SuperIteratorMethod_7C9BDB9A.FunctionObject_ClassMethod_E8608C04_Derived_run
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_Prototype_Constructor.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_Prototype_Constructor.verified.txt
@@ -31,6 +31,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C2EB3AE8_g
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2239
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Generator_Prototype_Constructor/g/FunctionObject_FunctionDeclaration_C2EB3AE8_g::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C2EB3AE8_g::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2248
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C2EB3AE8_g::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x224b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C2EB3AE8_g::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x224e
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_Prototype_Constructor/g/FunctionObject_FunctionDeclaration_C2EB3AE8_g::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Generator_Prototype_Constructor/g::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_C2EB3AE8_g::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2260
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_Prototype_Constructor/g/FunctionObject_FunctionDeclaration_C2EB3AE8_g::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Generator_Prototype_Constructor/g::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_C2EB3AE8_g::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C2EB3AE8_g
+
 
 		// Methods
 		.method public hidebysig static 
@@ -280,94 +368,6 @@
 	} // end of method Generator_Prototype_Constructor::__js_module_init__
 
 } // end of class Modules.Generator_Prototype_Constructor
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_Prototype_Constructor_9A80EE28.FunctionObject_FunctionDeclaration_C2EB3AE8_g
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2239
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Generator_Prototype_Constructor_9A80EE28.FunctionObject_FunctionDeclaration_C2EB3AE8_g::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C2EB3AE8_g::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2248
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C2EB3AE8_g::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x224b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C2EB3AE8_g::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x224e
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_Prototype_Constructor_9A80EE28.FunctionObject_FunctionDeclaration_C2EB3AE8_g::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Generator_Prototype_Constructor/g::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_C2EB3AE8_g::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2260
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_Prototype_Constructor_9A80EE28.FunctionObject_FunctionDeclaration_C2EB3AE8_g::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Generator_Prototype_Constructor/g::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_C2EB3AE8_g::ConstructBodyCore
-
-} // end of class FunctionObjects.Generator_Prototype_Constructor_9A80EE28.FunctionObject_FunctionDeclaration_C2EB3AE8_g
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_Prototype_ToStringTag.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_Prototype_ToStringTag.verified.txt
@@ -31,6 +31,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5DFC87C8_g
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x22e1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Generator_Prototype_ToStringTag/g/FunctionObject_FunctionDeclaration_5DFC87C8_g::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5DFC87C8_g::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22f0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5DFC87C8_g::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22f3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5DFC87C8_g::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22f6
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_Prototype_ToStringTag/g/FunctionObject_FunctionDeclaration_5DFC87C8_g::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Generator_Prototype_ToStringTag/g::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_5DFC87C8_g::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2308
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_Prototype_ToStringTag/g/FunctionObject_FunctionDeclaration_5DFC87C8_g::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Generator_Prototype_ToStringTag/g::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_5DFC87C8_g::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_5DFC87C8_g
+
 
 		// Methods
 		.method public hidebysig static 
@@ -316,94 +404,6 @@
 	} // end of method Generator_Prototype_ToStringTag::__js_module_init__
 
 } // end of class Modules.Generator_Prototype_ToStringTag
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_Prototype_ToStringTag_A2283B08.FunctionObject_FunctionDeclaration_5DFC87C8_g
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x22e1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Generator_Prototype_ToStringTag_A2283B08.FunctionObject_FunctionDeclaration_5DFC87C8_g::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5DFC87C8_g::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22f0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5DFC87C8_g::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22f3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5DFC87C8_g::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22f6
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_Prototype_ToStringTag_A2283B08.FunctionObject_FunctionDeclaration_5DFC87C8_g::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Generator_Prototype_ToStringTag/g::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_5DFC87C8_g::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2308
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_Prototype_ToStringTag_A2283B08.FunctionObject_FunctionDeclaration_5DFC87C8_g::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Generator_Prototype_ToStringTag/g::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_5DFC87C8_g::ConstructBodyCore
-
-} // end of class FunctionObjects.Generator_Prototype_ToStringTag_A2283B08.FunctionObject_FunctionDeclaration_5DFC87C8_g
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_SchedulerLocalsAcrossYield.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_SchedulerLocalsAcrossYield.verified.txt
@@ -42,6 +42,100 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_19D04A4D_test
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2292
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Generator_SchedulerLocalsAcrossYield/test/FunctionObject_FunctionDeclaration_19D04A4D_test::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_19D04A4D_test::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22a1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_19D04A4D_test::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22a4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_19D04A4D_test::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22a7
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_SchedulerLocalsAcrossYield/test/FunctionObject_FunctionDeclaration_19D04A4D_test::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Generator_SchedulerLocalsAcrossYield/test::__js_call__(object[], object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_19D04A4D_test::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22c0
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_SchedulerLocalsAcrossYield/test/FunctionObject_FunctionDeclaration_19D04A4D_test::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Generator_SchedulerLocalsAcrossYield/test::__js_call__(object[], object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_19D04A4D_test::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_19D04A4D_test
+
 
 		// Methods
 		.method public hidebysig static 
@@ -323,100 +417,6 @@
 	} // end of method Generator_SchedulerLocalsAcrossYield::__js_module_init__
 
 } // end of class Modules.Generator_SchedulerLocalsAcrossYield
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_SchedulerLocalsAcrossYield_6D83722E.FunctionObject_FunctionDeclaration_19D04A4D_test
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2292
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Generator_SchedulerLocalsAcrossYield_6D83722E.FunctionObject_FunctionDeclaration_19D04A4D_test::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_19D04A4D_test::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22a1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_19D04A4D_test::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22a4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_19D04A4D_test::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22a7
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_SchedulerLocalsAcrossYield_6D83722E.FunctionObject_FunctionDeclaration_19D04A4D_test::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Generator_SchedulerLocalsAcrossYield/test::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_19D04A4D_test::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22c0
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_SchedulerLocalsAcrossYield_6D83722E.FunctionObject_FunctionDeclaration_19D04A4D_test::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Generator_SchedulerLocalsAcrossYield/test::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_19D04A4D_test::ConstructBodyCore
-
-} // end of class FunctionObjects.Generator_SchedulerLocalsAcrossYield_6D83722E.FunctionObject_FunctionDeclaration_19D04A4D_test
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_StaticMethod_SimpleYield.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_StaticMethod_SimpleYield.verified.txt
@@ -51,6 +51,147 @@
 
 		} // end of class Scope_values
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_03FB2AC1_Gen
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x232b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Generator_StaticMethod_SimpleYield/Gen/FunctionObject_ClassConstructor_03FB2AC1_Gen::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_03FB2AC1_Gen::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x233a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_03FB2AC1_Gen::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x233d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_03FB2AC1_Gen::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2340
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_03FB2AC1_Gen::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x234c
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_03FB2AC1_Gen::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_03FB2AC1_Gen
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassStaticMethod_58F13DA0_Gen_values
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2358
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassStaticMethod_58F13DA0_Gen_values::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2360
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassStaticMethod_58F13DA0_Gen_values::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2363
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassStaticMethod_58F13DA0_Gen_values::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2366
+				// Header size: 1
+				// Code size: 6 (0x6)
+				.maxstack 8
+
+				IL_0000: call object Modules.Generator_StaticMethod_SimpleYield/Gen::values(object[], object)
+				IL_0005: ret
+			} // end of method FunctionObject_ClassStaticMethod_58F13DA0_Gen_values::CallCore
+
+		} // end of class FunctionObject_ClassStaticMethod_58F13DA0_Gen_values
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -410,147 +551,6 @@
 	} // end of method Generator_StaticMethod_SimpleYield::__js_module_init__
 
 } // end of class Modules.Generator_StaticMethod_SimpleYield
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_StaticMethod_SimpleYield_BF8C563C.FunctionObject_ClassConstructor_03FB2AC1_Gen
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x232b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Generator_StaticMethod_SimpleYield_BF8C563C.FunctionObject_ClassConstructor_03FB2AC1_Gen::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_03FB2AC1_Gen::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x233a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_03FB2AC1_Gen::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x233d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_03FB2AC1_Gen::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2340
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_03FB2AC1_Gen::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x234c
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_03FB2AC1_Gen::ConstructCore
-
-} // end of class FunctionObjects.Generator_StaticMethod_SimpleYield_BF8C563C.FunctionObject_ClassConstructor_03FB2AC1_Gen
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_StaticMethod_SimpleYield_BF8C563C.FunctionObject_ClassStaticMethod_58F13DA0_Gen_values
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2358
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassStaticMethod_58F13DA0_Gen_values::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2360
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassStaticMethod_58F13DA0_Gen_values::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2363
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassStaticMethod_58F13DA0_Gen_values::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2366
-		// Header size: 1
-		// Code size: 6 (0x6)
-		.maxstack 8
-
-		IL_0000: call object Modules.Generator_StaticMethod_SimpleYield/Gen::values(object[], object)
-		IL_0005: ret
-	} // end of method FunctionObject_ClassStaticMethod_58F13DA0_Gen_values::CallCore
-
-} // end of class FunctionObjects.Generator_StaticMethod_SimpleYield_BF8C563C.FunctionObject_ClassStaticMethod_58F13DA0_Gen_values
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ReturnWhileSuspended.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ReturnWhileSuspended.verified.txt
@@ -93,6 +93,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_93946DCA_g1
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bbd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g1/FunctionObject_FunctionDeclaration_93946DCA_g1::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_93946DCA_g1::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2bcc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_93946DCA_g1::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2bcf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_93946DCA_g1::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bd2
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g1/FunctionObject_FunctionDeclaration_93946DCA_g1::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g1::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_93946DCA_g1::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2be4
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g1/FunctionObject_FunctionDeclaration_93946DCA_g1::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g1::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_93946DCA_g1::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_93946DCA_g1
+
 
 		// Methods
 		.method public hidebysig static 
@@ -517,6 +605,94 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_92946C37_g2
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bf2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g2/FunctionObject_FunctionDeclaration_92946C37_g2::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_92946C37_g2::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2c01
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_92946C37_g2::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2c04
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_92946C37_g2::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c07
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g2/FunctionObject_FunctionDeclaration_92946C37_g2::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g2::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_92946C37_g2::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c19
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g2/FunctionObject_FunctionDeclaration_92946C37_g2::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g2::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_92946C37_g2::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_92946C37_g2
 
 
 		// Methods
@@ -1263,182 +1439,6 @@
 	} // end of method Generator_TryCatchFinally_ReturnWhileSuspended::__js_module_init__
 
 } // end of class Modules.Generator_TryCatchFinally_ReturnWhileSuspended
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_TryCatchFinally_ReturnWhileSuspended_2B233AAF.FunctionObject_FunctionDeclaration_93946DCA_g1
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bbd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Generator_TryCatchFinally_ReturnWhileSuspended_2B233AAF.FunctionObject_FunctionDeclaration_93946DCA_g1::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_93946DCA_g1::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2bcc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_93946DCA_g1::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2bcf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_93946DCA_g1::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bd2
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_TryCatchFinally_ReturnWhileSuspended_2B233AAF.FunctionObject_FunctionDeclaration_93946DCA_g1::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g1::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_93946DCA_g1::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2be4
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_TryCatchFinally_ReturnWhileSuspended_2B233AAF.FunctionObject_FunctionDeclaration_93946DCA_g1::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g1::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_93946DCA_g1::ConstructBodyCore
-
-} // end of class FunctionObjects.Generator_TryCatchFinally_ReturnWhileSuspended_2B233AAF.FunctionObject_FunctionDeclaration_93946DCA_g1
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_TryCatchFinally_ReturnWhileSuspended_2B233AAF.FunctionObject_FunctionDeclaration_92946C37_g2
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bf2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Generator_TryCatchFinally_ReturnWhileSuspended_2B233AAF.FunctionObject_FunctionDeclaration_92946C37_g2::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_92946C37_g2::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2c01
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_92946C37_g2::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2c04
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_92946C37_g2::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c07
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_TryCatchFinally_ReturnWhileSuspended_2B233AAF.FunctionObject_FunctionDeclaration_92946C37_g2::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g2::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_92946C37_g2::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c19
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_TryCatchFinally_ReturnWhileSuspended_2B233AAF.FunctionObject_FunctionDeclaration_92946C37_g2::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Generator_TryCatchFinally_ReturnWhileSuspended/g2::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_92946C37_g2::ConstructBodyCore
-
-} // end of class FunctionObjects.Generator_TryCatchFinally_ReturnWhileSuspended_2B233AAF.FunctionObject_FunctionDeclaration_92946C37_g2
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields.verified.txt
@@ -93,6 +93,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_587AD8E1_g
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2684
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/g/FunctionObject_FunctionDeclaration_587AD8E1_g::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_587AD8E1_g::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2693
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_587AD8E1_g::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2696
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_587AD8E1_g::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2699
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/g/FunctionObject_FunctionDeclaration_587AD8E1_g::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/g::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_587AD8E1_g::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26ab
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/g/FunctionObject_FunctionDeclaration_587AD8E1_g::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/g::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_587AD8E1_g::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_587AD8E1_g
+
 
 		// Methods
 		.method public hidebysig static 
@@ -690,94 +778,6 @@
 	} // end of method Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields::__js_module_init__
 
 } // end of class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields_11C15499.FunctionObject_FunctionDeclaration_587AD8E1_g
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2684
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields_11C15499.FunctionObject_FunctionDeclaration_587AD8E1_g::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_587AD8E1_g::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2693
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_587AD8E1_g::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2696
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_587AD8E1_g::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2699
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields_11C15499.FunctionObject_FunctionDeclaration_587AD8E1_g::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/g::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_587AD8E1_g::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26ab
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields_11C15499.FunctionObject_FunctionDeclaration_587AD8E1_g::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields/g::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_587AD8E1_g::ConstructBodyCore
-
-} // end of class FunctionObjects.Generator_TryCatchFinally_ThrowWhileSuspended_CatchYields_11C15499.FunctionObject_FunctionDeclaration_587AD8E1_g
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_Nested.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_Nested.verified.txt
@@ -135,6 +135,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1AC264FF_g
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x269f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/g/FunctionObject_FunctionDeclaration_1AC264FF_g::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_1AC264FF_g::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x26ae
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1AC264FF_g::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x26b1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1AC264FF_g::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x26b4
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/g/FunctionObject_FunctionDeclaration_1AC264FF_g::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/g::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_1AC264FF_g::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26c6
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/g/FunctionObject_FunctionDeclaration_1AC264FF_g::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/g::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_1AC264FF_g::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_1AC264FF_g
+
 
 		// Methods
 		.method public hidebysig static 
@@ -747,94 +835,6 @@
 	} // end of method Generator_TryCatchFinally_ThrowWhileSuspended_Nested::__js_module_init__
 
 } // end of class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_TryCatchFinally_ThrowWhileSuspended_Nested_476C9A2F.FunctionObject_FunctionDeclaration_1AC264FF_g
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x269f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Generator_TryCatchFinally_ThrowWhileSuspended_Nested_476C9A2F.FunctionObject_FunctionDeclaration_1AC264FF_g::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_1AC264FF_g::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x26ae
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1AC264FF_g::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x26b1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1AC264FF_g::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x26b4
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_TryCatchFinally_ThrowWhileSuspended_Nested_476C9A2F.FunctionObject_FunctionDeclaration_1AC264FF_g::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/g::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_1AC264FF_g::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26c6
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_TryCatchFinally_ThrowWhileSuspended_Nested_476C9A2F.FunctionObject_FunctionDeclaration_1AC264FF_g::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Nested/g::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_1AC264FF_g::ConstructBodyCore
-
-} // end of class FunctionObjects.Generator_TryCatchFinally_ThrowWhileSuspended_Nested_476C9A2F.FunctionObject_FunctionDeclaration_1AC264FF_g
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow.verified.txt
@@ -93,6 +93,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D7535F87_g
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x252c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/g/FunctionObject_FunctionDeclaration_D7535F87_g::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D7535F87_g::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x253b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D7535F87_g::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x253e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D7535F87_g::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2541
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/g/FunctionObject_FunctionDeclaration_D7535F87_g::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/g::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_D7535F87_g::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2553
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/g/FunctionObject_FunctionDeclaration_D7535F87_g::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/g::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_D7535F87_g::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_D7535F87_g
+
 
 		// Methods
 		.method public hidebysig static 
@@ -633,94 +721,6 @@
 	} // end of method Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow::__js_module_init__
 
 } // end of class Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow_9772A2B7.FunctionObject_FunctionDeclaration_D7535F87_g
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x252c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow_9772A2B7.FunctionObject_FunctionDeclaration_D7535F87_g::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D7535F87_g::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x253b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D7535F87_g::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x253e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D7535F87_g::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2541
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow_9772A2B7.FunctionObject_FunctionDeclaration_D7535F87_g::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/g::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_D7535F87_g::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2553
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow_9772A2B7.FunctionObject_FunctionDeclaration_D7535F87_g::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow/g::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_D7535F87_g::ConstructBodyCore
-
-} // end of class FunctionObjects.Generator_TryCatchFinally_ThrowWhileSuspended_Rethrow_9772A2B7.FunctionObject_FunctionDeclaration_D7535F87_g
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryFinally_Nested_ReturnWhileSuspended.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryFinally_Nested_ReturnWhileSuspended.verified.txt
@@ -115,6 +115,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_480897DC_g
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x268a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Generator_TryFinally_Nested_ReturnWhileSuspended/g/FunctionObject_FunctionDeclaration_480897DC_g::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_480897DC_g::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2699
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_480897DC_g::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x269c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_480897DC_g::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x269f
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_TryFinally_Nested_ReturnWhileSuspended/g/FunctionObject_FunctionDeclaration_480897DC_g::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Generator_TryFinally_Nested_ReturnWhileSuspended/g::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_480897DC_g::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26b1
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_TryFinally_Nested_ReturnWhileSuspended/g/FunctionObject_FunctionDeclaration_480897DC_g::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Generator_TryFinally_Nested_ReturnWhileSuspended/g::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_480897DC_g::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_480897DC_g
+
 
 		// Methods
 		.method public hidebysig static 
@@ -726,94 +814,6 @@
 	} // end of method Generator_TryFinally_Nested_ReturnWhileSuspended::__js_module_init__
 
 } // end of class Modules.Generator_TryFinally_Nested_ReturnWhileSuspended
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_TryFinally_Nested_ReturnWhileSuspended_2051C36C.FunctionObject_FunctionDeclaration_480897DC_g
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x268a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Generator_TryFinally_Nested_ReturnWhileSuspended_2051C36C.FunctionObject_FunctionDeclaration_480897DC_g::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_480897DC_g::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2699
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_480897DC_g::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x269c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_480897DC_g::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x269f
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_TryFinally_Nested_ReturnWhileSuspended_2051C36C.FunctionObject_FunctionDeclaration_480897DC_g::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Generator_TryFinally_Nested_ReturnWhileSuspended/g::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_480897DC_g::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26b1
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_TryFinally_Nested_ReturnWhileSuspended_2051C36C.FunctionObject_FunctionDeclaration_480897DC_g::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Generator_TryFinally_Nested_ReturnWhileSuspended/g::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_480897DC_g::ConstructBodyCore
-
-} // end of class FunctionObjects.Generator_TryFinally_Nested_ReturnWhileSuspended_2051C36C.FunctionObject_FunctionDeclaration_480897DC_g
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryFinally_ReturnWhileSuspended.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryFinally_ReturnWhileSuspended.verified.txt
@@ -73,6 +73,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F78F7418_g
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x24b4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Generator_TryFinally_ReturnWhileSuspended/g/FunctionObject_FunctionDeclaration_F78F7418_g::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F78F7418_g::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24c3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F78F7418_g::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24c6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F78F7418_g::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24c9
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_TryFinally_ReturnWhileSuspended/g/FunctionObject_FunctionDeclaration_F78F7418_g::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Generator_TryFinally_ReturnWhileSuspended/g::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_F78F7418_g::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24db
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_TryFinally_ReturnWhileSuspended/g/FunctionObject_FunctionDeclaration_F78F7418_g::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Generator_TryFinally_ReturnWhileSuspended/g::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_F78F7418_g::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_F78F7418_g
+
 
 		// Methods
 		.method public hidebysig static 
@@ -525,94 +613,6 @@
 	} // end of method Generator_TryFinally_ReturnWhileSuspended::__js_module_init__
 
 } // end of class Modules.Generator_TryFinally_ReturnWhileSuspended
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_TryFinally_ReturnWhileSuspended_7CAB1978.FunctionObject_FunctionDeclaration_F78F7418_g
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x24b4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Generator_TryFinally_ReturnWhileSuspended_7CAB1978.FunctionObject_FunctionDeclaration_F78F7418_g::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F78F7418_g::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24c3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F78F7418_g::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24c6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F78F7418_g::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24c9
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_TryFinally_ReturnWhileSuspended_7CAB1978.FunctionObject_FunctionDeclaration_F78F7418_g::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Generator_TryFinally_ReturnWhileSuspended/g::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_F78F7418_g::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24db
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_TryFinally_ReturnWhileSuspended_7CAB1978.FunctionObject_FunctionDeclaration_F78F7418_g::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Generator_TryFinally_ReturnWhileSuspended/g::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_F78F7418_g::ConstructBodyCore
-
-} // end of class FunctionObjects.Generator_TryFinally_ReturnWhileSuspended_7CAB1978.FunctionObject_FunctionDeclaration_F78F7418_g
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryFinally_ThrowWhileSuspended.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_TryFinally_ThrowWhileSuspended.verified.txt
@@ -73,6 +73,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C1602072_g
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x24bb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Generator_TryFinally_ThrowWhileSuspended/g/FunctionObject_FunctionDeclaration_C1602072_g::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C1602072_g::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24ca
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C1602072_g::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24cd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C1602072_g::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24d0
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_TryFinally_ThrowWhileSuspended/g/FunctionObject_FunctionDeclaration_C1602072_g::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Generator_TryFinally_ThrowWhileSuspended/g::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_C1602072_g::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24e2
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_TryFinally_ThrowWhileSuspended/g/FunctionObject_FunctionDeclaration_C1602072_g::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Generator_TryFinally_ThrowWhileSuspended/g::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_C1602072_g::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C1602072_g
+
 
 		// Methods
 		.method public hidebysig static 
@@ -579,94 +667,6 @@
 	} // end of method Generator_TryFinally_ThrowWhileSuspended::__js_module_init__
 
 } // end of class Modules.Generator_TryFinally_ThrowWhileSuspended
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_TryFinally_ThrowWhileSuspended_1EB2AA32.FunctionObject_FunctionDeclaration_C1602072_g
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x24bb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Generator_TryFinally_ThrowWhileSuspended_1EB2AA32.FunctionObject_FunctionDeclaration_C1602072_g::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C1602072_g::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24ca
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C1602072_g::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24cd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C1602072_g::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24d0
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_TryFinally_ThrowWhileSuspended_1EB2AA32.FunctionObject_FunctionDeclaration_C1602072_g::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Generator_TryFinally_ThrowWhileSuspended/g::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_C1602072_g::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24e2
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_TryFinally_ThrowWhileSuspended_1EB2AA32.FunctionObject_FunctionDeclaration_C1602072_g::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Generator_TryFinally_ThrowWhileSuspended/g::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_C1602072_g::ConstructBodyCore
-
-} // end of class FunctionObjects.Generator_TryFinally_ThrowWhileSuspended_1EB2AA32.FunctionObject_FunctionDeclaration_C1602072_g
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_ArrayBasic.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_ArrayBasic.verified.txt
@@ -31,6 +31,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E39A7D38_g
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2561
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Generator_YieldStar_ArrayBasic/g/FunctionObject_FunctionDeclaration_E39A7D38_g::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E39A7D38_g::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2570
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E39A7D38_g::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2573
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E39A7D38_g::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2576
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_YieldStar_ArrayBasic/g/FunctionObject_FunctionDeclaration_E39A7D38_g::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Generator_YieldStar_ArrayBasic/g::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_E39A7D38_g::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2588
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_YieldStar_ArrayBasic/g/FunctionObject_FunctionDeclaration_E39A7D38_g::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Generator_YieldStar_ArrayBasic/g::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_E39A7D38_g::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E39A7D38_g
+
 
 		// Methods
 		.method public hidebysig static 
@@ -553,94 +641,6 @@
 	} // end of method Generator_YieldStar_ArrayBasic::__js_module_init__
 
 } // end of class Modules.Generator_YieldStar_ArrayBasic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_YieldStar_ArrayBasic_E8497618.FunctionObject_FunctionDeclaration_E39A7D38_g
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2561
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Generator_YieldStar_ArrayBasic_E8497618.FunctionObject_FunctionDeclaration_E39A7D38_g::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E39A7D38_g::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2570
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E39A7D38_g::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2573
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E39A7D38_g::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2576
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_YieldStar_ArrayBasic_E8497618.FunctionObject_FunctionDeclaration_E39A7D38_g::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Generator_YieldStar_ArrayBasic/g::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_E39A7D38_g::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2588
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_YieldStar_ArrayBasic_E8497618.FunctionObject_FunctionDeclaration_E39A7D38_g::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Generator_YieldStar_ArrayBasic/g::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_E39A7D38_g::ConstructBodyCore
-
-} // end of class FunctionObjects.Generator_YieldStar_ArrayBasic_E8497618.FunctionObject_FunctionDeclaration_E39A7D38_g
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_NestedGenerator.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_NestedGenerator.verified.txt
@@ -31,6 +31,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_05E19C5E_inner
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2743
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Generator_YieldStar_NestedGenerator/inner/FunctionObject_FunctionDeclaration_05E19C5E_inner::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_05E19C5E_inner::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2752
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_05E19C5E_inner::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2755
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_05E19C5E_inner::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2758
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_YieldStar_NestedGenerator/inner/FunctionObject_FunctionDeclaration_05E19C5E_inner::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Generator_YieldStar_NestedGenerator/inner::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_05E19C5E_inner::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x276a
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_YieldStar_NestedGenerator/inner/FunctionObject_FunctionDeclaration_05E19C5E_inner::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Generator_YieldStar_NestedGenerator/inner::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_05E19C5E_inner::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_05E19C5E_inner
+
 
 		// Methods
 		.method public hidebysig static 
@@ -212,6 +300,99 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0AE70585_outer
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Generator_YieldStar_NestedGenerator/Scope _environment0_Generator_YieldStar_NestedGenerator
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Generator_YieldStar_NestedGenerator/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x2778
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Generator_YieldStar_NestedGenerator/Scope Modules.Generator_YieldStar_NestedGenerator/outer/FunctionObject_FunctionDeclaration_0AE70585_outer::_environment0_Generator_YieldStar_NestedGenerator
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.Generator_YieldStar_NestedGenerator/outer/FunctionObject_FunctionDeclaration_0AE70585_outer::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_0AE70585_outer::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x278e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0AE70585_outer::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2791
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0AE70585_outer::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2794
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_YieldStar_NestedGenerator/outer/FunctionObject_FunctionDeclaration_0AE70585_outer::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Generator_YieldStar_NestedGenerator/outer::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_0AE70585_outer::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x27a6
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_YieldStar_NestedGenerator/outer/FunctionObject_FunctionDeclaration_0AE70585_outer::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Generator_YieldStar_NestedGenerator/outer::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_0AE70585_outer::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_0AE70585_outer
 
 
 		// Methods
@@ -794,187 +975,6 @@
 	} // end of method Generator_YieldStar_NestedGenerator::__js_module_init__
 
 } // end of class Modules.Generator_YieldStar_NestedGenerator
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_YieldStar_NestedGenerator_4AFD7CAB.FunctionObject_FunctionDeclaration_05E19C5E_inner
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2743
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Generator_YieldStar_NestedGenerator_4AFD7CAB.FunctionObject_FunctionDeclaration_05E19C5E_inner::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_05E19C5E_inner::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2752
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_05E19C5E_inner::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2755
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_05E19C5E_inner::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2758
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_YieldStar_NestedGenerator_4AFD7CAB.FunctionObject_FunctionDeclaration_05E19C5E_inner::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Generator_YieldStar_NestedGenerator/inner::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_05E19C5E_inner::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x276a
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_YieldStar_NestedGenerator_4AFD7CAB.FunctionObject_FunctionDeclaration_05E19C5E_inner::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Generator_YieldStar_NestedGenerator/inner::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_05E19C5E_inner::ConstructBodyCore
-
-} // end of class FunctionObjects.Generator_YieldStar_NestedGenerator_4AFD7CAB.FunctionObject_FunctionDeclaration_05E19C5E_inner
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_YieldStar_NestedGenerator_4AFD7CAB.FunctionObject_FunctionDeclaration_0AE70585_outer
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Generator_YieldStar_NestedGenerator/Scope _environment0_Generator_YieldStar_NestedGenerator
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Generator_YieldStar_NestedGenerator/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x2778
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Generator_YieldStar_NestedGenerator/Scope FunctionObjects.Generator_YieldStar_NestedGenerator_4AFD7CAB.FunctionObject_FunctionDeclaration_0AE70585_outer::_environment0_Generator_YieldStar_NestedGenerator
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Generator_YieldStar_NestedGenerator_4AFD7CAB.FunctionObject_FunctionDeclaration_0AE70585_outer::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_0AE70585_outer::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x278e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0AE70585_outer::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2791
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0AE70585_outer::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2794
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_YieldStar_NestedGenerator_4AFD7CAB.FunctionObject_FunctionDeclaration_0AE70585_outer::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Generator_YieldStar_NestedGenerator/outer::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_0AE70585_outer::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27a6
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_YieldStar_NestedGenerator_4AFD7CAB.FunctionObject_FunctionDeclaration_0AE70585_outer::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Generator_YieldStar_NestedGenerator/outer::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_0AE70585_outer::ConstructBodyCore
-
-} // end of class FunctionObjects.Generator_YieldStar_NestedGenerator_4AFD7CAB.FunctionObject_FunctionDeclaration_0AE70585_outer
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_PassNextValue.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_PassNextValue.verified.txt
@@ -37,6 +37,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2473C97B_inner
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x26e2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Generator_YieldStar_PassNextValue/inner/FunctionObject_FunctionDeclaration_2473C97B_inner::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_2473C97B_inner::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x26f1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2473C97B_inner::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x26f4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2473C97B_inner::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x26f7
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_YieldStar_PassNextValue/inner/FunctionObject_FunctionDeclaration_2473C97B_inner::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Generator_YieldStar_PassNextValue/inner::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_2473C97B_inner::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2709
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_YieldStar_PassNextValue/inner/FunctionObject_FunctionDeclaration_2473C97B_inner::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Generator_YieldStar_PassNextValue/inner::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_2473C97B_inner::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_2473C97B_inner
+
 
 		// Methods
 		.method public hidebysig static 
@@ -227,6 +315,99 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2DAF6340_outer
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Generator_YieldStar_PassNextValue/Scope _environment0_Generator_YieldStar_PassNextValue
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Generator_YieldStar_PassNextValue/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x2717
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Generator_YieldStar_PassNextValue/Scope Modules.Generator_YieldStar_PassNextValue/outer/FunctionObject_FunctionDeclaration_2DAF6340_outer::_environment0_Generator_YieldStar_PassNextValue
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.Generator_YieldStar_PassNextValue/outer/FunctionObject_FunctionDeclaration_2DAF6340_outer::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_2DAF6340_outer::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x272d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2DAF6340_outer::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2730
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2DAF6340_outer::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2733
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_YieldStar_PassNextValue/outer/FunctionObject_FunctionDeclaration_2DAF6340_outer::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Generator_YieldStar_PassNextValue/outer::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_2DAF6340_outer::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2745
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_YieldStar_PassNextValue/outer/FunctionObject_FunctionDeclaration_2DAF6340_outer::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Generator_YieldStar_PassNextValue/outer::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_2DAF6340_outer::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_2DAF6340_outer
 
 
 		// Methods
@@ -778,187 +959,6 @@
 	} // end of method Generator_YieldStar_PassNextValue::__js_module_init__
 
 } // end of class Modules.Generator_YieldStar_PassNextValue
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_YieldStar_PassNextValue_46C4482A.FunctionObject_FunctionDeclaration_2473C97B_inner
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x26e2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Generator_YieldStar_PassNextValue_46C4482A.FunctionObject_FunctionDeclaration_2473C97B_inner::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_2473C97B_inner::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x26f1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2473C97B_inner::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x26f4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2473C97B_inner::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x26f7
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_YieldStar_PassNextValue_46C4482A.FunctionObject_FunctionDeclaration_2473C97B_inner::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Generator_YieldStar_PassNextValue/inner::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_2473C97B_inner::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2709
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_YieldStar_PassNextValue_46C4482A.FunctionObject_FunctionDeclaration_2473C97B_inner::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Generator_YieldStar_PassNextValue/inner::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_2473C97B_inner::ConstructBodyCore
-
-} // end of class FunctionObjects.Generator_YieldStar_PassNextValue_46C4482A.FunctionObject_FunctionDeclaration_2473C97B_inner
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_YieldStar_PassNextValue_46C4482A.FunctionObject_FunctionDeclaration_2DAF6340_outer
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Generator_YieldStar_PassNextValue/Scope _environment0_Generator_YieldStar_PassNextValue
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Generator_YieldStar_PassNextValue/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x2717
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Generator_YieldStar_PassNextValue/Scope FunctionObjects.Generator_YieldStar_PassNextValue_46C4482A.FunctionObject_FunctionDeclaration_2DAF6340_outer::_environment0_Generator_YieldStar_PassNextValue
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Generator_YieldStar_PassNextValue_46C4482A.FunctionObject_FunctionDeclaration_2DAF6340_outer::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_2DAF6340_outer::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x272d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2DAF6340_outer::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2730
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2DAF6340_outer::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2733
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_YieldStar_PassNextValue_46C4482A.FunctionObject_FunctionDeclaration_2DAF6340_outer::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Generator_YieldStar_PassNextValue/outer::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_2DAF6340_outer::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2745
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_YieldStar_PassNextValue_46C4482A.FunctionObject_FunctionDeclaration_2DAF6340_outer::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Generator_YieldStar_PassNextValue/outer::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_2DAF6340_outer::ConstructBodyCore
-
-} // end of class FunctionObjects.Generator_YieldStar_PassNextValue_46C4482A.FunctionObject_FunctionDeclaration_2DAF6340_outer
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_ReturnForwards.verified.txt
+++ b/tests/Jroc.Tests/Generator/Snapshots/GeneratorTests.Generator_YieldStar_ReturnForwards.verified.txt
@@ -31,6 +31,94 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C8D33BB4_inner
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x26c3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Generator_YieldStar_ReturnForwards/inner/FunctionObject_FunctionDeclaration_C8D33BB4_inner::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8D33BB4_inner::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x26d2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8D33BB4_inner::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x26d5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8D33BB4_inner::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x26d8
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_YieldStar_ReturnForwards/inner/FunctionObject_FunctionDeclaration_C8D33BB4_inner::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Generator_YieldStar_ReturnForwards/inner::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8D33BB4_inner::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26ea
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_YieldStar_ReturnForwards/inner/FunctionObject_FunctionDeclaration_C8D33BB4_inner::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Generator_YieldStar_ReturnForwards/inner::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8D33BB4_inner::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C8D33BB4_inner
+
 
 		// Methods
 		.method public hidebysig static 
@@ -212,6 +300,99 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2976944F_outer
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Generator_YieldStar_ReturnForwards/Scope _environment0_Generator_YieldStar_ReturnForwards
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Generator_YieldStar_ReturnForwards/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x26f8
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Generator_YieldStar_ReturnForwards/Scope Modules.Generator_YieldStar_ReturnForwards/outer/FunctionObject_FunctionDeclaration_2976944F_outer::_environment0_Generator_YieldStar_ReturnForwards
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.Generator_YieldStar_ReturnForwards/outer/FunctionObject_FunctionDeclaration_2976944F_outer::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_2976944F_outer::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x270e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2976944F_outer::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2711
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2976944F_outer::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2714
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_YieldStar_ReturnForwards/outer/FunctionObject_FunctionDeclaration_2976944F_outer::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Generator_YieldStar_ReturnForwards/outer::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_2976944F_outer::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2726
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Generator_YieldStar_ReturnForwards/outer/FunctionObject_FunctionDeclaration_2976944F_outer::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Generator_YieldStar_ReturnForwards/outer::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_2976944F_outer::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_2976944F_outer
 
 
 		// Methods
@@ -765,187 +946,6 @@
 	} // end of method Generator_YieldStar_ReturnForwards::__js_module_init__
 
 } // end of class Modules.Generator_YieldStar_ReturnForwards
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_YieldStar_ReturnForwards_3AA98361.FunctionObject_FunctionDeclaration_C8D33BB4_inner
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x26c3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Generator_YieldStar_ReturnForwards_3AA98361.FunctionObject_FunctionDeclaration_C8D33BB4_inner::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8D33BB4_inner::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x26d2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8D33BB4_inner::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x26d5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8D33BB4_inner::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x26d8
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_YieldStar_ReturnForwards_3AA98361.FunctionObject_FunctionDeclaration_C8D33BB4_inner::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Generator_YieldStar_ReturnForwards/inner::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8D33BB4_inner::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26ea
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_YieldStar_ReturnForwards_3AA98361.FunctionObject_FunctionDeclaration_C8D33BB4_inner::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Generator_YieldStar_ReturnForwards/inner::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8D33BB4_inner::ConstructBodyCore
-
-} // end of class FunctionObjects.Generator_YieldStar_ReturnForwards_3AA98361.FunctionObject_FunctionDeclaration_C8D33BB4_inner
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Generator_YieldStar_ReturnForwards_3AA98361.FunctionObject_FunctionDeclaration_2976944F_outer
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Generator_YieldStar_ReturnForwards/Scope _environment0_Generator_YieldStar_ReturnForwards
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Generator_YieldStar_ReturnForwards/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x26f8
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Generator_YieldStar_ReturnForwards/Scope FunctionObjects.Generator_YieldStar_ReturnForwards_3AA98361.FunctionObject_FunctionDeclaration_2976944F_outer::_environment0_Generator_YieldStar_ReturnForwards
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Generator_YieldStar_ReturnForwards_3AA98361.FunctionObject_FunctionDeclaration_2976944F_outer::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_2976944F_outer::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x270e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2976944F_outer::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2711
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2976944F_outer::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2714
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_YieldStar_ReturnForwards_3AA98361.FunctionObject_FunctionDeclaration_2976944F_outer::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Generator_YieldStar_ReturnForwards/outer::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_2976944F_outer::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2726
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Generator_YieldStar_ReturnForwards_3AA98361.FunctionObject_FunctionDeclaration_2976944F_outer::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Generator_YieldStar_ReturnForwards/outer::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_2976944F_outer::ConstructBodyCore
-
-} // end of class FunctionObjects.Generator_YieldStar_ReturnForwards_3AA98361.FunctionObject_FunctionDeclaration_2976944F_outer
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Cjs_Namespace.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Cjs_Namespace.verified.txt
@@ -812,6 +812,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_986BE060_L6C8
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope _environment0_Import_DynamicImport_Cjs_Namespace_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x25d3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L6C7/FunctionObject_FunctionExpression_986BE060_L6C8::_environment0_Import_DynamicImport_Cjs_Namespace_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_986BE060_L6C8::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x25e2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_986BE060_L6C8::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x25e5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_986BE060_L6C8::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x25e8
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L6C7/FunctionObject_FunctionExpression_986BE060_L6C8::_environment0_Import_DynamicImport_Cjs_Namespace_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L6C7::__js_call__(class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_986BE060_L6C8::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25fa
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L6C7/FunctionObject_FunctionExpression_986BE060_L6C8::_environment0_Import_DynamicImport_Cjs_Namespace_Lib
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L6C7::__js_call__(class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_986BE060_L6C8::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2608
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_986BE060_L6C8::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_986BE060_L6C8
+
 
 		// Methods
 		.method public hidebysig static 
@@ -873,6 +980,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E8D4DA26_L9C14
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope _environment0_Import_DynamicImport_Cjs_Namespace_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2617
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13/FunctionObject_FunctionExpression_E8D4DA26_L9C14::_environment0_Import_DynamicImport_Cjs_Namespace_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E8D4DA26_L9C14::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2626
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E8D4DA26_L9C14::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2629
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E8D4DA26_L9C14::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x262c
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13/FunctionObject_FunctionExpression_E8D4DA26_L9C14::_environment0_Import_DynamicImport_Cjs_Namespace_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13::__js_call__(class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_E8D4DA26_L9C14::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x263e
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13/FunctionObject_FunctionExpression_E8D4DA26_L9C14::_environment0_Import_DynamicImport_Cjs_Namespace_Lib
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13::__js_call__(class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_E8D4DA26_L9C14::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x264c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E8D4DA26_L9C14::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_E8D4DA26_L9C14
 
 
 		// Methods
@@ -946,7 +1160,7 @@
 			[1] object[],
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[4] class FunctionObjects.Import_DynamicImport_Cjs_Namespace_Lib_4A8F1652.FunctionObject_FunctionExpression_E8D4DA26_L9C14
+			[4] class Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13/FunctionObject_FunctionExpression_E8D4DA26_L9C14
 		)
 
 		IL_0000: newobj instance void Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope::.ctor()
@@ -1001,16 +1215,16 @@
 		IL_007a: ldc.i4.0
 		IL_007b: ldelem.ref
 		IL_007c: castclass Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope
-		IL_0081: newobj instance void FunctionObjects.Import_DynamicImport_Cjs_Namespace_Lib_4A8F1652.FunctionObject_FunctionExpression_E8D4DA26_L9C14::.ctor(class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope)
+		IL_0081: newobj instance void Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13/FunctionObject_FunctionExpression_E8D4DA26_L9C14::.ctor(class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope)
 		IL_0086: ldc.i4.0
 		IL_0087: conv.r8
 		IL_0088: ldstr ""
 		IL_008d: ldc.i4.0
 		IL_008e: ldc.i4.1
-		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_DynamicImport_Cjs_Namespace_Lib_4A8F1652.FunctionObject_FunctionExpression_E8D4DA26_L9C14>(!!0, float64, string, bool, bool)
+		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13/FunctionObject_FunctionExpression_E8D4DA26_L9C14>(!!0, float64, string, bool, bool)
 		IL_0094: stloc.s 4
 		IL_0096: ldloc.s 4
-		IL_0098: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class FunctionObjects.Import_DynamicImport_Cjs_Namespace_Lib_4A8F1652.FunctionObject_FunctionExpression_E8D4DA26_L9C14>(!!0)
+		IL_0098: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13/FunctionObject_FunctionExpression_E8D4DA26_L9C14>(!!0)
 		IL_009d: stloc.s 4
 		IL_009f: ldloc.3
 		IL_00a0: ldstr "value"
@@ -1028,220 +1242,6 @@
 	} // end of method Import_DynamicImport_Cjs_Namespace_Lib::__js_module_init__
 
 } // end of class Modules.Import_DynamicImport_Cjs_Namespace_Lib
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_DynamicImport_Cjs_Namespace_Lib_4A8F1652.FunctionObject_FunctionExpression_986BE060_L6C8
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope _environment0_Import_DynamicImport_Cjs_Namespace_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x25d3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Cjs_Namespace_Lib_4A8F1652.FunctionObject_FunctionExpression_986BE060_L6C8::_environment0_Import_DynamicImport_Cjs_Namespace_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_986BE060_L6C8::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x25e2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_986BE060_L6C8::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x25e5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_986BE060_L6C8::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x25e8
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Cjs_Namespace_Lib_4A8F1652.FunctionObject_FunctionExpression_986BE060_L6C8::_environment0_Import_DynamicImport_Cjs_Namespace_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L6C7::__js_call__(class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_986BE060_L6C8::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25fa
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Cjs_Namespace_Lib_4A8F1652.FunctionObject_FunctionExpression_986BE060_L6C8::_environment0_Import_DynamicImport_Cjs_Namespace_Lib
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L6C7::__js_call__(class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_986BE060_L6C8::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2608
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_986BE060_L6C8::ConstructCore
-
-} // end of class FunctionObjects.Import_DynamicImport_Cjs_Namespace_Lib_4A8F1652.FunctionObject_FunctionExpression_986BE060_L6C8
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_DynamicImport_Cjs_Namespace_Lib_4A8F1652.FunctionObject_FunctionExpression_E8D4DA26_L9C14
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope _environment0_Import_DynamicImport_Cjs_Namespace_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2617
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Cjs_Namespace_Lib_4A8F1652.FunctionObject_FunctionExpression_E8D4DA26_L9C14::_environment0_Import_DynamicImport_Cjs_Namespace_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E8D4DA26_L9C14::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2626
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E8D4DA26_L9C14::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2629
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E8D4DA26_L9C14::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x262c
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Cjs_Namespace_Lib_4A8F1652.FunctionObject_FunctionExpression_E8D4DA26_L9C14::_environment0_Import_DynamicImport_Cjs_Namespace_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13::__js_call__(class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_E8D4DA26_L9C14::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x263e
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Cjs_Namespace_Lib_4A8F1652.FunctionObject_FunctionExpression_E8D4DA26_L9C14::_environment0_Import_DynamicImport_Cjs_Namespace_Lib
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_DynamicImport_Cjs_Namespace_Lib/FunctionExpression_L9C13::__js_call__(class Modules.Import_DynamicImport_Cjs_Namespace_Lib/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_E8D4DA26_L9C14::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x264c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E8D4DA26_L9C14::ConstructCore
-
-} // end of class FunctionObjects.Import_DynamicImport_Cjs_Namespace_Lib_4A8F1652.FunctionObject_FunctionExpression_E8D4DA26_L9C14
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Esm_Namespace.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_DynamicImport_Esm_Namespace.verified.txt
@@ -775,6 +775,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_CFBAD72C_L3C28
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope _environment0_Import_DynamicImport_Esm_Namespace_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2fcf
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L3C27/FunctionObject_FunctionExpression_CFBAD72C_L3C28::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_CFBAD72C_L3C28::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2fde
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_CFBAD72C_L3C28::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2fe1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_CFBAD72C_L3C28::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2fe4
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L3C27/FunctionObject_FunctionExpression_CFBAD72C_L3C28::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L3C27::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_CFBAD72C_L3C28::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ff6
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L3C27/FunctionObject_FunctionExpression_CFBAD72C_L3C28::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L3C27::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_CFBAD72C_L3C28::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3004
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_CFBAD72C_L3C28::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_CFBAD72C_L3C28
+
 
 		// Methods
 		.method public hidebysig static 
@@ -826,6 +933,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5B6EF069_L4C26
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope _environment0_Import_DynamicImport_Esm_Namespace_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3013
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_5B6EF069_L4C26::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_5B6EF069_L4C26::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3022
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5B6EF069_L4C26::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3025
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5B6EF069_L4C26::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3028
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_5B6EF069_L4C26::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_5B6EF069_L4C26::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x303a
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_5B6EF069_L4C26::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_5B6EF069_L4C26::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3048
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_5B6EF069_L4C26::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_5B6EF069_L4C26
+
 
 		// Methods
 		.method public hidebysig static 
@@ -875,6 +1089,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A72B20E7_L5C30
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope _environment0_Import_DynamicImport_Esm_Namespace_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3057
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L5C29/FunctionObject_FunctionExpression_A72B20E7_L5C30::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_A72B20E7_L5C30::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3066
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A72B20E7_L5C30::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3069
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A72B20E7_L5C30::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x306c
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L5C29/FunctionObject_FunctionExpression_A72B20E7_L5C30::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L5C29::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_A72B20E7_L5C30::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x307e
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L5C29/FunctionObject_FunctionExpression_A72B20E7_L5C30::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L5C29::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_A72B20E7_L5C30::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x308c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_A72B20E7_L5C30::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_A72B20E7_L5C30
+
 
 		// Methods
 		.method public hidebysig static 
@@ -923,6 +1244,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3E2D2BB6_inc
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope _environment0_Import_DynamicImport_Esm_Namespace_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x309b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/inc/FunctionObject_FunctionDeclaration_3E2D2BB6_inc::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3E2D2BB6_inc::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x30aa
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3E2D2BB6_inc::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x30ad
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3E2D2BB6_inc::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x30b0
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/inc/FunctionObject_FunctionDeclaration_3E2D2BB6_inc::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/inc::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_3E2D2BB6_inc::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x30c2
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/inc/FunctionObject_FunctionDeclaration_3E2D2BB6_inc::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/inc::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_3E2D2BB6_inc::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x30d0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3E2D2BB6_inc::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_3E2D2BB6_inc
 
 
 		// Methods
@@ -987,6 +1415,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F229B707_readValue
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope _environment0_Import_DynamicImport_Esm_Namespace_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x30df
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/readValue/FunctionObject_FunctionDeclaration_F229B707_readValue::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F229B707_readValue::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x30ee
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F229B707_readValue::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x30f1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F229B707_readValue::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x30f4
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/readValue/FunctionObject_FunctionDeclaration_F229B707_readValue::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/readValue::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_F229B707_readValue::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3106
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/readValue/FunctionObject_FunctionDeclaration_F229B707_readValue::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/readValue::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_F229B707_readValue::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3114
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F229B707_readValue::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_F229B707_readValue
 
 
 		// Methods
@@ -1060,6 +1595,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope _environment0_Import_DynamicImport_Esm_Namespace_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3123
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3132
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3135
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3138
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x314a
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3158
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark
 
 
 		// Methods
@@ -1167,6 +1809,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3167
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x316f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3172
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3175
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_default::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3188
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_default::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3197
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1270,6 +2013,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x31a6
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x31ae
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x31b1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x31b4
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x31ce
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x31e4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1328,6 +2178,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_510E3483_L44C87
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope _environment0_Import_DynamicImport_Esm_Namespace_Lib
+				.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope capture0,
+						class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3245
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86/FunctionObject_FunctionExpression_510E3483_L44C87::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86/FunctionObject_FunctionExpression_510E3483_L44C87::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86/FunctionObject_FunctionExpression_510E3483_L44C87::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_510E3483_L44C87::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3262
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_510E3483_L44C87::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3265
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_510E3483_L44C87::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x3268
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86/FunctionObject_FunctionExpression_510E3483_L44C87::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_510E3483_L44C87::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x327a
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86/FunctionObject_FunctionExpression_510E3483_L44C87::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_510E3483_L44C87::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3288
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_510E3483_L44C87::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_510E3483_L44C87
+
 
 			// Methods
 			.method public hidebysig static 
@@ -1377,6 +2344,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3E619586_L45C94
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope _environment0_Import_DynamicImport_Esm_Namespace_Lib
+				.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope capture0,
+						class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3297
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93/FunctionObject_FunctionExpression_3E619586_L45C94::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93/FunctionObject_FunctionExpression_3E619586_L45C94::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93/FunctionObject_FunctionExpression_3E619586_L45C94::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_3E619586_L45C94::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x32b4
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_3E619586_L45C94::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x32b7
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_3E619586_L45C94::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x32ba
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93/FunctionObject_FunctionExpression_3E619586_L45C94::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_3E619586_L45C94::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x32cc
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93/FunctionObject_FunctionExpression_3E619586_L45C94::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_3E619586_L45C94::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x32da
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_3E619586_L45C94::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_3E619586_L45C94
 
 
 			// Methods
@@ -1431,6 +2515,128 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7A56BCB4_L55C87
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope _environment0_Import_DynamicImport_Esm_Namespace_Lib
+					.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+					.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/Scope _environment2_FunctionExpression_L54C9
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope capture0,
+							class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope capture1,
+							class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x3349
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86/FunctionObject_FunctionExpression_7A56BCB4_L55C87::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86/FunctionObject_FunctionExpression_7A56BCB4_L55C87::_environment1___jroc_esm_namespace
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86/FunctionObject_FunctionExpression_7A56BCB4_L55C87::_environment2_FunctionExpression_L54C9
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86/FunctionObject_FunctionExpression_7A56BCB4_L55C87::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_7A56BCB4_L55C87::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x336e
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_7A56BCB4_L55C87::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x3371
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_7A56BCB4_L55C87::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x3374
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86/FunctionObject_FunctionExpression_7A56BCB4_L55C87::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_7A56BCB4_L55C87::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x3386
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86/FunctionObject_FunctionExpression_7A56BCB4_L55C87::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_7A56BCB4_L55C87::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x3394
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_7A56BCB4_L55C87::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_7A56BCB4_L55C87
 
 
 				// Methods
@@ -1497,6 +2703,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A43F1FA8_L54C10
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope _environment0_Import_DynamicImport_Esm_Namespace_Lib
+				.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope capture0,
+						class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x32e9
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionObject_FunctionExpression_A43F1FA8_L54C10::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionObject_FunctionExpression_A43F1FA8_L54C10::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionObject_FunctionExpression_A43F1FA8_L54C10::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_A43F1FA8_L54C10::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3306
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_A43F1FA8_L54C10::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3309
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_A43F1FA8_L54C10::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x330c
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionObject_FunctionExpression_A43F1FA8_L54C10::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_A43F1FA8_L54C10::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3325
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionObject_FunctionExpression_A43F1FA8_L54C10::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_A43F1FA8_L54C10::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x333a
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_A43F1FA8_L54C10::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_A43F1FA8_L54C10
+
 
 			// Methods
 			.method public hidebysig static 
@@ -1518,7 +2847,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_7A56BCB4_L55C87,
+					[4] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86/FunctionObject_FunctionExpression_7A56BCB4_L55C87,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -1568,13 +2897,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_7A56BCB4_L55C87::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope, class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86/FunctionObject_FunctionExpression_7A56BCB4_L55C87::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope, class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_7A56BCB4_L55C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86/FunctionObject_FunctionExpression_7A56BCB4_L55C87>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -1793,6 +3122,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope _environment0_Import_DynamicImport_Esm_Namespace_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x31f3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3202
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3205
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3208
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3221
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3236
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1832,12 +3274,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_510E3483_L44C87,
-				[21] class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_3E619586_L45C94,
+				[20] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86/FunctionObject_FunctionExpression_510E3483_L44C87,
+				[21] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93/FunctionObject_FunctionExpression_3E619586_L45C94,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_A43F1FA8_L54C10
+				[25] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionObject_FunctionExpression_A43F1FA8_L54C10
 			)
 
 			IL_0000: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope::.ctor()
@@ -2043,13 +3485,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_510E3483_L44C87::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86/FunctionObject_FunctionExpression_510E3483_L44C87::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_510E3483_L44C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86/FunctionObject_FunctionExpression_510E3483_L44C87>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -2093,13 +3535,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_3E619586_L45C94::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93/FunctionObject_FunctionExpression_3E619586_L45C94::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_3E619586_L45C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93/FunctionObject_FunctionExpression_3E619586_L45C94>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -2269,13 +3711,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_A43F1FA8_L54C10::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionObject_FunctionExpression_A43F1FA8_L54C10::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_A43F1FA8_L54C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionObject_FunctionExpression_A43F1FA8_L54C10>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldc.i4.1
 				IL_0487: newarr [System.Runtime]System.Object
@@ -2393,6 +3835,127 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope _environment0_Import_DynamicImport_Esm_Namespace_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x33a3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x33b2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x33b5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x33b8
+				// Header size: 1
+				// Code size: 36 (0x24)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0017: ldarg.2
+				IL_0018: ldc.i4.1
+				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001e: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object, string, object)
+				IL_0023: ret
+			} // end of method FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x33dd
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::_environment0_Import_DynamicImport_Esm_Namespace_Lib
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.1
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object, string, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x33fe
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export
 
 
 		// Methods
@@ -2516,19 +4079,19 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope,
-			[1] class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default,
-			[2] class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get,
-			[3] class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace,
-			[4] class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export,
+			[1] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default,
+			[2] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get,
+			[3] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace,
+			[4] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export,
 			[5] object[],
-			[6] class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_3E2D2BB6_inc,
-			[7] class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_F229B707_readValue,
-			[8] class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark,
+			[6] class Modules.Import_DynamicImport_Esm_Namespace_Lib/inc/FunctionObject_FunctionDeclaration_3E2D2BB6_inc,
+			[7] class Modules.Import_DynamicImport_Esm_Namespace_Lib/readValue/FunctionObject_FunctionDeclaration_F229B707_readValue,
+			[8] class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark,
 			[9] object,
 			[10] object[],
-			[11] class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_CFBAD72C_L3C28,
-			[12] class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_5B6EF069_L4C26,
-			[13] class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_A72B20E7_L5C30
+			[11] class Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L3C27/FunctionObject_FunctionExpression_CFBAD72C_L3C28,
+			[12] class Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_5B6EF069_L4C26,
+			[13] class Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L5C29/FunctionObject_FunctionExpression_A72B20E7_L5C30
 		)
 
 		IL_0000: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope::.ctor()
@@ -2547,13 +4110,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_0022: newobj instance void FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_3E2D2BB6_inc::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
+		IL_0022: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/inc/FunctionObject_FunctionDeclaration_3E2D2BB6_inc::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "inc"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_3E2D2BB6_inc>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/inc/FunctionObject_FunctionDeclaration_3E2D2BB6_inc>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 6
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 6
@@ -2569,13 +4132,13 @@
 		IL_004d: ldc.i4.0
 		IL_004e: ldelem.ref
 		IL_004f: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_0054: newobj instance void FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_F229B707_readValue::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
+		IL_0054: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/readValue/FunctionObject_FunctionDeclaration_F229B707_readValue::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
 		IL_0059: ldc.i4.0
 		IL_005a: conv.r8
 		IL_005b: ldstr "readValue"
 		IL_0060: ldc.i4.0
 		IL_0061: ldc.i4.1
-		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_F229B707_readValue>(!!0, float64, string, bool, bool)
+		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/readValue/FunctionObject_FunctionDeclaration_F229B707_readValue>(!!0, float64, string, bool, bool)
 		IL_0067: stloc.s 7
 		IL_0069: ldloc.0
 		IL_006a: ldloc.s 7
@@ -2591,13 +4154,13 @@
 		IL_007f: ldc.i4.0
 		IL_0080: ldelem.ref
 		IL_0081: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_0086: newobj instance void FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
+		IL_0086: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
 		IL_008b: ldc.i4.0
 		IL_008c: conv.r8
 		IL_008d: ldstr "__jroc_esm_mark"
 		IL_0092: ldc.i4.0
 		IL_0093: ldc.i4.1
-		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark>(!!0, float64, string, bool, bool)
 		IL_0099: stloc.s 8
 		IL_009b: ldloc.0
 		IL_009c: ldloc.s 8
@@ -2609,13 +4172,13 @@
 		IL_00ab: ldloc.0
 		IL_00ac: stelem.ref
 		IL_00ad: stloc.s 5
-		IL_00af: newobj instance void FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default::.ctor()
+		IL_00af: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default::.ctor()
 		IL_00b4: ldc.i4.1
 		IL_00b5: conv.r8
 		IL_00b6: ldstr "__jroc_esm_default"
 		IL_00bb: ldc.i4.0
 		IL_00bc: ldc.i4.1
-		IL_00bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_00bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default>(!!0, float64, string, bool, bool)
 		IL_00c2: stloc.1
 		IL_00c3: ldc.i4.1
 		IL_00c4: newarr [System.Runtime]System.Object
@@ -2624,13 +4187,13 @@
 		IL_00cb: ldloc.0
 		IL_00cc: stelem.ref
 		IL_00cd: stloc.s 5
-		IL_00cf: newobj instance void FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get::.ctor()
+		IL_00cf: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get::.ctor()
 		IL_00d4: ldc.i4.2
 		IL_00d5: conv.r8
 		IL_00d6: ldstr "__jroc_esm_get"
 		IL_00db: ldc.i4.0
 		IL_00dc: ldc.i4.1
-		IL_00dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_00dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get>(!!0, float64, string, bool, bool)
 		IL_00e2: stloc.2
 		IL_00e3: ldc.i4.1
 		IL_00e4: newarr [System.Runtime]System.Object
@@ -2643,13 +4206,13 @@
 		IL_00f1: ldc.i4.0
 		IL_00f2: ldelem.ref
 		IL_00f3: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_00f8: newobj instance void FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
+		IL_00f8: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
 		IL_00fd: ldc.i4.1
 		IL_00fe: conv.r8
 		IL_00ff: ldstr "__jroc_esm_namespace"
 		IL_0104: ldc.i4.0
 		IL_0105: ldc.i4.1
-		IL_0106: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_0106: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace>(!!0, float64, string, bool, bool)
 		IL_010b: stloc.3
 		IL_010c: ldc.i4.1
 		IL_010d: newarr [System.Runtime]System.Object
@@ -2662,13 +4225,13 @@
 		IL_011a: ldc.i4.0
 		IL_011b: ldelem.ref
 		IL_011c: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_0121: newobj instance void FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
+		IL_0121: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
 		IL_0126: ldc.i4.2
 		IL_0127: conv.r8
 		IL_0128: ldstr "__jroc_esm_export"
 		IL_012d: ldc.i4.0
 		IL_012e: ldc.i4.1
-		IL_012f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_012f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export>(!!0, float64, string, bool, bool)
 		IL_0134: stloc.s 4
 		IL_0136: nop
 		IL_0137: ldloc.0
@@ -2691,13 +4254,13 @@
 		IL_0161: ldc.i4.0
 		IL_0162: ldelem.ref
 		IL_0163: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_0168: newobj instance void FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_CFBAD72C_L3C28::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
+		IL_0168: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L3C27/FunctionObject_FunctionExpression_CFBAD72C_L3C28::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
 		IL_016d: ldc.i4.0
 		IL_016e: conv.r8
 		IL_016f: ldstr ""
 		IL_0174: ldc.i4.0
 		IL_0175: ldc.i4.1
-		IL_0176: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_CFBAD72C_L3C28>(!!0, float64, string, bool, bool)
+		IL_0176: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L3C27/FunctionObject_FunctionExpression_CFBAD72C_L3C28>(!!0, float64, string, bool, bool)
 		IL_017b: stloc.s 11
 		IL_017d: ldloc.s 4
 		IL_017f: ldloc.s 5
@@ -2718,13 +4281,13 @@
 		IL_01a3: ldc.i4.0
 		IL_01a4: ldelem.ref
 		IL_01a5: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_01aa: newobj instance void FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_5B6EF069_L4C26::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
+		IL_01aa: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_5B6EF069_L4C26::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
 		IL_01af: ldc.i4.0
 		IL_01b0: conv.r8
 		IL_01b1: ldstr ""
 		IL_01b6: ldc.i4.0
 		IL_01b7: ldc.i4.1
-		IL_01b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_5B6EF069_L4C26>(!!0, float64, string, bool, bool)
+		IL_01b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_5B6EF069_L4C26>(!!0, float64, string, bool, bool)
 		IL_01bd: stloc.s 12
 		IL_01bf: ldloc.s 4
 		IL_01c1: ldloc.s 5
@@ -2745,13 +4308,13 @@
 		IL_01e5: ldc.i4.0
 		IL_01e6: ldelem.ref
 		IL_01e7: castclass Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope
-		IL_01ec: newobj instance void FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_A72B20E7_L5C30::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
+		IL_01ec: newobj instance void Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L5C29/FunctionObject_FunctionExpression_A72B20E7_L5C30::.ctor(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope)
 		IL_01f1: ldc.i4.0
 		IL_01f2: conv.r8
 		IL_01f3: ldstr ""
 		IL_01f8: ldc.i4.0
 		IL_01f9: ldc.i4.1
-		IL_01fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_A72B20E7_L5C30>(!!0, float64, string, bool, bool)
+		IL_01fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L5C29/FunctionObject_FunctionExpression_A72B20E7_L5C30>(!!0, float64, string, bool, bool)
 		IL_01ff: stloc.s 13
 		IL_0201: ldloc.s 4
 		IL_0203: ldloc.s 5
@@ -2767,1569 +4330,6 @@
 	} // end of method Import_DynamicImport_Esm_Namespace_Lib::__js_module_init__
 
 } // end of class Modules.Import_DynamicImport_Esm_Namespace_Lib
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_CFBAD72C_L3C28
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope _environment0_Import_DynamicImport_Esm_Namespace_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2fcf
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_CFBAD72C_L3C28::_environment0_Import_DynamicImport_Esm_Namespace_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_CFBAD72C_L3C28::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2fde
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_CFBAD72C_L3C28::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2fe1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_CFBAD72C_L3C28::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2fe4
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_CFBAD72C_L3C28::_environment0_Import_DynamicImport_Esm_Namespace_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L3C27::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_CFBAD72C_L3C28::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ff6
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_CFBAD72C_L3C28::_environment0_Import_DynamicImport_Esm_Namespace_Lib
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L3C27::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_CFBAD72C_L3C28::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3004
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_CFBAD72C_L3C28::ConstructCore
-
-} // end of class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_CFBAD72C_L3C28
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_5B6EF069_L4C26
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope _environment0_Import_DynamicImport_Esm_Namespace_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3013
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_5B6EF069_L4C26::_environment0_Import_DynamicImport_Esm_Namespace_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5B6EF069_L4C26::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3022
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5B6EF069_L4C26::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3025
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5B6EF069_L4C26::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3028
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_5B6EF069_L4C26::_environment0_Import_DynamicImport_Esm_Namespace_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_5B6EF069_L4C26::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x303a
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_5B6EF069_L4C26::_environment0_Import_DynamicImport_Esm_Namespace_Lib
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_5B6EF069_L4C26::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3048
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5B6EF069_L4C26::ConstructCore
-
-} // end of class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_5B6EF069_L4C26
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_A72B20E7_L5C30
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope _environment0_Import_DynamicImport_Esm_Namespace_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3057
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_A72B20E7_L5C30::_environment0_Import_DynamicImport_Esm_Namespace_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A72B20E7_L5C30::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3066
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A72B20E7_L5C30::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3069
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A72B20E7_L5C30::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x306c
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_A72B20E7_L5C30::_environment0_Import_DynamicImport_Esm_Namespace_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L5C29::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_A72B20E7_L5C30::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x307e
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_A72B20E7_L5C30::_environment0_Import_DynamicImport_Esm_Namespace_Lib
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/FunctionExpression_L5C29::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_A72B20E7_L5C30::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x308c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A72B20E7_L5C30::ConstructCore
-
-} // end of class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_A72B20E7_L5C30
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_3E2D2BB6_inc
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope _environment0_Import_DynamicImport_Esm_Namespace_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x309b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_3E2D2BB6_inc::_environment0_Import_DynamicImport_Esm_Namespace_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3E2D2BB6_inc::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x30aa
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3E2D2BB6_inc::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x30ad
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3E2D2BB6_inc::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x30b0
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_3E2D2BB6_inc::_environment0_Import_DynamicImport_Esm_Namespace_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/inc::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_3E2D2BB6_inc::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x30c2
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_3E2D2BB6_inc::_environment0_Import_DynamicImport_Esm_Namespace_Lib
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/inc::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_3E2D2BB6_inc::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x30d0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3E2D2BB6_inc::ConstructCore
-
-} // end of class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_3E2D2BB6_inc
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_F229B707_readValue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope _environment0_Import_DynamicImport_Esm_Namespace_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x30df
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_F229B707_readValue::_environment0_Import_DynamicImport_Esm_Namespace_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F229B707_readValue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x30ee
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F229B707_readValue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x30f1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F229B707_readValue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x30f4
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_F229B707_readValue::_environment0_Import_DynamicImport_Esm_Namespace_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/readValue::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_F229B707_readValue::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3106
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_F229B707_readValue::_environment0_Import_DynamicImport_Esm_Namespace_Lib
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/readValue::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_F229B707_readValue::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3114
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F229B707_readValue::ConstructCore
-
-} // end of class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_F229B707_readValue
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope _environment0_Import_DynamicImport_Esm_Namespace_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3123
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::_environment0_Import_DynamicImport_Esm_Namespace_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3132
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3135
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3138
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::_environment0_Import_DynamicImport_Esm_Namespace_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x314a
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::_environment0_Import_DynamicImport_Esm_Namespace_Lib
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3158
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark::ConstructCore
-
-} // end of class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_D81CF8CE___jroc_esm_mark
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3167
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x316f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3172
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3175
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_default::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3188
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_default::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3197
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default::ConstructCore
-
-} // end of class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_7FA32B6C___jroc_esm_default
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x31a6
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x31ae
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x31b1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x31b4
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x31ce
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x31e4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get::ConstructCore
-
-} // end of class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_532676B5___jroc_esm_get
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope _environment0_Import_DynamicImport_Esm_Namespace_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x31f3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::_environment0_Import_DynamicImport_Esm_Namespace_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3202
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3205
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3208
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::_environment0_Import_DynamicImport_Esm_Namespace_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3221
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::_environment0_Import_DynamicImport_Esm_Namespace_Lib
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3236
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace::ConstructCore
-
-} // end of class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_EE337336___jroc_esm_namespace
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_510E3483_L44C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope _environment0_Import_DynamicImport_Esm_Namespace_Lib
-	.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope capture0,
-			class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3245
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_510E3483_L44C87::_environment0_Import_DynamicImport_Esm_Namespace_Lib
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_510E3483_L44C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_510E3483_L44C87::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_510E3483_L44C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3262
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_510E3483_L44C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3265
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_510E3483_L44C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3268
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_510E3483_L44C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_510E3483_L44C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x327a
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_510E3483_L44C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L44C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_510E3483_L44C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3288
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_510E3483_L44C87::ConstructCore
-
-} // end of class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_510E3483_L44C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_3E619586_L45C94
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope _environment0_Import_DynamicImport_Esm_Namespace_Lib
-	.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope capture0,
-			class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3297
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_3E619586_L45C94::_environment0_Import_DynamicImport_Esm_Namespace_Lib
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_3E619586_L45C94::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_3E619586_L45C94::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_3E619586_L45C94::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x32b4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3E619586_L45C94::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x32b7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3E619586_L45C94::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x32ba
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_3E619586_L45C94::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_3E619586_L45C94::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x32cc
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_3E619586_L45C94::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L45C93::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_3E619586_L45C94::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x32da
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3E619586_L45C94::ConstructCore
-
-} // end of class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_3E619586_L45C94
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_A43F1FA8_L54C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope _environment0_Import_DynamicImport_Esm_Namespace_Lib
-	.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope capture0,
-			class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x32e9
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_A43F1FA8_L54C10::_environment0_Import_DynamicImport_Esm_Namespace_Lib
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_A43F1FA8_L54C10::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_A43F1FA8_L54C10::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_A43F1FA8_L54C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3306
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A43F1FA8_L54C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3309
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A43F1FA8_L54C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x330c
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_A43F1FA8_L54C10::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_A43F1FA8_L54C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3325
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_A43F1FA8_L54C10::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_A43F1FA8_L54C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x333a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A43F1FA8_L54C10::ConstructCore
-
-} // end of class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_A43F1FA8_L54C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_7A56BCB4_L55C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope _environment0_Import_DynamicImport_Esm_Namespace_Lib
-	.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/Scope _environment2_FunctionExpression_L54C9
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope capture0,
-			class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope capture1,
-			class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x3349
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_7A56BCB4_L55C87::_environment0_Import_DynamicImport_Esm_Namespace_Lib
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_7A56BCB4_L55C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_7A56BCB4_L55C87::_environment2_FunctionExpression_L54C9
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_7A56BCB4_L55C87::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_7A56BCB4_L55C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x336e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7A56BCB4_L55C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3371
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7A56BCB4_L55C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3374
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_7A56BCB4_L55C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_7A56BCB4_L55C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3386
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_7A56BCB4_L55C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_namespace/FunctionExpression_L54C9/FunctionExpression_L55C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_7A56BCB4_L55C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3394
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7A56BCB4_L55C87::ConstructCore
-
-} // end of class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionExpression_7A56BCB4_L55C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope _environment0_Import_DynamicImport_Esm_Namespace_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x33a3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::_environment0_Import_DynamicImport_Esm_Namespace_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x33b2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x33b5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x33b8
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::_environment0_Import_DynamicImport_Esm_Namespace_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0017: ldarg.2
-		IL_0018: ldc.i4.1
-		IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001e: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object, string, object)
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x33dd
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::_environment0_Import_DynamicImport_Esm_Namespace_Lib
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.1
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.Import_DynamicImport_Esm_Namespace_Lib/__jroc_esm_export::__js_call__(class Modules.Import_DynamicImport_Esm_Namespace_Lib/Scope, object, string, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x33fe
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export::ConstructCore
-
-} // end of class FunctionObjects.Import_DynamicImport_Esm_Namespace_Lib_791B1E6B.FunctionObject_FunctionDeclaration_F136BCF1___jroc_esm_export
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportNamedFrom.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportNamedFrom.verified.txt
@@ -53,6 +53,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportNamedFrom/Scope _environment0_Import_ExportNamedFrom
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportNamedFrom/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x35ed
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_mark/FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::_environment0_Import_ExportNamedFrom
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x35fc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x35ff
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3602
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_mark/FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::_environment0_Import_ExportNamedFrom
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_ExportNamedFrom/__jroc_esm_mark::__js_call__(class Modules.Import_ExportNamedFrom/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3614
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_mark/FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::_environment0_Import_ExportNamedFrom
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_ExportNamedFrom/__jroc_esm_mark::__js_call__(class Modules.Import_ExportNamedFrom/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3622
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark
+
 
 		// Methods
 		.method public hidebysig static 
@@ -159,6 +266,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3631
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3639
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x363c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x363f
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Import_ExportNamedFrom/__jroc_esm_default::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3652
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Import_ExportNamedFrom/__jroc_esm_default::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3661
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default
+
 
 		// Methods
 		.method public hidebysig static 
@@ -262,6 +470,115 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3670
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3678
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x367b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x367e
+				// Header size: 1
+				// Code size: 30 (0x1e)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0018: call object Modules.Import_ExportNamedFrom/__jroc_esm_get::__js_call__(object, object, string)
+				IL_001d: ret
+			} // end of method FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x369d
+				// Header size: 1
+				// Code size: 26 (0x1a)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0014: call object Modules.Import_ExportNamedFrom/__jroc_esm_get::__js_call__(object, object, string)
+				IL_0019: ret
+			} // end of method FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x36b8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get
+
 
 		// Methods
 		.method public hidebysig static 
@@ -320,6 +637,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_34E1A920_L37C87
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ExportNamedFrom/Scope _environment0_Import_ExportNamedFrom
+				.field private initonly class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ExportNamedFrom/Scope capture0,
+						class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3719
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86/FunctionObject_FunctionExpression_34E1A920_L37C87::_environment0_Import_ExportNamedFrom
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86/FunctionObject_FunctionExpression_34E1A920_L37C87::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86/FunctionObject_FunctionExpression_34E1A920_L37C87::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_34E1A920_L37C87::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3736
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_34E1A920_L37C87::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3739
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_34E1A920_L37C87::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x373c
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86/FunctionObject_FunctionExpression_34E1A920_L37C87::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_34E1A920_L37C87::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x374e
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86/FunctionObject_FunctionExpression_34E1A920_L37C87::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_34E1A920_L37C87::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x375c
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_34E1A920_L37C87::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_34E1A920_L37C87
+
 
 			// Methods
 			.method public hidebysig static 
@@ -369,6 +803,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_4DC27BA3_L38C94
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ExportNamedFrom/Scope _environment0_Import_ExportNamedFrom
+				.field private initonly class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ExportNamedFrom/Scope capture0,
+						class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x376b
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93/FunctionObject_FunctionExpression_4DC27BA3_L38C94::_environment0_Import_ExportNamedFrom
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93/FunctionObject_FunctionExpression_4DC27BA3_L38C94::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93/FunctionObject_FunctionExpression_4DC27BA3_L38C94::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_4DC27BA3_L38C94::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3788
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_4DC27BA3_L38C94::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x378b
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_4DC27BA3_L38C94::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x378e
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93/FunctionObject_FunctionExpression_4DC27BA3_L38C94::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_4DC27BA3_L38C94::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x37a0
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93/FunctionObject_FunctionExpression_4DC27BA3_L38C94::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_4DC27BA3_L38C94::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x37ae
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_4DC27BA3_L38C94::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_4DC27BA3_L38C94
 
 
 			// Methods
@@ -423,6 +974,128 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8BD69ABA_L48C87
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Import_ExportNamedFrom/Scope _environment0_Import_ExportNamedFrom
+					.field private initonly class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+					.field private initonly class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/Scope _environment2_FunctionExpression_L47C9
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Import_ExportNamedFrom/Scope capture0,
+							class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope capture1,
+							class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x381d
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86/FunctionObject_FunctionExpression_8BD69ABA_L48C87::_environment0_Import_ExportNamedFrom
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86/FunctionObject_FunctionExpression_8BD69ABA_L48C87::_environment1___jroc_esm_namespace
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86/FunctionObject_FunctionExpression_8BD69ABA_L48C87::_environment2_FunctionExpression_L47C9
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86/FunctionObject_FunctionExpression_8BD69ABA_L48C87::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_8BD69ABA_L48C87::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x3842
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_8BD69ABA_L48C87::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x3845
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_8BD69ABA_L48C87::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x3848
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86/FunctionObject_FunctionExpression_8BD69ABA_L48C87::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_8BD69ABA_L48C87::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x385a
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86/FunctionObject_FunctionExpression_8BD69ABA_L48C87::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_8BD69ABA_L48C87::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x3868
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_8BD69ABA_L48C87::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_8BD69ABA_L48C87
 
 
 				// Methods
@@ -489,6 +1162,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2217D24C_L47C10
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ExportNamedFrom/Scope _environment0_Import_ExportNamedFrom
+				.field private initonly class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ExportNamedFrom/Scope capture0,
+						class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x37bd
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionObject_FunctionExpression_2217D24C_L47C10::_environment0_Import_ExportNamedFrom
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionObject_FunctionExpression_2217D24C_L47C10::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionObject_FunctionExpression_2217D24C_L47C10::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_2217D24C_L47C10::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x37da
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_2217D24C_L47C10::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x37dd
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_2217D24C_L47C10::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x37e0
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionObject_FunctionExpression_2217D24C_L47C10::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_2217D24C_L47C10::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x37f9
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionObject_FunctionExpression_2217D24C_L47C10::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_2217D24C_L47C10::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x380e
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_2217D24C_L47C10::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_2217D24C_L47C10
+
 
 			// Methods
 			.method public hidebysig static 
@@ -510,7 +1306,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_8BD69ABA_L48C87,
+					[4] class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86/FunctionObject_FunctionExpression_8BD69ABA_L48C87,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -560,13 +1356,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_8BD69ABA_L48C87::.ctor(class Modules.Import_ExportNamedFrom/Scope, class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope, class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86/FunctionObject_FunctionExpression_8BD69ABA_L48C87::.ctor(class Modules.Import_ExportNamedFrom/Scope, class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope, class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_8BD69ABA_L48C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86/FunctionObject_FunctionExpression_8BD69ABA_L48C87>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -785,6 +1581,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportNamedFrom/Scope _environment0_Import_ExportNamedFrom
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportNamedFrom/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x36c7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::_environment0_Import_ExportNamedFrom
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x36d6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x36d9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x36dc
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::_environment0_Import_ExportNamedFrom
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportNamedFrom/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x36f5
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::_environment0_Import_ExportNamedFrom
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportNamedFrom/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x370a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace
+
 
 		// Methods
 		.method public hidebysig static 
@@ -824,12 +1733,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_34E1A920_L37C87,
-				[21] class FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_4DC27BA3_L38C94,
+				[20] class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86/FunctionObject_FunctionExpression_34E1A920_L37C87,
+				[21] class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93/FunctionObject_FunctionExpression_4DC27BA3_L38C94,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_2217D24C_L47C10
+				[25] class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionObject_FunctionExpression_2217D24C_L47C10
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope::.ctor()
@@ -1035,13 +1944,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_34E1A920_L37C87::.ctor(class Modules.Import_ExportNamedFrom/Scope, class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86/FunctionObject_FunctionExpression_34E1A920_L37C87::.ctor(class Modules.Import_ExportNamedFrom/Scope, class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_34E1A920_L37C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86/FunctionObject_FunctionExpression_34E1A920_L37C87>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -1085,13 +1994,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_4DC27BA3_L38C94::.ctor(class Modules.Import_ExportNamedFrom/Scope, class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93/FunctionObject_FunctionExpression_4DC27BA3_L38C94::.ctor(class Modules.Import_ExportNamedFrom/Scope, class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_4DC27BA3_L38C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93/FunctionObject_FunctionExpression_4DC27BA3_L38C94>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -1261,13 +2170,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_2217D24C_L47C10::.ctor(class Modules.Import_ExportNamedFrom/Scope, class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionObject_FunctionExpression_2217D24C_L47C10::.ctor(class Modules.Import_ExportNamedFrom/Scope, class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_2217D24C_L47C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionObject_FunctionExpression_2217D24C_L47C10>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldc.i4.1
 				IL_0487: newarr [System.Runtime]System.Object
@@ -1386,6 +2295,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportNamedFrom/Scope _environment0_Import_ExportNamedFrom
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportNamedFrom/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3877
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_export/FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::_environment0_Import_ExportNamedFrom
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3886
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3889
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x388c
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_export/FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::_environment0_Import_ExportNamedFrom
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Import_ExportNamedFrom/__jroc_esm_export::__js_call__(class Modules.Import_ExportNamedFrom/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x38ac
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom/Scope Modules.Import_ExportNamedFrom/__jroc_esm_export/FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::_environment0_Import_ExportNamedFrom
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Import_ExportNamedFrom/__jroc_esm_export::__js_call__(class Modules.Import_ExportNamedFrom/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x38c8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1499,13 +2527,13 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportNamedFrom/Scope,
-			[1] class FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default,
-			[2] class FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get,
-			[3] class FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace,
-			[4] class FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export,
+			[1] class Modules.Import_ExportNamedFrom/__jroc_esm_default/FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default,
+			[2] class Modules.Import_ExportNamedFrom/__jroc_esm_get/FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get,
+			[3] class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace,
+			[4] class Modules.Import_ExportNamedFrom/__jroc_esm_export/FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export,
 			[5] object,
 			[6] object[],
-			[7] class FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark,
+			[7] class Modules.Import_ExportNamedFrom/__jroc_esm_mark/FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark,
 			[8] object,
 			[9] object
 		)
@@ -1526,13 +2554,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_ExportNamedFrom/Scope
-		IL_0022: newobj instance void FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::.ctor(class Modules.Import_ExportNamedFrom/Scope)
+		IL_0022: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_mark/FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::.ctor(class Modules.Import_ExportNamedFrom/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom/__jroc_esm_mark/FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 7
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 7
@@ -1544,13 +2572,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 6
-		IL_004b: newobj instance void FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_default/FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom/__jroc_esm_default/FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -1559,13 +2587,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 6
-		IL_006b: newobj instance void FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_get/FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom/__jroc_esm_get/FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -1578,13 +2606,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_ExportNamedFrom/Scope
-		IL_0094: newobj instance void FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::.ctor(class Modules.Import_ExportNamedFrom/Scope)
+		IL_0094: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::.ctor(class Modules.Import_ExportNamedFrom/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -1597,13 +2625,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_ExportNamedFrom/Scope
-		IL_00bd: newobj instance void FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::.ctor(class Modules.Import_ExportNamedFrom/Scope)
+		IL_00bd: newobj instance void Modules.Import_ExportNamedFrom/__jroc_esm_export/FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::.ctor(class Modules.Import_ExportNamedFrom/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom/__jroc_esm_export/FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 4
 		IL_00d2: nop
 		IL_00d3: ldloc.0
@@ -1699,6 +2727,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_64A3B1F3_L7C28
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportNamedFrom_LibB/Scope _environment0_Import_ExportNamedFrom_LibB
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportNamedFrom_LibB/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x38d7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L7C27/FunctionObject_FunctionExpression_64A3B1F3_L7C28::_environment0_Import_ExportNamedFrom_LibB
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_64A3B1F3_L7C28::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x38e6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_64A3B1F3_L7C28::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x38e9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_64A3B1F3_L7C28::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x38ec
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L7C27/FunctionObject_FunctionExpression_64A3B1F3_L7C28::_environment0_Import_ExportNamedFrom_LibB
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L7C27::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_64A3B1F3_L7C28::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x38fe
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L7C27/FunctionObject_FunctionExpression_64A3B1F3_L7C28::_environment0_Import_ExportNamedFrom_LibB
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L7C27::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_64A3B1F3_L7C28::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x390c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_64A3B1F3_L7C28::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_64A3B1F3_L7C28
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1754,6 +2889,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_59981EE9_L8C30
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportNamedFrom_LibB/Scope _environment0_Import_ExportNamedFrom_LibB
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportNamedFrom_LibB/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x391b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L8C29/FunctionObject_FunctionExpression_59981EE9_L8C30::_environment0_Import_ExportNamedFrom_LibB
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_59981EE9_L8C30::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x392a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_59981EE9_L8C30::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x392d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_59981EE9_L8C30::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3930
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L8C29/FunctionObject_FunctionExpression_59981EE9_L8C30::_environment0_Import_ExportNamedFrom_LibB
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L8C29::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_59981EE9_L8C30::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3942
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L8C29/FunctionObject_FunctionExpression_59981EE9_L8C30::_environment0_Import_ExportNamedFrom_LibB
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L8C29::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_59981EE9_L8C30::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3950
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_59981EE9_L8C30::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_59981EE9_L8C30
 
 
 		// Methods
@@ -1832,6 +3074,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportNamedFrom_LibB/Scope _environment0_Import_ExportNamedFrom_LibB
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportNamedFrom_LibB/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x395f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::_environment0_Import_ExportNamedFrom_LibB
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x396e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3971
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3974
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::_environment0_Import_ExportNamedFrom_LibB
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3986
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::_environment0_Import_ExportNamedFrom_LibB
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3994
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark
 
 
 		// Methods
@@ -1939,6 +3288,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x39a3
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x39ab
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x39ae
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x39b1
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_default::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x39c4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_default::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x39d3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2042,6 +3492,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x39e2
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x39ea
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x39ed
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x39f0
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a0a
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a20
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2100,6 +3657,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FF471FD3_L36C87
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ExportNamedFrom_LibB/Scope _environment0_Import_ExportNamedFrom_LibB
+				.field private initonly class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ExportNamedFrom_LibB/Scope capture0,
+						class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3a81
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_FF471FD3_L36C87::_environment0_Import_ExportNamedFrom_LibB
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_FF471FD3_L36C87::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_FF471FD3_L36C87::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_FF471FD3_L36C87::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3a9e
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_FF471FD3_L36C87::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3aa1
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_FF471FD3_L36C87::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x3aa4
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_FF471FD3_L36C87::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_FF471FD3_L36C87::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3ab6
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_FF471FD3_L36C87::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_FF471FD3_L36C87::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3ac4
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_FF471FD3_L36C87::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_FF471FD3_L36C87
+
 
 			// Methods
 			.method public hidebysig static 
@@ -2149,6 +3823,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7803A6D6_L37C94
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ExportNamedFrom_LibB/Scope _environment0_Import_ExportNamedFrom_LibB
+				.field private initonly class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ExportNamedFrom_LibB/Scope capture0,
+						class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3ad3
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_7803A6D6_L37C94::_environment0_Import_ExportNamedFrom_LibB
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_7803A6D6_L37C94::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_7803A6D6_L37C94::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_7803A6D6_L37C94::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3af0
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_7803A6D6_L37C94::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3af3
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_7803A6D6_L37C94::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x3af6
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_7803A6D6_L37C94::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_7803A6D6_L37C94::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3b08
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_7803A6D6_L37C94::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_7803A6D6_L37C94::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3b16
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_7803A6D6_L37C94::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_7803A6D6_L37C94
 
 
 			// Methods
@@ -2203,6 +3994,128 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_42DBC8A8_L47C87
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Import_ExportNamedFrom_LibB/Scope _environment0_Import_ExportNamedFrom_LibB
+					.field private initonly class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+					.field private initonly class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/Scope _environment2_FunctionExpression_L46C9
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Import_ExportNamedFrom_LibB/Scope capture0,
+							class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope capture1,
+							class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x3b85
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_42DBC8A8_L47C87::_environment0_Import_ExportNamedFrom_LibB
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_42DBC8A8_L47C87::_environment1___jroc_esm_namespace
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_42DBC8A8_L47C87::_environment2_FunctionExpression_L46C9
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_42DBC8A8_L47C87::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_42DBC8A8_L47C87::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x3baa
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_42DBC8A8_L47C87::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x3bad
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_42DBC8A8_L47C87::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x3bb0
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_42DBC8A8_L47C87::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_42DBC8A8_L47C87::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x3bc2
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_42DBC8A8_L47C87::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_42DBC8A8_L47C87::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x3bd0
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_42DBC8A8_L47C87::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_42DBC8A8_L47C87
 
 
 				// Methods
@@ -2269,6 +4182,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_69D44793_L46C10
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ExportNamedFrom_LibB/Scope _environment0_Import_ExportNamedFrom_LibB
+				.field private initonly class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ExportNamedFrom_LibB/Scope capture0,
+						class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3b25
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_69D44793_L46C10::_environment0_Import_ExportNamedFrom_LibB
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_69D44793_L46C10::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_69D44793_L46C10::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_69D44793_L46C10::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3b42
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_69D44793_L46C10::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3b45
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_69D44793_L46C10::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x3b48
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_69D44793_L46C10::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_69D44793_L46C10::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3b61
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_69D44793_L46C10::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_69D44793_L46C10::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3b76
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_69D44793_L46C10::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_69D44793_L46C10
+
 
 			// Methods
 			.method public hidebysig static 
@@ -2290,7 +4326,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_42DBC8A8_L47C87,
+					[4] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_42DBC8A8_L47C87,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -2340,13 +4376,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_42DBC8A8_L47C87::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope, class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope, class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_42DBC8A8_L47C87::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope, class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope, class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_42DBC8A8_L47C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_42DBC8A8_L47C87>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -2565,6 +4601,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportNamedFrom_LibB/Scope _environment0_Import_ExportNamedFrom_LibB
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportNamedFrom_LibB/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a2f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::_environment0_Import_ExportNamedFrom_LibB
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3a3e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3a41
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a44
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::_environment0_Import_ExportNamedFrom_LibB
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a5d
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::_environment0_Import_ExportNamedFrom_LibB
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a72
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2604,12 +4753,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_FF471FD3_L36C87,
-				[21] class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_7803A6D6_L37C94,
+				[20] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_FF471FD3_L36C87,
+				[21] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_7803A6D6_L37C94,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_69D44793_L46C10
+				[25] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_69D44793_L46C10
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope::.ctor()
@@ -2815,13 +4964,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_FF471FD3_L36C87::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope, class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_FF471FD3_L36C87::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope, class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_FF471FD3_L36C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_FF471FD3_L36C87>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -2865,13 +5014,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_7803A6D6_L37C94::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope, class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_7803A6D6_L37C94::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope, class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_7803A6D6_L37C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_7803A6D6_L37C94>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -3041,13 +5190,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_69D44793_L46C10::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope, class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_69D44793_L46C10::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope, class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_69D44793_L46C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_69D44793_L46C10>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldc.i4.1
 				IL_0487: newarr [System.Runtime]System.Object
@@ -3166,6 +5315,127 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportNamedFrom_LibB/Scope _environment0_Import_ExportNamedFrom_LibB
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportNamedFrom_LibB/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3bdf
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::_environment0_Import_ExportNamedFrom_LibB
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3bee
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3bf1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3bf4
+				// Header size: 1
+				// Code size: 36 (0x24)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::_environment0_Import_ExportNamedFrom_LibB
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0017: ldarg.2
+				IL_0018: ldc.i4.1
+				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001e: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object, string, object)
+				IL_0023: ret
+			} // end of method FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3c19
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::_environment0_Import_ExportNamedFrom_LibB
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.1
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object, string, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3c3a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export
+
 
 		// Methods
 		.method public hidebysig static 
@@ -3280,16 +5550,16 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportNamedFrom_LibB/Scope,
-			[1] class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default,
-			[2] class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get,
-			[3] class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace,
-			[4] class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export,
+			[1] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_default/FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default,
+			[2] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_get/FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get,
+			[3] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace,
+			[4] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export,
 			[5] object[],
-			[6] class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark,
+			[6] class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark,
 			[7] object,
 			[8] object[],
-			[9] class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_64A3B1F3_L7C28,
-			[10] class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_59981EE9_L8C30
+			[9] class Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L7C27/FunctionObject_FunctionExpression_64A3B1F3_L7C28,
+			[10] class Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L8C29/FunctionObject_FunctionExpression_59981EE9_L8C30
 		)
 
 		IL_0000: newobj instance void Modules.Import_ExportNamedFrom_LibB/Scope::.ctor()
@@ -3308,13 +5578,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_ExportNamedFrom_LibB/Scope
-		IL_0022: newobj instance void FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope)
+		IL_0022: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 6
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 6
@@ -3326,13 +5596,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 5
-		IL_004b: newobj instance void FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_default/FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_default/FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -3341,13 +5611,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 5
-		IL_006b: newobj instance void FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_get/FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_get/FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -3360,13 +5630,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_ExportNamedFrom_LibB/Scope
-		IL_0094: newobj instance void FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope)
+		IL_0094: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -3379,13 +5649,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_ExportNamedFrom_LibB/Scope
-		IL_00bd: newobj instance void FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope)
+		IL_00bd: newobj instance void Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 4
 		IL_00d2: nop
 		IL_00d3: ldloc.0
@@ -3415,13 +5685,13 @@
 		IL_0112: ldc.i4.0
 		IL_0113: ldelem.ref
 		IL_0114: castclass Modules.Import_ExportNamedFrom_LibB/Scope
-		IL_0119: newobj instance void FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_64A3B1F3_L7C28::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope)
+		IL_0119: newobj instance void Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L7C27/FunctionObject_FunctionExpression_64A3B1F3_L7C28::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope)
 		IL_011e: ldc.i4.0
 		IL_011f: conv.r8
 		IL_0120: ldstr ""
 		IL_0125: ldc.i4.0
 		IL_0126: ldc.i4.1
-		IL_0127: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_64A3B1F3_L7C28>(!!0, float64, string, bool, bool)
+		IL_0127: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L7C27/FunctionObject_FunctionExpression_64A3B1F3_L7C28>(!!0, float64, string, bool, bool)
 		IL_012c: stloc.s 9
 		IL_012e: ldloc.s 4
 		IL_0130: ldloc.s 5
@@ -3442,13 +5712,13 @@
 		IL_0154: ldc.i4.0
 		IL_0155: ldelem.ref
 		IL_0156: castclass Modules.Import_ExportNamedFrom_LibB/Scope
-		IL_015b: newobj instance void FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_59981EE9_L8C30::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope)
+		IL_015b: newobj instance void Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L8C29/FunctionObject_FunctionExpression_59981EE9_L8C30::.ctor(class Modules.Import_ExportNamedFrom_LibB/Scope)
 		IL_0160: ldc.i4.0
 		IL_0161: conv.r8
 		IL_0162: ldstr ""
 		IL_0167: ldc.i4.0
 		IL_0168: ldc.i4.1
-		IL_0169: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_59981EE9_L8C30>(!!0, float64, string, bool, bool)
+		IL_0169: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L8C29/FunctionObject_FunctionExpression_59981EE9_L8C30>(!!0, float64, string, bool, bool)
 		IL_016e: stloc.s 10
 		IL_0170: ldloc.s 4
 		IL_0172: ldloc.s 5
@@ -3488,6 +5758,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B2972973_L5C12
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3c49
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_B2972973_L5C12::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3c51
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_B2972973_L5C12::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3c54
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_B2972973_L5C12::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3c57
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Import_ExportNamedFrom_LibA/FunctionExpression_L5C11::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_B2972973_L5C12::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3c6a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Import_ExportNamedFrom_LibA/FunctionExpression_L5C11::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_B2972973_L5C12::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3c79
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_B2972973_L5C12::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_B2972973_L5C12
 
 
 		// Methods
@@ -3604,2377 +5975,6 @@
 	} // end of method Import_ExportNamedFrom_LibA::__js_module_init__
 
 } // end of class Modules.Import_ExportNamedFrom_LibA
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportNamedFrom/Scope _environment0_Import_ExportNamedFrom
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportNamedFrom/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x35ed
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportNamedFrom/Scope FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::_environment0_Import_ExportNamedFrom
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x35fc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x35ff
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3602
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportNamedFrom/Scope FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::_environment0_Import_ExportNamedFrom
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportNamedFrom/__jroc_esm_mark::__js_call__(class Modules.Import_ExportNamedFrom/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3614
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportNamedFrom/Scope FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::_environment0_Import_ExportNamedFrom
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportNamedFrom/__jroc_esm_mark::__js_call__(class Modules.Import_ExportNamedFrom/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3622
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_B9AC7A65___jroc_esm_mark
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3631
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3639
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x363c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x363f
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Import_ExportNamedFrom/__jroc_esm_default::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3652
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Import_ExportNamedFrom/__jroc_esm_default::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3661
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_406CE641___jroc_esm_default
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3670
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3678
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x367b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x367e
-		// Header size: 1
-		// Code size: 30 (0x1e)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0018: call object Modules.Import_ExportNamedFrom/__jroc_esm_get::__js_call__(object, object, string)
-		IL_001d: ret
-	} // end of method FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x369d
-		// Header size: 1
-		// Code size: 26 (0x1a)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0014: call object Modules.Import_ExportNamedFrom/__jroc_esm_get::__js_call__(object, object, string)
-		IL_0019: ret
-	} // end of method FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x36b8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_044D06F8___jroc_esm_get
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportNamedFrom/Scope _environment0_Import_ExportNamedFrom
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportNamedFrom/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x36c7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportNamedFrom/Scope FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::_environment0_Import_ExportNamedFrom
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x36d6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x36d9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x36dc
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportNamedFrom/Scope FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::_environment0_Import_ExportNamedFrom
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportNamedFrom/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x36f5
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportNamedFrom/Scope FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::_environment0_Import_ExportNamedFrom
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportNamedFrom/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x370a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_D9EED683___jroc_esm_namespace
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_34E1A920_L37C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportNamedFrom/Scope _environment0_Import_ExportNamedFrom
-	.field private initonly class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportNamedFrom/Scope capture0,
-			class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3719
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportNamedFrom/Scope FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_34E1A920_L37C87::_environment0_Import_ExportNamedFrom
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_34E1A920_L37C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_34E1A920_L37C87::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_34E1A920_L37C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3736
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_34E1A920_L37C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3739
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_34E1A920_L37C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x373c
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_34E1A920_L37C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_34E1A920_L37C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x374e
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_34E1A920_L37C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L37C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_34E1A920_L37C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x375c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_34E1A920_L37C87::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_34E1A920_L37C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_4DC27BA3_L38C94
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportNamedFrom/Scope _environment0_Import_ExportNamedFrom
-	.field private initonly class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportNamedFrom/Scope capture0,
-			class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x376b
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportNamedFrom/Scope FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_4DC27BA3_L38C94::_environment0_Import_ExportNamedFrom
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_4DC27BA3_L38C94::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_4DC27BA3_L38C94::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_4DC27BA3_L38C94::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3788
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_4DC27BA3_L38C94::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x378b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_4DC27BA3_L38C94::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x378e
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_4DC27BA3_L38C94::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_4DC27BA3_L38C94::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x37a0
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_4DC27BA3_L38C94::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L38C93::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_4DC27BA3_L38C94::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x37ae
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_4DC27BA3_L38C94::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_4DC27BA3_L38C94
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_2217D24C_L47C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportNamedFrom/Scope _environment0_Import_ExportNamedFrom
-	.field private initonly class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportNamedFrom/Scope capture0,
-			class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x37bd
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportNamedFrom/Scope FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_2217D24C_L47C10::_environment0_Import_ExportNamedFrom
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_2217D24C_L47C10::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_2217D24C_L47C10::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_2217D24C_L47C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x37da
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2217D24C_L47C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x37dd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2217D24C_L47C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x37e0
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_2217D24C_L47C10::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_2217D24C_L47C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x37f9
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_2217D24C_L47C10::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_2217D24C_L47C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x380e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2217D24C_L47C10::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_2217D24C_L47C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_8BD69ABA_L48C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportNamedFrom/Scope _environment0_Import_ExportNamedFrom
-	.field private initonly class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/Scope _environment2_FunctionExpression_L47C9
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportNamedFrom/Scope capture0,
-			class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope capture1,
-			class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x381d
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportNamedFrom/Scope FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_8BD69ABA_L48C87::_environment0_Import_ExportNamedFrom
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_8BD69ABA_L48C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/Scope FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_8BD69ABA_L48C87::_environment2_FunctionExpression_L47C9
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_8BD69ABA_L48C87::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_8BD69ABA_L48C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3842
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_8BD69ABA_L48C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3845
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_8BD69ABA_L48C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3848
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_8BD69ABA_L48C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_8BD69ABA_L48C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x385a
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_8BD69ABA_L48C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportNamedFrom/__jroc_esm_namespace/FunctionExpression_L47C9/FunctionExpression_L48C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_8BD69ABA_L48C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3868
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_8BD69ABA_L48C87::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionExpression_8BD69ABA_L48C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportNamedFrom/Scope _environment0_Import_ExportNamedFrom
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportNamedFrom/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3877
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportNamedFrom/Scope FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::_environment0_Import_ExportNamedFrom
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3886
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3889
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x388c
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportNamedFrom/Scope FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::_environment0_Import_ExportNamedFrom
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Import_ExportNamedFrom/__jroc_esm_export::__js_call__(class Modules.Import_ExportNamedFrom/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x38ac
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportNamedFrom/Scope FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::_environment0_Import_ExportNamedFrom
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Import_ExportNamedFrom/__jroc_esm_export::__js_call__(class Modules.Import_ExportNamedFrom/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x38c8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportNamedFrom_4CC4EBD0.FunctionObject_FunctionDeclaration_13F3597A___jroc_esm_export
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_64A3B1F3_L7C28
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportNamedFrom_LibB/Scope _environment0_Import_ExportNamedFrom_LibB
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportNamedFrom_LibB/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x38d7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_64A3B1F3_L7C28::_environment0_Import_ExportNamedFrom_LibB
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_64A3B1F3_L7C28::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x38e6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_64A3B1F3_L7C28::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x38e9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_64A3B1F3_L7C28::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x38ec
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_64A3B1F3_L7C28::_environment0_Import_ExportNamedFrom_LibB
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L7C27::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_64A3B1F3_L7C28::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x38fe
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_64A3B1F3_L7C28::_environment0_Import_ExportNamedFrom_LibB
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L7C27::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_64A3B1F3_L7C28::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x390c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_64A3B1F3_L7C28::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_64A3B1F3_L7C28
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_59981EE9_L8C30
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportNamedFrom_LibB/Scope _environment0_Import_ExportNamedFrom_LibB
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportNamedFrom_LibB/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x391b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_59981EE9_L8C30::_environment0_Import_ExportNamedFrom_LibB
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_59981EE9_L8C30::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x392a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_59981EE9_L8C30::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x392d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_59981EE9_L8C30::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3930
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_59981EE9_L8C30::_environment0_Import_ExportNamedFrom_LibB
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L8C29::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_59981EE9_L8C30::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3942
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_59981EE9_L8C30::_environment0_Import_ExportNamedFrom_LibB
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportNamedFrom_LibB/FunctionExpression_L8C29::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_59981EE9_L8C30::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3950
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_59981EE9_L8C30::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_59981EE9_L8C30
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportNamedFrom_LibB/Scope _environment0_Import_ExportNamedFrom_LibB
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportNamedFrom_LibB/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x395f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::_environment0_Import_ExportNamedFrom_LibB
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x396e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3971
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3974
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::_environment0_Import_ExportNamedFrom_LibB
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3986
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::_environment0_Import_ExportNamedFrom_LibB
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3994
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_4D12571F___jroc_esm_mark
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x39a3
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x39ab
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x39ae
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x39b1
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_default::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x39c4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_default::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x39d3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_1C9F6BB3___jroc_esm_default
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x39e2
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x39ea
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x39ed
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x39f0
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a0a
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a20
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_9E9452BA___jroc_esm_get
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportNamedFrom_LibB/Scope _environment0_Import_ExportNamedFrom_LibB
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportNamedFrom_LibB/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a2f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::_environment0_Import_ExportNamedFrom_LibB
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3a3e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3a41
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a44
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::_environment0_Import_ExportNamedFrom_LibB
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a5d
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::_environment0_Import_ExportNamedFrom_LibB
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a72
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_105ADE9D___jroc_esm_namespace
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_FF471FD3_L36C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportNamedFrom_LibB/Scope _environment0_Import_ExportNamedFrom_LibB
-	.field private initonly class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportNamedFrom_LibB/Scope capture0,
-			class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a81
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_FF471FD3_L36C87::_environment0_Import_ExportNamedFrom_LibB
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_FF471FD3_L36C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_FF471FD3_L36C87::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_FF471FD3_L36C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3a9e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FF471FD3_L36C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3aa1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FF471FD3_L36C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3aa4
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_FF471FD3_L36C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_FF471FD3_L36C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ab6
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_FF471FD3_L36C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L36C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_FF471FD3_L36C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ac4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_FF471FD3_L36C87::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_FF471FD3_L36C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_7803A6D6_L37C94
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportNamedFrom_LibB/Scope _environment0_Import_ExportNamedFrom_LibB
-	.field private initonly class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportNamedFrom_LibB/Scope capture0,
-			class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ad3
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_7803A6D6_L37C94::_environment0_Import_ExportNamedFrom_LibB
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_7803A6D6_L37C94::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_7803A6D6_L37C94::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_7803A6D6_L37C94::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3af0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7803A6D6_L37C94::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3af3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7803A6D6_L37C94::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3af6
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_7803A6D6_L37C94::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_7803A6D6_L37C94::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b08
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_7803A6D6_L37C94::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L37C93::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_7803A6D6_L37C94::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b16
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7803A6D6_L37C94::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_7803A6D6_L37C94
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_69D44793_L46C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportNamedFrom_LibB/Scope _environment0_Import_ExportNamedFrom_LibB
-	.field private initonly class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportNamedFrom_LibB/Scope capture0,
-			class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b25
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_69D44793_L46C10::_environment0_Import_ExportNamedFrom_LibB
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_69D44793_L46C10::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_69D44793_L46C10::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_69D44793_L46C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3b42
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_69D44793_L46C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3b45
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_69D44793_L46C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b48
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_69D44793_L46C10::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_69D44793_L46C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b61
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_69D44793_L46C10::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_69D44793_L46C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b76
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_69D44793_L46C10::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_69D44793_L46C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_42DBC8A8_L47C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportNamedFrom_LibB/Scope _environment0_Import_ExportNamedFrom_LibB
-	.field private initonly class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/Scope _environment2_FunctionExpression_L46C9
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportNamedFrom_LibB/Scope capture0,
-			class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope capture1,
-			class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b85
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_42DBC8A8_L47C87::_environment0_Import_ExportNamedFrom_LibB
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_42DBC8A8_L47C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/Scope FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_42DBC8A8_L47C87::_environment2_FunctionExpression_L46C9
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_42DBC8A8_L47C87::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_42DBC8A8_L47C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3baa
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_42DBC8A8_L47C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3bad
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_42DBC8A8_L47C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3bb0
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_42DBC8A8_L47C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_42DBC8A8_L47C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3bc2
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_42DBC8A8_L47C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_42DBC8A8_L47C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3bd0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_42DBC8A8_L47C87::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionExpression_42DBC8A8_L47C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportNamedFrom_LibB/Scope _environment0_Import_ExportNamedFrom_LibB
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportNamedFrom_LibB/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3bdf
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportNamedFrom_LibB/Scope FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::_environment0_Import_ExportNamedFrom_LibB
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3bee
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3bf1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3bf4
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::_environment0_Import_ExportNamedFrom_LibB
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0017: ldarg.2
-		IL_0018: ldc.i4.1
-		IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001e: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object, string, object)
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c19
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportNamedFrom_LibB/Scope FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::_environment0_Import_ExportNamedFrom_LibB
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.1
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.Import_ExportNamedFrom_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportNamedFrom_LibB/Scope, object, string, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c3a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportNamedFrom_LibB_29176602.FunctionObject_FunctionDeclaration_C1962974___jroc_esm_export
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportNamedFrom_LibA_2817646F.FunctionObject_FunctionExpression_B2972973_L5C12
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3c49
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_B2972973_L5C12::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3c51
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_B2972973_L5C12::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3c54
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_B2972973_L5C12::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c57
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Import_ExportNamedFrom_LibA/FunctionExpression_L5C11::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_B2972973_L5C12::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c6a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Import_ExportNamedFrom_LibA/FunctionExpression_L5C11::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_B2972973_L5C12::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c79
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_B2972973_L5C12::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportNamedFrom_LibA_2817646F.FunctionObject_FunctionExpression_B2972973_L5C12
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFrom.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFrom.verified.txt
@@ -53,6 +53,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportStarFrom/Scope _environment0_Import_ExportStarFrom
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportStarFrom/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x37d8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::_environment0_Import_ExportStarFrom
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x37e7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x37ea
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x37ed
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::_environment0_Import_ExportStarFrom
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_ExportStarFrom/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFrom/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x37ff
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::_environment0_Import_ExportStarFrom
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_ExportStarFrom/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFrom/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x380d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark
+
 
 		// Methods
 		.method public hidebysig static 
@@ -159,6 +266,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x381c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3824
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3827
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x382a
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Import_ExportStarFrom/__jroc_esm_default::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x383d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Import_ExportStarFrom/__jroc_esm_default::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x384c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default
+
 
 		// Methods
 		.method public hidebysig static 
@@ -262,6 +470,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x385b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3863
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3866
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3869
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Import_ExportStarFrom/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3883
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Import_ExportStarFrom/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3899
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get
+
 
 		// Methods
 		.method public hidebysig static 
@@ -320,6 +635,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5774ECAB_L39C87
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ExportStarFrom/Scope _environment0_Import_ExportStarFrom
+				.field private initonly class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ExportStarFrom/Scope capture0,
+						class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x38fa
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_5774ECAB_L39C87::_environment0_Import_ExportStarFrom
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_5774ECAB_L39C87::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_5774ECAB_L39C87::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_5774ECAB_L39C87::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3917
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_5774ECAB_L39C87::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x391a
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_5774ECAB_L39C87::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x391d
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_5774ECAB_L39C87::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_5774ECAB_L39C87::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x392f
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_5774ECAB_L39C87::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_5774ECAB_L39C87::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x393d
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_5774ECAB_L39C87::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_5774ECAB_L39C87
+
 
 			// Methods
 			.method public hidebysig static 
@@ -369,6 +801,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5849C53F_L40C94
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ExportStarFrom/Scope _environment0_Import_ExportStarFrom
+				.field private initonly class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ExportStarFrom/Scope capture0,
+						class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x394c
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_5849C53F_L40C94::_environment0_Import_ExportStarFrom
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_5849C53F_L40C94::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_5849C53F_L40C94::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_5849C53F_L40C94::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3969
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_5849C53F_L40C94::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x396c
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_5849C53F_L40C94::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x396f
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_5849C53F_L40C94::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_5849C53F_L40C94::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3981
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_5849C53F_L40C94::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_5849C53F_L40C94::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x398f
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_5849C53F_L40C94::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_5849C53F_L40C94
 
 
 			// Methods
@@ -423,6 +972,128 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8E8605EC_L50C87
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Import_ExportStarFrom/Scope _environment0_Import_ExportStarFrom
+					.field private initonly class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+					.field private initonly class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/Scope _environment2_FunctionExpression_L49C9
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Import_ExportStarFrom/Scope capture0,
+							class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope capture1,
+							class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x39fe
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_8E8605EC_L50C87::_environment0_Import_ExportStarFrom
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_8E8605EC_L50C87::_environment1___jroc_esm_namespace
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_8E8605EC_L50C87::_environment2_FunctionExpression_L49C9
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_8E8605EC_L50C87::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_8E8605EC_L50C87::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x3a23
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_8E8605EC_L50C87::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x3a26
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_8E8605EC_L50C87::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x3a29
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_8E8605EC_L50C87::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_8E8605EC_L50C87::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x3a3b
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_8E8605EC_L50C87::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_8E8605EC_L50C87::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x3a49
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_8E8605EC_L50C87::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_8E8605EC_L50C87
 
 
 				// Methods
@@ -489,6 +1160,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6930940B_L49C10
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ExportStarFrom/Scope _environment0_Import_ExportStarFrom
+				.field private initonly class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ExportStarFrom/Scope capture0,
+						class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x399e
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_6930940B_L49C10::_environment0_Import_ExportStarFrom
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_6930940B_L49C10::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_6930940B_L49C10::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_6930940B_L49C10::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x39bb
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_6930940B_L49C10::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x39be
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_6930940B_L49C10::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x39c1
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_6930940B_L49C10::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_6930940B_L49C10::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x39da
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_6930940B_L49C10::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_6930940B_L49C10::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x39ef
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_6930940B_L49C10::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_6930940B_L49C10
+
 
 			// Methods
 			.method public hidebysig static 
@@ -510,7 +1304,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_8E8605EC_L50C87,
+					[4] class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_8E8605EC_L50C87,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -560,13 +1354,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_8E8605EC_L50C87::.ctor(class Modules.Import_ExportStarFrom/Scope, class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope, class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_8E8605EC_L50C87::.ctor(class Modules.Import_ExportStarFrom/Scope, class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope, class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_8E8605EC_L50C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_8E8605EC_L50C87>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -785,6 +1579,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportStarFrom/Scope _environment0_Import_ExportStarFrom
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportStarFrom/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x38a8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::_environment0_Import_ExportStarFrom
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x38b7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x38ba
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x38bd
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::_environment0_Import_ExportStarFrom
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFrom/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x38d6
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::_environment0_Import_ExportStarFrom
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFrom/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x38eb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace
+
 
 		// Methods
 		.method public hidebysig static 
@@ -824,12 +1731,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_5774ECAB_L39C87,
-				[21] class FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_5849C53F_L40C94,
+				[20] class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_5774ECAB_L39C87,
+				[21] class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_5849C53F_L40C94,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_6930940B_L49C10
+				[25] class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_6930940B_L49C10
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope::.ctor()
@@ -1035,13 +1942,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_5774ECAB_L39C87::.ctor(class Modules.Import_ExportStarFrom/Scope, class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_5774ECAB_L39C87::.ctor(class Modules.Import_ExportStarFrom/Scope, class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_5774ECAB_L39C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_5774ECAB_L39C87>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -1085,13 +1992,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_5849C53F_L40C94::.ctor(class Modules.Import_ExportStarFrom/Scope, class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_5849C53F_L40C94::.ctor(class Modules.Import_ExportStarFrom/Scope, class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_5849C53F_L40C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_5849C53F_L40C94>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -1261,13 +2168,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_6930940B_L49C10::.ctor(class Modules.Import_ExportStarFrom/Scope, class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_6930940B_L49C10::.ctor(class Modules.Import_ExportStarFrom/Scope, class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_6930940B_L49C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_6930940B_L49C10>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldc.i4.1
 				IL_0487: newarr [System.Runtime]System.Object
@@ -1386,6 +2293,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_52197845___jroc_esm_export
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportStarFrom/Scope _environment0_Import_ExportStarFrom
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportStarFrom/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a58
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_export/FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::_environment0_Import_ExportStarFrom
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3a67
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3a6a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a6d
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_export/FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::_environment0_Import_ExportStarFrom
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Import_ExportStarFrom/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFrom/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a8d
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFrom/Scope Modules.Import_ExportStarFrom/__jroc_esm_export/FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::_environment0_Import_ExportStarFrom
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Import_ExportStarFrom/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFrom/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3aa9
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_52197845___jroc_esm_export
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1499,14 +2525,14 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportStarFrom/Scope,
-			[1] class FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default,
-			[2] class FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get,
-			[3] class FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace,
-			[4] class FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_52197845___jroc_esm_export,
+			[1] class Modules.Import_ExportStarFrom/__jroc_esm_default/FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default,
+			[2] class Modules.Import_ExportStarFrom/__jroc_esm_get/FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get,
+			[3] class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace,
+			[4] class Modules.Import_ExportStarFrom/__jroc_esm_export/FunctionObject_FunctionDeclaration_52197845___jroc_esm_export,
 			[5] object,
 			[6] object,
 			[7] object[],
-			[8] class FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark,
+			[8] class Modules.Import_ExportStarFrom/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark,
 			[9] object,
 			[10] object
 		)
@@ -1527,13 +2553,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_ExportStarFrom/Scope
-		IL_0022: newobj instance void FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::.ctor(class Modules.Import_ExportStarFrom/Scope)
+		IL_0022: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::.ctor(class Modules.Import_ExportStarFrom/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 8
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 8
@@ -1545,13 +2571,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 7
-		IL_004b: newobj instance void FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_default/FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom/__jroc_esm_default/FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -1560,13 +2586,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 7
-		IL_006b: newobj instance void FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_get/FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom/__jroc_esm_get/FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -1579,13 +2605,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_ExportStarFrom/Scope
-		IL_0094: newobj instance void FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::.ctor(class Modules.Import_ExportStarFrom/Scope)
+		IL_0094: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::.ctor(class Modules.Import_ExportStarFrom/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -1598,13 +2624,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_ExportStarFrom/Scope
-		IL_00bd: newobj instance void FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::.ctor(class Modules.Import_ExportStarFrom/Scope)
+		IL_00bd: newobj instance void Modules.Import_ExportStarFrom/__jroc_esm_export/FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::.ctor(class Modules.Import_ExportStarFrom/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_52197845___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom/__jroc_esm_export/FunctionObject_FunctionDeclaration_52197845___jroc_esm_export>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 4
 		IL_00d2: nop
 		IL_00d3: ldloc.0
@@ -1744,6 +2770,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportStarFrom_LibB/Scope _environment0_Import_ExportStarFrom_LibB
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportStarFrom_LibB/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b5c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::_environment0_Import_ExportStarFrom_LibB
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3b6b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3b6e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b71
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::_environment0_Import_ExportStarFrom_LibB
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b83
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::_environment0_Import_ExportStarFrom_LibB
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b91
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1850,6 +2983,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3ba0
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3ba8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3bab
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3bae
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_default::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3bc1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_default::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3bd0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1953,6 +3187,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3bdf
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3be7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3bea
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3bed
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3c07
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3c1d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2011,6 +3352,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_19C9F4C3_L39C87
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ExportStarFrom_LibB/Scope _environment0_Import_ExportStarFrom_LibB
+				.field private initonly class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ExportStarFrom_LibB/Scope capture0,
+						class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3c7e
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_19C9F4C3_L39C87::_environment0_Import_ExportStarFrom_LibB
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_19C9F4C3_L39C87::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_19C9F4C3_L39C87::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_19C9F4C3_L39C87::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3c9b
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_19C9F4C3_L39C87::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3c9e
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_19C9F4C3_L39C87::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x3ca1
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_19C9F4C3_L39C87::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_19C9F4C3_L39C87::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3cb3
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_19C9F4C3_L39C87::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_19C9F4C3_L39C87::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3cc1
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_19C9F4C3_L39C87::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_19C9F4C3_L39C87
+
 
 			// Methods
 			.method public hidebysig static 
@@ -2060,6 +3518,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D1AA4B47_L40C94
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ExportStarFrom_LibB/Scope _environment0_Import_ExportStarFrom_LibB
+				.field private initonly class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ExportStarFrom_LibB/Scope capture0,
+						class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3cd0
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_D1AA4B47_L40C94::_environment0_Import_ExportStarFrom_LibB
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_D1AA4B47_L40C94::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_D1AA4B47_L40C94::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_D1AA4B47_L40C94::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3ced
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_D1AA4B47_L40C94::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3cf0
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_D1AA4B47_L40C94::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x3cf3
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_D1AA4B47_L40C94::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_D1AA4B47_L40C94::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3d05
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_D1AA4B47_L40C94::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_D1AA4B47_L40C94::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3d13
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_D1AA4B47_L40C94::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_D1AA4B47_L40C94
 
 
 			// Methods
@@ -2114,6 +3689,128 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2C8A7AA4_L50C87
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Import_ExportStarFrom_LibB/Scope _environment0_Import_ExportStarFrom_LibB
+					.field private initonly class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+					.field private initonly class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/Scope _environment2_FunctionExpression_L49C9
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Import_ExportStarFrom_LibB/Scope capture0,
+							class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope capture1,
+							class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x3d82
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_2C8A7AA4_L50C87::_environment0_Import_ExportStarFrom_LibB
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_2C8A7AA4_L50C87::_environment1___jroc_esm_namespace
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_2C8A7AA4_L50C87::_environment2_FunctionExpression_L49C9
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_2C8A7AA4_L50C87::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_2C8A7AA4_L50C87::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x3da7
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_2C8A7AA4_L50C87::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x3daa
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_2C8A7AA4_L50C87::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x3dad
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_2C8A7AA4_L50C87::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_2C8A7AA4_L50C87::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x3dbf
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_2C8A7AA4_L50C87::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_2C8A7AA4_L50C87::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x3dcd
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_2C8A7AA4_L50C87::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_2C8A7AA4_L50C87
 
 
 				// Methods
@@ -2180,6 +3877,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_14DFC423_L49C10
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ExportStarFrom_LibB/Scope _environment0_Import_ExportStarFrom_LibB
+				.field private initonly class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ExportStarFrom_LibB/Scope capture0,
+						class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3d22
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_14DFC423_L49C10::_environment0_Import_ExportStarFrom_LibB
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_14DFC423_L49C10::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_14DFC423_L49C10::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_14DFC423_L49C10::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3d3f
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_14DFC423_L49C10::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3d42
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_14DFC423_L49C10::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x3d45
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_14DFC423_L49C10::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_14DFC423_L49C10::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3d5e
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_14DFC423_L49C10::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_14DFC423_L49C10::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3d73
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_14DFC423_L49C10::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_14DFC423_L49C10
+
 
 			// Methods
 			.method public hidebysig static 
@@ -2201,7 +4021,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_2C8A7AA4_L50C87,
+					[4] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_2C8A7AA4_L50C87,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -2251,13 +4071,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_2C8A7AA4_L50C87::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope, class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope, class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_2C8A7AA4_L50C87::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope, class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope, class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_2C8A7AA4_L50C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_2C8A7AA4_L50C87>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -2476,6 +4296,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportStarFrom_LibB/Scope _environment0_Import_ExportStarFrom_LibB
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportStarFrom_LibB/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3c2c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::_environment0_Import_ExportStarFrom_LibB
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3c3b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3c3e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3c41
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::_environment0_Import_ExportStarFrom_LibB
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3c5a
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::_environment0_Import_ExportStarFrom_LibB
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3c6f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2515,12 +4448,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_19C9F4C3_L39C87,
-				[21] class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_D1AA4B47_L40C94,
+				[20] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_19C9F4C3_L39C87,
+				[21] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_D1AA4B47_L40C94,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_14DFC423_L49C10
+				[25] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_14DFC423_L49C10
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope::.ctor()
@@ -2726,13 +4659,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_19C9F4C3_L39C87::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope, class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_19C9F4C3_L39C87::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope, class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_19C9F4C3_L39C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_19C9F4C3_L39C87>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -2776,13 +4709,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_D1AA4B47_L40C94::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope, class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_D1AA4B47_L40C94::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope, class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_D1AA4B47_L40C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_D1AA4B47_L40C94>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -2952,13 +4885,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_14DFC423_L49C10::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope, class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_14DFC423_L49C10::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope, class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_14DFC423_L49C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_14DFC423_L49C10>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldc.i4.1
 				IL_0487: newarr [System.Runtime]System.Object
@@ -3077,6 +5010,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportStarFrom_LibB/Scope _environment0_Import_ExportStarFrom_LibB
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportStarFrom_LibB/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ddc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::_environment0_Import_ExportStarFrom_LibB
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3deb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3dee
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3df1
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::_environment0_Import_ExportStarFrom_LibB
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3e11
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::_environment0_Import_ExportStarFrom_LibB
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3e2d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export
+
 
 		// Methods
 		.method public hidebysig static 
@@ -3169,6 +5221,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3D87220C_L10C43
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ExportStarFrom_LibB/Scope _environment0_Import_ExportStarFrom_LibB
+				.field private initonly class Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope _environment1_FunctionExpression_L10C3
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ExportStarFrom_LibB/Scope capture0,
+						class Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3b0a
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3D87220C_L10C43::_environment0_Import_ExportStarFrom_LibB
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3D87220C_L10C43::_environment1_FunctionExpression_L10C3
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3D87220C_L10C43::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_3D87220C_L10C43::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3b27
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_3D87220C_L10C43::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3b2a
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_3D87220C_L10C43::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x3b2d
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3D87220C_L10C43::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_3D87220C_L10C43::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3b3f
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3D87220C_L10C43::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_3D87220C_L10C43::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3b4d
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_3D87220C_L10C43::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_3D87220C_L10C43
+
 
 			// Methods
 			.method public hidebysig static 
@@ -3235,6 +5404,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_599477C0_L10C4
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportStarFrom_LibB/Scope _environment0_Import_ExportStarFrom_LibB
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportStarFrom_LibB/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ab8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionObject_FunctionExpression_599477C0_L10C4::_environment0_Import_ExportStarFrom_LibB
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_599477C0_L10C4::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3ac7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_599477C0_L10C4::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3aca
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_599477C0_L10C4::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3acd
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionObject_FunctionExpression_599477C0_L10C4::_environment0_Import_ExportStarFrom_LibB
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_599477C0_L10C4::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ae6
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionObject_FunctionExpression_599477C0_L10C4::_environment0_Import_ExportStarFrom_LibB
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_599477C0_L10C4::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3afb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_599477C0_L10C4::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_599477C0_L10C4
+
 
 		// Methods
 		.method public hidebysig static 
@@ -3259,7 +5541,7 @@
 				[2] object[],
 				[3] object,
 				[4] object[],
-				[5] class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_3D87220C_L10C43
+				[5] class Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3D87220C_L10C43
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope::.ctor()
@@ -3300,13 +5582,13 @@
 			IL_0042: ldelem.ref
 			IL_0043: castclass Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope
 			IL_0048: ldloc.s 4
-			IL_004a: newobj instance void FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_3D87220C_L10C43::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope, class Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope, object[])
+			IL_004a: newobj instance void Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3D87220C_L10C43::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope, class Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope, object[])
 			IL_004f: ldc.i4.0
 			IL_0050: conv.r8
 			IL_0051: ldstr ""
 			IL_0056: ldc.i4.0
 			IL_0057: ldc.i4.1
-			IL_0058: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_3D87220C_L10C43>(!!0, float64, string, bool, bool)
+			IL_0058: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3D87220C_L10C43>(!!0, float64, string, bool, bool)
 			IL_005d: stloc.s 5
 			IL_005f: ldloc.1
 			IL_0060: ldloc.2
@@ -3434,14 +5716,14 @@
 		.maxstack 10
 		.locals init (
 			[0] class Modules.Import_ExportStarFrom_LibB/Scope,
-			[1] class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default,
-			[2] class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get,
-			[3] class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace,
+			[1] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_default/FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default,
+			[2] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_get/FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get,
+			[3] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace,
 			[4] object,
 			[5] object,
 			[6] object[],
-			[7] class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark,
-			[8] class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export,
+			[7] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark,
+			[8] class Modules.Import_ExportStarFrom_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export,
 			[9] object,
 			[10] bool,
 			[11] object,
@@ -3450,7 +5732,7 @@
 			[14] object,
 			[15] object,
 			[16] object,
-			[17] class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_599477C0_L10C4
+			[17] class Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionObject_FunctionExpression_599477C0_L10C4
 		)
 
 		IL_0000: newobj instance void Modules.Import_ExportStarFrom_LibB/Scope::.ctor()
@@ -3469,13 +5751,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_ExportStarFrom_LibB/Scope
-		IL_0022: newobj instance void FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope)
+		IL_0022: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 7
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 7
@@ -3487,13 +5769,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 6
-		IL_004b: newobj instance void FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_default/FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/__jroc_esm_default/FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -3502,13 +5784,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 6
-		IL_006b: newobj instance void FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_get/FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/__jroc_esm_get/FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -3521,13 +5803,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_ExportStarFrom_LibB/Scope
-		IL_0094: newobj instance void FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope)
+		IL_0094: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -3540,13 +5822,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_ExportStarFrom_LibB/Scope
-		IL_00bd: newobj instance void FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope)
+		IL_00bd: newobj instance void Modules.Import_ExportStarFrom_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 8
 		IL_00d2: ldloc.0
 		IL_00d3: ldloc.s 8
@@ -3687,13 +5969,13 @@
 			IL_0245: ldc.i4.0
 			IL_0246: ldelem.ref
 			IL_0247: castclass Modules.Import_ExportStarFrom_LibB/Scope
-			IL_024c: newobj instance void FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_599477C0_L10C4::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope)
+			IL_024c: newobj instance void Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionObject_FunctionExpression_599477C0_L10C4::.ctor(class Modules.Import_ExportStarFrom_LibB/Scope)
 			IL_0251: ldc.i4.1
 			IL_0252: conv.r8
 			IL_0253: ldstr ""
 			IL_0258: ldc.i4.0
 			IL_0259: ldc.i4.1
-			IL_025a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_599477C0_L10C4>(!!0, float64, string, bool, bool)
+			IL_025a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionObject_FunctionExpression_599477C0_L10C4>(!!0, float64, string, bool, bool)
 			IL_025f: stloc.s 17
 			IL_0261: ldc.i4.1
 			IL_0262: newarr [System.Runtime]System.Object
@@ -3743,6 +6025,101 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A96CE50C_Base
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3e3c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_A96CE50C_Base::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3e44
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A96CE50C_Base::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3e47
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A96CE50C_Base::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3e4a
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Import_ExportStarFrom_LibA/Base::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_A96CE50C_Base::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3e56
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Import_ExportStarFrom_LibA/Base::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_A96CE50C_Base::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3e5e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A96CE50C_Base::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_A96CE50C_Base
 
 
 		// Methods
@@ -3809,7 +6186,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportStarFrom_LibA/Scope,
-			[1] class FunctionObjects.Import_ExportStarFrom_LibA_1438CE92.FunctionObject_FunctionDeclaration_A96CE50C_Base,
+			[1] class Modules.Import_ExportStarFrom_LibA/Base/FunctionObject_FunctionDeclaration_A96CE50C_Base,
 			[2] object,
 			[3] object[],
 			[4] object
@@ -3824,13 +6201,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.Import_ExportStarFrom_LibA_1438CE92.FunctionObject_FunctionDeclaration_A96CE50C_Base::.ctor()
+		IL_0011: newobj instance void Modules.Import_ExportStarFrom_LibA/Base/FunctionObject_FunctionDeclaration_A96CE50C_Base::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "Base"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFrom_LibA_1438CE92.FunctionObject_FunctionDeclaration_A96CE50C_Base>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFrom_LibA/Base/FunctionObject_FunctionDeclaration_A96CE50C_Base>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -3873,2383 +6250,6 @@
 	} // end of method Import_ExportStarFrom_LibA::__js_module_init__
 
 } // end of class Modules.Import_ExportStarFrom_LibA
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFrom/Scope _environment0_Import_ExportStarFrom
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFrom/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x37d8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFrom/Scope FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::_environment0_Import_ExportStarFrom
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x37e7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x37ea
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x37ed
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFrom/Scope FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::_environment0_Import_ExportStarFrom
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFrom/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFrom/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x37ff
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFrom/Scope FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::_environment0_Import_ExportStarFrom
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFrom/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFrom/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x380d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_4FC01BE2___jroc_esm_mark
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x381c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3824
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3827
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x382a
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Import_ExportStarFrom/__jroc_esm_default::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x383d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Import_ExportStarFrom/__jroc_esm_default::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x384c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_C40C1BC0___jroc_esm_default
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x385b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3863
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3866
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3869
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Import_ExportStarFrom/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3883
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Import_ExportStarFrom/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3899
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_D6B46661___jroc_esm_get
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFrom/Scope _environment0_Import_ExportStarFrom
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFrom/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x38a8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFrom/Scope FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::_environment0_Import_ExportStarFrom
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x38b7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x38ba
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x38bd
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFrom/Scope FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::_environment0_Import_ExportStarFrom
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFrom/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x38d6
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFrom/Scope FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::_environment0_Import_ExportStarFrom
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFrom/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x38eb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_471E2DEA___jroc_esm_namespace
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_5774ECAB_L39C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFrom/Scope _environment0_Import_ExportStarFrom
-	.field private initonly class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFrom/Scope capture0,
-			class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x38fa
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFrom/Scope FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_5774ECAB_L39C87::_environment0_Import_ExportStarFrom
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_5774ECAB_L39C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_5774ECAB_L39C87::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_5774ECAB_L39C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3917
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5774ECAB_L39C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x391a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5774ECAB_L39C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x391d
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_5774ECAB_L39C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_5774ECAB_L39C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x392f
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_5774ECAB_L39C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L39C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_5774ECAB_L39C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x393d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5774ECAB_L39C87::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_5774ECAB_L39C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_5849C53F_L40C94
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFrom/Scope _environment0_Import_ExportStarFrom
-	.field private initonly class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFrom/Scope capture0,
-			class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x394c
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFrom/Scope FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_5849C53F_L40C94::_environment0_Import_ExportStarFrom
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_5849C53F_L40C94::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_5849C53F_L40C94::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_5849C53F_L40C94::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3969
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5849C53F_L40C94::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x396c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5849C53F_L40C94::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x396f
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_5849C53F_L40C94::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_5849C53F_L40C94::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3981
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_5849C53F_L40C94::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L40C93::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_5849C53F_L40C94::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x398f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5849C53F_L40C94::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_5849C53F_L40C94
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_6930940B_L49C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFrom/Scope _environment0_Import_ExportStarFrom
-	.field private initonly class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFrom/Scope capture0,
-			class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x399e
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFrom/Scope FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_6930940B_L49C10::_environment0_Import_ExportStarFrom
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_6930940B_L49C10::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_6930940B_L49C10::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_6930940B_L49C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x39bb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6930940B_L49C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x39be
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6930940B_L49C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x39c1
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_6930940B_L49C10::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_6930940B_L49C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x39da
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_6930940B_L49C10::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_6930940B_L49C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x39ef
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_6930940B_L49C10::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_6930940B_L49C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_8E8605EC_L50C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFrom/Scope _environment0_Import_ExportStarFrom
-	.field private initonly class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/Scope _environment2_FunctionExpression_L49C9
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFrom/Scope capture0,
-			class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope capture1,
-			class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x39fe
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFrom/Scope FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_8E8605EC_L50C87::_environment0_Import_ExportStarFrom
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportStarFrom/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_8E8605EC_L50C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/Scope FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_8E8605EC_L50C87::_environment2_FunctionExpression_L49C9
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_8E8605EC_L50C87::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_8E8605EC_L50C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3a23
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_8E8605EC_L50C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3a26
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_8E8605EC_L50C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a29
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_8E8605EC_L50C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_8E8605EC_L50C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a3b
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_8E8605EC_L50C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFrom/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_8E8605EC_L50C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a49
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_8E8605EC_L50C87::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionExpression_8E8605EC_L50C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_52197845___jroc_esm_export
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFrom/Scope _environment0_Import_ExportStarFrom
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFrom/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a58
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFrom/Scope FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::_environment0_Import_ExportStarFrom
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3a67
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3a6a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a6d
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFrom/Scope FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::_environment0_Import_ExportStarFrom
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Import_ExportStarFrom/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFrom/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a8d
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFrom/Scope FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::_environment0_Import_ExportStarFrom
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Import_ExportStarFrom/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFrom/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3aa9
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_52197845___jroc_esm_export::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFrom_C9620A87.FunctionObject_FunctionDeclaration_52197845___jroc_esm_export
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_599477C0_L10C4
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFrom_LibB/Scope _environment0_Import_ExportStarFrom_LibB
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFrom_LibB/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ab8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_599477C0_L10C4::_environment0_Import_ExportStarFrom_LibB
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_599477C0_L10C4::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3ac7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_599477C0_L10C4::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3aca
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_599477C0_L10C4::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3acd
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_599477C0_L10C4::_environment0_Import_ExportStarFrom_LibB
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_599477C0_L10C4::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ae6
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_599477C0_L10C4::_environment0_Import_ExportStarFrom_LibB
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_599477C0_L10C4::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3afb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_599477C0_L10C4::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_599477C0_L10C4
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_3D87220C_L10C43
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFrom_LibB/Scope _environment0_Import_ExportStarFrom_LibB
-	.field private initonly class Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope _environment1_FunctionExpression_L10C3
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFrom_LibB/Scope capture0,
-			class Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b0a
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_3D87220C_L10C43::_environment0_Import_ExportStarFrom_LibB
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/Scope FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_3D87220C_L10C43::_environment1_FunctionExpression_L10C3
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_3D87220C_L10C43::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_3D87220C_L10C43::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3b27
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3D87220C_L10C43::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3b2a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3D87220C_L10C43::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b2d
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_3D87220C_L10C43::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_3D87220C_L10C43::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b3f
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_3D87220C_L10C43::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFrom_LibB/FunctionExpression_L10C3/FunctionExpression_L10C42::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_3D87220C_L10C43::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b4d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3D87220C_L10C43::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_3D87220C_L10C43
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFrom_LibB/Scope _environment0_Import_ExportStarFrom_LibB
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFrom_LibB/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b5c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::_environment0_Import_ExportStarFrom_LibB
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3b6b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3b6e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b71
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::_environment0_Import_ExportStarFrom_LibB
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b83
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::_environment0_Import_ExportStarFrom_LibB
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b91
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_7C526E6A___jroc_esm_mark
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3ba0
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3ba8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3bab
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3bae
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_default::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3bc1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_default::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3bd0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_472994C8___jroc_esm_default
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3bdf
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3be7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3bea
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3bed
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c07
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c1d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_F1464CB9___jroc_esm_get
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFrom_LibB/Scope _environment0_Import_ExportStarFrom_LibB
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFrom_LibB/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c2c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::_environment0_Import_ExportStarFrom_LibB
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3c3b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3c3e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c41
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::_environment0_Import_ExportStarFrom_LibB
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c5a
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::_environment0_Import_ExportStarFrom_LibB
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c6f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_5ED23A42___jroc_esm_namespace
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_19C9F4C3_L39C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFrom_LibB/Scope _environment0_Import_ExportStarFrom_LibB
-	.field private initonly class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFrom_LibB/Scope capture0,
-			class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c7e
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_19C9F4C3_L39C87::_environment0_Import_ExportStarFrom_LibB
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_19C9F4C3_L39C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_19C9F4C3_L39C87::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_19C9F4C3_L39C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3c9b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_19C9F4C3_L39C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3c9e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_19C9F4C3_L39C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ca1
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_19C9F4C3_L39C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_19C9F4C3_L39C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3cb3
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_19C9F4C3_L39C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L39C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_19C9F4C3_L39C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3cc1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_19C9F4C3_L39C87::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_19C9F4C3_L39C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_D1AA4B47_L40C94
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFrom_LibB/Scope _environment0_Import_ExportStarFrom_LibB
-	.field private initonly class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFrom_LibB/Scope capture0,
-			class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3cd0
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_D1AA4B47_L40C94::_environment0_Import_ExportStarFrom_LibB
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_D1AA4B47_L40C94::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_D1AA4B47_L40C94::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_D1AA4B47_L40C94::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3ced
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D1AA4B47_L40C94::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3cf0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D1AA4B47_L40C94::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3cf3
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_D1AA4B47_L40C94::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_D1AA4B47_L40C94::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3d05
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_D1AA4B47_L40C94::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L40C93::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_D1AA4B47_L40C94::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3d13
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D1AA4B47_L40C94::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_D1AA4B47_L40C94
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_14DFC423_L49C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFrom_LibB/Scope _environment0_Import_ExportStarFrom_LibB
-	.field private initonly class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFrom_LibB/Scope capture0,
-			class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3d22
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_14DFC423_L49C10::_environment0_Import_ExportStarFrom_LibB
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_14DFC423_L49C10::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_14DFC423_L49C10::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_14DFC423_L49C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3d3f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_14DFC423_L49C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3d42
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_14DFC423_L49C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3d45
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_14DFC423_L49C10::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_14DFC423_L49C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3d5e
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_14DFC423_L49C10::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_14DFC423_L49C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3d73
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_14DFC423_L49C10::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_14DFC423_L49C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_2C8A7AA4_L50C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFrom_LibB/Scope _environment0_Import_ExportStarFrom_LibB
-	.field private initonly class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/Scope _environment2_FunctionExpression_L49C9
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFrom_LibB/Scope capture0,
-			class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope capture1,
-			class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x3d82
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_2C8A7AA4_L50C87::_environment0_Import_ExportStarFrom_LibB
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_2C8A7AA4_L50C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/Scope FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_2C8A7AA4_L50C87::_environment2_FunctionExpression_L49C9
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_2C8A7AA4_L50C87::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_2C8A7AA4_L50C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3da7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2C8A7AA4_L50C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3daa
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2C8A7AA4_L50C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3dad
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_2C8A7AA4_L50C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_2C8A7AA4_L50C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3dbf
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_2C8A7AA4_L50C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_2C8A7AA4_L50C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3dcd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2C8A7AA4_L50C87::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionExpression_2C8A7AA4_L50C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFrom_LibB/Scope _environment0_Import_ExportStarFrom_LibB
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFrom_LibB/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ddc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFrom_LibB/Scope FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::_environment0_Import_ExportStarFrom_LibB
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3deb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3dee
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3df1
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::_environment0_Import_ExportStarFrom_LibB
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3e11
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFrom_LibB/Scope FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::_environment0_Import_ExportStarFrom_LibB
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Import_ExportStarFrom_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFrom_LibB/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3e2d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFrom_LibB_1338CCFF.FunctionObject_FunctionDeclaration_D11FCDAD___jroc_esm_export
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFrom_LibA_1438CE92.FunctionObject_FunctionDeclaration_A96CE50C_Base
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3e3c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_A96CE50C_Base::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3e44
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A96CE50C_Base::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3e47
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A96CE50C_Base::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3e4a
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Import_ExportStarFrom_LibA/Base::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_A96CE50C_Base::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3e56
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Import_ExportStarFrom_LibA/Base::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_A96CE50C_Base::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3e5e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A96CE50C_Base::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFrom_LibA_1438CE92.FunctionObject_FunctionDeclaration_A96CE50C_Base
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFromMultiHop.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ExportStarFromMultiHop.verified.txt
@@ -53,6 +53,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportStarFromMultiHop/Scope _environment0_Import_ExportStarFromMultiHop
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportStarFromMultiHop/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4dfa
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4e09
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4e0c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4e0f
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4e21
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4e2f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark
+
 
 		// Methods
 		.method public hidebysig static 
@@ -159,6 +266,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4e3e
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4e46
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4e49
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4e4c
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_default::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4e5f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_default::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4e6e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default
+
 
 		// Methods
 		.method public hidebysig static 
@@ -262,6 +470,115 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4e7d
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4e85
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4e88
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4e8b
+				// Header size: 1
+				// Code size: 30 (0x1e)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0018: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_get::__js_call__(object, object, string)
+				IL_001d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4eaa
+				// Header size: 1
+				// Code size: 26 (0x1a)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0014: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_get::__js_call__(object, object, string)
+				IL_0019: ret
+			} // end of method FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4ec5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get
+
 
 		// Methods
 		.method public hidebysig static 
@@ -320,6 +637,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_426DB65A_L38C87
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ExportStarFromMultiHop/Scope _environment0_Import_ExportStarFromMultiHop
+				.field private initonly class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ExportStarFromMultiHop/Scope capture0,
+						class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x4f26
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_426DB65A_L38C87::_environment0_Import_ExportStarFromMultiHop
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_426DB65A_L38C87::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_426DB65A_L38C87::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_426DB65A_L38C87::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x4f43
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_426DB65A_L38C87::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x4f46
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_426DB65A_L38C87::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x4f49
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_426DB65A_L38C87::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_426DB65A_L38C87::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x4f5b
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_426DB65A_L38C87::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_426DB65A_L38C87::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x4f69
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_426DB65A_L38C87::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_426DB65A_L38C87
+
 
 			// Methods
 			.method public hidebysig static 
@@ -369,6 +803,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_551A5557_L39C94
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ExportStarFromMultiHop/Scope _environment0_Import_ExportStarFromMultiHop
+				.field private initonly class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ExportStarFromMultiHop/Scope capture0,
+						class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x4f78
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_551A5557_L39C94::_environment0_Import_ExportStarFromMultiHop
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_551A5557_L39C94::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_551A5557_L39C94::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_551A5557_L39C94::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x4f95
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_551A5557_L39C94::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x4f98
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_551A5557_L39C94::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x4f9b
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_551A5557_L39C94::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_551A5557_L39C94::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x4fad
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_551A5557_L39C94::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_551A5557_L39C94::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x4fbb
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_551A5557_L39C94::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_551A5557_L39C94
 
 
 			// Methods
@@ -423,6 +974,128 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DD0FD664_L49C87
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Import_ExportStarFromMultiHop/Scope _environment0_Import_ExportStarFromMultiHop
+					.field private initonly class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+					.field private initonly class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/Scope _environment2_FunctionExpression_L48C9
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Import_ExportStarFromMultiHop/Scope capture0,
+							class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope capture1,
+							class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x502a
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DD0FD664_L49C87::_environment0_Import_ExportStarFromMultiHop
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DD0FD664_L49C87::_environment1___jroc_esm_namespace
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DD0FD664_L49C87::_environment2_FunctionExpression_L48C9
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DD0FD664_L49C87::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_DD0FD664_L49C87::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x504f
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_DD0FD664_L49C87::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x5052
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_DD0FD664_L49C87::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x5055
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DD0FD664_L49C87::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_DD0FD664_L49C87::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x5067
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DD0FD664_L49C87::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_DD0FD664_L49C87::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x5075
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_DD0FD664_L49C87::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_DD0FD664_L49C87
 
 
 				// Methods
@@ -489,6 +1162,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_BF7DD9E1_L48C10
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ExportStarFromMultiHop/Scope _environment0_Import_ExportStarFromMultiHop
+				.field private initonly class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ExportStarFromMultiHop/Scope capture0,
+						class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x4fca
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_BF7DD9E1_L48C10::_environment0_Import_ExportStarFromMultiHop
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_BF7DD9E1_L48C10::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_BF7DD9E1_L48C10::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_BF7DD9E1_L48C10::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x4fe7
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_BF7DD9E1_L48C10::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x4fea
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_BF7DD9E1_L48C10::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x4fed
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_BF7DD9E1_L48C10::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_BF7DD9E1_L48C10::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x5006
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_BF7DD9E1_L48C10::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_BF7DD9E1_L48C10::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x501b
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_BF7DD9E1_L48C10::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_BF7DD9E1_L48C10
+
 
 			// Methods
 			.method public hidebysig static 
@@ -510,7 +1306,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_DD0FD664_L49C87,
+					[4] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DD0FD664_L49C87,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -560,13 +1356,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_DD0FD664_L49C87::.ctor(class Modules.Import_ExportStarFromMultiHop/Scope, class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope, class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DD0FD664_L49C87::.ctor(class Modules.Import_ExportStarFromMultiHop/Scope, class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope, class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_DD0FD664_L49C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DD0FD664_L49C87>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -785,6 +1581,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportStarFromMultiHop/Scope _environment0_Import_ExportStarFromMultiHop
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportStarFromMultiHop/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4ed4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4ee3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4ee6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4ee9
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFromMultiHop/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4f02
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFromMultiHop/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4f17
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace
+
 
 		// Methods
 		.method public hidebysig static 
@@ -824,12 +1733,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_426DB65A_L38C87,
-				[21] class FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_551A5557_L39C94,
+				[20] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_426DB65A_L38C87,
+				[21] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_551A5557_L39C94,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_BF7DD9E1_L48C10
+				[25] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_BF7DD9E1_L48C10
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope::.ctor()
@@ -1035,13 +1944,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_426DB65A_L38C87::.ctor(class Modules.Import_ExportStarFromMultiHop/Scope, class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_426DB65A_L38C87::.ctor(class Modules.Import_ExportStarFromMultiHop/Scope, class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_426DB65A_L38C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_426DB65A_L38C87>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -1085,13 +1994,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_551A5557_L39C94::.ctor(class Modules.Import_ExportStarFromMultiHop/Scope, class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_551A5557_L39C94::.ctor(class Modules.Import_ExportStarFromMultiHop/Scope, class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_551A5557_L39C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_551A5557_L39C94>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -1261,13 +2170,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_BF7DD9E1_L48C10::.ctor(class Modules.Import_ExportStarFromMultiHop/Scope, class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_BF7DD9E1_L48C10::.ctor(class Modules.Import_ExportStarFromMultiHop/Scope, class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_BF7DD9E1_L48C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_BF7DD9E1_L48C10>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldc.i4.1
 				IL_0487: newarr [System.Runtime]System.Object
@@ -1386,6 +2295,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportStarFromMultiHop/Scope _environment0_Import_ExportStarFromMultiHop
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportStarFromMultiHop/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5084
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_export/FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5093
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5096
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5099
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_export/FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x50b9
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop/Scope Modules.Import_ExportStarFromMultiHop/__jroc_esm_export/FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x50d5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1499,13 +2527,13 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportStarFromMultiHop/Scope,
-			[1] class FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default,
-			[2] class FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get,
-			[3] class FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace,
-			[4] class FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export,
+			[1] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_default/FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default,
+			[2] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_get/FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get,
+			[3] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace,
+			[4] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_export/FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export,
 			[5] object,
 			[6] object[],
-			[7] class FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark,
+			[7] class Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark,
 			[8] object,
 			[9] object
 		)
@@ -1526,13 +2554,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_ExportStarFromMultiHop/Scope
-		IL_0022: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::.ctor(class Modules.Import_ExportStarFromMultiHop/Scope)
+		IL_0022: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::.ctor(class Modules.Import_ExportStarFromMultiHop/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 7
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 7
@@ -1544,13 +2572,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 6
-		IL_004b: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_default/FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop/__jroc_esm_default/FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -1559,13 +2587,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 6
-		IL_006b: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_get/FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop/__jroc_esm_get/FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -1578,13 +2606,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_ExportStarFromMultiHop/Scope
-		IL_0094: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::.ctor(class Modules.Import_ExportStarFromMultiHop/Scope)
+		IL_0094: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::.ctor(class Modules.Import_ExportStarFromMultiHop/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -1597,13 +2625,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_ExportStarFromMultiHop/Scope
-		IL_00bd: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::.ctor(class Modules.Import_ExportStarFromMultiHop/Scope)
+		IL_00bd: newobj instance void Modules.Import_ExportStarFromMultiHop/__jroc_esm_export/FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::.ctor(class Modules.Import_ExportStarFromMultiHop/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop/__jroc_esm_export/FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 4
 		IL_00d2: nop
 		IL_00d3: ldloc.0
@@ -1726,6 +2754,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/Scope _environment0_Import_ExportStarFromMultiHop_LibC
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportStarFromMultiHop_LibC/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5188
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark/FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop_LibC
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5197
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x519a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x519d
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark/FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop_LibC
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x51af
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark/FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop_LibC
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x51bd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1832,6 +2967,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x51cc
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x51d4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x51d7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x51da
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_default::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x51ed
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_default::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x51fc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1935,6 +3171,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x520b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5213
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5216
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5219
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5233
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5249
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1993,6 +3336,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3C5C10DA_L39C87
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/Scope _environment0_Import_ExportStarFromMultiHop_LibC
+				.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ExportStarFromMultiHop_LibC/Scope capture0,
+						class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x52aa
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_3C5C10DA_L39C87::_environment0_Import_ExportStarFromMultiHop_LibC
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_3C5C10DA_L39C87::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_3C5C10DA_L39C87::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_3C5C10DA_L39C87::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x52c7
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_3C5C10DA_L39C87::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x52ca
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_3C5C10DA_L39C87::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x52cd
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_3C5C10DA_L39C87::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_3C5C10DA_L39C87::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x52df
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_3C5C10DA_L39C87::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_3C5C10DA_L39C87::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x52ed
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_3C5C10DA_L39C87::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_3C5C10DA_L39C87
+
 
 			// Methods
 			.method public hidebysig static 
@@ -2042,6 +3502,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1B8705E6_L40C94
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/Scope _environment0_Import_ExportStarFromMultiHop_LibC
+				.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ExportStarFromMultiHop_LibC/Scope capture0,
+						class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x52fc
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_1B8705E6_L40C94::_environment0_Import_ExportStarFromMultiHop_LibC
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_1B8705E6_L40C94::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_1B8705E6_L40C94::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_1B8705E6_L40C94::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x5319
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_1B8705E6_L40C94::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x531c
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_1B8705E6_L40C94::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x531f
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_1B8705E6_L40C94::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_1B8705E6_L40C94::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x5331
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_1B8705E6_L40C94::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_1B8705E6_L40C94::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x533f
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_1B8705E6_L40C94::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_1B8705E6_L40C94
 
 
 			// Methods
@@ -2096,6 +3673,128 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_73299A15_L50C87
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/Scope _environment0_Import_ExportStarFromMultiHop_LibC
+					.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+					.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/Scope _environment2_FunctionExpression_L49C9
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Import_ExportStarFromMultiHop_LibC/Scope capture0,
+							class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope capture1,
+							class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x53ae
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_73299A15_L50C87::_environment0_Import_ExportStarFromMultiHop_LibC
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_73299A15_L50C87::_environment1___jroc_esm_namespace
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_73299A15_L50C87::_environment2_FunctionExpression_L49C9
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_73299A15_L50C87::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_73299A15_L50C87::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x53d3
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_73299A15_L50C87::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x53d6
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_73299A15_L50C87::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x53d9
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_73299A15_L50C87::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_73299A15_L50C87::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x53eb
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_73299A15_L50C87::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_73299A15_L50C87::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x53f9
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_73299A15_L50C87::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_73299A15_L50C87
 
 
 				// Methods
@@ -2162,6 +3861,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1CF36C60_L49C10
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/Scope _environment0_Import_ExportStarFromMultiHop_LibC
+				.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ExportStarFromMultiHop_LibC/Scope capture0,
+						class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x534e
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_1CF36C60_L49C10::_environment0_Import_ExportStarFromMultiHop_LibC
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_1CF36C60_L49C10::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_1CF36C60_L49C10::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_1CF36C60_L49C10::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x536b
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_1CF36C60_L49C10::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x536e
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_1CF36C60_L49C10::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x5371
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_1CF36C60_L49C10::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_1CF36C60_L49C10::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x538a
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_1CF36C60_L49C10::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_1CF36C60_L49C10::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x539f
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_1CF36C60_L49C10::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_1CF36C60_L49C10
+
 
 			// Methods
 			.method public hidebysig static 
@@ -2183,7 +4005,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_73299A15_L50C87,
+					[4] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_73299A15_L50C87,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -2233,13 +4055,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_73299A15_L50C87::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope, class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_73299A15_L50C87::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope, class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_73299A15_L50C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86/FunctionObject_FunctionExpression_73299A15_L50C87>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -2458,6 +4280,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/Scope _environment0_Import_ExportStarFromMultiHop_LibC
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportStarFromMultiHop_LibC/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5258
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop_LibC
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5267
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x526a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x526d
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop_LibC
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5286
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop_LibC
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x529b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2497,12 +4432,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_3C5C10DA_L39C87,
-				[21] class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_1B8705E6_L40C94,
+				[20] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_3C5C10DA_L39C87,
+				[21] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_1B8705E6_L40C94,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_1CF36C60_L49C10
+				[25] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_1CF36C60_L49C10
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope::.ctor()
@@ -2708,13 +4643,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_3C5C10DA_L39C87::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_3C5C10DA_L39C87::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_3C5C10DA_L39C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86/FunctionObject_FunctionExpression_3C5C10DA_L39C87>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -2758,13 +4693,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_1B8705E6_L40C94::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_1B8705E6_L40C94::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_1B8705E6_L40C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93/FunctionObject_FunctionExpression_1B8705E6_L40C94>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -2934,13 +4869,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_1CF36C60_L49C10::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_1CF36C60_L49C10::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_1CF36C60_L49C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionObject_FunctionExpression_1CF36C60_L49C10>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldc.i4.1
 				IL_0487: newarr [System.Runtime]System.Object
@@ -3059,6 +4994,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/Scope _environment0_Import_ExportStarFromMultiHop_LibC
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportStarFromMultiHop_LibC/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5408
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_export/FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop_LibC
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5417
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x541a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x541d
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_export/FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop_LibC
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x543d
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_export/FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop_LibC
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5459
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export
+
 
 		// Methods
 		.method public hidebysig static 
@@ -3151,6 +5205,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3220FB25_L10C43
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/Scope _environment0_Import_ExportStarFromMultiHop_LibC
+				.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope _environment1_FunctionExpression_L10C3
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ExportStarFromMultiHop_LibC/Scope capture0,
+						class Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x5136
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3220FB25_L10C43::_environment0_Import_ExportStarFromMultiHop_LibC
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3220FB25_L10C43::_environment1_FunctionExpression_L10C3
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3220FB25_L10C43::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_3220FB25_L10C43::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x5153
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_3220FB25_L10C43::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x5156
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_3220FB25_L10C43::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x5159
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3220FB25_L10C43::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_3220FB25_L10C43::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x516b
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3220FB25_L10C43::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_3220FB25_L10C43::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x5179
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_3220FB25_L10C43::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_3220FB25_L10C43
+
 
 			// Methods
 			.method public hidebysig static 
@@ -3217,6 +5388,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DA9C5919_L10C4
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/Scope _environment0_Import_ExportStarFromMultiHop_LibC
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportStarFromMultiHop_LibC/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x50e4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionObject_FunctionExpression_DA9C5919_L10C4::_environment0_Import_ExportStarFromMultiHop_LibC
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_DA9C5919_L10C4::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x50f3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_DA9C5919_L10C4::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x50f6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_DA9C5919_L10C4::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x50f9
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionObject_FunctionExpression_DA9C5919_L10C4::_environment0_Import_ExportStarFromMultiHop_LibC
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_DA9C5919_L10C4::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5112
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionObject_FunctionExpression_DA9C5919_L10C4::_environment0_Import_ExportStarFromMultiHop_LibC
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_DA9C5919_L10C4::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5127
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_DA9C5919_L10C4::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_DA9C5919_L10C4
+
 
 		// Methods
 		.method public hidebysig static 
@@ -3241,7 +5525,7 @@
 				[2] object[],
 				[3] object,
 				[4] object[],
-				[5] class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_3220FB25_L10C43
+				[5] class Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3220FB25_L10C43
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope::.ctor()
@@ -3282,13 +5566,13 @@
 			IL_0042: ldelem.ref
 			IL_0043: castclass Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope
 			IL_0048: ldloc.s 4
-			IL_004a: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_3220FB25_L10C43::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, class Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope, object[])
+			IL_004a: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3220FB25_L10C43::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, class Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope, object[])
 			IL_004f: ldc.i4.0
 			IL_0050: conv.r8
 			IL_0051: ldstr ""
 			IL_0056: ldc.i4.0
 			IL_0057: ldc.i4.1
-			IL_0058: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_3220FB25_L10C43>(!!0, float64, string, bool, bool)
+			IL_0058: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42/FunctionObject_FunctionExpression_3220FB25_L10C43>(!!0, float64, string, bool, bool)
 			IL_005d: stloc.s 5
 			IL_005f: ldloc.1
 			IL_0060: ldloc.2
@@ -3416,14 +5700,14 @@
 		.maxstack 10
 		.locals init (
 			[0] class Modules.Import_ExportStarFromMultiHop_LibC/Scope,
-			[1] class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default,
-			[2] class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get,
-			[3] class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace,
+			[1] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_default/FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default,
+			[2] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_get/FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get,
+			[3] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace,
 			[4] object,
 			[5] object,
 			[6] object[],
-			[7] class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark,
-			[8] class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export,
+			[7] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark/FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark,
+			[8] class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_export/FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export,
 			[9] object,
 			[10] bool,
 			[11] object,
@@ -3432,7 +5716,7 @@
 			[14] object,
 			[15] object,
 			[16] object,
-			[17] class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_DA9C5919_L10C4
+			[17] class Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionObject_FunctionExpression_DA9C5919_L10C4
 		)
 
 		IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/Scope::.ctor()
@@ -3451,13 +5735,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_ExportStarFromMultiHop_LibC/Scope
-		IL_0022: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope)
+		IL_0022: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark/FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark/FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 7
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 7
@@ -3469,13 +5753,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 6
-		IL_004b: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_default/FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_default/FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -3484,13 +5768,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 6
-		IL_006b: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_get/FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_get/FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -3503,13 +5787,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_ExportStarFromMultiHop_LibC/Scope
-		IL_0094: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope)
+		IL_0094: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -3522,13 +5806,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_ExportStarFromMultiHop_LibC/Scope
-		IL_00bd: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope)
+		IL_00bd: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_export/FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_export/FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 8
 		IL_00d2: ldloc.0
 		IL_00d3: ldloc.s 8
@@ -3669,13 +5953,13 @@
 			IL_0245: ldc.i4.0
 			IL_0246: ldelem.ref
 			IL_0247: castclass Modules.Import_ExportStarFromMultiHop_LibC/Scope
-			IL_024c: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_DA9C5919_L10C4::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope)
+			IL_024c: newobj instance void Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionObject_FunctionExpression_DA9C5919_L10C4::.ctor(class Modules.Import_ExportStarFromMultiHop_LibC/Scope)
 			IL_0251: ldc.i4.1
 			IL_0252: conv.r8
 			IL_0253: ldstr ""
 			IL_0258: ldc.i4.0
 			IL_0259: ldc.i4.1
-			IL_025a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_DA9C5919_L10C4>(!!0, float64, string, bool, bool)
+			IL_025a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionObject_FunctionExpression_DA9C5919_L10C4>(!!0, float64, string, bool, bool)
 			IL_025f: stloc.s 17
 			IL_0261: ldc.i4.1
 			IL_0262: newarr [System.Runtime]System.Object
@@ -3725,6 +6009,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_19A18F00_L3C28
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/Scope _environment0_Import_ExportStarFromMultiHop_LibB
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportStarFromMultiHop_LibB/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5468
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L3C27/FunctionObject_FunctionExpression_19A18F00_L3C28::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_19A18F00_L3C28::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5477
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_19A18F00_L3C28::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x547a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_19A18F00_L3C28::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x547d
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L3C27/FunctionObject_FunctionExpression_19A18F00_L3C28::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L3C27::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_19A18F00_L3C28::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x548f
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L3C27/FunctionObject_FunctionExpression_19A18F00_L3C28::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L3C27::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_19A18F00_L3C28::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x549d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_19A18F00_L3C28::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_19A18F00_L3C28
 
 
 		// Methods
@@ -3798,6 +6189,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/Scope _environment0_Import_ExportStarFromMultiHop_LibB
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportStarFromMultiHop_LibB/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5550
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x555f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5562
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5565
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5577
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5585
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark
 
 
 		// Methods
@@ -3905,6 +6403,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5594
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x559c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x559f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x55a2
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_default::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x55b5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_default::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x55c4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default
+
 
 		// Methods
 		.method public hidebysig static 
@@ -4008,6 +6607,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x55d3
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x55db
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x55de
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x55e1
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x55fb
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5611
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get
+
 
 		// Methods
 		.method public hidebysig static 
@@ -4066,6 +6772,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_11771A92_L41C87
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/Scope _environment0_Import_ExportStarFromMultiHop_LibB
+				.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ExportStarFromMultiHop_LibB/Scope capture0,
+						class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x5672
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86/FunctionObject_FunctionExpression_11771A92_L41C87::_environment0_Import_ExportStarFromMultiHop_LibB
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86/FunctionObject_FunctionExpression_11771A92_L41C87::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86/FunctionObject_FunctionExpression_11771A92_L41C87::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_11771A92_L41C87::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x568f
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_11771A92_L41C87::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x5692
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_11771A92_L41C87::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x5695
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86/FunctionObject_FunctionExpression_11771A92_L41C87::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_11771A92_L41C87::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x56a7
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86/FunctionObject_FunctionExpression_11771A92_L41C87::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_11771A92_L41C87::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x56b5
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_11771A92_L41C87::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_11771A92_L41C87
+
 
 			// Methods
 			.method public hidebysig static 
@@ -4115,6 +6938,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_00CEFBE9_L42C94
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/Scope _environment0_Import_ExportStarFromMultiHop_LibB
+				.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ExportStarFromMultiHop_LibB/Scope capture0,
+						class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x56c4
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93/FunctionObject_FunctionExpression_00CEFBE9_L42C94::_environment0_Import_ExportStarFromMultiHop_LibB
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93/FunctionObject_FunctionExpression_00CEFBE9_L42C94::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93/FunctionObject_FunctionExpression_00CEFBE9_L42C94::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_00CEFBE9_L42C94::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x56e1
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_00CEFBE9_L42C94::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x56e4
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_00CEFBE9_L42C94::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x56e7
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93/FunctionObject_FunctionExpression_00CEFBE9_L42C94::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_00CEFBE9_L42C94::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x56f9
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93/FunctionObject_FunctionExpression_00CEFBE9_L42C94::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_00CEFBE9_L42C94::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x5707
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_00CEFBE9_L42C94::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_00CEFBE9_L42C94
 
 
 			// Methods
@@ -4169,6 +7109,128 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_269D42B9_L52C87
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/Scope _environment0_Import_ExportStarFromMultiHop_LibB
+					.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+					.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/Scope _environment2_FunctionExpression_L51C9
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Import_ExportStarFromMultiHop_LibB/Scope capture0,
+							class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope capture1,
+							class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x5776
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86/FunctionObject_FunctionExpression_269D42B9_L52C87::_environment0_Import_ExportStarFromMultiHop_LibB
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86/FunctionObject_FunctionExpression_269D42B9_L52C87::_environment1___jroc_esm_namespace
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86/FunctionObject_FunctionExpression_269D42B9_L52C87::_environment2_FunctionExpression_L51C9
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86/FunctionObject_FunctionExpression_269D42B9_L52C87::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_269D42B9_L52C87::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x579b
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_269D42B9_L52C87::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x579e
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_269D42B9_L52C87::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x57a1
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86/FunctionObject_FunctionExpression_269D42B9_L52C87::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_269D42B9_L52C87::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x57b3
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86/FunctionObject_FunctionExpression_269D42B9_L52C87::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_269D42B9_L52C87::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x57c1
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_269D42B9_L52C87::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_269D42B9_L52C87
 
 
 				// Methods
@@ -4235,6 +7297,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_63D03172_L51C10
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/Scope _environment0_Import_ExportStarFromMultiHop_LibB
+				.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ExportStarFromMultiHop_LibB/Scope capture0,
+						class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x5716
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionObject_FunctionExpression_63D03172_L51C10::_environment0_Import_ExportStarFromMultiHop_LibB
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionObject_FunctionExpression_63D03172_L51C10::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionObject_FunctionExpression_63D03172_L51C10::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_63D03172_L51C10::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x5733
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_63D03172_L51C10::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x5736
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_63D03172_L51C10::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x5739
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionObject_FunctionExpression_63D03172_L51C10::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_63D03172_L51C10::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x5752
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionObject_FunctionExpression_63D03172_L51C10::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_63D03172_L51C10::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x5767
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_63D03172_L51C10::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_63D03172_L51C10
+
 
 			// Methods
 			.method public hidebysig static 
@@ -4256,7 +7441,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_269D42B9_L52C87,
+					[4] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86/FunctionObject_FunctionExpression_269D42B9_L52C87,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -4306,13 +7491,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_269D42B9_L52C87::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope, class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86/FunctionObject_FunctionExpression_269D42B9_L52C87::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope, class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_269D42B9_L52C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86/FunctionObject_FunctionExpression_269D42B9_L52C87>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -4531,6 +7716,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/Scope _environment0_Import_ExportStarFromMultiHop_LibB
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportStarFromMultiHop_LibB/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5620
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x562f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5632
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5635
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x564e
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5663
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace
+
 
 		// Methods
 		.method public hidebysig static 
@@ -4570,12 +7868,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_11771A92_L41C87,
-				[21] class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_00CEFBE9_L42C94,
+				[20] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86/FunctionObject_FunctionExpression_11771A92_L41C87,
+				[21] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93/FunctionObject_FunctionExpression_00CEFBE9_L42C94,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_63D03172_L51C10
+				[25] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionObject_FunctionExpression_63D03172_L51C10
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope::.ctor()
@@ -4781,13 +8079,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_11771A92_L41C87::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86/FunctionObject_FunctionExpression_11771A92_L41C87::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_11771A92_L41C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86/FunctionObject_FunctionExpression_11771A92_L41C87>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -4831,13 +8129,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_00CEFBE9_L42C94::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93/FunctionObject_FunctionExpression_00CEFBE9_L42C94::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_00CEFBE9_L42C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93/FunctionObject_FunctionExpression_00CEFBE9_L42C94>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -5007,13 +8305,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_63D03172_L51C10::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionObject_FunctionExpression_63D03172_L51C10::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_63D03172_L51C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionObject_FunctionExpression_63D03172_L51C10>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldc.i4.1
 				IL_0487: newarr [System.Runtime]System.Object
@@ -5132,6 +8430,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/Scope _environment0_Import_ExportStarFromMultiHop_LibB
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportStarFromMultiHop_LibB/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x57d0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x57df
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x57e2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x57e5
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5805
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5821
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export
+
 
 		// Methods
 		.method public hidebysig static 
@@ -5224,6 +8641,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_777D73E3_L11C43
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/Scope _environment0_Import_ExportStarFromMultiHop_LibB
+				.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope _environment1_FunctionExpression_L11C3
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ExportStarFromMultiHop_LibB/Scope capture0,
+						class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x54fe
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42/FunctionObject_FunctionExpression_777D73E3_L11C43::_environment0_Import_ExportStarFromMultiHop_LibB
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42/FunctionObject_FunctionExpression_777D73E3_L11C43::_environment1_FunctionExpression_L11C3
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42/FunctionObject_FunctionExpression_777D73E3_L11C43::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_777D73E3_L11C43::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x551b
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_777D73E3_L11C43::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x551e
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_777D73E3_L11C43::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x5521
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42/FunctionObject_FunctionExpression_777D73E3_L11C43::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_777D73E3_L11C43::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x5533
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42/FunctionObject_FunctionExpression_777D73E3_L11C43::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_777D73E3_L11C43::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x5541
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_777D73E3_L11C43::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_777D73E3_L11C43
+
 
 			// Methods
 			.method public hidebysig static 
@@ -5290,6 +8824,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9F0212B6_L11C4
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/Scope _environment0_Import_ExportStarFromMultiHop_LibB
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportStarFromMultiHop_LibB/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x54ac
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionObject_FunctionExpression_9F0212B6_L11C4::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_9F0212B6_L11C4::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x54bb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_9F0212B6_L11C4::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x54be
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_9F0212B6_L11C4::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x54c1
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionObject_FunctionExpression_9F0212B6_L11C4::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_9F0212B6_L11C4::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x54da
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionObject_FunctionExpression_9F0212B6_L11C4::_environment0_Import_ExportStarFromMultiHop_LibB
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_9F0212B6_L11C4::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x54ef
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_9F0212B6_L11C4::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_9F0212B6_L11C4
+
 
 		// Methods
 		.method public hidebysig static 
@@ -5314,7 +8961,7 @@
 				[2] object[],
 				[3] object,
 				[4] object[],
-				[5] class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_777D73E3_L11C43
+				[5] class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42/FunctionObject_FunctionExpression_777D73E3_L11C43
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope::.ctor()
@@ -5355,13 +9002,13 @@
 			IL_0042: ldelem.ref
 			IL_0043: castclass Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope
 			IL_0048: ldloc.s 4
-			IL_004a: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_777D73E3_L11C43::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope, object[])
+			IL_004a: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42/FunctionObject_FunctionExpression_777D73E3_L11C43::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope, object[])
 			IL_004f: ldc.i4.0
 			IL_0050: conv.r8
 			IL_0051: ldstr ""
 			IL_0056: ldc.i4.0
 			IL_0057: ldc.i4.1
-			IL_0058: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_777D73E3_L11C43>(!!0, float64, string, bool, bool)
+			IL_0058: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42/FunctionObject_FunctionExpression_777D73E3_L11C43>(!!0, float64, string, bool, bool)
 			IL_005d: stloc.s 5
 			IL_005f: ldloc.1
 			IL_0060: ldloc.2
@@ -5494,17 +9141,17 @@
 		.maxstack 10
 		.locals init (
 			[0] class Modules.Import_ExportStarFromMultiHop_LibB/Scope,
-			[1] class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default,
-			[2] class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get,
-			[3] class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace,
+			[1] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_default/FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default,
+			[2] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_get/FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get,
+			[3] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace,
 			[4] object,
 			[5] object,
 			[6] object[],
-			[7] class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark,
-			[8] class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export,
+			[7] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark,
+			[8] class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export,
 			[9] object,
 			[10] object[],
-			[11] class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_19A18F00_L3C28,
+			[11] class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L3C27/FunctionObject_FunctionExpression_19A18F00_L3C28,
 			[12] bool,
 			[13] object,
 			[14] object,
@@ -5512,7 +9159,7 @@
 			[16] object,
 			[17] object,
 			[18] object,
-			[19] class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_9F0212B6_L11C4
+			[19] class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionObject_FunctionExpression_9F0212B6_L11C4
 		)
 
 		IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/Scope::.ctor()
@@ -5531,13 +9178,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
-		IL_0022: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope)
+		IL_0022: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark/FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 7
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 7
@@ -5549,13 +9196,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 6
-		IL_004b: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_default/FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_default/FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -5564,13 +9211,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 6
-		IL_006b: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_get/FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_get/FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -5583,13 +9230,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
-		IL_0094: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope)
+		IL_0094: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -5602,13 +9249,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
-		IL_00bd: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope)
+		IL_00bd: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export/FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 8
 		IL_00d2: ldloc.0
 		IL_00d3: ldloc.s 8
@@ -5637,13 +9284,13 @@
 		IL_010d: ldc.i4.0
 		IL_010e: ldelem.ref
 		IL_010f: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
-		IL_0114: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_19A18F00_L3C28::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope)
+		IL_0114: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L3C27/FunctionObject_FunctionExpression_19A18F00_L3C28::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope)
 		IL_0119: ldc.i4.0
 		IL_011a: conv.r8
 		IL_011b: ldstr ""
 		IL_0120: ldc.i4.0
 		IL_0121: ldc.i4.1
-		IL_0122: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_19A18F00_L3C28>(!!0, float64, string, bool, bool)
+		IL_0122: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L3C27/FunctionObject_FunctionExpression_19A18F00_L3C28>(!!0, float64, string, bool, bool)
 		IL_0127: stloc.s 11
 		IL_0129: ldloc.s 9
 		IL_012b: ldloc.s 6
@@ -5779,13 +9426,13 @@
 			IL_028f: ldc.i4.0
 			IL_0290: ldelem.ref
 			IL_0291: castclass Modules.Import_ExportStarFromMultiHop_LibB/Scope
-			IL_0296: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_9F0212B6_L11C4::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope)
+			IL_0296: newobj instance void Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionObject_FunctionExpression_9F0212B6_L11C4::.ctor(class Modules.Import_ExportStarFromMultiHop_LibB/Scope)
 			IL_029b: ldc.i4.1
 			IL_029c: conv.r8
 			IL_029d: ldstr ""
 			IL_02a2: ldc.i4.0
 			IL_02a3: ldc.i4.1
-			IL_02a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_9F0212B6_L11C4>(!!0, float64, string, bool, bool)
+			IL_02a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionObject_FunctionExpression_9F0212B6_L11C4>(!!0, float64, string, bool, bool)
 			IL_02a9: stloc.s 19
 			IL_02ab: ldc.i4.1
 			IL_02ac: newarr [System.Runtime]System.Object
@@ -5839,6 +9486,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_732A343F_L3C28
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportStarFromMultiHop_LibA/Scope _environment0_Import_ExportStarFromMultiHop_LibA
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportStarFromMultiHop_LibA/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5830
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L3C27/FunctionObject_FunctionExpression_732A343F_L3C28::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_732A343F_L3C28::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x583f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_732A343F_L3C28::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5842
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_732A343F_L3C28::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5845
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L3C27/FunctionObject_FunctionExpression_732A343F_L3C28::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L3C27::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_732A343F_L3C28::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5857
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L3C27/FunctionObject_FunctionExpression_732A343F_L3C28::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L3C27::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_732A343F_L3C28::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5865
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_732A343F_L3C28::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_732A343F_L3C28
+
 
 		// Methods
 		.method public hidebysig static 
@@ -5889,6 +9643,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D475FD19_L4C27
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportStarFromMultiHop_LibA/Scope _environment0_Import_ExportStarFromMultiHop_LibA
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportStarFromMultiHop_LibA/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5874
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L4C26/FunctionObject_FunctionExpression_D475FD19_L4C27::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_D475FD19_L4C27::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5883
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D475FD19_L4C27::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5886
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D475FD19_L4C27::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5889
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L4C26/FunctionObject_FunctionExpression_D475FD19_L4C27::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L4C26::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_D475FD19_L4C27::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x589b
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L4C26/FunctionObject_FunctionExpression_D475FD19_L4C27::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L4C26::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_D475FD19_L4C27::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x58a9
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_D475FD19_L4C27::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_D475FD19_L4C27
 
 
 		// Methods
@@ -5962,6 +9823,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportStarFromMultiHop_LibA/Scope _environment0_Import_ExportStarFromMultiHop_LibA
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportStarFromMultiHop_LibA/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x58b8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark/FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x58c7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x58ca
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x58cd
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark/FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x58df
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark/FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x58ed
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark
 
 
 		// Methods
@@ -6069,6 +10037,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x58fc
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5904
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5907
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x590a
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_default::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x591d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_default::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x592c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default
+
 
 		// Methods
 		.method public hidebysig static 
@@ -6172,6 +10241,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x593b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5943
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5946
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5949
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5963
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5979
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get
+
 
 		// Methods
 		.method public hidebysig static 
@@ -6230,6 +10406,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C376DAAB_L36C87
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ExportStarFromMultiHop_LibA/Scope _environment0_Import_ExportStarFromMultiHop_LibA
+				.field private initonly class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ExportStarFromMultiHop_LibA/Scope capture0,
+						class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x59da
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_C376DAAB_L36C87::_environment0_Import_ExportStarFromMultiHop_LibA
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_C376DAAB_L36C87::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_C376DAAB_L36C87::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_C376DAAB_L36C87::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x59f7
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_C376DAAB_L36C87::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x59fa
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_C376DAAB_L36C87::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x59fd
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_C376DAAB_L36C87::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_C376DAAB_L36C87::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x5a0f
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_C376DAAB_L36C87::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_C376DAAB_L36C87::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x5a1d
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_C376DAAB_L36C87::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_C376DAAB_L36C87
+
 
 			// Methods
 			.method public hidebysig static 
@@ -6279,6 +10572,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3D70962E_L37C94
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ExportStarFromMultiHop_LibA/Scope _environment0_Import_ExportStarFromMultiHop_LibA
+				.field private initonly class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ExportStarFromMultiHop_LibA/Scope capture0,
+						class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x5a2c
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_3D70962E_L37C94::_environment0_Import_ExportStarFromMultiHop_LibA
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_3D70962E_L37C94::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_3D70962E_L37C94::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_3D70962E_L37C94::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x5a49
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_3D70962E_L37C94::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x5a4c
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_3D70962E_L37C94::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x5a4f
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_3D70962E_L37C94::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_3D70962E_L37C94::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x5a61
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_3D70962E_L37C94::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_3D70962E_L37C94::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x5a6f
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_3D70962E_L37C94::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_3D70962E_L37C94
 
 
 			// Methods
@@ -6333,6 +10743,128 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_085B51F0_L47C87
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Import_ExportStarFromMultiHop_LibA/Scope _environment0_Import_ExportStarFromMultiHop_LibA
+					.field private initonly class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+					.field private initonly class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/Scope _environment2_FunctionExpression_L46C9
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Import_ExportStarFromMultiHop_LibA/Scope capture0,
+							class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope capture1,
+							class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x5ade
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_085B51F0_L47C87::_environment0_Import_ExportStarFromMultiHop_LibA
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_085B51F0_L47C87::_environment1___jroc_esm_namespace
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_085B51F0_L47C87::_environment2_FunctionExpression_L46C9
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_085B51F0_L47C87::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_085B51F0_L47C87::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x5b03
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_085B51F0_L47C87::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x5b06
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_085B51F0_L47C87::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x5b09
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_085B51F0_L47C87::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_085B51F0_L47C87::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x5b1b
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_085B51F0_L47C87::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_085B51F0_L47C87::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x5b29
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_085B51F0_L47C87::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_085B51F0_L47C87
 
 
 				// Methods
@@ -6399,6 +10931,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_39AC3F9B_L46C10
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ExportStarFromMultiHop_LibA/Scope _environment0_Import_ExportStarFromMultiHop_LibA
+				.field private initonly class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ExportStarFromMultiHop_LibA/Scope capture0,
+						class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x5a7e
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_39AC3F9B_L46C10::_environment0_Import_ExportStarFromMultiHop_LibA
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_39AC3F9B_L46C10::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_39AC3F9B_L46C10::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_39AC3F9B_L46C10::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x5a9b
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_39AC3F9B_L46C10::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x5a9e
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_39AC3F9B_L46C10::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x5aa1
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_39AC3F9B_L46C10::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_39AC3F9B_L46C10::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x5aba
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_39AC3F9B_L46C10::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_39AC3F9B_L46C10::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x5acf
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_39AC3F9B_L46C10::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_39AC3F9B_L46C10
+
 
 			// Methods
 			.method public hidebysig static 
@@ -6420,7 +11075,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_085B51F0_L47C87,
+					[4] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_085B51F0_L47C87,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -6470,13 +11125,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_085B51F0_L47C87::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope, class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_085B51F0_L47C87::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope, class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_085B51F0_L47C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86/FunctionObject_FunctionExpression_085B51F0_L47C87>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -6695,6 +11350,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportStarFromMultiHop_LibA/Scope _environment0_Import_ExportStarFromMultiHop_LibA
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportStarFromMultiHop_LibA/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5988
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5997
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x599a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x599d
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x59b6
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x59cb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace
+
 
 		// Methods
 		.method public hidebysig static 
@@ -6734,12 +11502,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_C376DAAB_L36C87,
-				[21] class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_3D70962E_L37C94,
+				[20] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_C376DAAB_L36C87,
+				[21] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_3D70962E_L37C94,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_39AC3F9B_L46C10
+				[25] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_39AC3F9B_L46C10
 			)
 
 			IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope::.ctor()
@@ -6945,13 +11713,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_C376DAAB_L36C87::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_C376DAAB_L36C87::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_C376DAAB_L36C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86/FunctionObject_FunctionExpression_C376DAAB_L36C87>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -6995,13 +11763,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_3D70962E_L37C94::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_3D70962E_L37C94::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_3D70962E_L37C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93/FunctionObject_FunctionExpression_3D70962E_L37C94>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -7171,13 +11939,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_39AC3F9B_L46C10::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_39AC3F9B_L46C10::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_39AC3F9B_L46C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionObject_FunctionExpression_39AC3F9B_L46C10>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldc.i4.1
 				IL_0487: newarr [System.Runtime]System.Object
@@ -7295,6 +12063,127 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ExportStarFromMultiHop_LibA/Scope _environment0_Import_ExportStarFromMultiHop_LibA
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ExportStarFromMultiHop_LibA/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5b38
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export/FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5b47
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5b4a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5b4d
+				// Header size: 1
+				// Code size: 36 (0x24)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export/FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0017: ldarg.2
+				IL_0018: ldc.i4.1
+				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001e: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object, string, object)
+				IL_0023: ret
+			} // end of method FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5b72
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export/FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop_LibA
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.1
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object, string, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5b93
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export
 
 
 		// Methods
@@ -7419,16 +12308,16 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ExportStarFromMultiHop_LibA/Scope,
-			[1] class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default,
-			[2] class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get,
-			[3] class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace,
-			[4] class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export,
+			[1] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_default/FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default,
+			[2] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_get/FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get,
+			[3] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace,
+			[4] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export/FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export,
 			[5] object[],
-			[6] class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark,
+			[6] class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark/FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark,
 			[7] object,
 			[8] object[],
-			[9] class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_732A343F_L3C28,
-			[10] class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_D475FD19_L4C27
+			[9] class Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L3C27/FunctionObject_FunctionExpression_732A343F_L3C28,
+			[10] class Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L4C26/FunctionObject_FunctionExpression_D475FD19_L4C27
 		)
 
 		IL_0000: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/Scope::.ctor()
@@ -7447,13 +12336,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
-		IL_0022: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope)
+		IL_0022: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark/FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark/FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 6
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 6
@@ -7465,13 +12354,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 5
-		IL_004b: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_default/FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_default/FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -7480,13 +12369,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 5
-		IL_006b: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_get/FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_get/FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -7499,13 +12388,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
-		IL_0094: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope)
+		IL_0094: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -7518,13 +12407,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
-		IL_00bd: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope)
+		IL_00bd: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export/FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export/FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 4
 		IL_00d2: nop
 		IL_00d3: ldloc.0
@@ -7547,13 +12436,13 @@
 		IL_00fd: ldc.i4.0
 		IL_00fe: ldelem.ref
 		IL_00ff: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
-		IL_0104: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_732A343F_L3C28::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope)
+		IL_0104: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L3C27/FunctionObject_FunctionExpression_732A343F_L3C28::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope)
 		IL_0109: ldc.i4.0
 		IL_010a: conv.r8
 		IL_010b: ldstr ""
 		IL_0110: ldc.i4.0
 		IL_0111: ldc.i4.1
-		IL_0112: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_732A343F_L3C28>(!!0, float64, string, bool, bool)
+		IL_0112: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L3C27/FunctionObject_FunctionExpression_732A343F_L3C28>(!!0, float64, string, bool, bool)
 		IL_0117: stloc.s 9
 		IL_0119: ldloc.s 4
 		IL_011b: ldloc.s 5
@@ -7574,13 +12463,13 @@
 		IL_013f: ldc.i4.0
 		IL_0140: ldelem.ref
 		IL_0141: castclass Modules.Import_ExportStarFromMultiHop_LibA/Scope
-		IL_0146: newobj instance void FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_D475FD19_L4C27::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope)
+		IL_0146: newobj instance void Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L4C26/FunctionObject_FunctionExpression_D475FD19_L4C27::.ctor(class Modules.Import_ExportStarFromMultiHop_LibA/Scope)
 		IL_014b: ldc.i4.0
 		IL_014c: conv.r8
 		IL_014d: ldstr ""
 		IL_0152: ldc.i4.0
 		IL_0153: ldc.i4.1
-		IL_0154: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_D475FD19_L4C27>(!!0, float64, string, bool, bool)
+		IL_0154: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L4C26/FunctionObject_FunctionExpression_D475FD19_L4C27>(!!0, float64, string, bool, bool)
 		IL_0159: stloc.s 10
 		IL_015b: ldloc.s 4
 		IL_015d: ldloc.s 5
@@ -7598,4895 +12487,6 @@
 	} // end of method Import_ExportStarFromMultiHop_LibA::__js_module_init__
 
 } // end of class Modules.Import_ExportStarFromMultiHop_LibA
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop/Scope _environment0_Import_ExportStarFromMultiHop
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4dfa
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop/Scope FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4e09
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4e0c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4e0f
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop/Scope FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4e21
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop/Scope FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4e2f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_D48FB74A___jroc_esm_mark
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x4e3e
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4e46
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4e49
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4e4c
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_default::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4e5f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_default::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4e6e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_84DC3428___jroc_esm_default
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x4e7d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4e85
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4e88
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4e8b
-		// Header size: 1
-		// Code size: 30 (0x1e)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0018: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_get::__js_call__(object, object, string)
-		IL_001d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4eaa
-		// Header size: 1
-		// Code size: 26 (0x1a)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0014: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_get::__js_call__(object, object, string)
-		IL_0019: ret
-	} // end of method FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4ec5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_6E3CEC19___jroc_esm_get
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop/Scope _environment0_Import_ExportStarFromMultiHop
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4ed4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop/Scope FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4ee3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4ee6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4ee9
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop/Scope FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFromMultiHop/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4f02
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop/Scope FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFromMultiHop/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4f17
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_90C314A2___jroc_esm_namespace
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_426DB65A_L38C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop/Scope _environment0_Import_ExportStarFromMultiHop
-	.field private initonly class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop/Scope capture0,
-			class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x4f26
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop/Scope FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_426DB65A_L38C87::_environment0_Import_ExportStarFromMultiHop
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_426DB65A_L38C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_426DB65A_L38C87::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_426DB65A_L38C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4f43
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_426DB65A_L38C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4f46
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_426DB65A_L38C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4f49
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_426DB65A_L38C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_426DB65A_L38C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4f5b
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_426DB65A_L38C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_426DB65A_L38C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4f69
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_426DB65A_L38C87::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_426DB65A_L38C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_551A5557_L39C94
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop/Scope _environment0_Import_ExportStarFromMultiHop
-	.field private initonly class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop/Scope capture0,
-			class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x4f78
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop/Scope FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_551A5557_L39C94::_environment0_Import_ExportStarFromMultiHop
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_551A5557_L39C94::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_551A5557_L39C94::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_551A5557_L39C94::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4f95
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_551A5557_L39C94::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4f98
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_551A5557_L39C94::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4f9b
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_551A5557_L39C94::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_551A5557_L39C94::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4fad
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_551A5557_L39C94::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_551A5557_L39C94::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4fbb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_551A5557_L39C94::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_551A5557_L39C94
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_BF7DD9E1_L48C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop/Scope _environment0_Import_ExportStarFromMultiHop
-	.field private initonly class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop/Scope capture0,
-			class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x4fca
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop/Scope FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_BF7DD9E1_L48C10::_environment0_Import_ExportStarFromMultiHop
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_BF7DD9E1_L48C10::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_BF7DD9E1_L48C10::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_BF7DD9E1_L48C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4fe7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_BF7DD9E1_L48C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4fea
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_BF7DD9E1_L48C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4fed
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_BF7DD9E1_L48C10::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_BF7DD9E1_L48C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5006
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_BF7DD9E1_L48C10::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_BF7DD9E1_L48C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x501b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_BF7DD9E1_L48C10::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_BF7DD9E1_L48C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_DD0FD664_L49C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop/Scope _environment0_Import_ExportStarFromMultiHop
-	.field private initonly class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/Scope _environment2_FunctionExpression_L48C9
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop/Scope capture0,
-			class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope capture1,
-			class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x502a
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop/Scope FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_DD0FD664_L49C87::_environment0_Import_ExportStarFromMultiHop
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_DD0FD664_L49C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/Scope FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_DD0FD664_L49C87::_environment2_FunctionExpression_L48C9
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_DD0FD664_L49C87::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_DD0FD664_L49C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x504f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DD0FD664_L49C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5052
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DD0FD664_L49C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5055
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_DD0FD664_L49C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_DD0FD664_L49C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5067
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_DD0FD664_L49C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_DD0FD664_L49C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5075
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DD0FD664_L49C87::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionExpression_DD0FD664_L49C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop/Scope _environment0_Import_ExportStarFromMultiHop
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5084
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop/Scope FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5093
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5096
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5099
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop/Scope FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x50b9
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop/Scope FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Import_ExportStarFromMultiHop/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x50d5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_7FE87A5F.FunctionObject_FunctionDeclaration_1F9A448D___jroc_esm_export
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_DA9C5919_L10C4
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/Scope _environment0_Import_ExportStarFromMultiHop_LibC
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop_LibC/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x50e4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_DA9C5919_L10C4::_environment0_Import_ExportStarFromMultiHop_LibC
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DA9C5919_L10C4::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x50f3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DA9C5919_L10C4::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x50f6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DA9C5919_L10C4::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x50f9
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_DA9C5919_L10C4::_environment0_Import_ExportStarFromMultiHop_LibC
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_DA9C5919_L10C4::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5112
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_DA9C5919_L10C4::_environment0_Import_ExportStarFromMultiHop_LibC
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_DA9C5919_L10C4::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5127
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DA9C5919_L10C4::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_DA9C5919_L10C4
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_3220FB25_L10C43
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/Scope _environment0_Import_ExportStarFromMultiHop_LibC
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope _environment1_FunctionExpression_L10C3
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop_LibC/Scope capture0,
-			class Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x5136
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_3220FB25_L10C43::_environment0_Import_ExportStarFromMultiHop_LibC
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_3220FB25_L10C43::_environment1_FunctionExpression_L10C3
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_3220FB25_L10C43::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_3220FB25_L10C43::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5153
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3220FB25_L10C43::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5156
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3220FB25_L10C43::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5159
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_3220FB25_L10C43::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_3220FB25_L10C43::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x516b
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_3220FB25_L10C43::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibC/FunctionExpression_L10C3/FunctionExpression_L10C42::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_3220FB25_L10C43::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5179
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3220FB25_L10C43::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_3220FB25_L10C43
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/Scope _environment0_Import_ExportStarFromMultiHop_LibC
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop_LibC/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5188
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop_LibC
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5197
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x519a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x519d
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop_LibC
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x51af
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop_LibC
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x51bd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_10685681___jroc_esm_mark
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x51cc
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x51d4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x51d7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x51da
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_default::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x51ed
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_default::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x51fc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_70E9B29D___jroc_esm_default
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x520b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5213
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5216
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5219
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5233
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5249
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_882C5F3C___jroc_esm_get
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/Scope _environment0_Import_ExportStarFromMultiHop_LibC
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop_LibC/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5258
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop_LibC
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5267
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x526a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x526d
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop_LibC
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5286
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop_LibC
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x529b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_A36C344F___jroc_esm_namespace
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_3C5C10DA_L39C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/Scope _environment0_Import_ExportStarFromMultiHop_LibC
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop_LibC/Scope capture0,
-			class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x52aa
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_3C5C10DA_L39C87::_environment0_Import_ExportStarFromMultiHop_LibC
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_3C5C10DA_L39C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_3C5C10DA_L39C87::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_3C5C10DA_L39C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x52c7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3C5C10DA_L39C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x52ca
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3C5C10DA_L39C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x52cd
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_3C5C10DA_L39C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_3C5C10DA_L39C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x52df
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_3C5C10DA_L39C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L39C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_3C5C10DA_L39C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x52ed
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3C5C10DA_L39C87::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_3C5C10DA_L39C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_1B8705E6_L40C94
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/Scope _environment0_Import_ExportStarFromMultiHop_LibC
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop_LibC/Scope capture0,
-			class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x52fc
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_1B8705E6_L40C94::_environment0_Import_ExportStarFromMultiHop_LibC
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_1B8705E6_L40C94::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_1B8705E6_L40C94::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_1B8705E6_L40C94::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5319
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1B8705E6_L40C94::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x531c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1B8705E6_L40C94::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x531f
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_1B8705E6_L40C94::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_1B8705E6_L40C94::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5331
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_1B8705E6_L40C94::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L40C93::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_1B8705E6_L40C94::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x533f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1B8705E6_L40C94::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_1B8705E6_L40C94
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_1CF36C60_L49C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/Scope _environment0_Import_ExportStarFromMultiHop_LibC
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop_LibC/Scope capture0,
-			class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x534e
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_1CF36C60_L49C10::_environment0_Import_ExportStarFromMultiHop_LibC
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_1CF36C60_L49C10::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_1CF36C60_L49C10::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_1CF36C60_L49C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x536b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1CF36C60_L49C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x536e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1CF36C60_L49C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5371
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_1CF36C60_L49C10::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_1CF36C60_L49C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x538a
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_1CF36C60_L49C10::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_1CF36C60_L49C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x539f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1CF36C60_L49C10::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_1CF36C60_L49C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_73299A15_L50C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/Scope _environment0_Import_ExportStarFromMultiHop_LibC
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/Scope _environment2_FunctionExpression_L49C9
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop_LibC/Scope capture0,
-			class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope capture1,
-			class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x53ae
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_73299A15_L50C87::_environment0_Import_ExportStarFromMultiHop_LibC
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_73299A15_L50C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_73299A15_L50C87::_environment2_FunctionExpression_L49C9
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_73299A15_L50C87::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_73299A15_L50C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x53d3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_73299A15_L50C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x53d6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_73299A15_L50C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x53d9
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_73299A15_L50C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_73299A15_L50C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x53eb
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_73299A15_L50C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_namespace/FunctionExpression_L49C9/FunctionExpression_L50C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_73299A15_L50C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x53f9
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_73299A15_L50C87::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionExpression_73299A15_L50C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibC/Scope _environment0_Import_ExportStarFromMultiHop_LibC
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop_LibC/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5408
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop_LibC
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5417
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x541a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x541d
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop_LibC
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x543d
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibC/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop_LibC
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Import_ExportStarFromMultiHop_LibC/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibC/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5459
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibC_8F4A4CE4.FunctionObject_FunctionDeclaration_C16F4BC6___jroc_esm_export
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_19A18F00_L3C28
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/Scope _environment0_Import_ExportStarFromMultiHop_LibB
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop_LibB/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5468
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_19A18F00_L3C28::_environment0_Import_ExportStarFromMultiHop_LibB
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_19A18F00_L3C28::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5477
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_19A18F00_L3C28::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x547a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_19A18F00_L3C28::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x547d
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_19A18F00_L3C28::_environment0_Import_ExportStarFromMultiHop_LibB
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L3C27::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_19A18F00_L3C28::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x548f
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_19A18F00_L3C28::_environment0_Import_ExportStarFromMultiHop_LibB
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L3C27::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_19A18F00_L3C28::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x549d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_19A18F00_L3C28::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_19A18F00_L3C28
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_9F0212B6_L11C4
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/Scope _environment0_Import_ExportStarFromMultiHop_LibB
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop_LibB/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x54ac
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_9F0212B6_L11C4::_environment0_Import_ExportStarFromMultiHop_LibB
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_9F0212B6_L11C4::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x54bb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9F0212B6_L11C4::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x54be
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9F0212B6_L11C4::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x54c1
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_9F0212B6_L11C4::_environment0_Import_ExportStarFromMultiHop_LibB
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_9F0212B6_L11C4::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x54da
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_9F0212B6_L11C4::_environment0_Import_ExportStarFromMultiHop_LibB
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_9F0212B6_L11C4::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x54ef
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_9F0212B6_L11C4::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_9F0212B6_L11C4
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_777D73E3_L11C43
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/Scope _environment0_Import_ExportStarFromMultiHop_LibB
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope _environment1_FunctionExpression_L11C3
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop_LibB/Scope capture0,
-			class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x54fe
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_777D73E3_L11C43::_environment0_Import_ExportStarFromMultiHop_LibB
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_777D73E3_L11C43::_environment1_FunctionExpression_L11C3
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_777D73E3_L11C43::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_777D73E3_L11C43::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x551b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_777D73E3_L11C43::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x551e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_777D73E3_L11C43::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5521
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_777D73E3_L11C43::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_777D73E3_L11C43::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5533
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_777D73E3_L11C43::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibB/FunctionExpression_L11C3/FunctionExpression_L11C42::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_777D73E3_L11C43::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5541
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_777D73E3_L11C43::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_777D73E3_L11C43
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/Scope _environment0_Import_ExportStarFromMultiHop_LibB
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop_LibB/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5550
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop_LibB
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x555f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5562
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5565
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop_LibB
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5577
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop_LibB
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5585
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_4EDFD112___jroc_esm_mark
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x5594
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x559c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x559f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x55a2
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_default::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x55b5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_default::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x55c4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_0BD504F0___jroc_esm_default
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x55d3
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x55db
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x55de
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x55e1
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x55fb
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5611
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_13AA0971___jroc_esm_get
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/Scope _environment0_Import_ExportStarFromMultiHop_LibB
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop_LibB/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5620
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop_LibB
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x562f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5632
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5635
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop_LibB
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x564e
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop_LibB
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5663
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_6C0AB59A___jroc_esm_namespace
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_11771A92_L41C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/Scope _environment0_Import_ExportStarFromMultiHop_LibB
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop_LibB/Scope capture0,
-			class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x5672
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_11771A92_L41C87::_environment0_Import_ExportStarFromMultiHop_LibB
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_11771A92_L41C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_11771A92_L41C87::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_11771A92_L41C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x568f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_11771A92_L41C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5692
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_11771A92_L41C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5695
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_11771A92_L41C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_11771A92_L41C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x56a7
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_11771A92_L41C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L41C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_11771A92_L41C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x56b5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_11771A92_L41C87::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_11771A92_L41C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_00CEFBE9_L42C94
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/Scope _environment0_Import_ExportStarFromMultiHop_LibB
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop_LibB/Scope capture0,
-			class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x56c4
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_00CEFBE9_L42C94::_environment0_Import_ExportStarFromMultiHop_LibB
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_00CEFBE9_L42C94::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_00CEFBE9_L42C94::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_00CEFBE9_L42C94::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x56e1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_00CEFBE9_L42C94::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x56e4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_00CEFBE9_L42C94::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x56e7
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_00CEFBE9_L42C94::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_00CEFBE9_L42C94::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x56f9
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_00CEFBE9_L42C94::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L42C93::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_00CEFBE9_L42C94::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5707
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_00CEFBE9_L42C94::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_00CEFBE9_L42C94
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_63D03172_L51C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/Scope _environment0_Import_ExportStarFromMultiHop_LibB
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop_LibB/Scope capture0,
-			class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x5716
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_63D03172_L51C10::_environment0_Import_ExportStarFromMultiHop_LibB
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_63D03172_L51C10::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_63D03172_L51C10::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_63D03172_L51C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5733
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_63D03172_L51C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5736
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_63D03172_L51C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5739
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_63D03172_L51C10::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_63D03172_L51C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5752
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_63D03172_L51C10::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_63D03172_L51C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5767
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_63D03172_L51C10::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_63D03172_L51C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_269D42B9_L52C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/Scope _environment0_Import_ExportStarFromMultiHop_LibB
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/Scope _environment2_FunctionExpression_L51C9
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop_LibB/Scope capture0,
-			class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope capture1,
-			class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x5776
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_269D42B9_L52C87::_environment0_Import_ExportStarFromMultiHop_LibB
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_269D42B9_L52C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_269D42B9_L52C87::_environment2_FunctionExpression_L51C9
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_269D42B9_L52C87::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_269D42B9_L52C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x579b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_269D42B9_L52C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x579e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_269D42B9_L52C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x57a1
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_269D42B9_L52C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_269D42B9_L52C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x57b3
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_269D42B9_L52C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_namespace/FunctionExpression_L51C9/FunctionExpression_L52C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_269D42B9_L52C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x57c1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_269D42B9_L52C87::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionExpression_269D42B9_L52C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibB/Scope _environment0_Import_ExportStarFromMultiHop_LibB
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop_LibB/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x57d0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop_LibB
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x57df
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x57e2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x57e5
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop_LibB
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5805
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibB/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop_LibB
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Import_ExportStarFromMultiHop_LibB/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibB/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5821
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibB_904A4E77.FunctionObject_FunctionDeclaration_88CB4755___jroc_esm_export
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_732A343F_L3C28
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibA/Scope _environment0_Import_ExportStarFromMultiHop_LibA
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop_LibA/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5830
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_732A343F_L3C28::_environment0_Import_ExportStarFromMultiHop_LibA
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_732A343F_L3C28::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x583f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_732A343F_L3C28::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5842
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_732A343F_L3C28::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5845
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_732A343F_L3C28::_environment0_Import_ExportStarFromMultiHop_LibA
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L3C27::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_732A343F_L3C28::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5857
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_732A343F_L3C28::_environment0_Import_ExportStarFromMultiHop_LibA
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L3C27::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_732A343F_L3C28::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5865
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_732A343F_L3C28::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_732A343F_L3C28
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_D475FD19_L4C27
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibA/Scope _environment0_Import_ExportStarFromMultiHop_LibA
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop_LibA/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5874
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_D475FD19_L4C27::_environment0_Import_ExportStarFromMultiHop_LibA
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D475FD19_L4C27::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5883
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D475FD19_L4C27::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5886
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D475FD19_L4C27::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5889
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_D475FD19_L4C27::_environment0_Import_ExportStarFromMultiHop_LibA
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L4C26::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_D475FD19_L4C27::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x589b
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_D475FD19_L4C27::_environment0_Import_ExportStarFromMultiHop_LibA
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibA/FunctionExpression_L4C26::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_D475FD19_L4C27::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x58a9
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D475FD19_L4C27::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_D475FD19_L4C27
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibA/Scope _environment0_Import_ExportStarFromMultiHop_LibA
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop_LibA/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x58b8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop_LibA
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x58c7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x58ca
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x58cd
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop_LibA
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x58df
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::_environment0_Import_ExportStarFromMultiHop_LibA
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_mark::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x58ed
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_2470DB97___jroc_esm_mark
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x58fc
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5904
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5907
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x590a
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_default::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x591d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_default::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x592c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_AB0AF24B___jroc_esm_default
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x593b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5943
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5946
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5949
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5963
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5979
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_E177C342___jroc_esm_get
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibA/Scope _environment0_Import_ExportStarFromMultiHop_LibA
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop_LibA/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5988
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop_LibA
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5997
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x599a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x599d
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop_LibA
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x59b6
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::_environment0_Import_ExportStarFromMultiHop_LibA
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x59cb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_44AE4EC5___jroc_esm_namespace
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_C376DAAB_L36C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibA/Scope _environment0_Import_ExportStarFromMultiHop_LibA
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop_LibA/Scope capture0,
-			class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x59da
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_C376DAAB_L36C87::_environment0_Import_ExportStarFromMultiHop_LibA
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_C376DAAB_L36C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_C376DAAB_L36C87::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_C376DAAB_L36C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x59f7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C376DAAB_L36C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x59fa
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C376DAAB_L36C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x59fd
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_C376DAAB_L36C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_C376DAAB_L36C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5a0f
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_C376DAAB_L36C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L36C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_C376DAAB_L36C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5a1d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C376DAAB_L36C87::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_C376DAAB_L36C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_3D70962E_L37C94
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibA/Scope _environment0_Import_ExportStarFromMultiHop_LibA
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop_LibA/Scope capture0,
-			class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x5a2c
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_3D70962E_L37C94::_environment0_Import_ExportStarFromMultiHop_LibA
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_3D70962E_L37C94::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_3D70962E_L37C94::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_3D70962E_L37C94::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5a49
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3D70962E_L37C94::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5a4c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3D70962E_L37C94::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5a4f
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_3D70962E_L37C94::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_3D70962E_L37C94::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5a61
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_3D70962E_L37C94::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L37C93::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_3D70962E_L37C94::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5a6f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3D70962E_L37C94::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_3D70962E_L37C94
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_39AC3F9B_L46C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibA/Scope _environment0_Import_ExportStarFromMultiHop_LibA
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop_LibA/Scope capture0,
-			class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x5a7e
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_39AC3F9B_L46C10::_environment0_Import_ExportStarFromMultiHop_LibA
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_39AC3F9B_L46C10::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_39AC3F9B_L46C10::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_39AC3F9B_L46C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5a9b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_39AC3F9B_L46C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5a9e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_39AC3F9B_L46C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5aa1
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_39AC3F9B_L46C10::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_39AC3F9B_L46C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5aba
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_39AC3F9B_L46C10::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_39AC3F9B_L46C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5acf
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_39AC3F9B_L46C10::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_39AC3F9B_L46C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_085B51F0_L47C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibA/Scope _environment0_Import_ExportStarFromMultiHop_LibA
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/Scope _environment2_FunctionExpression_L46C9
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop_LibA/Scope capture0,
-			class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope capture1,
-			class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x5ade
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_085B51F0_L47C87::_environment0_Import_ExportStarFromMultiHop_LibA
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_085B51F0_L47C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_085B51F0_L47C87::_environment2_FunctionExpression_L46C9
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_085B51F0_L47C87::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_085B51F0_L47C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5b03
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_085B51F0_L47C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5b06
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_085B51F0_L47C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5b09
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_085B51F0_L47C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_085B51F0_L47C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5b1b
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_085B51F0_L47C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_namespace/FunctionExpression_L46C9/FunctionExpression_L47C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_085B51F0_L47C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5b29
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_085B51F0_L47C87::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionExpression_085B51F0_L47C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ExportStarFromMultiHop_LibA/Scope _environment0_Import_ExportStarFromMultiHop_LibA
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ExportStarFromMultiHop_LibA/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5b38
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop_LibA
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5b47
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5b4a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5b4d
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop_LibA
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0017: ldarg.2
-		IL_0018: ldc.i4.1
-		IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001e: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object, string, object)
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5b72
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ExportStarFromMultiHop_LibA/Scope FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::_environment0_Import_ExportStarFromMultiHop_LibA
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.1
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.Import_ExportStarFromMultiHop_LibA/__jroc_esm_export::__js_call__(class Modules.Import_ExportStarFromMultiHop_LibA/Scope, object, string, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5b93
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export::ConstructCore
-
-} // end of class FunctionObjects.Import_ExportStarFromMultiHop_LibA_914A500A.FunctionObject_FunctionDeclaration_596BBA2C___jroc_esm_export
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ImportMeta_Url.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_ImportMeta_Url.verified.txt
@@ -53,6 +53,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ImportMeta_Url/Scope _environment0_Import_ImportMeta_Url
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ImportMeta_Url/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a16
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_mark/FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::_environment0_Import_ImportMeta_Url
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3a25
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3a28
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a2b
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_mark/FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::_environment0_Import_ImportMeta_Url
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_ImportMeta_Url/__jroc_esm_mark::__js_call__(class Modules.Import_ImportMeta_Url/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a3d
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_mark/FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::_environment0_Import_ImportMeta_Url
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_ImportMeta_Url/__jroc_esm_mark::__js_call__(class Modules.Import_ImportMeta_Url/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a4b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark
+
 
 		// Methods
 		.method public hidebysig static 
@@ -159,6 +266,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3a5a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3a62
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3a65
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a68
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Import_ImportMeta_Url/__jroc_esm_default::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a7b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Import_ImportMeta_Url/__jroc_esm_default::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a8a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default
+
 
 		// Methods
 		.method public hidebysig static 
@@ -262,6 +470,115 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3a99
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3aa1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3aa4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3aa7
+				// Header size: 1
+				// Code size: 30 (0x1e)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0018: call object Modules.Import_ImportMeta_Url/__jroc_esm_get::__js_call__(object, object, string)
+				IL_001d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ac6
+				// Header size: 1
+				// Code size: 26 (0x1a)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0014: call object Modules.Import_ImportMeta_Url/__jroc_esm_get::__js_call__(object, object, string)
+				IL_0019: ret
+			} // end of method FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ae1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get
+
 
 		// Methods
 		.method public hidebysig static 
@@ -320,6 +637,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F53969EA_L49C87
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ImportMeta_Url/Scope _environment0_Import_ImportMeta_Url
+				.field private initonly class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ImportMeta_Url/Scope capture0,
+						class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3b42
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_F53969EA_L49C87::_environment0_Import_ImportMeta_Url
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_F53969EA_L49C87::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_F53969EA_L49C87::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_F53969EA_L49C87::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3b5f
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_F53969EA_L49C87::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3b62
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_F53969EA_L49C87::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x3b65
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_F53969EA_L49C87::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_F53969EA_L49C87::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3b77
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_F53969EA_L49C87::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_F53969EA_L49C87::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3b85
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_F53969EA_L49C87::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_F53969EA_L49C87
+
 
 			// Methods
 			.method public hidebysig static 
@@ -369,6 +803,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_195CD488_L50C94
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ImportMeta_Url/Scope _environment0_Import_ImportMeta_Url
+				.field private initonly class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ImportMeta_Url/Scope capture0,
+						class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3b94
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_195CD488_L50C94::_environment0_Import_ImportMeta_Url
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_195CD488_L50C94::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_195CD488_L50C94::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_195CD488_L50C94::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3bb1
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_195CD488_L50C94::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3bb4
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_195CD488_L50C94::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x3bb7
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_195CD488_L50C94::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_195CD488_L50C94::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3bc9
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_195CD488_L50C94::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_195CD488_L50C94::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3bd7
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_195CD488_L50C94::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_195CD488_L50C94
 
 
 			// Methods
@@ -423,6 +974,128 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D44B8B4D_L60C87
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Import_ImportMeta_Url/Scope _environment0_Import_ImportMeta_Url
+					.field private initonly class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+					.field private initonly class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/Scope _environment2_FunctionExpression_L59C9
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Import_ImportMeta_Url/Scope capture0,
+							class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope capture1,
+							class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x3c46
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_D44B8B4D_L60C87::_environment0_Import_ImportMeta_Url
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_D44B8B4D_L60C87::_environment1___jroc_esm_namespace
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_D44B8B4D_L60C87::_environment2_FunctionExpression_L59C9
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_D44B8B4D_L60C87::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_D44B8B4D_L60C87::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x3c6b
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_D44B8B4D_L60C87::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x3c6e
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_D44B8B4D_L60C87::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x3c71
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_D44B8B4D_L60C87::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_D44B8B4D_L60C87::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x3c83
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_D44B8B4D_L60C87::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_D44B8B4D_L60C87::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x3c91
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_D44B8B4D_L60C87::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_D44B8B4D_L60C87
 
 
 				// Methods
@@ -489,6 +1162,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_24DD1933_L59C10
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ImportMeta_Url/Scope _environment0_Import_ImportMeta_Url
+				.field private initonly class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ImportMeta_Url/Scope capture0,
+						class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3be6
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_24DD1933_L59C10::_environment0_Import_ImportMeta_Url
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_24DD1933_L59C10::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_24DD1933_L59C10::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_24DD1933_L59C10::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3c03
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_24DD1933_L59C10::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3c06
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_24DD1933_L59C10::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x3c09
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_24DD1933_L59C10::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_24DD1933_L59C10::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3c22
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_24DD1933_L59C10::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_24DD1933_L59C10::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3c37
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_24DD1933_L59C10::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_24DD1933_L59C10
+
 
 			// Methods
 			.method public hidebysig static 
@@ -510,7 +1306,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_D44B8B4D_L60C87,
+					[4] class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_D44B8B4D_L60C87,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -560,13 +1356,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_D44B8B4D_L60C87::.ctor(class Modules.Import_ImportMeta_Url/Scope, class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope, class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_D44B8B4D_L60C87::.ctor(class Modules.Import_ImportMeta_Url/Scope, class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope, class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_D44B8B4D_L60C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_D44B8B4D_L60C87>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -785,6 +1581,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ImportMeta_Url/Scope _environment0_Import_ImportMeta_Url
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ImportMeta_Url/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3af0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::_environment0_Import_ImportMeta_Url
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3aff
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3b02
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b05
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::_environment0_Import_ImportMeta_Url
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace::__js_call__(class Modules.Import_ImportMeta_Url/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b1e
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::_environment0_Import_ImportMeta_Url
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace::__js_call__(class Modules.Import_ImportMeta_Url/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b33
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace
+
 
 		// Methods
 		.method public hidebysig static 
@@ -824,12 +1733,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_F53969EA_L49C87,
-				[21] class FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_195CD488_L50C94,
+				[20] class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_F53969EA_L49C87,
+				[21] class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_195CD488_L50C94,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_24DD1933_L59C10
+				[25] class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_24DD1933_L59C10
 			)
 
 			IL_0000: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope::.ctor()
@@ -1035,13 +1944,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_F53969EA_L49C87::.ctor(class Modules.Import_ImportMeta_Url/Scope, class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_F53969EA_L49C87::.ctor(class Modules.Import_ImportMeta_Url/Scope, class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_F53969EA_L49C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_F53969EA_L49C87>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -1085,13 +1994,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_195CD488_L50C94::.ctor(class Modules.Import_ImportMeta_Url/Scope, class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_195CD488_L50C94::.ctor(class Modules.Import_ImportMeta_Url/Scope, class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_195CD488_L50C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_195CD488_L50C94>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -1261,13 +2170,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_24DD1933_L59C10::.ctor(class Modules.Import_ImportMeta_Url/Scope, class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_24DD1933_L59C10::.ctor(class Modules.Import_ImportMeta_Url/Scope, class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_24DD1933_L59C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_24DD1933_L59C10>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldc.i4.1
 				IL_0487: newarr [System.Runtime]System.Object
@@ -1386,6 +2295,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ImportMeta_Url/Scope _environment0_Import_ImportMeta_Url
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ImportMeta_Url/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ca0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_export/FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::_environment0_Import_ImportMeta_Url
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3caf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3cb2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3cb5
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_export/FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::_environment0_Import_ImportMeta_Url
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Import_ImportMeta_Url/__jroc_esm_export::__js_call__(class Modules.Import_ImportMeta_Url/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3cd5
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url/Scope Modules.Import_ImportMeta_Url/__jroc_esm_export/FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::_environment0_Import_ImportMeta_Url
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Import_ImportMeta_Url/__jroc_esm_export::__js_call__(class Modules.Import_ImportMeta_Url/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3cf1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1499,10 +2527,10 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ImportMeta_Url/Scope,
-			[1] class FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default,
-			[2] class FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get,
-			[3] class FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace,
-			[4] class FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export,
+			[1] class Modules.Import_ImportMeta_Url/__jroc_esm_default/FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default,
+			[2] class Modules.Import_ImportMeta_Url/__jroc_esm_get/FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get,
+			[3] class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace,
+			[4] class Modules.Import_ImportMeta_Url/__jroc_esm_export/FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export,
 			[5] object,
 			[6] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUrlModule,
 			[7] object,
@@ -1510,7 +2538,7 @@
 			[9] object,
 			[10] object,
 			[11] object[],
-			[12] class FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark,
+			[12] class Modules.Import_ImportMeta_Url/__jroc_esm_mark/FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark,
 			[13] object,
 			[14] object,
 			[15] bool,
@@ -1533,13 +2561,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_ImportMeta_Url/Scope
-		IL_0022: newobj instance void FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::.ctor(class Modules.Import_ImportMeta_Url/Scope)
+		IL_0022: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_mark/FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::.ctor(class Modules.Import_ImportMeta_Url/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url/__jroc_esm_mark/FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 12
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 12
@@ -1551,13 +2579,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 11
-		IL_004b: newobj instance void FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_default/FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url/__jroc_esm_default/FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -1566,13 +2594,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 11
-		IL_006b: newobj instance void FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_get/FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url/__jroc_esm_get/FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -1585,13 +2613,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_ImportMeta_Url/Scope
-		IL_0094: newobj instance void FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::.ctor(class Modules.Import_ImportMeta_Url/Scope)
+		IL_0094: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::.ctor(class Modules.Import_ImportMeta_Url/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -1604,13 +2632,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_ImportMeta_Url/Scope
-		IL_00bd: newobj instance void FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::.ctor(class Modules.Import_ImportMeta_Url/Scope)
+		IL_00bd: newobj instance void Modules.Import_ImportMeta_Url/__jroc_esm_export/FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::.ctor(class Modules.Import_ImportMeta_Url/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url/__jroc_esm_export/FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 4
 		IL_00d2: nop
 		IL_00d3: ldloc.0
@@ -1941,6 +2969,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5F55E90D_L3C34
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ImportMeta_Url_Lib/Scope _environment0_Import_ImportMeta_Url_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ImportMeta_Url_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3d00
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L3C33/FunctionObject_FunctionExpression_5F55E90D_L3C34::_environment0_Import_ImportMeta_Url_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_5F55E90D_L3C34::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3d0f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5F55E90D_L3C34::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3d12
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5F55E90D_L3C34::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3d15
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L3C33/FunctionObject_FunctionExpression_5F55E90D_L3C34::_environment0_Import_ImportMeta_Url_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L3C33::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_5F55E90D_L3C34::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3d27
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L3C33/FunctionObject_FunctionExpression_5F55E90D_L3C34::_environment0_Import_ImportMeta_Url_Lib
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L3C33::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_5F55E90D_L3C34::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3d35
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_5F55E90D_L3C34::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_5F55E90D_L3C34
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1991,6 +3126,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9FE7D048_L4C47
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ImportMeta_Url_Lib/Scope _environment0_Import_ImportMeta_Url_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ImportMeta_Url_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3d44
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L4C46/FunctionObject_FunctionExpression_9FE7D048_L4C47::_environment0_Import_ImportMeta_Url_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_9FE7D048_L4C47::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3d53
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_9FE7D048_L4C47::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3d56
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_9FE7D048_L4C47::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3d59
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L4C46/FunctionObject_FunctionExpression_9FE7D048_L4C47::_environment0_Import_ImportMeta_Url_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L4C46::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_9FE7D048_L4C47::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3d6b
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L4C46/FunctionObject_FunctionExpression_9FE7D048_L4C47::_environment0_Import_ImportMeta_Url_Lib
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L4C46::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_9FE7D048_L4C47::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3d79
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_9FE7D048_L4C47::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_9FE7D048_L4C47
 
 
 		// Methods
@@ -2043,6 +3285,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_40C0441F_L5C52
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ImportMeta_Url_Lib/Scope _environment0_Import_ImportMeta_Url_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ImportMeta_Url_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3d88
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L5C51/FunctionObject_FunctionExpression_40C0441F_L5C52::_environment0_Import_ImportMeta_Url_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_40C0441F_L5C52::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3d97
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_40C0441F_L5C52::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3d9a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_40C0441F_L5C52::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3d9d
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L5C51/FunctionObject_FunctionExpression_40C0441F_L5C52::_environment0_Import_ImportMeta_Url_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L5C51::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_40C0441F_L5C52::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3daf
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L5C51/FunctionObject_FunctionExpression_40C0441F_L5C52::_environment0_Import_ImportMeta_Url_Lib
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L5C51::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_40C0441F_L5C52::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3dbd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_40C0441F_L5C52::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_40C0441F_L5C52
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2093,6 +3442,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_53921123_L6C48
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ImportMeta_Url_Lib/Scope _environment0_Import_ImportMeta_Url_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ImportMeta_Url_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3dcc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L6C47/FunctionObject_FunctionExpression_53921123_L6C48::_environment0_Import_ImportMeta_Url_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_53921123_L6C48::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3ddb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_53921123_L6C48::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3dde
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_53921123_L6C48::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3de1
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L6C47/FunctionObject_FunctionExpression_53921123_L6C48::_environment0_Import_ImportMeta_Url_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L6C47::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_53921123_L6C48::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3df3
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L6C47/FunctionObject_FunctionExpression_53921123_L6C48::_environment0_Import_ImportMeta_Url_Lib
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L6C47::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_53921123_L6C48::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3e01
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_53921123_L6C48::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_53921123_L6C48
 
 
 		// Methods
@@ -2166,6 +3622,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ImportMeta_Url_Lib/Scope _environment0_Import_ImportMeta_Url_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ImportMeta_Url_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3e10
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::_environment0_Import_ImportMeta_Url_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3e1f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3e22
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3e25
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::_environment0_Import_ImportMeta_Url_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3e37
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::_environment0_Import_ImportMeta_Url_Lib
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3e45
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark
 
 
 		// Methods
@@ -2273,6 +3836,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3e54
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3e5c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3e5f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3e62
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_default::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3e75
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_default::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3e84
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2376,6 +4040,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3e93
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3e9b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3e9e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ea1
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ebb
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ed1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2434,6 +4205,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_AB4BFBDB_L40C87
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ImportMeta_Url_Lib/Scope _environment0_Import_ImportMeta_Url_Lib
+				.field private initonly class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ImportMeta_Url_Lib/Scope capture0,
+						class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3f32
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86/FunctionObject_FunctionExpression_AB4BFBDB_L40C87::_environment0_Import_ImportMeta_Url_Lib
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86/FunctionObject_FunctionExpression_AB4BFBDB_L40C87::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86/FunctionObject_FunctionExpression_AB4BFBDB_L40C87::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_AB4BFBDB_L40C87::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3f4f
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_AB4BFBDB_L40C87::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3f52
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_AB4BFBDB_L40C87::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x3f55
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86/FunctionObject_FunctionExpression_AB4BFBDB_L40C87::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_AB4BFBDB_L40C87::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3f67
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86/FunctionObject_FunctionExpression_AB4BFBDB_L40C87::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_AB4BFBDB_L40C87::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3f75
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_AB4BFBDB_L40C87::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_AB4BFBDB_L40C87
+
 
 			// Methods
 			.method public hidebysig static 
@@ -2483,6 +4371,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_989F5CDE_L41C94
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ImportMeta_Url_Lib/Scope _environment0_Import_ImportMeta_Url_Lib
+				.field private initonly class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ImportMeta_Url_Lib/Scope capture0,
+						class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3f84
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93/FunctionObject_FunctionExpression_989F5CDE_L41C94::_environment0_Import_ImportMeta_Url_Lib
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93/FunctionObject_FunctionExpression_989F5CDE_L41C94::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93/FunctionObject_FunctionExpression_989F5CDE_L41C94::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_989F5CDE_L41C94::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3fa1
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_989F5CDE_L41C94::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3fa4
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_989F5CDE_L41C94::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x3fa7
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93/FunctionObject_FunctionExpression_989F5CDE_L41C94::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_989F5CDE_L41C94::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3fb9
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93/FunctionObject_FunctionExpression_989F5CDE_L41C94::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_989F5CDE_L41C94::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3fc7
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_989F5CDE_L41C94::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_989F5CDE_L41C94
 
 
 			// Methods
@@ -2537,6 +4542,128 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2BD4DD7C_L51C87
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Import_ImportMeta_Url_Lib/Scope _environment0_Import_ImportMeta_Url_Lib
+					.field private initonly class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+					.field private initonly class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/Scope _environment2_FunctionExpression_L50C9
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Import_ImportMeta_Url_Lib/Scope capture0,
+							class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope capture1,
+							class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x4036
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86/FunctionObject_FunctionExpression_2BD4DD7C_L51C87::_environment0_Import_ImportMeta_Url_Lib
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86/FunctionObject_FunctionExpression_2BD4DD7C_L51C87::_environment1___jroc_esm_namespace
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86/FunctionObject_FunctionExpression_2BD4DD7C_L51C87::_environment2_FunctionExpression_L50C9
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86/FunctionObject_FunctionExpression_2BD4DD7C_L51C87::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_2BD4DD7C_L51C87::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x405b
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_2BD4DD7C_L51C87::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x405e
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_2BD4DD7C_L51C87::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x4061
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86/FunctionObject_FunctionExpression_2BD4DD7C_L51C87::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_2BD4DD7C_L51C87::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x4073
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86/FunctionObject_FunctionExpression_2BD4DD7C_L51C87::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_2BD4DD7C_L51C87::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x4081
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_2BD4DD7C_L51C87::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_2BD4DD7C_L51C87
 
 
 				// Methods
@@ -2603,6 +4730,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A9BE71C4_L50C10
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_ImportMeta_Url_Lib/Scope _environment0_Import_ImportMeta_Url_Lib
+				.field private initonly class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_ImportMeta_Url_Lib/Scope capture0,
+						class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3fd6
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionObject_FunctionExpression_A9BE71C4_L50C10::_environment0_Import_ImportMeta_Url_Lib
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionObject_FunctionExpression_A9BE71C4_L50C10::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionObject_FunctionExpression_A9BE71C4_L50C10::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_A9BE71C4_L50C10::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3ff3
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_A9BE71C4_L50C10::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3ff6
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_A9BE71C4_L50C10::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x3ff9
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionObject_FunctionExpression_A9BE71C4_L50C10::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_A9BE71C4_L50C10::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x4012
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionObject_FunctionExpression_A9BE71C4_L50C10::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_A9BE71C4_L50C10::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x4027
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_A9BE71C4_L50C10::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_A9BE71C4_L50C10
+
 
 			// Methods
 			.method public hidebysig static 
@@ -2624,7 +4874,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_2BD4DD7C_L51C87,
+					[4] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86/FunctionObject_FunctionExpression_2BD4DD7C_L51C87,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -2674,13 +4924,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_2BD4DD7C_L51C87::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope, class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope, class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86/FunctionObject_FunctionExpression_2BD4DD7C_L51C87::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope, class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope, class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_2BD4DD7C_L51C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86/FunctionObject_FunctionExpression_2BD4DD7C_L51C87>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -2899,6 +5149,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ImportMeta_Url_Lib/Scope _environment0_Import_ImportMeta_Url_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ImportMeta_Url_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ee0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::_environment0_Import_ImportMeta_Url_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3eef
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3ef2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ef5
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::_environment0_Import_ImportMeta_Url_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3f0e
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::_environment0_Import_ImportMeta_Url_Lib
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3f23
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2938,12 +5301,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_AB4BFBDB_L40C87,
-				[21] class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_989F5CDE_L41C94,
+				[20] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86/FunctionObject_FunctionExpression_AB4BFBDB_L40C87,
+				[21] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93/FunctionObject_FunctionExpression_989F5CDE_L41C94,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_A9BE71C4_L50C10
+				[25] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionObject_FunctionExpression_A9BE71C4_L50C10
 			)
 
 			IL_0000: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope::.ctor()
@@ -3149,13 +5512,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_AB4BFBDB_L40C87::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope, class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86/FunctionObject_FunctionExpression_AB4BFBDB_L40C87::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope, class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_AB4BFBDB_L40C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86/FunctionObject_FunctionExpression_AB4BFBDB_L40C87>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -3199,13 +5562,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_989F5CDE_L41C94::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope, class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93/FunctionObject_FunctionExpression_989F5CDE_L41C94::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope, class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_989F5CDE_L41C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93/FunctionObject_FunctionExpression_989F5CDE_L41C94>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -3375,13 +5738,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_A9BE71C4_L50C10::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope, class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionObject_FunctionExpression_A9BE71C4_L50C10::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope, class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_A9BE71C4_L50C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionObject_FunctionExpression_A9BE71C4_L50C10>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldc.i4.1
 				IL_0487: newarr [System.Runtime]System.Object
@@ -3499,6 +5862,127 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_ImportMeta_Url_Lib/Scope _environment0_Import_ImportMeta_Url_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_ImportMeta_Url_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4090
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::_environment0_Import_ImportMeta_Url_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x409f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x40a2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x40a5
+				// Header size: 1
+				// Code size: 36 (0x24)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::_environment0_Import_ImportMeta_Url_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0017: ldarg.2
+				IL_0018: ldc.i4.1
+				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001e: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object, string, object)
+				IL_0023: ret
+			} // end of method FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x40ca
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::_environment0_Import_ImportMeta_Url_Lib
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.1
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object, string, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x40eb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export
 
 
 		// Methods
@@ -3642,18 +6126,18 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_ImportMeta_Url_Lib/Scope,
-			[1] class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default,
-			[2] class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get,
-			[3] class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace,
-			[4] class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export,
+			[1] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default,
+			[2] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get,
+			[3] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace,
+			[4] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export,
 			[5] object[],
-			[6] class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark,
+			[6] class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark,
 			[7] object,
 			[8] object[],
-			[9] class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_5F55E90D_L3C34,
-			[10] class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_9FE7D048_L4C47,
-			[11] class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_40C0441F_L5C52,
-			[12] class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_53921123_L6C48,
+			[9] class Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L3C33/FunctionObject_FunctionExpression_5F55E90D_L3C34,
+			[10] class Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L4C46/FunctionObject_FunctionExpression_9FE7D048_L4C47,
+			[11] class Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L5C51/FunctionObject_FunctionExpression_40C0441F_L5C52,
+			[12] class Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L6C47/FunctionObject_FunctionExpression_53921123_L6C48,
 			[13] bool,
 			[14] object,
 			[15] object
@@ -3675,13 +6159,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_0022: newobj instance void FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope)
+		IL_0022: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 6
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 6
@@ -3693,13 +6177,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 5
-		IL_004b: newobj instance void FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -3708,13 +6192,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 5
-		IL_006b: newobj instance void FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -3727,13 +6211,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_0094: newobj instance void FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope)
+		IL_0094: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -3746,13 +6230,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_00bd: newobj instance void FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope)
+		IL_00bd: newobj instance void Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 4
 		IL_00d2: nop
 		IL_00d3: ldloc.0
@@ -3775,13 +6259,13 @@
 		IL_00fd: ldc.i4.0
 		IL_00fe: ldelem.ref
 		IL_00ff: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_0104: newobj instance void FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_5F55E90D_L3C34::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope)
+		IL_0104: newobj instance void Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L3C33/FunctionObject_FunctionExpression_5F55E90D_L3C34::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope)
 		IL_0109: ldc.i4.0
 		IL_010a: conv.r8
 		IL_010b: ldstr ""
 		IL_0110: ldc.i4.0
 		IL_0111: ldc.i4.1
-		IL_0112: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_5F55E90D_L3C34>(!!0, float64, string, bool, bool)
+		IL_0112: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L3C33/FunctionObject_FunctionExpression_5F55E90D_L3C34>(!!0, float64, string, bool, bool)
 		IL_0117: stloc.s 9
 		IL_0119: ldloc.s 4
 		IL_011b: ldloc.s 5
@@ -3802,13 +6286,13 @@
 		IL_013f: ldc.i4.0
 		IL_0140: ldelem.ref
 		IL_0141: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_0146: newobj instance void FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_9FE7D048_L4C47::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope)
+		IL_0146: newobj instance void Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L4C46/FunctionObject_FunctionExpression_9FE7D048_L4C47::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope)
 		IL_014b: ldc.i4.0
 		IL_014c: conv.r8
 		IL_014d: ldstr ""
 		IL_0152: ldc.i4.0
 		IL_0153: ldc.i4.1
-		IL_0154: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_9FE7D048_L4C47>(!!0, float64, string, bool, bool)
+		IL_0154: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L4C46/FunctionObject_FunctionExpression_9FE7D048_L4C47>(!!0, float64, string, bool, bool)
 		IL_0159: stloc.s 10
 		IL_015b: ldloc.s 4
 		IL_015d: ldloc.s 5
@@ -3829,13 +6313,13 @@
 		IL_0181: ldc.i4.0
 		IL_0182: ldelem.ref
 		IL_0183: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_0188: newobj instance void FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_40C0441F_L5C52::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope)
+		IL_0188: newobj instance void Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L5C51/FunctionObject_FunctionExpression_40C0441F_L5C52::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope)
 		IL_018d: ldc.i4.0
 		IL_018e: conv.r8
 		IL_018f: ldstr ""
 		IL_0194: ldc.i4.0
 		IL_0195: ldc.i4.1
-		IL_0196: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_40C0441F_L5C52>(!!0, float64, string, bool, bool)
+		IL_0196: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L5C51/FunctionObject_FunctionExpression_40C0441F_L5C52>(!!0, float64, string, bool, bool)
 		IL_019b: stloc.s 11
 		IL_019d: ldloc.s 4
 		IL_019f: ldloc.s 5
@@ -3856,13 +6340,13 @@
 		IL_01c3: ldc.i4.0
 		IL_01c4: ldelem.ref
 		IL_01c5: castclass Modules.Import_ImportMeta_Url_Lib/Scope
-		IL_01ca: newobj instance void FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_53921123_L6C48::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope)
+		IL_01ca: newobj instance void Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L6C47/FunctionObject_FunctionExpression_53921123_L6C48::.ctor(class Modules.Import_ImportMeta_Url_Lib/Scope)
 		IL_01cf: ldc.i4.0
 		IL_01d0: conv.r8
 		IL_01d1: ldstr ""
 		IL_01d6: ldc.i4.0
 		IL_01d7: ldc.i4.1
-		IL_01d8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_53921123_L6C48>(!!0, float64, string, bool, bool)
+		IL_01d8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L6C47/FunctionObject_FunctionExpression_53921123_L6C48>(!!0, float64, string, bool, bool)
 		IL_01dd: stloc.s 12
 		IL_01df: ldloc.s 4
 		IL_01e1: ldloc.s 5
@@ -3948,2490 +6432,6 @@
 	} // end of method Import_ImportMeta_Url_Lib::__js_module_init__
 
 } // end of class Modules.Import_ImportMeta_Url_Lib
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ImportMeta_Url/Scope _environment0_Import_ImportMeta_Url
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ImportMeta_Url/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a16
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ImportMeta_Url/Scope FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::_environment0_Import_ImportMeta_Url
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3a25
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3a28
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a2b
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ImportMeta_Url/Scope FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::_environment0_Import_ImportMeta_Url
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ImportMeta_Url/__jroc_esm_mark::__js_call__(class Modules.Import_ImportMeta_Url/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a3d
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ImportMeta_Url/Scope FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::_environment0_Import_ImportMeta_Url
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ImportMeta_Url/__jroc_esm_mark::__js_call__(class Modules.Import_ImportMeta_Url/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a4b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark::ConstructCore
-
-} // end of class FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_71337532___jroc_esm_mark
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3a5a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3a62
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3a65
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a68
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Import_ImportMeta_Url/__jroc_esm_default::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a7b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Import_ImportMeta_Url/__jroc_esm_default::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a8a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default::ConstructCore
-
-} // end of class FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_F7D46B90___jroc_esm_default
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3a99
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3aa1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3aa4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3aa7
-		// Header size: 1
-		// Code size: 30 (0x1e)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0018: call object Modules.Import_ImportMeta_Url/__jroc_esm_get::__js_call__(object, object, string)
-		IL_001d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ac6
-		// Header size: 1
-		// Code size: 26 (0x1a)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0014: call object Modules.Import_ImportMeta_Url/__jroc_esm_get::__js_call__(object, object, string)
-		IL_0019: ret
-	} // end of method FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ae1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get::ConstructCore
-
-} // end of class FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_B766E911___jroc_esm_get
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ImportMeta_Url/Scope _environment0_Import_ImportMeta_Url
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ImportMeta_Url/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3af0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ImportMeta_Url/Scope FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::_environment0_Import_ImportMeta_Url
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3aff
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3b02
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b05
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ImportMeta_Url/Scope FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::_environment0_Import_ImportMeta_Url
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace::__js_call__(class Modules.Import_ImportMeta_Url/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b1e
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ImportMeta_Url/Scope FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::_environment0_Import_ImportMeta_Url
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace::__js_call__(class Modules.Import_ImportMeta_Url/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b33
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace::ConstructCore
-
-} // end of class FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_68727C3A___jroc_esm_namespace
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_F53969EA_L49C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ImportMeta_Url/Scope _environment0_Import_ImportMeta_Url
-	.field private initonly class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ImportMeta_Url/Scope capture0,
-			class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b42
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ImportMeta_Url/Scope FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_F53969EA_L49C87::_environment0_Import_ImportMeta_Url
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_F53969EA_L49C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_F53969EA_L49C87::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_F53969EA_L49C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3b5f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F53969EA_L49C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3b62
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F53969EA_L49C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b65
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_F53969EA_L49C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_F53969EA_L49C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b77
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_F53969EA_L49C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L49C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_F53969EA_L49C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b85
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F53969EA_L49C87::ConstructCore
-
-} // end of class FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_F53969EA_L49C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_195CD488_L50C94
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ImportMeta_Url/Scope _environment0_Import_ImportMeta_Url
-	.field private initonly class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ImportMeta_Url/Scope capture0,
-			class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b94
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ImportMeta_Url/Scope FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_195CD488_L50C94::_environment0_Import_ImportMeta_Url
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_195CD488_L50C94::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_195CD488_L50C94::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_195CD488_L50C94::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3bb1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_195CD488_L50C94::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3bb4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_195CD488_L50C94::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3bb7
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_195CD488_L50C94::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_195CD488_L50C94::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3bc9
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_195CD488_L50C94::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L50C93::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_195CD488_L50C94::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3bd7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_195CD488_L50C94::ConstructCore
-
-} // end of class FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_195CD488_L50C94
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_24DD1933_L59C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ImportMeta_Url/Scope _environment0_Import_ImportMeta_Url
-	.field private initonly class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ImportMeta_Url/Scope capture0,
-			class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3be6
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ImportMeta_Url/Scope FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_24DD1933_L59C10::_environment0_Import_ImportMeta_Url
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_24DD1933_L59C10::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_24DD1933_L59C10::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_24DD1933_L59C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3c03
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_24DD1933_L59C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3c06
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_24DD1933_L59C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c09
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_24DD1933_L59C10::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_24DD1933_L59C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c22
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_24DD1933_L59C10::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_24DD1933_L59C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c37
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_24DD1933_L59C10::ConstructCore
-
-} // end of class FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_24DD1933_L59C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_D44B8B4D_L60C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ImportMeta_Url/Scope _environment0_Import_ImportMeta_Url
-	.field private initonly class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/Scope _environment2_FunctionExpression_L59C9
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ImportMeta_Url/Scope capture0,
-			class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope capture1,
-			class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c46
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ImportMeta_Url/Scope FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_D44B8B4D_L60C87::_environment0_Import_ImportMeta_Url
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/Scope FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_D44B8B4D_L60C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/Scope FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_D44B8B4D_L60C87::_environment2_FunctionExpression_L59C9
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_D44B8B4D_L60C87::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_D44B8B4D_L60C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3c6b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D44B8B4D_L60C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3c6e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D44B8B4D_L60C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c71
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_D44B8B4D_L60C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_D44B8B4D_L60C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c83
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_D44B8B4D_L60C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ImportMeta_Url/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_D44B8B4D_L60C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c91
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D44B8B4D_L60C87::ConstructCore
-
-} // end of class FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionExpression_D44B8B4D_L60C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ImportMeta_Url/Scope _environment0_Import_ImportMeta_Url
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ImportMeta_Url/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ca0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ImportMeta_Url/Scope FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::_environment0_Import_ImportMeta_Url
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3caf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3cb2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3cb5
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ImportMeta_Url/Scope FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::_environment0_Import_ImportMeta_Url
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Import_ImportMeta_Url/__jroc_esm_export::__js_call__(class Modules.Import_ImportMeta_Url/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3cd5
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ImportMeta_Url/Scope FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::_environment0_Import_ImportMeta_Url
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Import_ImportMeta_Url/__jroc_esm_export::__js_call__(class Modules.Import_ImportMeta_Url/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3cf1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export::ConstructCore
-
-} // end of class FunctionObjects.Import_ImportMeta_Url_8BE85B17.FunctionObject_FunctionDeclaration_C0F1D975___jroc_esm_export
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_5F55E90D_L3C34
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ImportMeta_Url_Lib/Scope _environment0_Import_ImportMeta_Url_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ImportMeta_Url_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3d00
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_5F55E90D_L3C34::_environment0_Import_ImportMeta_Url_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5F55E90D_L3C34::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3d0f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5F55E90D_L3C34::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3d12
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5F55E90D_L3C34::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3d15
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_5F55E90D_L3C34::_environment0_Import_ImportMeta_Url_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L3C33::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_5F55E90D_L3C34::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3d27
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_5F55E90D_L3C34::_environment0_Import_ImportMeta_Url_Lib
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L3C33::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_5F55E90D_L3C34::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3d35
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5F55E90D_L3C34::ConstructCore
-
-} // end of class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_5F55E90D_L3C34
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_9FE7D048_L4C47
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ImportMeta_Url_Lib/Scope _environment0_Import_ImportMeta_Url_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ImportMeta_Url_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3d44
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_9FE7D048_L4C47::_environment0_Import_ImportMeta_Url_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_9FE7D048_L4C47::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3d53
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9FE7D048_L4C47::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3d56
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9FE7D048_L4C47::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3d59
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_9FE7D048_L4C47::_environment0_Import_ImportMeta_Url_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L4C46::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_9FE7D048_L4C47::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3d6b
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_9FE7D048_L4C47::_environment0_Import_ImportMeta_Url_Lib
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L4C46::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_9FE7D048_L4C47::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3d79
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_9FE7D048_L4C47::ConstructCore
-
-} // end of class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_9FE7D048_L4C47
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_40C0441F_L5C52
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ImportMeta_Url_Lib/Scope _environment0_Import_ImportMeta_Url_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ImportMeta_Url_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3d88
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_40C0441F_L5C52::_environment0_Import_ImportMeta_Url_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_40C0441F_L5C52::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3d97
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_40C0441F_L5C52::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3d9a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_40C0441F_L5C52::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3d9d
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_40C0441F_L5C52::_environment0_Import_ImportMeta_Url_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L5C51::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_40C0441F_L5C52::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3daf
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_40C0441F_L5C52::_environment0_Import_ImportMeta_Url_Lib
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L5C51::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_40C0441F_L5C52::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3dbd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_40C0441F_L5C52::ConstructCore
-
-} // end of class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_40C0441F_L5C52
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_53921123_L6C48
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ImportMeta_Url_Lib/Scope _environment0_Import_ImportMeta_Url_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ImportMeta_Url_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3dcc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_53921123_L6C48::_environment0_Import_ImportMeta_Url_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_53921123_L6C48::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3ddb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_53921123_L6C48::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3dde
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_53921123_L6C48::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3de1
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_53921123_L6C48::_environment0_Import_ImportMeta_Url_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L6C47::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_53921123_L6C48::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3df3
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_53921123_L6C48::_environment0_Import_ImportMeta_Url_Lib
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ImportMeta_Url_Lib/FunctionExpression_L6C47::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_53921123_L6C48::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3e01
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_53921123_L6C48::ConstructCore
-
-} // end of class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_53921123_L6C48
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ImportMeta_Url_Lib/Scope _environment0_Import_ImportMeta_Url_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ImportMeta_Url_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3e10
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::_environment0_Import_ImportMeta_Url_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3e1f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3e22
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3e25
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::_environment0_Import_ImportMeta_Url_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3e37
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::_environment0_Import_ImportMeta_Url_Lib
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3e45
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark::ConstructCore
-
-} // end of class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_D8A95DB2___jroc_esm_mark
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3e54
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3e5c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3e5f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3e62
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_default::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3e75
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_default::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3e84
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default::ConstructCore
-
-} // end of class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_9BF10910___jroc_esm_default
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3e93
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3e9b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3e9e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ea1
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ebb
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ed1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get::ConstructCore
-
-} // end of class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_DB8CAE91___jroc_esm_get
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ImportMeta_Url_Lib/Scope _environment0_Import_ImportMeta_Url_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ImportMeta_Url_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ee0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::_environment0_Import_ImportMeta_Url_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3eef
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3ef2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ef5
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::_environment0_Import_ImportMeta_Url_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3f0e
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::_environment0_Import_ImportMeta_Url_Lib
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3f23
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace::ConstructCore
-
-} // end of class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_963E15BA___jroc_esm_namespace
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_AB4BFBDB_L40C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ImportMeta_Url_Lib/Scope _environment0_Import_ImportMeta_Url_Lib
-	.field private initonly class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ImportMeta_Url_Lib/Scope capture0,
-			class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3f32
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_AB4BFBDB_L40C87::_environment0_Import_ImportMeta_Url_Lib
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_AB4BFBDB_L40C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_AB4BFBDB_L40C87::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_AB4BFBDB_L40C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3f4f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_AB4BFBDB_L40C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3f52
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_AB4BFBDB_L40C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3f55
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_AB4BFBDB_L40C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_AB4BFBDB_L40C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3f67
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_AB4BFBDB_L40C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L40C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_AB4BFBDB_L40C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3f75
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_AB4BFBDB_L40C87::ConstructCore
-
-} // end of class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_AB4BFBDB_L40C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_989F5CDE_L41C94
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ImportMeta_Url_Lib/Scope _environment0_Import_ImportMeta_Url_Lib
-	.field private initonly class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ImportMeta_Url_Lib/Scope capture0,
-			class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3f84
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_989F5CDE_L41C94::_environment0_Import_ImportMeta_Url_Lib
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_989F5CDE_L41C94::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_989F5CDE_L41C94::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_989F5CDE_L41C94::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3fa1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_989F5CDE_L41C94::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3fa4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_989F5CDE_L41C94::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3fa7
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_989F5CDE_L41C94::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_989F5CDE_L41C94::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3fb9
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_989F5CDE_L41C94::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L41C93::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_989F5CDE_L41C94::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3fc7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_989F5CDE_L41C94::ConstructCore
-
-} // end of class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_989F5CDE_L41C94
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_A9BE71C4_L50C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ImportMeta_Url_Lib/Scope _environment0_Import_ImportMeta_Url_Lib
-	.field private initonly class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ImportMeta_Url_Lib/Scope capture0,
-			class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3fd6
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_A9BE71C4_L50C10::_environment0_Import_ImportMeta_Url_Lib
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_A9BE71C4_L50C10::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_A9BE71C4_L50C10::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_A9BE71C4_L50C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3ff3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A9BE71C4_L50C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3ff6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A9BE71C4_L50C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ff9
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_A9BE71C4_L50C10::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_A9BE71C4_L50C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4012
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_A9BE71C4_L50C10::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_A9BE71C4_L50C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4027
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A9BE71C4_L50C10::ConstructCore
-
-} // end of class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_A9BE71C4_L50C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_2BD4DD7C_L51C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ImportMeta_Url_Lib/Scope _environment0_Import_ImportMeta_Url_Lib
-	.field private initonly class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/Scope _environment2_FunctionExpression_L50C9
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ImportMeta_Url_Lib/Scope capture0,
-			class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope capture1,
-			class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x4036
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_2BD4DD7C_L51C87::_environment0_Import_ImportMeta_Url_Lib
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_2BD4DD7C_L51C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_2BD4DD7C_L51C87::_environment2_FunctionExpression_L50C9
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_2BD4DD7C_L51C87::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_2BD4DD7C_L51C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x405b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2BD4DD7C_L51C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x405e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2BD4DD7C_L51C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4061
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_2BD4DD7C_L51C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_2BD4DD7C_L51C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4073
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_2BD4DD7C_L51C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_namespace/FunctionExpression_L50C9/FunctionExpression_L51C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_2BD4DD7C_L51C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4081
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2BD4DD7C_L51C87::ConstructCore
-
-} // end of class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionExpression_2BD4DD7C_L51C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_ImportMeta_Url_Lib/Scope _environment0_Import_ImportMeta_Url_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_ImportMeta_Url_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4090
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_ImportMeta_Url_Lib/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::_environment0_Import_ImportMeta_Url_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x409f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x40a2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x40a5
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::_environment0_Import_ImportMeta_Url_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0017: ldarg.2
-		IL_0018: ldc.i4.1
-		IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001e: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object, string, object)
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x40ca
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_ImportMeta_Url_Lib/Scope FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::_environment0_Import_ImportMeta_Url_Lib
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.1
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.Import_ImportMeta_Url_Lib/__jroc_esm_export::__js_call__(class Modules.Import_ImportMeta_Url_Lib/Scope, object, string, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x40eb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export::ConstructCore
-
-} // end of class FunctionObjects.Import_ImportMeta_Url_Lib_06FE7B97.FunctionObject_FunctionDeclaration_321B35F5___jroc_esm_export
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Cycle.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Cycle.verified.txt
@@ -53,6 +53,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_LiveBindings_Cycle/Scope _environment0_Import_LiveBindings_Cycle
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_LiveBindings_Cycle/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4449
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_mark/FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::_environment0_Import_LiveBindings_Cycle
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4458
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x445b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x445e
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_mark/FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::_environment0_Import_LiveBindings_Cycle
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4470
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_mark/FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::_environment0_Import_LiveBindings_Cycle
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x447e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark
+
 
 		// Methods
 		.method public hidebysig static 
@@ -159,6 +266,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x448d
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4495
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4498
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x449b
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_default::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x44ae
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_default::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x44bd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default
+
 
 		// Methods
 		.method public hidebysig static 
@@ -262,6 +470,115 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x44cc
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x44d4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x44d7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x44da
+				// Header size: 1
+				// Code size: 30 (0x1e)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0018: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, string)
+				IL_001d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x44f9
+				// Header size: 1
+				// Code size: 26 (0x1a)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0014: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, string)
+				IL_0019: ret
+			} // end of method FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4514
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get
+
 
 		// Methods
 		.method public hidebysig static 
@@ -320,6 +637,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_24F05EA7_L49C87
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_LiveBindings_Cycle/Scope _environment0_Import_LiveBindings_Cycle
+				.field private initonly class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_LiveBindings_Cycle/Scope capture0,
+						class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x4575
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_24F05EA7_L49C87::_environment0_Import_LiveBindings_Cycle
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_24F05EA7_L49C87::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_24F05EA7_L49C87::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_24F05EA7_L49C87::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x4592
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_24F05EA7_L49C87::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x4595
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_24F05EA7_L49C87::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x4598
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_24F05EA7_L49C87::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_24F05EA7_L49C87::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x45aa
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_24F05EA7_L49C87::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_24F05EA7_L49C87::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x45b8
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_24F05EA7_L49C87::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_24F05EA7_L49C87
+
 
 			// Methods
 			.method public hidebysig static 
@@ -369,6 +803,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_41B20EC9_L50C94
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_LiveBindings_Cycle/Scope _environment0_Import_LiveBindings_Cycle
+				.field private initonly class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_LiveBindings_Cycle/Scope capture0,
+						class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x45c7
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_41B20EC9_L50C94::_environment0_Import_LiveBindings_Cycle
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_41B20EC9_L50C94::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_41B20EC9_L50C94::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_41B20EC9_L50C94::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x45e4
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_41B20EC9_L50C94::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x45e7
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_41B20EC9_L50C94::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x45ea
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_41B20EC9_L50C94::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_41B20EC9_L50C94::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x45fc
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_41B20EC9_L50C94::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_41B20EC9_L50C94::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x460a
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_41B20EC9_L50C94::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_41B20EC9_L50C94
 
 
 			// Methods
@@ -423,6 +974,128 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C20CC8F8_L60C87
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Import_LiveBindings_Cycle/Scope _environment0_Import_LiveBindings_Cycle
+					.field private initonly class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+					.field private initonly class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/Scope _environment2_FunctionExpression_L59C9
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Import_LiveBindings_Cycle/Scope capture0,
+							class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope capture1,
+							class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x4679
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_C20CC8F8_L60C87::_environment0_Import_LiveBindings_Cycle
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_C20CC8F8_L60C87::_environment1___jroc_esm_namespace
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_C20CC8F8_L60C87::_environment2_FunctionExpression_L59C9
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_C20CC8F8_L60C87::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_C20CC8F8_L60C87::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x469e
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_C20CC8F8_L60C87::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x46a1
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_C20CC8F8_L60C87::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x46a4
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_C20CC8F8_L60C87::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_C20CC8F8_L60C87::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x46b6
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_C20CC8F8_L60C87::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_C20CC8F8_L60C87::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x46c4
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_C20CC8F8_L60C87::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_C20CC8F8_L60C87
 
 
 				// Methods
@@ -489,6 +1162,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_EA77382C_L59C10
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_LiveBindings_Cycle/Scope _environment0_Import_LiveBindings_Cycle
+				.field private initonly class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_LiveBindings_Cycle/Scope capture0,
+						class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x4619
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_EA77382C_L59C10::_environment0_Import_LiveBindings_Cycle
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_EA77382C_L59C10::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_EA77382C_L59C10::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_EA77382C_L59C10::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x4636
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_EA77382C_L59C10::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x4639
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_EA77382C_L59C10::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x463c
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_EA77382C_L59C10::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_EA77382C_L59C10::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x4655
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_EA77382C_L59C10::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_EA77382C_L59C10::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x466a
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_EA77382C_L59C10::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_EA77382C_L59C10
+
 
 			// Methods
 			.method public hidebysig static 
@@ -510,7 +1306,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_C20CC8F8_L60C87,
+					[4] class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_C20CC8F8_L60C87,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -560,13 +1356,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_C20CC8F8_L60C87::.ctor(class Modules.Import_LiveBindings_Cycle/Scope, class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope, class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_C20CC8F8_L60C87::.ctor(class Modules.Import_LiveBindings_Cycle/Scope, class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope, class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_C20CC8F8_L60C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86/FunctionObject_FunctionExpression_C20CC8F8_L60C87>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -785,6 +1581,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_LiveBindings_Cycle/Scope _environment0_Import_LiveBindings_Cycle
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_LiveBindings_Cycle/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4523
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::_environment0_Import_LiveBindings_Cycle
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4532
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4535
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4538
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::_environment0_Import_LiveBindings_Cycle
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Cycle/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4551
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::_environment0_Import_LiveBindings_Cycle
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Cycle/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4566
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace
+
 
 		// Methods
 		.method public hidebysig static 
@@ -824,12 +1733,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_24F05EA7_L49C87,
-				[21] class FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_41B20EC9_L50C94,
+				[20] class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_24F05EA7_L49C87,
+				[21] class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_41B20EC9_L50C94,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_EA77382C_L59C10
+				[25] class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_EA77382C_L59C10
 			)
 
 			IL_0000: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope::.ctor()
@@ -1035,13 +1944,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_24F05EA7_L49C87::.ctor(class Modules.Import_LiveBindings_Cycle/Scope, class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_24F05EA7_L49C87::.ctor(class Modules.Import_LiveBindings_Cycle/Scope, class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_24F05EA7_L49C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86/FunctionObject_FunctionExpression_24F05EA7_L49C87>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -1085,13 +1994,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_41B20EC9_L50C94::.ctor(class Modules.Import_LiveBindings_Cycle/Scope, class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_41B20EC9_L50C94::.ctor(class Modules.Import_LiveBindings_Cycle/Scope, class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_41B20EC9_L50C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93/FunctionObject_FunctionExpression_41B20EC9_L50C94>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -1261,13 +2170,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_EA77382C_L59C10::.ctor(class Modules.Import_LiveBindings_Cycle/Scope, class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_EA77382C_L59C10::.ctor(class Modules.Import_LiveBindings_Cycle/Scope, class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_EA77382C_L59C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionObject_FunctionExpression_EA77382C_L59C10>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldc.i4.1
 				IL_0487: newarr [System.Runtime]System.Object
@@ -1386,6 +2295,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_LiveBindings_Cycle/Scope _environment0_Import_LiveBindings_Cycle
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_LiveBindings_Cycle/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x46d3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_export/FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::_environment0_Import_LiveBindings_Cycle
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x46e2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x46e5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x46e8
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_export/FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::_environment0_Import_LiveBindings_Cycle
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4708
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle/Scope Modules.Import_LiveBindings_Cycle/__jroc_esm_export/FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::_environment0_Import_LiveBindings_Cycle
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4724
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1499,14 +2527,14 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_LiveBindings_Cycle/Scope,
-			[1] class FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default,
-			[2] class FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get,
-			[3] class FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace,
-			[4] class FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export,
+			[1] class Modules.Import_LiveBindings_Cycle/__jroc_esm_default/FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default,
+			[2] class Modules.Import_LiveBindings_Cycle/__jroc_esm_get/FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get,
+			[3] class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace,
+			[4] class Modules.Import_LiveBindings_Cycle/__jroc_esm_export/FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export,
 			[5] object,
 			[6] object,
 			[7] object[],
-			[8] class FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark,
+			[8] class Modules.Import_LiveBindings_Cycle/__jroc_esm_mark/FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark,
 			[9] object,
 			[10] object
 		)
@@ -1527,13 +2555,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_LiveBindings_Cycle/Scope
-		IL_0022: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::.ctor(class Modules.Import_LiveBindings_Cycle/Scope)
+		IL_0022: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_mark/FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::.ctor(class Modules.Import_LiveBindings_Cycle/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle/__jroc_esm_mark/FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 8
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 8
@@ -1545,13 +2573,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 7
-		IL_004b: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_default/FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle/__jroc_esm_default/FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -1560,13 +2588,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 7
-		IL_006b: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_get/FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle/__jroc_esm_get/FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -1579,13 +2607,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_LiveBindings_Cycle/Scope
-		IL_0094: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::.ctor(class Modules.Import_LiveBindings_Cycle/Scope)
+		IL_0094: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::.ctor(class Modules.Import_LiveBindings_Cycle/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -1598,13 +2626,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_LiveBindings_Cycle/Scope
-		IL_00bd: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::.ctor(class Modules.Import_LiveBindings_Cycle/Scope)
+		IL_00bd: newobj instance void Modules.Import_LiveBindings_Cycle/__jroc_esm_export/FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::.ctor(class Modules.Import_LiveBindings_Cycle/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle/__jroc_esm_export/FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 4
 		IL_00d2: nop
 		IL_00d3: ldloc.0
@@ -1863,6 +2891,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F51DDE75_L3C24
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_LiveBindings_Cycle_A/Scope _environment0_Import_LiveBindings_Cycle_A
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_LiveBindings_Cycle_A/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4733
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L3C23/FunctionObject_FunctionExpression_F51DDE75_L3C24::_environment0_Import_LiveBindings_Cycle_A
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_F51DDE75_L3C24::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4742
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F51DDE75_L3C24::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4745
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F51DDE75_L3C24::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4748
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L3C23/FunctionObject_FunctionExpression_F51DDE75_L3C24::_environment0_Import_LiveBindings_Cycle_A
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_F51DDE75_L3C24::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x475a
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L3C23/FunctionObject_FunctionExpression_F51DDE75_L3C24::_environment0_Import_LiveBindings_Cycle_A
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_F51DDE75_L3C24::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4768
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_F51DDE75_L3C24::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_F51DDE75_L3C24
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1914,6 +3049,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F52E2FA3_L4C27
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_LiveBindings_Cycle_A/Scope _environment0_Import_LiveBindings_Cycle_A
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_LiveBindings_Cycle_A/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4777
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L4C26/FunctionObject_FunctionExpression_F52E2FA3_L4C27::_environment0_Import_LiveBindings_Cycle_A
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_F52E2FA3_L4C27::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4786
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F52E2FA3_L4C27::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4789
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F52E2FA3_L4C27::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x478c
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L4C26/FunctionObject_FunctionExpression_F52E2FA3_L4C27::_environment0_Import_LiveBindings_Cycle_A
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L4C26::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_F52E2FA3_L4C27::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x479e
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L4C26/FunctionObject_FunctionExpression_F52E2FA3_L4C27::_environment0_Import_LiveBindings_Cycle_A
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L4C26::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_F52E2FA3_L4C27::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x47ac
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_F52E2FA3_L4C27::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_F52E2FA3_L4C27
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1963,6 +3205,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DB677C44_L5C32
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_LiveBindings_Cycle_A/Scope _environment0_Import_LiveBindings_Cycle_A
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_LiveBindings_Cycle_A/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x47bb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L5C31/FunctionObject_FunctionExpression_DB677C44_L5C32::_environment0_Import_LiveBindings_Cycle_A
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_DB677C44_L5C32::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x47ca
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_DB677C44_L5C32::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x47cd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_DB677C44_L5C32::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x47d0
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L5C31/FunctionObject_FunctionExpression_DB677C44_L5C32::_environment0_Import_LiveBindings_Cycle_A
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L5C31::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_DB677C44_L5C32::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x47e2
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L5C31/FunctionObject_FunctionExpression_DB677C44_L5C32::_environment0_Import_LiveBindings_Cycle_A
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L5C31::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_DB677C44_L5C32::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x47f0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_DB677C44_L5C32::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_DB677C44_L5C32
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2011,6 +3360,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A6850688_incA
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_LiveBindings_Cycle_A/Scope _environment0_Import_LiveBindings_Cycle_A
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_LiveBindings_Cycle_A/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x47ff
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/incA/FunctionObject_FunctionDeclaration_A6850688_incA::_environment0_Import_LiveBindings_Cycle_A
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A6850688_incA::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x480e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A6850688_incA::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4811
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A6850688_incA::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4814
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/incA/FunctionObject_FunctionDeclaration_A6850688_incA::_environment0_Import_LiveBindings_Cycle_A
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_LiveBindings_Cycle_A/incA::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_A6850688_incA::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4826
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/incA/FunctionObject_FunctionDeclaration_A6850688_incA::_environment0_Import_LiveBindings_Cycle_A
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_LiveBindings_Cycle_A/incA::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_A6850688_incA::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4834
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A6850688_incA::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_A6850688_incA
 
 
 		// Methods
@@ -2075,6 +3531,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_FF39EC14_getBFromA
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_LiveBindings_Cycle_A/Scope _environment0_Import_LiveBindings_Cycle_A
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_LiveBindings_Cycle_A/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4843
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/getBFromA/FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::_environment0_Import_LiveBindings_Cycle_A
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4852
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4855
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4858
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/getBFromA/FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::_environment0_Import_LiveBindings_Cycle_A
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_LiveBindings_Cycle_A/getBFromA::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x486a
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/getBFromA/FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::_environment0_Import_LiveBindings_Cycle_A
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_LiveBindings_Cycle_A/getBFromA::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4878
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_FF39EC14_getBFromA
 
 
 		// Methods
@@ -2166,6 +3729,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_LiveBindings_Cycle_A/Scope _environment0_Import_LiveBindings_Cycle_A
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_LiveBindings_Cycle_A/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4887
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark/FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::_environment0_Import_LiveBindings_Cycle_A
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4896
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4899
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x489c
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark/FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::_environment0_Import_LiveBindings_Cycle_A
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x48ae
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark/FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::_environment0_Import_LiveBindings_Cycle_A
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x48bc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark
 
 
 		// Methods
@@ -2273,6 +3943,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x48cb
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x48d3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x48d6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x48d9
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_default::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x48ec
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_default::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x48fb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2376,6 +4147,115 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x490a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4912
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4915
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4918
+				// Header size: 1
+				// Code size: 30 (0x1e)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0018: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_get::__js_call__(object, object, string)
+				IL_001d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4937
+				// Header size: 1
+				// Code size: 26 (0x1a)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0014: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_get::__js_call__(object, object, string)
+				IL_0019: ret
+			} // end of method FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4952
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2434,6 +4314,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3611CC4D_L47C87
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_LiveBindings_Cycle_A/Scope _environment0_Import_LiveBindings_Cycle_A
+				.field private initonly class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_LiveBindings_Cycle_A/Scope capture0,
+						class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x49b3
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_3611CC4D_L47C87::_environment0_Import_LiveBindings_Cycle_A
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_3611CC4D_L47C87::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_3611CC4D_L47C87::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_3611CC4D_L47C87::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x49d0
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_3611CC4D_L47C87::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x49d3
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_3611CC4D_L47C87::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x49d6
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_3611CC4D_L47C87::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_3611CC4D_L47C87::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x49e8
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_3611CC4D_L47C87::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_3611CC4D_L47C87::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x49f6
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_3611CC4D_L47C87::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_3611CC4D_L47C87
+
 
 			// Methods
 			.method public hidebysig static 
@@ -2483,6 +4480,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_675FF296_L48C94
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_LiveBindings_Cycle_A/Scope _environment0_Import_LiveBindings_Cycle_A
+				.field private initonly class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_LiveBindings_Cycle_A/Scope capture0,
+						class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x4a05
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_675FF296_L48C94::_environment0_Import_LiveBindings_Cycle_A
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_675FF296_L48C94::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_675FF296_L48C94::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_675FF296_L48C94::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x4a22
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_675FF296_L48C94::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x4a25
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_675FF296_L48C94::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x4a28
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_675FF296_L48C94::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_675FF296_L48C94::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x4a3a
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_675FF296_L48C94::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_675FF296_L48C94::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x4a48
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_675FF296_L48C94::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_675FF296_L48C94
 
 
 			// Methods
@@ -2537,6 +4651,128 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_ECD7FE35_L58C87
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Import_LiveBindings_Cycle_A/Scope _environment0_Import_LiveBindings_Cycle_A
+					.field private initonly class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+					.field private initonly class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/Scope _environment2_FunctionExpression_L57C9
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Import_LiveBindings_Cycle_A/Scope capture0,
+							class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope capture1,
+							class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x4ab7
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_ECD7FE35_L58C87::_environment0_Import_LiveBindings_Cycle_A
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_ECD7FE35_L58C87::_environment1___jroc_esm_namespace
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_ECD7FE35_L58C87::_environment2_FunctionExpression_L57C9
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_ECD7FE35_L58C87::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_ECD7FE35_L58C87::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x4adc
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_ECD7FE35_L58C87::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x4adf
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_ECD7FE35_L58C87::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x4ae2
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_ECD7FE35_L58C87::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_ECD7FE35_L58C87::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x4af4
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_ECD7FE35_L58C87::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_ECD7FE35_L58C87::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x4b02
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_ECD7FE35_L58C87::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_ECD7FE35_L58C87
 
 
 				// Methods
@@ -2603,6 +4839,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F16F71B4_L57C10
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_LiveBindings_Cycle_A/Scope _environment0_Import_LiveBindings_Cycle_A
+				.field private initonly class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_LiveBindings_Cycle_A/Scope capture0,
+						class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x4a57
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_F16F71B4_L57C10::_environment0_Import_LiveBindings_Cycle_A
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_F16F71B4_L57C10::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_F16F71B4_L57C10::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_F16F71B4_L57C10::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x4a74
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_F16F71B4_L57C10::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x4a77
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_F16F71B4_L57C10::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x4a7a
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_F16F71B4_L57C10::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_F16F71B4_L57C10::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x4a93
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_F16F71B4_L57C10::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_F16F71B4_L57C10::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x4aa8
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_F16F71B4_L57C10::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_F16F71B4_L57C10
+
 
 			// Methods
 			.method public hidebysig static 
@@ -2624,7 +4983,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_ECD7FE35_L58C87,
+					[4] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_ECD7FE35_L58C87,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -2674,13 +5033,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_ECD7FE35_L58C87::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope, class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope, class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_ECD7FE35_L58C87::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope, class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope, class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_ECD7FE35_L58C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_ECD7FE35_L58C87>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -2899,6 +5258,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_LiveBindings_Cycle_A/Scope _environment0_Import_LiveBindings_Cycle_A
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_LiveBindings_Cycle_A/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4961
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::_environment0_Import_LiveBindings_Cycle_A
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4970
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4973
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4976
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::_environment0_Import_LiveBindings_Cycle_A
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x498f
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::_environment0_Import_LiveBindings_Cycle_A
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x49a4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2938,12 +5410,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_3611CC4D_L47C87,
-				[21] class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_675FF296_L48C94,
+				[20] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_3611CC4D_L47C87,
+				[21] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_675FF296_L48C94,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_F16F71B4_L57C10
+				[25] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_F16F71B4_L57C10
 			)
 
 			IL_0000: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope::.ctor()
@@ -3149,13 +5621,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_3611CC4D_L47C87::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope, class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_3611CC4D_L47C87::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope, class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_3611CC4D_L47C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_3611CC4D_L47C87>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -3199,13 +5671,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_675FF296_L48C94::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope, class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_675FF296_L48C94::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope, class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_675FF296_L48C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_675FF296_L48C94>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -3375,13 +5847,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_F16F71B4_L57C10::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope, class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_F16F71B4_L57C10::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope, class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_F16F71B4_L57C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_F16F71B4_L57C10>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldc.i4.1
 				IL_0487: newarr [System.Runtime]System.Object
@@ -3499,6 +5971,127 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_LiveBindings_Cycle_A/Scope _environment0_Import_LiveBindings_Cycle_A
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_LiveBindings_Cycle_A/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4b11
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export/FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::_environment0_Import_LiveBindings_Cycle_A
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4b20
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4b23
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4b26
+				// Header size: 1
+				// Code size: 36 (0x24)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export/FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::_environment0_Import_LiveBindings_Cycle_A
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0017: ldarg.2
+				IL_0018: ldc.i4.1
+				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001e: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object, string, object)
+				IL_0023: ret
+			} // end of method FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4b4b
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export/FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::_environment0_Import_LiveBindings_Cycle_A
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.1
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object, string, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4b6c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export
 
 
 		// Methods
@@ -3623,19 +6216,19 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_LiveBindings_Cycle_A/Scope,
-			[1] class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default,
-			[2] class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace,
-			[3] class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export,
+			[1] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_default/FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default,
+			[2] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace,
+			[3] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export/FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export,
 			[4] object[],
-			[5] class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_A6850688_incA,
-			[6] class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_FF39EC14_getBFromA,
-			[7] class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark,
-			[8] class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get,
+			[5] class Modules.Import_LiveBindings_Cycle_A/incA/FunctionObject_FunctionDeclaration_A6850688_incA,
+			[6] class Modules.Import_LiveBindings_Cycle_A/getBFromA/FunctionObject_FunctionDeclaration_FF39EC14_getBFromA,
+			[7] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark/FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark,
+			[8] class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_get/FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get,
 			[9] object,
 			[10] object[],
-			[11] class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_F51DDE75_L3C24,
-			[12] class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_F52E2FA3_L4C27,
-			[13] class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_DB677C44_L5C32
+			[11] class Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L3C23/FunctionObject_FunctionExpression_F51DDE75_L3C24,
+			[12] class Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L4C26/FunctionObject_FunctionExpression_F52E2FA3_L4C27,
+			[13] class Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L5C31/FunctionObject_FunctionExpression_DB677C44_L5C32
 		)
 
 		IL_0000: newobj instance void Modules.Import_LiveBindings_Cycle_A/Scope::.ctor()
@@ -3654,13 +6247,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_0022: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_A6850688_incA::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
+		IL_0022: newobj instance void Modules.Import_LiveBindings_Cycle_A/incA/FunctionObject_FunctionDeclaration_A6850688_incA::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "incA"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_A6850688_incA>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/incA/FunctionObject_FunctionDeclaration_A6850688_incA>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 5
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 5
@@ -3676,13 +6269,13 @@
 		IL_004d: ldc.i4.0
 		IL_004e: ldelem.ref
 		IL_004f: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_0054: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
+		IL_0054: newobj instance void Modules.Import_LiveBindings_Cycle_A/getBFromA/FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
 		IL_0059: ldc.i4.0
 		IL_005a: conv.r8
 		IL_005b: ldstr "getBFromA"
 		IL_0060: ldc.i4.0
 		IL_0061: ldc.i4.1
-		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_FF39EC14_getBFromA>(!!0, float64, string, bool, bool)
+		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/getBFromA/FunctionObject_FunctionDeclaration_FF39EC14_getBFromA>(!!0, float64, string, bool, bool)
 		IL_0067: stloc.s 6
 		IL_0069: ldloc.0
 		IL_006a: ldloc.s 6
@@ -3698,13 +6291,13 @@
 		IL_007f: ldc.i4.0
 		IL_0080: ldelem.ref
 		IL_0081: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_0086: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
+		IL_0086: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark/FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
 		IL_008b: ldc.i4.0
 		IL_008c: conv.r8
 		IL_008d: ldstr "__jroc_esm_mark"
 		IL_0092: ldc.i4.0
 		IL_0093: ldc.i4.1
-		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark/FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark>(!!0, float64, string, bool, bool)
 		IL_0099: stloc.s 7
 		IL_009b: ldloc.0
 		IL_009c: ldloc.s 7
@@ -3716,13 +6309,13 @@
 		IL_00ab: ldloc.0
 		IL_00ac: stelem.ref
 		IL_00ad: stloc.s 4
-		IL_00af: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default::.ctor()
+		IL_00af: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_default/FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default::.ctor()
 		IL_00b4: ldc.i4.1
 		IL_00b5: conv.r8
 		IL_00b6: ldstr "__jroc_esm_default"
 		IL_00bb: ldc.i4.0
 		IL_00bc: ldc.i4.1
-		IL_00bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_00bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_default/FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default>(!!0, float64, string, bool, bool)
 		IL_00c2: stloc.1
 		IL_00c3: ldc.i4.1
 		IL_00c4: newarr [System.Runtime]System.Object
@@ -3731,13 +6324,13 @@
 		IL_00cb: ldloc.0
 		IL_00cc: stelem.ref
 		IL_00cd: stloc.s 4
-		IL_00cf: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get::.ctor()
+		IL_00cf: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_get/FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get::.ctor()
 		IL_00d4: ldc.i4.2
 		IL_00d5: conv.r8
 		IL_00d6: ldstr "__jroc_esm_get"
 		IL_00db: ldc.i4.0
 		IL_00dc: ldc.i4.1
-		IL_00dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_00dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_get/FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get>(!!0, float64, string, bool, bool)
 		IL_00e2: stloc.s 8
 		IL_00e4: ldloc.0
 		IL_00e5: ldloc.s 8
@@ -3753,13 +6346,13 @@
 		IL_00fa: ldc.i4.0
 		IL_00fb: ldelem.ref
 		IL_00fc: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_0101: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
+		IL_0101: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
 		IL_0106: ldc.i4.1
 		IL_0107: conv.r8
 		IL_0108: ldstr "__jroc_esm_namespace"
 		IL_010d: ldc.i4.0
 		IL_010e: ldc.i4.1
-		IL_010f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_010f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace>(!!0, float64, string, bool, bool)
 		IL_0114: stloc.2
 		IL_0115: ldc.i4.1
 		IL_0116: newarr [System.Runtime]System.Object
@@ -3772,13 +6365,13 @@
 		IL_0123: ldc.i4.0
 		IL_0124: ldelem.ref
 		IL_0125: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_012a: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
+		IL_012a: newobj instance void Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export/FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
 		IL_012f: ldc.i4.2
 		IL_0130: conv.r8
 		IL_0131: ldstr "__jroc_esm_export"
 		IL_0136: ldc.i4.0
 		IL_0137: ldc.i4.1
-		IL_0138: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_0138: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export/FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export>(!!0, float64, string, bool, bool)
 		IL_013d: stloc.3
 		IL_013e: nop
 		IL_013f: ldloc.0
@@ -3801,13 +6394,13 @@
 		IL_0169: ldc.i4.0
 		IL_016a: ldelem.ref
 		IL_016b: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_0170: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_F51DDE75_L3C24::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
+		IL_0170: newobj instance void Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L3C23/FunctionObject_FunctionExpression_F51DDE75_L3C24::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
 		IL_0175: ldc.i4.0
 		IL_0176: conv.r8
 		IL_0177: ldstr ""
 		IL_017c: ldc.i4.0
 		IL_017d: ldc.i4.1
-		IL_017e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_F51DDE75_L3C24>(!!0, float64, string, bool, bool)
+		IL_017e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L3C23/FunctionObject_FunctionExpression_F51DDE75_L3C24>(!!0, float64, string, bool, bool)
 		IL_0183: stloc.s 11
 		IL_0185: ldloc.3
 		IL_0186: ldloc.s 4
@@ -3828,13 +6421,13 @@
 		IL_01aa: ldc.i4.0
 		IL_01ab: ldelem.ref
 		IL_01ac: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_01b1: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_F52E2FA3_L4C27::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
+		IL_01b1: newobj instance void Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L4C26/FunctionObject_FunctionExpression_F52E2FA3_L4C27::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
 		IL_01b6: ldc.i4.0
 		IL_01b7: conv.r8
 		IL_01b8: ldstr ""
 		IL_01bd: ldc.i4.0
 		IL_01be: ldc.i4.1
-		IL_01bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_F52E2FA3_L4C27>(!!0, float64, string, bool, bool)
+		IL_01bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L4C26/FunctionObject_FunctionExpression_F52E2FA3_L4C27>(!!0, float64, string, bool, bool)
 		IL_01c4: stloc.s 12
 		IL_01c6: ldloc.3
 		IL_01c7: ldloc.s 4
@@ -3855,13 +6448,13 @@
 		IL_01eb: ldc.i4.0
 		IL_01ec: ldelem.ref
 		IL_01ed: castclass Modules.Import_LiveBindings_Cycle_A/Scope
-		IL_01f2: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_DB677C44_L5C32::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
+		IL_01f2: newobj instance void Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L5C31/FunctionObject_FunctionExpression_DB677C44_L5C32::.ctor(class Modules.Import_LiveBindings_Cycle_A/Scope)
 		IL_01f7: ldc.i4.0
 		IL_01f8: conv.r8
 		IL_01f9: ldstr ""
 		IL_01fe: ldc.i4.0
 		IL_01ff: ldc.i4.1
-		IL_0200: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_DB677C44_L5C32>(!!0, float64, string, bool, bool)
+		IL_0200: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L5C31/FunctionObject_FunctionExpression_DB677C44_L5C32>(!!0, float64, string, bool, bool)
 		IL_0205: stloc.s 13
 		IL_0207: ldloc.3
 		IL_0208: ldloc.s 4
@@ -3912,6 +6505,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C9BC5402_L3C24
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_LiveBindings_Cycle_B/Scope _environment0_Import_LiveBindings_Cycle_B
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_LiveBindings_Cycle_B/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4b7b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L3C23/FunctionObject_FunctionExpression_C9BC5402_L3C24::_environment0_Import_LiveBindings_Cycle_B
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_C9BC5402_L3C24::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4b8a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C9BC5402_L3C24::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4b8d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C9BC5402_L3C24::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4b90
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L3C23/FunctionObject_FunctionExpression_C9BC5402_L3C24::_environment0_Import_LiveBindings_Cycle_B
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_C9BC5402_L3C24::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4ba2
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L3C23/FunctionObject_FunctionExpression_C9BC5402_L3C24::_environment0_Import_LiveBindings_Cycle_B
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_C9BC5402_L3C24::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4bb0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_C9BC5402_L3C24::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_C9BC5402_L3C24
 
 
 		// Methods
@@ -3964,6 +6664,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_80025DF0_L4C27
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_LiveBindings_Cycle_B/Scope _environment0_Import_LiveBindings_Cycle_B
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_LiveBindings_Cycle_B/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4bbf
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L4C26/FunctionObject_FunctionExpression_80025DF0_L4C27::_environment0_Import_LiveBindings_Cycle_B
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_80025DF0_L4C27::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4bce
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_80025DF0_L4C27::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4bd1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_80025DF0_L4C27::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4bd4
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L4C26/FunctionObject_FunctionExpression_80025DF0_L4C27::_environment0_Import_LiveBindings_Cycle_B
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L4C26::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_80025DF0_L4C27::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4be6
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L4C26/FunctionObject_FunctionExpression_80025DF0_L4C27::_environment0_Import_LiveBindings_Cycle_B
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L4C26::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_80025DF0_L4C27::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4bf4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_80025DF0_L4C27::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_80025DF0_L4C27
+
 
 		// Methods
 		.method public hidebysig static 
@@ -4013,6 +6820,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0C08ABDF_L5C32
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_LiveBindings_Cycle_B/Scope _environment0_Import_LiveBindings_Cycle_B
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_LiveBindings_Cycle_B/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4c03
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L5C31/FunctionObject_FunctionExpression_0C08ABDF_L5C32::_environment0_Import_LiveBindings_Cycle_B
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_0C08ABDF_L5C32::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4c12
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_0C08ABDF_L5C32::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4c15
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_0C08ABDF_L5C32::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4c18
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L5C31/FunctionObject_FunctionExpression_0C08ABDF_L5C32::_environment0_Import_LiveBindings_Cycle_B
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L5C31::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_0C08ABDF_L5C32::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4c2a
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L5C31/FunctionObject_FunctionExpression_0C08ABDF_L5C32::_environment0_Import_LiveBindings_Cycle_B
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L5C31::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_0C08ABDF_L5C32::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4c38
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_0C08ABDF_L5C32::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_0C08ABDF_L5C32
+
 
 		// Methods
 		.method public hidebysig static 
@@ -4061,6 +6975,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_ED85635A_incB
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_LiveBindings_Cycle_B/Scope _environment0_Import_LiveBindings_Cycle_B
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_LiveBindings_Cycle_B/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4c47
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/incB/FunctionObject_FunctionDeclaration_ED85635A_incB::_environment0_Import_LiveBindings_Cycle_B
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_ED85635A_incB::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4c56
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_ED85635A_incB::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4c59
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_ED85635A_incB::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4c5c
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/incB/FunctionObject_FunctionDeclaration_ED85635A_incB::_environment0_Import_LiveBindings_Cycle_B
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_LiveBindings_Cycle_B/incB::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_ED85635A_incB::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4c6e
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/incB/FunctionObject_FunctionDeclaration_ED85635A_incB::_environment0_Import_LiveBindings_Cycle_B
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_LiveBindings_Cycle_B/incB::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_ED85635A_incB::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4c7c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_ED85635A_incB::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_ED85635A_incB
 
 
 		// Methods
@@ -4125,6 +7146,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DB44C203_getAFromB
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_LiveBindings_Cycle_B/Scope _environment0_Import_LiveBindings_Cycle_B
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_LiveBindings_Cycle_B/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4c8b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/getAFromB/FunctionObject_FunctionDeclaration_DB44C203_getAFromB::_environment0_Import_LiveBindings_Cycle_B
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DB44C203_getAFromB::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4c9a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DB44C203_getAFromB::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4c9d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DB44C203_getAFromB::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4ca0
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/getAFromB/FunctionObject_FunctionDeclaration_DB44C203_getAFromB::_environment0_Import_LiveBindings_Cycle_B
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_LiveBindings_Cycle_B/getAFromB::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_DB44C203_getAFromB::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4cb2
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/getAFromB/FunctionObject_FunctionDeclaration_DB44C203_getAFromB::_environment0_Import_LiveBindings_Cycle_B
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_LiveBindings_Cycle_B/getAFromB::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_DB44C203_getAFromB::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4cc0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DB44C203_getAFromB::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_DB44C203_getAFromB
 
 
 		// Methods
@@ -4216,6 +7344,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_LiveBindings_Cycle_B/Scope _environment0_Import_LiveBindings_Cycle_B
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_LiveBindings_Cycle_B/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4ccf
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark/FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::_environment0_Import_LiveBindings_Cycle_B
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4cde
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4ce1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4ce4
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark/FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::_environment0_Import_LiveBindings_Cycle_B
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4cf6
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark/FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::_environment0_Import_LiveBindings_Cycle_B
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4d04
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark
 
 
 		// Methods
@@ -4323,6 +7558,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4d13
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4d1b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4d1e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4d21
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_default::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4d34
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_default::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4d43
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default
+
 
 		// Methods
 		.method public hidebysig static 
@@ -4426,6 +7762,115 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4d52
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4d5a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4d5d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4d60
+				// Header size: 1
+				// Code size: 30 (0x1e)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0018: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_get::__js_call__(object, object, string)
+				IL_001d: ret
+			} // end of method FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4d7f
+				// Header size: 1
+				// Code size: 26 (0x1a)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0014: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_get::__js_call__(object, object, string)
+				IL_0019: ret
+			} // end of method FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4d9a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get
+
 
 		// Methods
 		.method public hidebysig static 
@@ -4484,6 +7929,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C63EA5BE_L47C87
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_LiveBindings_Cycle_B/Scope _environment0_Import_LiveBindings_Cycle_B
+				.field private initonly class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_LiveBindings_Cycle_B/Scope capture0,
+						class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x4dfb
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_C63EA5BE_L47C87::_environment0_Import_LiveBindings_Cycle_B
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_C63EA5BE_L47C87::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_C63EA5BE_L47C87::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_C63EA5BE_L47C87::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x4e18
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_C63EA5BE_L47C87::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x4e1b
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_C63EA5BE_L47C87::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x4e1e
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_C63EA5BE_L47C87::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_C63EA5BE_L47C87::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x4e30
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_C63EA5BE_L47C87::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_C63EA5BE_L47C87::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x4e3e
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_C63EA5BE_L47C87::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_C63EA5BE_L47C87
+
 
 			// Methods
 			.method public hidebysig static 
@@ -4533,6 +8095,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_AFA10769_L48C94
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_LiveBindings_Cycle_B/Scope _environment0_Import_LiveBindings_Cycle_B
+				.field private initonly class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_LiveBindings_Cycle_B/Scope capture0,
+						class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x4e4d
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_AFA10769_L48C94::_environment0_Import_LiveBindings_Cycle_B
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_AFA10769_L48C94::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_AFA10769_L48C94::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_AFA10769_L48C94::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x4e6a
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_AFA10769_L48C94::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x4e6d
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_AFA10769_L48C94::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x4e70
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_AFA10769_L48C94::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_AFA10769_L48C94::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x4e82
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_AFA10769_L48C94::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_AFA10769_L48C94::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x4e90
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_AFA10769_L48C94::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_AFA10769_L48C94
 
 
 			// Methods
@@ -4587,6 +8266,128 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_CF15D56A_L58C87
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Import_LiveBindings_Cycle_B/Scope _environment0_Import_LiveBindings_Cycle_B
+					.field private initonly class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+					.field private initonly class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/Scope _environment2_FunctionExpression_L57C9
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Import_LiveBindings_Cycle_B/Scope capture0,
+							class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope capture1,
+							class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x4eff
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_CF15D56A_L58C87::_environment0_Import_LiveBindings_Cycle_B
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_CF15D56A_L58C87::_environment1___jroc_esm_namespace
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_CF15D56A_L58C87::_environment2_FunctionExpression_L57C9
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_CF15D56A_L58C87::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_CF15D56A_L58C87::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x4f24
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_CF15D56A_L58C87::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x4f27
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_CF15D56A_L58C87::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x4f2a
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_CF15D56A_L58C87::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_CF15D56A_L58C87::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x4f3c
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_CF15D56A_L58C87::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_CF15D56A_L58C87::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x4f4a
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_CF15D56A_L58C87::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_CF15D56A_L58C87
 
 
 				// Methods
@@ -4653,6 +8454,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D61C0121_L57C10
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_LiveBindings_Cycle_B/Scope _environment0_Import_LiveBindings_Cycle_B
+				.field private initonly class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_LiveBindings_Cycle_B/Scope capture0,
+						class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x4e9f
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_D61C0121_L57C10::_environment0_Import_LiveBindings_Cycle_B
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_D61C0121_L57C10::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_D61C0121_L57C10::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_D61C0121_L57C10::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x4ebc
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_D61C0121_L57C10::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x4ebf
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_D61C0121_L57C10::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x4ec2
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_D61C0121_L57C10::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_D61C0121_L57C10::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x4edb
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_D61C0121_L57C10::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_D61C0121_L57C10::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x4ef0
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_D61C0121_L57C10::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_D61C0121_L57C10
+
 
 			// Methods
 			.method public hidebysig static 
@@ -4674,7 +8598,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_CF15D56A_L58C87,
+					[4] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_CF15D56A_L58C87,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -4724,13 +8648,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_CF15D56A_L58C87::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope, class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope, class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_CF15D56A_L58C87::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope, class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope, class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_CF15D56A_L58C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86/FunctionObject_FunctionExpression_CF15D56A_L58C87>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -4949,6 +8873,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_LiveBindings_Cycle_B/Scope _environment0_Import_LiveBindings_Cycle_B
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_LiveBindings_Cycle_B/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4da9
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::_environment0_Import_LiveBindings_Cycle_B
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4db8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4dbb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4dbe
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::_environment0_Import_LiveBindings_Cycle_B
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4dd7
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::_environment0_Import_LiveBindings_Cycle_B
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4dec
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace
+
 
 		// Methods
 		.method public hidebysig static 
@@ -4988,12 +9025,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_C63EA5BE_L47C87,
-				[21] class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_AFA10769_L48C94,
+				[20] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_C63EA5BE_L47C87,
+				[21] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_AFA10769_L48C94,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_D61C0121_L57C10
+				[25] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_D61C0121_L57C10
 			)
 
 			IL_0000: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope::.ctor()
@@ -5199,13 +9236,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_C63EA5BE_L47C87::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope, class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_C63EA5BE_L47C87::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope, class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_C63EA5BE_L47C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86/FunctionObject_FunctionExpression_C63EA5BE_L47C87>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -5249,13 +9286,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_AFA10769_L48C94::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope, class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_AFA10769_L48C94::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope, class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_AFA10769_L48C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93/FunctionObject_FunctionExpression_AFA10769_L48C94>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -5425,13 +9462,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_D61C0121_L57C10::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope, class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_D61C0121_L57C10::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope, class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_D61C0121_L57C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionObject_FunctionExpression_D61C0121_L57C10>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldc.i4.1
 				IL_0487: newarr [System.Runtime]System.Object
@@ -5549,6 +9586,127 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_LiveBindings_Cycle_B/Scope _environment0_Import_LiveBindings_Cycle_B
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_LiveBindings_Cycle_B/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4f59
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export/FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::_environment0_Import_LiveBindings_Cycle_B
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4f68
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4f6b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4f6e
+				// Header size: 1
+				// Code size: 36 (0x24)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export/FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::_environment0_Import_LiveBindings_Cycle_B
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0017: ldarg.2
+				IL_0018: ldc.i4.1
+				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001e: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object, string, object)
+				IL_0023: ret
+			} // end of method FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4f93
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export/FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::_environment0_Import_LiveBindings_Cycle_B
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.1
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object, string, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4fb4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export
 
 
 		// Methods
@@ -5673,19 +9831,19 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_LiveBindings_Cycle_B/Scope,
-			[1] class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default,
-			[2] class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace,
-			[3] class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export,
+			[1] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_default/FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default,
+			[2] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace,
+			[3] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export/FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export,
 			[4] object[],
-			[5] class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_ED85635A_incB,
-			[6] class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_DB44C203_getAFromB,
-			[7] class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark,
-			[8] class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get,
+			[5] class Modules.Import_LiveBindings_Cycle_B/incB/FunctionObject_FunctionDeclaration_ED85635A_incB,
+			[6] class Modules.Import_LiveBindings_Cycle_B/getAFromB/FunctionObject_FunctionDeclaration_DB44C203_getAFromB,
+			[7] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark/FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark,
+			[8] class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_get/FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get,
 			[9] object,
 			[10] object[],
-			[11] class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_C9BC5402_L3C24,
-			[12] class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_80025DF0_L4C27,
-			[13] class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_0C08ABDF_L5C32
+			[11] class Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L3C23/FunctionObject_FunctionExpression_C9BC5402_L3C24,
+			[12] class Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L4C26/FunctionObject_FunctionExpression_80025DF0_L4C27,
+			[13] class Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L5C31/FunctionObject_FunctionExpression_0C08ABDF_L5C32
 		)
 
 		IL_0000: newobj instance void Modules.Import_LiveBindings_Cycle_B/Scope::.ctor()
@@ -5704,13 +9862,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_0022: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_ED85635A_incB::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
+		IL_0022: newobj instance void Modules.Import_LiveBindings_Cycle_B/incB/FunctionObject_FunctionDeclaration_ED85635A_incB::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "incB"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_ED85635A_incB>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/incB/FunctionObject_FunctionDeclaration_ED85635A_incB>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 5
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 5
@@ -5726,13 +9884,13 @@
 		IL_004d: ldc.i4.0
 		IL_004e: ldelem.ref
 		IL_004f: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_0054: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_DB44C203_getAFromB::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
+		IL_0054: newobj instance void Modules.Import_LiveBindings_Cycle_B/getAFromB/FunctionObject_FunctionDeclaration_DB44C203_getAFromB::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
 		IL_0059: ldc.i4.0
 		IL_005a: conv.r8
 		IL_005b: ldstr "getAFromB"
 		IL_0060: ldc.i4.0
 		IL_0061: ldc.i4.1
-		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_DB44C203_getAFromB>(!!0, float64, string, bool, bool)
+		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/getAFromB/FunctionObject_FunctionDeclaration_DB44C203_getAFromB>(!!0, float64, string, bool, bool)
 		IL_0067: stloc.s 6
 		IL_0069: ldloc.0
 		IL_006a: ldloc.s 6
@@ -5748,13 +9906,13 @@
 		IL_007f: ldc.i4.0
 		IL_0080: ldelem.ref
 		IL_0081: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_0086: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
+		IL_0086: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark/FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
 		IL_008b: ldc.i4.0
 		IL_008c: conv.r8
 		IL_008d: ldstr "__jroc_esm_mark"
 		IL_0092: ldc.i4.0
 		IL_0093: ldc.i4.1
-		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark/FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark>(!!0, float64, string, bool, bool)
 		IL_0099: stloc.s 7
 		IL_009b: ldloc.0
 		IL_009c: ldloc.s 7
@@ -5766,13 +9924,13 @@
 		IL_00ab: ldloc.0
 		IL_00ac: stelem.ref
 		IL_00ad: stloc.s 4
-		IL_00af: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default::.ctor()
+		IL_00af: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_default/FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default::.ctor()
 		IL_00b4: ldc.i4.1
 		IL_00b5: conv.r8
 		IL_00b6: ldstr "__jroc_esm_default"
 		IL_00bb: ldc.i4.0
 		IL_00bc: ldc.i4.1
-		IL_00bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_00bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_default/FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default>(!!0, float64, string, bool, bool)
 		IL_00c2: stloc.1
 		IL_00c3: ldc.i4.1
 		IL_00c4: newarr [System.Runtime]System.Object
@@ -5781,13 +9939,13 @@
 		IL_00cb: ldloc.0
 		IL_00cc: stelem.ref
 		IL_00cd: stloc.s 4
-		IL_00cf: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get::.ctor()
+		IL_00cf: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_get/FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get::.ctor()
 		IL_00d4: ldc.i4.2
 		IL_00d5: conv.r8
 		IL_00d6: ldstr "__jroc_esm_get"
 		IL_00db: ldc.i4.0
 		IL_00dc: ldc.i4.1
-		IL_00dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_00dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_get/FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get>(!!0, float64, string, bool, bool)
 		IL_00e2: stloc.s 8
 		IL_00e4: ldloc.0
 		IL_00e5: ldloc.s 8
@@ -5803,13 +9961,13 @@
 		IL_00fa: ldc.i4.0
 		IL_00fb: ldelem.ref
 		IL_00fc: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_0101: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
+		IL_0101: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
 		IL_0106: ldc.i4.1
 		IL_0107: conv.r8
 		IL_0108: ldstr "__jroc_esm_namespace"
 		IL_010d: ldc.i4.0
 		IL_010e: ldc.i4.1
-		IL_010f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_010f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace>(!!0, float64, string, bool, bool)
 		IL_0114: stloc.2
 		IL_0115: ldc.i4.1
 		IL_0116: newarr [System.Runtime]System.Object
@@ -5822,13 +9980,13 @@
 		IL_0123: ldc.i4.0
 		IL_0124: ldelem.ref
 		IL_0125: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_012a: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
+		IL_012a: newobj instance void Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export/FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
 		IL_012f: ldc.i4.2
 		IL_0130: conv.r8
 		IL_0131: ldstr "__jroc_esm_export"
 		IL_0136: ldc.i4.0
 		IL_0137: ldc.i4.1
-		IL_0138: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_0138: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export/FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export>(!!0, float64, string, bool, bool)
 		IL_013d: stloc.3
 		IL_013e: nop
 		IL_013f: ldloc.0
@@ -5851,13 +10009,13 @@
 		IL_0169: ldc.i4.0
 		IL_016a: ldelem.ref
 		IL_016b: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_0170: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_C9BC5402_L3C24::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
+		IL_0170: newobj instance void Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L3C23/FunctionObject_FunctionExpression_C9BC5402_L3C24::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
 		IL_0175: ldc.i4.0
 		IL_0176: conv.r8
 		IL_0177: ldstr ""
 		IL_017c: ldc.i4.0
 		IL_017d: ldc.i4.1
-		IL_017e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_C9BC5402_L3C24>(!!0, float64, string, bool, bool)
+		IL_017e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L3C23/FunctionObject_FunctionExpression_C9BC5402_L3C24>(!!0, float64, string, bool, bool)
 		IL_0183: stloc.s 11
 		IL_0185: ldloc.3
 		IL_0186: ldloc.s 4
@@ -5878,13 +10036,13 @@
 		IL_01aa: ldc.i4.0
 		IL_01ab: ldelem.ref
 		IL_01ac: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_01b1: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_80025DF0_L4C27::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
+		IL_01b1: newobj instance void Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L4C26/FunctionObject_FunctionExpression_80025DF0_L4C27::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
 		IL_01b6: ldc.i4.0
 		IL_01b7: conv.r8
 		IL_01b8: ldstr ""
 		IL_01bd: ldc.i4.0
 		IL_01be: ldc.i4.1
-		IL_01bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_80025DF0_L4C27>(!!0, float64, string, bool, bool)
+		IL_01bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L4C26/FunctionObject_FunctionExpression_80025DF0_L4C27>(!!0, float64, string, bool, bool)
 		IL_01c4: stloc.s 12
 		IL_01c6: ldloc.3
 		IL_01c7: ldloc.s 4
@@ -5905,13 +10063,13 @@
 		IL_01eb: ldc.i4.0
 		IL_01ec: ldelem.ref
 		IL_01ed: castclass Modules.Import_LiveBindings_Cycle_B/Scope
-		IL_01f2: newobj instance void FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_0C08ABDF_L5C32::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
+		IL_01f2: newobj instance void Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L5C31/FunctionObject_FunctionExpression_0C08ABDF_L5C32::.ctor(class Modules.Import_LiveBindings_Cycle_B/Scope)
 		IL_01f7: ldc.i4.0
 		IL_01f8: conv.r8
 		IL_01f9: ldstr ""
 		IL_01fe: ldc.i4.0
 		IL_01ff: ldc.i4.1
-		IL_0200: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_0C08ABDF_L5C32>(!!0, float64, string, bool, bool)
+		IL_0200: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L5C31/FunctionObject_FunctionExpression_0C08ABDF_L5C32>(!!0, float64, string, bool, bool)
 		IL_0205: stloc.s 13
 		IL_0207: ldloc.3
 		IL_0208: ldloc.s 4
@@ -5934,4164 +10092,6 @@
 	} // end of method Import_LiveBindings_Cycle_B::__js_module_init__
 
 } // end of class Modules.Import_LiveBindings_Cycle_B
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle/Scope _environment0_Import_LiveBindings_Cycle
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4449
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle/Scope FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::_environment0_Import_LiveBindings_Cycle
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4458
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x445b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x445e
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle/Scope FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::_environment0_Import_LiveBindings_Cycle
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4470
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle/Scope FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::_environment0_Import_LiveBindings_Cycle
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x447e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_3566699D___jroc_esm_mark
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x448d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4495
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4498
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x449b
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_default::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x44ae
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_default::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x44bd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_534D3E39___jroc_esm_default
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x44cc
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x44d4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x44d7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x44da
-		// Header size: 1
-		// Code size: 30 (0x1e)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0018: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, string)
-		IL_001d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x44f9
-		// Header size: 1
-		// Code size: 26 (0x1a)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0014: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_get::__js_call__(object, object, string)
-		IL_0019: ret
-	} // end of method FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4514
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_C25DBDE0___jroc_esm_get
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle/Scope _environment0_Import_LiveBindings_Cycle
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4523
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle/Scope FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::_environment0_Import_LiveBindings_Cycle
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4532
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4535
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4538
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle/Scope FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::_environment0_Import_LiveBindings_Cycle
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Cycle/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4551
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle/Scope FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::_environment0_Import_LiveBindings_Cycle
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Cycle/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4566
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_5E2BC46B___jroc_esm_namespace
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_24F05EA7_L49C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle/Scope _environment0_Import_LiveBindings_Cycle
-	.field private initonly class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle/Scope capture0,
-			class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x4575
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle/Scope FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_24F05EA7_L49C87::_environment0_Import_LiveBindings_Cycle
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_24F05EA7_L49C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_24F05EA7_L49C87::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_24F05EA7_L49C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4592
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_24F05EA7_L49C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4595
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_24F05EA7_L49C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4598
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_24F05EA7_L49C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_24F05EA7_L49C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x45aa
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_24F05EA7_L49C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L49C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_24F05EA7_L49C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x45b8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_24F05EA7_L49C87::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_24F05EA7_L49C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_41B20EC9_L50C94
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle/Scope _environment0_Import_LiveBindings_Cycle
-	.field private initonly class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle/Scope capture0,
-			class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x45c7
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle/Scope FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_41B20EC9_L50C94::_environment0_Import_LiveBindings_Cycle
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_41B20EC9_L50C94::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_41B20EC9_L50C94::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_41B20EC9_L50C94::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x45e4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_41B20EC9_L50C94::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x45e7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_41B20EC9_L50C94::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x45ea
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_41B20EC9_L50C94::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_41B20EC9_L50C94::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x45fc
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_41B20EC9_L50C94::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L50C93::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_41B20EC9_L50C94::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x460a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_41B20EC9_L50C94::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_41B20EC9_L50C94
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_EA77382C_L59C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle/Scope _environment0_Import_LiveBindings_Cycle
-	.field private initonly class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle/Scope capture0,
-			class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x4619
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle/Scope FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_EA77382C_L59C10::_environment0_Import_LiveBindings_Cycle
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_EA77382C_L59C10::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_EA77382C_L59C10::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_EA77382C_L59C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4636
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_EA77382C_L59C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4639
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_EA77382C_L59C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x463c
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_EA77382C_L59C10::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_EA77382C_L59C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4655
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_EA77382C_L59C10::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_EA77382C_L59C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x466a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_EA77382C_L59C10::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_EA77382C_L59C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_C20CC8F8_L60C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle/Scope _environment0_Import_LiveBindings_Cycle
-	.field private initonly class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/Scope _environment2_FunctionExpression_L59C9
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle/Scope capture0,
-			class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope capture1,
-			class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x4679
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle/Scope FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_C20CC8F8_L60C87::_environment0_Import_LiveBindings_Cycle
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/Scope FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_C20CC8F8_L60C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/Scope FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_C20CC8F8_L60C87::_environment2_FunctionExpression_L59C9
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_C20CC8F8_L60C87::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_C20CC8F8_L60C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x469e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C20CC8F8_L60C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x46a1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C20CC8F8_L60C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x46a4
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_C20CC8F8_L60C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_C20CC8F8_L60C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x46b6
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_C20CC8F8_L60C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_namespace/FunctionExpression_L59C9/FunctionExpression_L60C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_C20CC8F8_L60C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x46c4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C20CC8F8_L60C87::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionExpression_C20CC8F8_L60C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle/Scope _environment0_Import_LiveBindings_Cycle
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x46d3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle/Scope FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::_environment0_Import_LiveBindings_Cycle
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x46e2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x46e5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x46e8
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle/Scope FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::_environment0_Import_LiveBindings_Cycle
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4708
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle/Scope FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::_environment0_Import_LiveBindings_Cycle
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Import_LiveBindings_Cycle/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4724
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_869D9318.FunctionObject_FunctionDeclaration_BEDDA8B2___jroc_esm_export
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_F51DDE75_L3C24
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle_A/Scope _environment0_Import_LiveBindings_Cycle_A
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle_A/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4733
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_F51DDE75_L3C24::_environment0_Import_LiveBindings_Cycle_A
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F51DDE75_L3C24::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4742
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F51DDE75_L3C24::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4745
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F51DDE75_L3C24::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4748
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_F51DDE75_L3C24::_environment0_Import_LiveBindings_Cycle_A
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_F51DDE75_L3C24::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x475a
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_F51DDE75_L3C24::_environment0_Import_LiveBindings_Cycle_A
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_F51DDE75_L3C24::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4768
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F51DDE75_L3C24::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_F51DDE75_L3C24
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_F52E2FA3_L4C27
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle_A/Scope _environment0_Import_LiveBindings_Cycle_A
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle_A/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4777
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_F52E2FA3_L4C27::_environment0_Import_LiveBindings_Cycle_A
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F52E2FA3_L4C27::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4786
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F52E2FA3_L4C27::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4789
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F52E2FA3_L4C27::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x478c
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_F52E2FA3_L4C27::_environment0_Import_LiveBindings_Cycle_A
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L4C26::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_F52E2FA3_L4C27::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x479e
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_F52E2FA3_L4C27::_environment0_Import_LiveBindings_Cycle_A
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L4C26::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_F52E2FA3_L4C27::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x47ac
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F52E2FA3_L4C27::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_F52E2FA3_L4C27
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_DB677C44_L5C32
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle_A/Scope _environment0_Import_LiveBindings_Cycle_A
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle_A/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x47bb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_DB677C44_L5C32::_environment0_Import_LiveBindings_Cycle_A
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DB677C44_L5C32::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x47ca
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DB677C44_L5C32::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x47cd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DB677C44_L5C32::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x47d0
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_DB677C44_L5C32::_environment0_Import_LiveBindings_Cycle_A
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L5C31::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_DB677C44_L5C32::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x47e2
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_DB677C44_L5C32::_environment0_Import_LiveBindings_Cycle_A
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Cycle_A/FunctionExpression_L5C31::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_DB677C44_L5C32::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x47f0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DB677C44_L5C32::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_DB677C44_L5C32
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_A6850688_incA
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle_A/Scope _environment0_Import_LiveBindings_Cycle_A
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle_A/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x47ff
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_A6850688_incA::_environment0_Import_LiveBindings_Cycle_A
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A6850688_incA::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x480e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A6850688_incA::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4811
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A6850688_incA::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4814
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_A6850688_incA::_environment0_Import_LiveBindings_Cycle_A
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Cycle_A/incA::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_A6850688_incA::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4826
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_A6850688_incA::_environment0_Import_LiveBindings_Cycle_A
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Cycle_A/incA::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_A6850688_incA::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4834
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A6850688_incA::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_A6850688_incA
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_FF39EC14_getBFromA
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle_A/Scope _environment0_Import_LiveBindings_Cycle_A
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle_A/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4843
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::_environment0_Import_LiveBindings_Cycle_A
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4852
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4855
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4858
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::_environment0_Import_LiveBindings_Cycle_A
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Cycle_A/getBFromA::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x486a
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::_environment0_Import_LiveBindings_Cycle_A
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Cycle_A/getBFromA::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4878
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_FF39EC14_getBFromA::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_FF39EC14_getBFromA
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle_A/Scope _environment0_Import_LiveBindings_Cycle_A
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle_A/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4887
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::_environment0_Import_LiveBindings_Cycle_A
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4896
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4899
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x489c
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::_environment0_Import_LiveBindings_Cycle_A
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x48ae
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::_environment0_Import_LiveBindings_Cycle_A
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x48bc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_53FCE099___jroc_esm_mark
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x48cb
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x48d3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x48d6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x48d9
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_default::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x48ec
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_default::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x48fb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_6E119715___jroc_esm_default
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x490a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4912
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4915
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4918
-		// Header size: 1
-		// Code size: 30 (0x1e)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0018: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_get::__js_call__(object, object, string)
-		IL_001d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4937
-		// Header size: 1
-		// Code size: 26 (0x1a)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0014: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_get::__js_call__(object, object, string)
-		IL_0019: ret
-	} // end of method FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4952
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_D4378D24___jroc_esm_get
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle_A/Scope _environment0_Import_LiveBindings_Cycle_A
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle_A/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4961
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::_environment0_Import_LiveBindings_Cycle_A
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4970
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4973
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4976
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::_environment0_Import_LiveBindings_Cycle_A
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x498f
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::_environment0_Import_LiveBindings_Cycle_A
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x49a4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_A85C0D17___jroc_esm_namespace
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_3611CC4D_L47C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle_A/Scope _environment0_Import_LiveBindings_Cycle_A
-	.field private initonly class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle_A/Scope capture0,
-			class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x49b3
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_3611CC4D_L47C87::_environment0_Import_LiveBindings_Cycle_A
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_3611CC4D_L47C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_3611CC4D_L47C87::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_3611CC4D_L47C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x49d0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3611CC4D_L47C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x49d3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3611CC4D_L47C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x49d6
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_3611CC4D_L47C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_3611CC4D_L47C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x49e8
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_3611CC4D_L47C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L47C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_3611CC4D_L47C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x49f6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3611CC4D_L47C87::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_3611CC4D_L47C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_675FF296_L48C94
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle_A/Scope _environment0_Import_LiveBindings_Cycle_A
-	.field private initonly class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle_A/Scope capture0,
-			class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x4a05
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_675FF296_L48C94::_environment0_Import_LiveBindings_Cycle_A
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_675FF296_L48C94::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_675FF296_L48C94::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_675FF296_L48C94::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4a22
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_675FF296_L48C94::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4a25
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_675FF296_L48C94::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4a28
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_675FF296_L48C94::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_675FF296_L48C94::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4a3a
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_675FF296_L48C94::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L48C93::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_675FF296_L48C94::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4a48
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_675FF296_L48C94::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_675FF296_L48C94
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_F16F71B4_L57C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle_A/Scope _environment0_Import_LiveBindings_Cycle_A
-	.field private initonly class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle_A/Scope capture0,
-			class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x4a57
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_F16F71B4_L57C10::_environment0_Import_LiveBindings_Cycle_A
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_F16F71B4_L57C10::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_F16F71B4_L57C10::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_F16F71B4_L57C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4a74
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F16F71B4_L57C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4a77
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F16F71B4_L57C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4a7a
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_F16F71B4_L57C10::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_F16F71B4_L57C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4a93
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_F16F71B4_L57C10::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_F16F71B4_L57C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4aa8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F16F71B4_L57C10::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_F16F71B4_L57C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_ECD7FE35_L58C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle_A/Scope _environment0_Import_LiveBindings_Cycle_A
-	.field private initonly class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/Scope _environment2_FunctionExpression_L57C9
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle_A/Scope capture0,
-			class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope capture1,
-			class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x4ab7
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_ECD7FE35_L58C87::_environment0_Import_LiveBindings_Cycle_A
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_ECD7FE35_L58C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_ECD7FE35_L58C87::_environment2_FunctionExpression_L57C9
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_ECD7FE35_L58C87::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_ECD7FE35_L58C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4adc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_ECD7FE35_L58C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4adf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_ECD7FE35_L58C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4ae2
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_ECD7FE35_L58C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_ECD7FE35_L58C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4af4
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_ECD7FE35_L58C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_ECD7FE35_L58C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4b02
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_ECD7FE35_L58C87::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionExpression_ECD7FE35_L58C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle_A/Scope _environment0_Import_LiveBindings_Cycle_A
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle_A/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4b11
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle_A/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::_environment0_Import_LiveBindings_Cycle_A
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4b20
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4b23
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4b26
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::_environment0_Import_LiveBindings_Cycle_A
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0017: ldarg.2
-		IL_0018: ldc.i4.1
-		IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001e: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object, string, object)
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4b4b
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_A/Scope FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::_environment0_Import_LiveBindings_Cycle_A
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.1
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.Import_LiveBindings_Cycle_A/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_A/Scope, object, string, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4b6c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_A_BE5ED7CC.FunctionObject_FunctionDeclaration_5C7CDA3E___jroc_esm_export
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_C9BC5402_L3C24
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle_B/Scope _environment0_Import_LiveBindings_Cycle_B
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle_B/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4b7b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_C9BC5402_L3C24::_environment0_Import_LiveBindings_Cycle_B
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C9BC5402_L3C24::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4b8a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C9BC5402_L3C24::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4b8d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C9BC5402_L3C24::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4b90
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_C9BC5402_L3C24::_environment0_Import_LiveBindings_Cycle_B
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_C9BC5402_L3C24::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4ba2
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_C9BC5402_L3C24::_environment0_Import_LiveBindings_Cycle_B
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_C9BC5402_L3C24::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4bb0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C9BC5402_L3C24::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_C9BC5402_L3C24
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_80025DF0_L4C27
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle_B/Scope _environment0_Import_LiveBindings_Cycle_B
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle_B/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4bbf
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_80025DF0_L4C27::_environment0_Import_LiveBindings_Cycle_B
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_80025DF0_L4C27::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4bce
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_80025DF0_L4C27::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4bd1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_80025DF0_L4C27::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4bd4
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_80025DF0_L4C27::_environment0_Import_LiveBindings_Cycle_B
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L4C26::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_80025DF0_L4C27::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4be6
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_80025DF0_L4C27::_environment0_Import_LiveBindings_Cycle_B
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L4C26::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_80025DF0_L4C27::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4bf4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_80025DF0_L4C27::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_80025DF0_L4C27
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_0C08ABDF_L5C32
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle_B/Scope _environment0_Import_LiveBindings_Cycle_B
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle_B/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4c03
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_0C08ABDF_L5C32::_environment0_Import_LiveBindings_Cycle_B
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_0C08ABDF_L5C32::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4c12
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_0C08ABDF_L5C32::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4c15
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_0C08ABDF_L5C32::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4c18
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_0C08ABDF_L5C32::_environment0_Import_LiveBindings_Cycle_B
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L5C31::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_0C08ABDF_L5C32::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4c2a
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_0C08ABDF_L5C32::_environment0_Import_LiveBindings_Cycle_B
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Cycle_B/FunctionExpression_L5C31::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_0C08ABDF_L5C32::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4c38
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_0C08ABDF_L5C32::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_0C08ABDF_L5C32
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_ED85635A_incB
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle_B/Scope _environment0_Import_LiveBindings_Cycle_B
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle_B/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4c47
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_ED85635A_incB::_environment0_Import_LiveBindings_Cycle_B
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_ED85635A_incB::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4c56
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_ED85635A_incB::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4c59
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_ED85635A_incB::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4c5c
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_ED85635A_incB::_environment0_Import_LiveBindings_Cycle_B
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Cycle_B/incB::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_ED85635A_incB::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4c6e
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_ED85635A_incB::_environment0_Import_LiveBindings_Cycle_B
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Cycle_B/incB::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_ED85635A_incB::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4c7c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_ED85635A_incB::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_ED85635A_incB
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_DB44C203_getAFromB
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle_B/Scope _environment0_Import_LiveBindings_Cycle_B
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle_B/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4c8b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_DB44C203_getAFromB::_environment0_Import_LiveBindings_Cycle_B
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DB44C203_getAFromB::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4c9a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DB44C203_getAFromB::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4c9d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DB44C203_getAFromB::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4ca0
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_DB44C203_getAFromB::_environment0_Import_LiveBindings_Cycle_B
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Cycle_B/getAFromB::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_DB44C203_getAFromB::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4cb2
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_DB44C203_getAFromB::_environment0_Import_LiveBindings_Cycle_B
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Cycle_B/getAFromB::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_DB44C203_getAFromB::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4cc0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DB44C203_getAFromB::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_DB44C203_getAFromB
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle_B/Scope _environment0_Import_LiveBindings_Cycle_B
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle_B/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4ccf
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::_environment0_Import_LiveBindings_Cycle_B
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4cde
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4ce1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4ce4
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::_environment0_Import_LiveBindings_Cycle_B
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4cf6
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::_environment0_Import_LiveBindings_Cycle_B
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4d04
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_1EA06D08___jroc_esm_mark
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x4d13
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4d1b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4d1e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4d21
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_default::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4d34
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_default::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4d43
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_A64AF6E6___jroc_esm_default
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x4d52
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4d5a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4d5d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4d60
-		// Header size: 1
-		// Code size: 30 (0x1e)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0018: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_get::__js_call__(object, object, string)
-		IL_001d: ret
-	} // end of method FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4d7f
-		// Header size: 1
-		// Code size: 26 (0x1a)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0014: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_get::__js_call__(object, object, string)
-		IL_0019: ret
-	} // end of method FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4d9a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_85CCE0CF___jroc_esm_get
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle_B/Scope _environment0_Import_LiveBindings_Cycle_B
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle_B/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4da9
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::_environment0_Import_LiveBindings_Cycle_B
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4db8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4dbb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4dbe
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::_environment0_Import_LiveBindings_Cycle_B
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4dd7
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::_environment0_Import_LiveBindings_Cycle_B
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4dec
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_C8232E58___jroc_esm_namespace
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_C63EA5BE_L47C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle_B/Scope _environment0_Import_LiveBindings_Cycle_B
-	.field private initonly class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle_B/Scope capture0,
-			class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x4dfb
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_C63EA5BE_L47C87::_environment0_Import_LiveBindings_Cycle_B
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_C63EA5BE_L47C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_C63EA5BE_L47C87::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_C63EA5BE_L47C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4e18
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C63EA5BE_L47C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4e1b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C63EA5BE_L47C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4e1e
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_C63EA5BE_L47C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_C63EA5BE_L47C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4e30
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_C63EA5BE_L47C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L47C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_C63EA5BE_L47C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4e3e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C63EA5BE_L47C87::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_C63EA5BE_L47C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_AFA10769_L48C94
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle_B/Scope _environment0_Import_LiveBindings_Cycle_B
-	.field private initonly class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle_B/Scope capture0,
-			class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x4e4d
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_AFA10769_L48C94::_environment0_Import_LiveBindings_Cycle_B
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_AFA10769_L48C94::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_AFA10769_L48C94::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_AFA10769_L48C94::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4e6a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_AFA10769_L48C94::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4e6d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_AFA10769_L48C94::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4e70
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_AFA10769_L48C94::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_AFA10769_L48C94::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4e82
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_AFA10769_L48C94::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L48C93::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_AFA10769_L48C94::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4e90
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_AFA10769_L48C94::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_AFA10769_L48C94
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_D61C0121_L57C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle_B/Scope _environment0_Import_LiveBindings_Cycle_B
-	.field private initonly class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle_B/Scope capture0,
-			class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x4e9f
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_D61C0121_L57C10::_environment0_Import_LiveBindings_Cycle_B
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_D61C0121_L57C10::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_D61C0121_L57C10::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_D61C0121_L57C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4ebc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D61C0121_L57C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4ebf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D61C0121_L57C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4ec2
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_D61C0121_L57C10::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_D61C0121_L57C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4edb
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_D61C0121_L57C10::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_D61C0121_L57C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4ef0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D61C0121_L57C10::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_D61C0121_L57C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_CF15D56A_L58C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle_B/Scope _environment0_Import_LiveBindings_Cycle_B
-	.field private initonly class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/Scope _environment2_FunctionExpression_L57C9
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle_B/Scope capture0,
-			class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope capture1,
-			class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x4eff
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_CF15D56A_L58C87::_environment0_Import_LiveBindings_Cycle_B
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_CF15D56A_L58C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_CF15D56A_L58C87::_environment2_FunctionExpression_L57C9
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_CF15D56A_L58C87::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_CF15D56A_L58C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4f24
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_CF15D56A_L58C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4f27
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_CF15D56A_L58C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4f2a
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_CF15D56A_L58C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_CF15D56A_L58C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4f3c
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_CF15D56A_L58C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_namespace/FunctionExpression_L57C9/FunctionExpression_L58C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_CF15D56A_L58C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4f4a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_CF15D56A_L58C87::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionExpression_CF15D56A_L58C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Cycle_B/Scope _environment0_Import_LiveBindings_Cycle_B
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Cycle_B/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4f59
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Cycle_B/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::_environment0_Import_LiveBindings_Cycle_B
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4f68
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4f6b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4f6e
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::_environment0_Import_LiveBindings_Cycle_B
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0017: ldarg.2
-		IL_0018: ldc.i4.1
-		IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001e: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object, string, object)
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4f93
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Cycle_B/Scope FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::_environment0_Import_LiveBindings_Cycle_B
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.1
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.Import_LiveBindings_Cycle_B/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Cycle_B/Scope, object, string, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4fb4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Cycle_B_C15EDC85.FunctionObject_FunctionDeclaration_43DF66FB___jroc_esm_export
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Named.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_LiveBindings_Named.verified.txt
@@ -53,6 +53,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_LiveBindings_Named/Scope _environment0_Import_LiveBindings_Named
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_LiveBindings_Named/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x359c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_mark/FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::_environment0_Import_LiveBindings_Named
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x35ab
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x35ae
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x35b1
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_mark/FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::_environment0_Import_LiveBindings_Named
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_LiveBindings_Named/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Named/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x35c3
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_mark/FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::_environment0_Import_LiveBindings_Named
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_LiveBindings_Named/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Named/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x35d1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark
+
 
 		// Methods
 		.method public hidebysig static 
@@ -159,6 +266,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x35e0
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x35e8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x35eb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x35ee
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Import_LiveBindings_Named/__jroc_esm_default::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3601
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Import_LiveBindings_Named/__jroc_esm_default::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3610
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default
+
 
 		// Methods
 		.method public hidebysig static 
@@ -262,6 +470,115 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x361f
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3627
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x362a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x362d
+				// Header size: 1
+				// Code size: 30 (0x1e)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0018: call object Modules.Import_LiveBindings_Named/__jroc_esm_get::__js_call__(object, object, string)
+				IL_001d: ret
+			} // end of method FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x364c
+				// Header size: 1
+				// Code size: 26 (0x1a)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0014: call object Modules.Import_LiveBindings_Named/__jroc_esm_get::__js_call__(object, object, string)
+				IL_0019: ret
+			} // end of method FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3667
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get
+
 
 		// Methods
 		.method public hidebysig static 
@@ -320,6 +637,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_10552A8E_L38C87
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_LiveBindings_Named/Scope _environment0_Import_LiveBindings_Named
+				.field private initonly class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_LiveBindings_Named/Scope capture0,
+						class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x36c8
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_10552A8E_L38C87::_environment0_Import_LiveBindings_Named
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_10552A8E_L38C87::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_10552A8E_L38C87::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_10552A8E_L38C87::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x36e5
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_10552A8E_L38C87::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x36e8
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_10552A8E_L38C87::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x36eb
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_10552A8E_L38C87::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_10552A8E_L38C87::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x36fd
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_10552A8E_L38C87::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_10552A8E_L38C87::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x370b
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_10552A8E_L38C87::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_10552A8E_L38C87
+
 
 			// Methods
 			.method public hidebysig static 
@@ -369,6 +803,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2301C98B_L39C94
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_LiveBindings_Named/Scope _environment0_Import_LiveBindings_Named
+				.field private initonly class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_LiveBindings_Named/Scope capture0,
+						class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x371a
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2301C98B_L39C94::_environment0_Import_LiveBindings_Named
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2301C98B_L39C94::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2301C98B_L39C94::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_2301C98B_L39C94::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3737
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_2301C98B_L39C94::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x373a
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_2301C98B_L39C94::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x373d
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2301C98B_L39C94::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_2301C98B_L39C94::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x374f
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2301C98B_L39C94::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_2301C98B_L39C94::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x375d
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_2301C98B_L39C94::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_2301C98B_L39C94
 
 
 			// Methods
@@ -423,6 +974,128 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_EB245588_L49C87
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Import_LiveBindings_Named/Scope _environment0_Import_LiveBindings_Named
+					.field private initonly class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+					.field private initonly class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/Scope _environment2_FunctionExpression_L48C9
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Import_LiveBindings_Named/Scope capture0,
+							class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope capture1,
+							class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x37cc
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_EB245588_L49C87::_environment0_Import_LiveBindings_Named
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_EB245588_L49C87::_environment1___jroc_esm_namespace
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_EB245588_L49C87::_environment2_FunctionExpression_L48C9
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_EB245588_L49C87::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_EB245588_L49C87::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x37f1
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_EB245588_L49C87::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x37f4
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_EB245588_L49C87::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x37f7
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_EB245588_L49C87::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_EB245588_L49C87::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x3809
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_EB245588_L49C87::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_EB245588_L49C87::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x3817
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_EB245588_L49C87::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_EB245588_L49C87
 
 
 				// Methods
@@ -489,6 +1162,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C05233E5_L48C10
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_LiveBindings_Named/Scope _environment0_Import_LiveBindings_Named
+				.field private initonly class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_LiveBindings_Named/Scope capture0,
+						class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x376c
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_C05233E5_L48C10::_environment0_Import_LiveBindings_Named
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_C05233E5_L48C10::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_C05233E5_L48C10::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_C05233E5_L48C10::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3789
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_C05233E5_L48C10::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x378c
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_C05233E5_L48C10::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x378f
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_C05233E5_L48C10::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_C05233E5_L48C10::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x37a8
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_C05233E5_L48C10::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_C05233E5_L48C10::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x37bd
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_C05233E5_L48C10::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_C05233E5_L48C10
+
 
 			// Methods
 			.method public hidebysig static 
@@ -510,7 +1306,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_EB245588_L49C87,
+					[4] class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_EB245588_L49C87,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -560,13 +1356,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_EB245588_L49C87::.ctor(class Modules.Import_LiveBindings_Named/Scope, class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope, class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_EB245588_L49C87::.ctor(class Modules.Import_LiveBindings_Named/Scope, class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope, class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_EB245588_L49C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_EB245588_L49C87>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -785,6 +1581,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_LiveBindings_Named/Scope _environment0_Import_LiveBindings_Named
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_LiveBindings_Named/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3676
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::_environment0_Import_LiveBindings_Named
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3685
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3688
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x368b
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::_environment0_Import_LiveBindings_Named
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Named/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x36a4
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::_environment0_Import_LiveBindings_Named
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Named/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x36b9
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace
+
 
 		// Methods
 		.method public hidebysig static 
@@ -824,12 +1733,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_10552A8E_L38C87,
-				[21] class FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_2301C98B_L39C94,
+				[20] class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_10552A8E_L38C87,
+				[21] class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2301C98B_L39C94,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_C05233E5_L48C10
+				[25] class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_C05233E5_L48C10
 			)
 
 			IL_0000: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope::.ctor()
@@ -1035,13 +1944,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_10552A8E_L38C87::.ctor(class Modules.Import_LiveBindings_Named/Scope, class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_10552A8E_L38C87::.ctor(class Modules.Import_LiveBindings_Named/Scope, class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_10552A8E_L38C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_10552A8E_L38C87>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -1085,13 +1994,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_2301C98B_L39C94::.ctor(class Modules.Import_LiveBindings_Named/Scope, class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2301C98B_L39C94::.ctor(class Modules.Import_LiveBindings_Named/Scope, class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_2301C98B_L39C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2301C98B_L39C94>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -1261,13 +2170,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_C05233E5_L48C10::.ctor(class Modules.Import_LiveBindings_Named/Scope, class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_C05233E5_L48C10::.ctor(class Modules.Import_LiveBindings_Named/Scope, class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_C05233E5_L48C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_C05233E5_L48C10>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldc.i4.1
 				IL_0487: newarr [System.Runtime]System.Object
@@ -1386,6 +2295,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_LiveBindings_Named/Scope _environment0_Import_LiveBindings_Named
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_LiveBindings_Named/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3826
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_export/FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::_environment0_Import_LiveBindings_Named
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3835
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3838
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x383b
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_export/FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::_environment0_Import_LiveBindings_Named
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Import_LiveBindings_Named/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Named/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x385b
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named/Scope Modules.Import_LiveBindings_Named/__jroc_esm_export/FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::_environment0_Import_LiveBindings_Named
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Import_LiveBindings_Named/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Named/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3877
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1499,13 +2527,13 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_LiveBindings_Named/Scope,
-			[1] class FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default,
-			[2] class FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get,
-			[3] class FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace,
-			[4] class FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export,
+			[1] class Modules.Import_LiveBindings_Named/__jroc_esm_default/FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default,
+			[2] class Modules.Import_LiveBindings_Named/__jroc_esm_get/FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get,
+			[3] class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace,
+			[4] class Modules.Import_LiveBindings_Named/__jroc_esm_export/FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export,
 			[5] object,
 			[6] object[],
-			[7] class FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark,
+			[7] class Modules.Import_LiveBindings_Named/__jroc_esm_mark/FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark,
 			[8] object,
 			[9] object
 		)
@@ -1526,13 +2554,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_LiveBindings_Named/Scope
-		IL_0022: newobj instance void FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::.ctor(class Modules.Import_LiveBindings_Named/Scope)
+		IL_0022: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_mark/FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::.ctor(class Modules.Import_LiveBindings_Named/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named/__jroc_esm_mark/FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 7
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 7
@@ -1544,13 +2572,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 6
-		IL_004b: newobj instance void FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_default/FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named/__jroc_esm_default/FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -1559,13 +2587,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 6
-		IL_006b: newobj instance void FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_get/FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named/__jroc_esm_get/FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -1578,13 +2606,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_LiveBindings_Named/Scope
-		IL_0094: newobj instance void FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::.ctor(class Modules.Import_LiveBindings_Named/Scope)
+		IL_0094: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::.ctor(class Modules.Import_LiveBindings_Named/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -1597,13 +2625,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_LiveBindings_Named/Scope
-		IL_00bd: newobj instance void FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::.ctor(class Modules.Import_LiveBindings_Named/Scope)
+		IL_00bd: newobj instance void Modules.Import_LiveBindings_Named/__jroc_esm_export/FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::.ctor(class Modules.Import_LiveBindings_Named/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named/__jroc_esm_export/FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 4
 		IL_00d2: nop
 		IL_00d3: ldloc.0
@@ -1702,6 +2730,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_66DDEB30_L3C24
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_LiveBindings_Named_Lib/Scope _environment0_Import_LiveBindings_Named_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_LiveBindings_Named_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3886
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L3C23/FunctionObject_FunctionExpression_66DDEB30_L3C24::_environment0_Import_LiveBindings_Named_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_66DDEB30_L3C24::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3895
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_66DDEB30_L3C24::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3898
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_66DDEB30_L3C24::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x389b
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L3C23/FunctionObject_FunctionExpression_66DDEB30_L3C24::_environment0_Import_LiveBindings_Named_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_66DDEB30_L3C24::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x38ad
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L3C23/FunctionObject_FunctionExpression_66DDEB30_L3C24::_environment0_Import_LiveBindings_Named_Lib
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_66DDEB30_L3C24::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x38bb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_66DDEB30_L3C24::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_66DDEB30_L3C24
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1753,6 +2888,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0FCF6501_L4C26
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_LiveBindings_Named_Lib/Scope _environment0_Import_LiveBindings_Named_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_LiveBindings_Named_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x38ca
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_0FCF6501_L4C26::_environment0_Import_LiveBindings_Named_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_0FCF6501_L4C26::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x38d9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_0FCF6501_L4C26::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x38dc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_0FCF6501_L4C26::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x38df
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_0FCF6501_L4C26::_environment0_Import_LiveBindings_Named_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_0FCF6501_L4C26::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x38f1
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_0FCF6501_L4C26::_environment0_Import_LiveBindings_Named_Lib
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_0FCF6501_L4C26::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x38ff
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_0FCF6501_L4C26::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_0FCF6501_L4C26
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1801,6 +3043,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_AF3BD2AE_inc
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_LiveBindings_Named_Lib/Scope _environment0_Import_LiveBindings_Named_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_LiveBindings_Named_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x390e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/inc/FunctionObject_FunctionDeclaration_AF3BD2AE_inc::_environment0_Import_LiveBindings_Named_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_AF3BD2AE_inc::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x391d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_AF3BD2AE_inc::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3920
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_AF3BD2AE_inc::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3923
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/inc/FunctionObject_FunctionDeclaration_AF3BD2AE_inc::_environment0_Import_LiveBindings_Named_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_LiveBindings_Named_Lib/inc::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_AF3BD2AE_inc::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3935
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/inc/FunctionObject_FunctionDeclaration_AF3BD2AE_inc::_environment0_Import_LiveBindings_Named_Lib
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_LiveBindings_Named_Lib/inc::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_AF3BD2AE_inc::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3943
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_AF3BD2AE_inc::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_AF3BD2AE_inc
 
 
 		// Methods
@@ -1887,6 +3236,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_LiveBindings_Named_Lib/Scope _environment0_Import_LiveBindings_Named_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_LiveBindings_Named_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3952
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::_environment0_Import_LiveBindings_Named_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3961
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3964
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3967
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::_environment0_Import_LiveBindings_Named_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3979
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::_environment0_Import_LiveBindings_Named_Lib
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3987
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark
 
 
 		// Methods
@@ -1994,6 +3450,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3996
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x399e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x39a1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x39a4
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_default::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x39b7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_default::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x39c6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2097,6 +3654,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x39d5
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x39dd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x39e0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x39e3
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x39fd
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a13
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2155,6 +3819,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F24EF04E_L38C87
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_LiveBindings_Named_Lib/Scope _environment0_Import_LiveBindings_Named_Lib
+				.field private initonly class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_LiveBindings_Named_Lib/Scope capture0,
+						class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3a74
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_F24EF04E_L38C87::_environment0_Import_LiveBindings_Named_Lib
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_F24EF04E_L38C87::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_F24EF04E_L38C87::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_F24EF04E_L38C87::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3a91
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_F24EF04E_L38C87::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3a94
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_F24EF04E_L38C87::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x3a97
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_F24EF04E_L38C87::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_F24EF04E_L38C87::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3aa9
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_F24EF04E_L38C87::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_F24EF04E_L38C87::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3ab7
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_F24EF04E_L38C87::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_F24EF04E_L38C87
+
 
 			// Methods
 			.method public hidebysig static 
@@ -2204,6 +3985,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_04FB8F4B_L39C94
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_LiveBindings_Named_Lib/Scope _environment0_Import_LiveBindings_Named_Lib
+				.field private initonly class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_LiveBindings_Named_Lib/Scope capture0,
+						class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3ac6
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_04FB8F4B_L39C94::_environment0_Import_LiveBindings_Named_Lib
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_04FB8F4B_L39C94::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_04FB8F4B_L39C94::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_04FB8F4B_L39C94::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3ae3
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_04FB8F4B_L39C94::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3ae6
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_04FB8F4B_L39C94::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x3ae9
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_04FB8F4B_L39C94::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_04FB8F4B_L39C94::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3afb
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_04FB8F4B_L39C94::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_04FB8F4B_L39C94::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3b09
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_04FB8F4B_L39C94::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_04FB8F4B_L39C94
 
 
 			// Methods
@@ -2258,6 +4156,128 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E975A0C8_L49C87
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Import_LiveBindings_Named_Lib/Scope _environment0_Import_LiveBindings_Named_Lib
+					.field private initonly class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+					.field private initonly class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/Scope _environment2_FunctionExpression_L48C9
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Import_LiveBindings_Named_Lib/Scope capture0,
+							class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope capture1,
+							class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x3b78
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_E975A0C8_L49C87::_environment0_Import_LiveBindings_Named_Lib
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_E975A0C8_L49C87::_environment1___jroc_esm_namespace
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_E975A0C8_L49C87::_environment2_FunctionExpression_L48C9
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_E975A0C8_L49C87::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_E975A0C8_L49C87::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x3b9d
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_E975A0C8_L49C87::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x3ba0
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_E975A0C8_L49C87::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x3ba3
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_E975A0C8_L49C87::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_E975A0C8_L49C87::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x3bb5
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_E975A0C8_L49C87::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_E975A0C8_L49C87::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x3bc3
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_E975A0C8_L49C87::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_E975A0C8_L49C87
 
 
 				// Methods
@@ -2324,6 +4344,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3B7B1C25_L48C10
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_LiveBindings_Named_Lib/Scope _environment0_Import_LiveBindings_Named_Lib
+				.field private initonly class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_LiveBindings_Named_Lib/Scope capture0,
+						class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3b18
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_3B7B1C25_L48C10::_environment0_Import_LiveBindings_Named_Lib
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_3B7B1C25_L48C10::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_3B7B1C25_L48C10::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_3B7B1C25_L48C10::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3b35
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_3B7B1C25_L48C10::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3b38
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_3B7B1C25_L48C10::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x3b3b
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_3B7B1C25_L48C10::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_3B7B1C25_L48C10::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3b54
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_3B7B1C25_L48C10::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_3B7B1C25_L48C10::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3b69
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_3B7B1C25_L48C10::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_3B7B1C25_L48C10
+
 
 			// Methods
 			.method public hidebysig static 
@@ -2345,7 +4488,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_E975A0C8_L49C87,
+					[4] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_E975A0C8_L49C87,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -2395,13 +4538,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_E975A0C8_L49C87::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope, class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope, class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_E975A0C8_L49C87::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope, class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope, class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_E975A0C8_L49C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_E975A0C8_L49C87>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -2620,6 +4763,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_LiveBindings_Named_Lib/Scope _environment0_Import_LiveBindings_Named_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_LiveBindings_Named_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a22
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::_environment0_Import_LiveBindings_Named_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3a31
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3a34
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a37
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::_environment0_Import_LiveBindings_Named_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a50
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::_environment0_Import_LiveBindings_Named_Lib
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a65
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2659,12 +4915,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_F24EF04E_L38C87,
-				[21] class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_04FB8F4B_L39C94,
+				[20] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_F24EF04E_L38C87,
+				[21] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_04FB8F4B_L39C94,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_3B7B1C25_L48C10
+				[25] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_3B7B1C25_L48C10
 			)
 
 			IL_0000: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope::.ctor()
@@ -2870,13 +5126,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_F24EF04E_L38C87::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope, class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_F24EF04E_L38C87::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope, class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_F24EF04E_L38C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_F24EF04E_L38C87>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -2920,13 +5176,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_04FB8F4B_L39C94::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope, class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_04FB8F4B_L39C94::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope, class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_04FB8F4B_L39C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_04FB8F4B_L39C94>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -3096,13 +5352,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_3B7B1C25_L48C10::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope, class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_3B7B1C25_L48C10::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope, class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_3B7B1C25_L48C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_3B7B1C25_L48C10>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldc.i4.1
 				IL_0487: newarr [System.Runtime]System.Object
@@ -3220,6 +5476,127 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_LiveBindings_Named_Lib/Scope _environment0_Import_LiveBindings_Named_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_LiveBindings_Named_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3bd2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::_environment0_Import_LiveBindings_Named_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3be1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3be4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3be7
+				// Header size: 1
+				// Code size: 36 (0x24)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::_environment0_Import_LiveBindings_Named_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0017: ldarg.2
+				IL_0018: ldc.i4.1
+				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001e: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object, string, object)
+				IL_0023: ret
+			} // end of method FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3c0c
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::_environment0_Import_LiveBindings_Named_Lib
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.1
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object, string, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3c2d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export
 
 
 		// Methods
@@ -3340,17 +5717,17 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_LiveBindings_Named_Lib/Scope,
-			[1] class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default,
-			[2] class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get,
-			[3] class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace,
-			[4] class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export,
+			[1] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default,
+			[2] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get,
+			[3] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace,
+			[4] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export,
 			[5] object[],
-			[6] class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_AF3BD2AE_inc,
-			[7] class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark,
+			[6] class Modules.Import_LiveBindings_Named_Lib/inc/FunctionObject_FunctionDeclaration_AF3BD2AE_inc,
+			[7] class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark,
 			[8] object,
 			[9] object[],
-			[10] class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_66DDEB30_L3C24,
-			[11] class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_0FCF6501_L4C26
+			[10] class Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L3C23/FunctionObject_FunctionExpression_66DDEB30_L3C24,
+			[11] class Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_0FCF6501_L4C26
 		)
 
 		IL_0000: newobj instance void Modules.Import_LiveBindings_Named_Lib/Scope::.ctor()
@@ -3369,13 +5746,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_LiveBindings_Named_Lib/Scope
-		IL_0022: newobj instance void FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_AF3BD2AE_inc::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope)
+		IL_0022: newobj instance void Modules.Import_LiveBindings_Named_Lib/inc/FunctionObject_FunctionDeclaration_AF3BD2AE_inc::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "inc"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_AF3BD2AE_inc>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/inc/FunctionObject_FunctionDeclaration_AF3BD2AE_inc>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 6
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 6
@@ -3391,13 +5768,13 @@
 		IL_004d: ldc.i4.0
 		IL_004e: ldelem.ref
 		IL_004f: castclass Modules.Import_LiveBindings_Named_Lib/Scope
-		IL_0054: newobj instance void FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope)
+		IL_0054: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope)
 		IL_0059: ldc.i4.0
 		IL_005a: conv.r8
 		IL_005b: ldstr "__jroc_esm_mark"
 		IL_0060: ldc.i4.0
 		IL_0061: ldc.i4.1
-		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark>(!!0, float64, string, bool, bool)
 		IL_0067: stloc.s 7
 		IL_0069: ldloc.0
 		IL_006a: ldloc.s 7
@@ -3409,13 +5786,13 @@
 		IL_0079: ldloc.0
 		IL_007a: stelem.ref
 		IL_007b: stloc.s 5
-		IL_007d: newobj instance void FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default::.ctor()
+		IL_007d: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default::.ctor()
 		IL_0082: ldc.i4.1
 		IL_0083: conv.r8
 		IL_0084: ldstr "__jroc_esm_default"
 		IL_0089: ldc.i4.0
 		IL_008a: ldc.i4.1
-		IL_008b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_008b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default>(!!0, float64, string, bool, bool)
 		IL_0090: stloc.1
 		IL_0091: ldc.i4.1
 		IL_0092: newarr [System.Runtime]System.Object
@@ -3424,13 +5801,13 @@
 		IL_0099: ldloc.0
 		IL_009a: stelem.ref
 		IL_009b: stloc.s 5
-		IL_009d: newobj instance void FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get::.ctor()
+		IL_009d: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get::.ctor()
 		IL_00a2: ldc.i4.2
 		IL_00a3: conv.r8
 		IL_00a4: ldstr "__jroc_esm_get"
 		IL_00a9: ldc.i4.0
 		IL_00aa: ldc.i4.1
-		IL_00ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_00ab: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get>(!!0, float64, string, bool, bool)
 		IL_00b0: stloc.2
 		IL_00b1: ldc.i4.1
 		IL_00b2: newarr [System.Runtime]System.Object
@@ -3443,13 +5820,13 @@
 		IL_00bf: ldc.i4.0
 		IL_00c0: ldelem.ref
 		IL_00c1: castclass Modules.Import_LiveBindings_Named_Lib/Scope
-		IL_00c6: newobj instance void FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope)
+		IL_00c6: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope)
 		IL_00cb: ldc.i4.1
 		IL_00cc: conv.r8
 		IL_00cd: ldstr "__jroc_esm_namespace"
 		IL_00d2: ldc.i4.0
 		IL_00d3: ldc.i4.1
-		IL_00d4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00d4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace>(!!0, float64, string, bool, bool)
 		IL_00d9: stloc.3
 		IL_00da: ldc.i4.1
 		IL_00db: newarr [System.Runtime]System.Object
@@ -3462,13 +5839,13 @@
 		IL_00e8: ldc.i4.0
 		IL_00e9: ldelem.ref
 		IL_00ea: castclass Modules.Import_LiveBindings_Named_Lib/Scope
-		IL_00ef: newobj instance void FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope)
+		IL_00ef: newobj instance void Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope)
 		IL_00f4: ldc.i4.2
 		IL_00f5: conv.r8
 		IL_00f6: ldstr "__jroc_esm_export"
 		IL_00fb: ldc.i4.0
 		IL_00fc: ldc.i4.1
-		IL_00fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export>(!!0, float64, string, bool, bool)
 		IL_0102: stloc.s 4
 		IL_0104: nop
 		IL_0105: ldloc.0
@@ -3491,13 +5868,13 @@
 		IL_012f: ldc.i4.0
 		IL_0130: ldelem.ref
 		IL_0131: castclass Modules.Import_LiveBindings_Named_Lib/Scope
-		IL_0136: newobj instance void FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_66DDEB30_L3C24::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope)
+		IL_0136: newobj instance void Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L3C23/FunctionObject_FunctionExpression_66DDEB30_L3C24::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope)
 		IL_013b: ldc.i4.0
 		IL_013c: conv.r8
 		IL_013d: ldstr ""
 		IL_0142: ldc.i4.0
 		IL_0143: ldc.i4.1
-		IL_0144: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_66DDEB30_L3C24>(!!0, float64, string, bool, bool)
+		IL_0144: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L3C23/FunctionObject_FunctionExpression_66DDEB30_L3C24>(!!0, float64, string, bool, bool)
 		IL_0149: stloc.s 10
 		IL_014b: ldloc.s 4
 		IL_014d: ldloc.s 5
@@ -3518,13 +5895,13 @@
 		IL_0171: ldc.i4.0
 		IL_0172: ldelem.ref
 		IL_0173: castclass Modules.Import_LiveBindings_Named_Lib/Scope
-		IL_0178: newobj instance void FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_0FCF6501_L4C26::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope)
+		IL_0178: newobj instance void Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_0FCF6501_L4C26::.ctor(class Modules.Import_LiveBindings_Named_Lib/Scope)
 		IL_017d: ldc.i4.0
 		IL_017e: conv.r8
 		IL_017f: ldstr ""
 		IL_0184: ldc.i4.0
 		IL_0185: ldc.i4.1
-		IL_0186: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_0FCF6501_L4C26>(!!0, float64, string, bool, bool)
+		IL_0186: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_0FCF6501_L4C26>(!!0, float64, string, bool, bool)
 		IL_018b: stloc.s 11
 		IL_018d: ldloc.s 4
 		IL_018f: ldloc.s 5
@@ -3540,2383 +5917,6 @@
 	} // end of method Import_LiveBindings_Named_Lib::__js_module_init__
 
 } // end of class Modules.Import_LiveBindings_Named_Lib
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Named/Scope _environment0_Import_LiveBindings_Named
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Named/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x359c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Named/Scope FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::_environment0_Import_LiveBindings_Named
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x35ab
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x35ae
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x35b1
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Named/Scope FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::_environment0_Import_LiveBindings_Named
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Named/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Named/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x35c3
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Named/Scope FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::_environment0_Import_LiveBindings_Named
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Named/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Named/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x35d1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_B05BE636___jroc_esm_mark
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x35e0
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x35e8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x35eb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x35ee
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Import_LiveBindings_Named/__jroc_esm_default::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3601
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Import_LiveBindings_Named/__jroc_esm_default::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3610
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_49435FF4___jroc_esm_default
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x361f
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3627
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x362a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x362d
-		// Header size: 1
-		// Code size: 30 (0x1e)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0018: call object Modules.Import_LiveBindings_Named/__jroc_esm_get::__js_call__(object, object, string)
-		IL_001d: ret
-	} // end of method FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x364c
-		// Header size: 1
-		// Code size: 26 (0x1a)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0014: call object Modules.Import_LiveBindings_Named/__jroc_esm_get::__js_call__(object, object, string)
-		IL_0019: ret
-	} // end of method FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3667
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_7B686C8D___jroc_esm_get
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Named/Scope _environment0_Import_LiveBindings_Named
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Named/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3676
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Named/Scope FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::_environment0_Import_LiveBindings_Named
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3685
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3688
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x368b
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Named/Scope FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::_environment0_Import_LiveBindings_Named
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Named/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x36a4
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Named/Scope FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::_environment0_Import_LiveBindings_Named
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Named/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x36b9
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_73BB37EE___jroc_esm_namespace
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_10552A8E_L38C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Named/Scope _environment0_Import_LiveBindings_Named
-	.field private initonly class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Named/Scope capture0,
-			class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x36c8
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Named/Scope FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_10552A8E_L38C87::_environment0_Import_LiveBindings_Named
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_10552A8E_L38C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_10552A8E_L38C87::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_10552A8E_L38C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x36e5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_10552A8E_L38C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x36e8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_10552A8E_L38C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x36eb
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_10552A8E_L38C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_10552A8E_L38C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x36fd
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_10552A8E_L38C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_10552A8E_L38C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x370b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_10552A8E_L38C87::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_10552A8E_L38C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_2301C98B_L39C94
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Named/Scope _environment0_Import_LiveBindings_Named
-	.field private initonly class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Named/Scope capture0,
-			class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x371a
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Named/Scope FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_2301C98B_L39C94::_environment0_Import_LiveBindings_Named
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_2301C98B_L39C94::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_2301C98B_L39C94::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_2301C98B_L39C94::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3737
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2301C98B_L39C94::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x373a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2301C98B_L39C94::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x373d
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_2301C98B_L39C94::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_2301C98B_L39C94::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x374f
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_2301C98B_L39C94::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_2301C98B_L39C94::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x375d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2301C98B_L39C94::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_2301C98B_L39C94
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_C05233E5_L48C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Named/Scope _environment0_Import_LiveBindings_Named
-	.field private initonly class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Named/Scope capture0,
-			class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x376c
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Named/Scope FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_C05233E5_L48C10::_environment0_Import_LiveBindings_Named
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_C05233E5_L48C10::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_C05233E5_L48C10::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_C05233E5_L48C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3789
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C05233E5_L48C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x378c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C05233E5_L48C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x378f
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_C05233E5_L48C10::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_C05233E5_L48C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x37a8
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_C05233E5_L48C10::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_C05233E5_L48C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x37bd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C05233E5_L48C10::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_C05233E5_L48C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_EB245588_L49C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Named/Scope _environment0_Import_LiveBindings_Named
-	.field private initonly class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/Scope _environment2_FunctionExpression_L48C9
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Named/Scope capture0,
-			class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope capture1,
-			class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x37cc
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Named/Scope FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_EB245588_L49C87::_environment0_Import_LiveBindings_Named
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/Scope FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_EB245588_L49C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/Scope FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_EB245588_L49C87::_environment2_FunctionExpression_L48C9
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_EB245588_L49C87::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_EB245588_L49C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x37f1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_EB245588_L49C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x37f4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_EB245588_L49C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x37f7
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_EB245588_L49C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_EB245588_L49C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3809
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_EB245588_L49C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Named/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_EB245588_L49C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3817
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_EB245588_L49C87::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionExpression_EB245588_L49C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Named/Scope _environment0_Import_LiveBindings_Named
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Named/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3826
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Named/Scope FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::_environment0_Import_LiveBindings_Named
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3835
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3838
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x383b
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Named/Scope FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::_environment0_Import_LiveBindings_Named
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Import_LiveBindings_Named/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Named/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x385b
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Named/Scope FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::_environment0_Import_LiveBindings_Named
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Import_LiveBindings_Named/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Named/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3877
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Named_51794E43.FunctionObject_FunctionDeclaration_AA402619___jroc_esm_export
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_66DDEB30_L3C24
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Named_Lib/Scope _environment0_Import_LiveBindings_Named_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Named_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3886
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_66DDEB30_L3C24::_environment0_Import_LiveBindings_Named_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_66DDEB30_L3C24::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3895
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_66DDEB30_L3C24::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3898
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_66DDEB30_L3C24::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x389b
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_66DDEB30_L3C24::_environment0_Import_LiveBindings_Named_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_66DDEB30_L3C24::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x38ad
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_66DDEB30_L3C24::_environment0_Import_LiveBindings_Named_Lib
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L3C23::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_66DDEB30_L3C24::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x38bb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_66DDEB30_L3C24::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_66DDEB30_L3C24
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_0FCF6501_L4C26
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Named_Lib/Scope _environment0_Import_LiveBindings_Named_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Named_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x38ca
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_0FCF6501_L4C26::_environment0_Import_LiveBindings_Named_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_0FCF6501_L4C26::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x38d9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_0FCF6501_L4C26::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x38dc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_0FCF6501_L4C26::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x38df
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_0FCF6501_L4C26::_environment0_Import_LiveBindings_Named_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_0FCF6501_L4C26::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x38f1
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_0FCF6501_L4C26::_environment0_Import_LiveBindings_Named_Lib
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Named_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_0FCF6501_L4C26::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x38ff
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_0FCF6501_L4C26::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_0FCF6501_L4C26
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_AF3BD2AE_inc
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Named_Lib/Scope _environment0_Import_LiveBindings_Named_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Named_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x390e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_AF3BD2AE_inc::_environment0_Import_LiveBindings_Named_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_AF3BD2AE_inc::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x391d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_AF3BD2AE_inc::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3920
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_AF3BD2AE_inc::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3923
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_AF3BD2AE_inc::_environment0_Import_LiveBindings_Named_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Named_Lib/inc::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_AF3BD2AE_inc::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3935
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_AF3BD2AE_inc::_environment0_Import_LiveBindings_Named_Lib
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Named_Lib/inc::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_AF3BD2AE_inc::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3943
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_AF3BD2AE_inc::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_AF3BD2AE_inc
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Named_Lib/Scope _environment0_Import_LiveBindings_Named_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Named_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3952
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::_environment0_Import_LiveBindings_Named_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3961
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3964
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3967
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::_environment0_Import_LiveBindings_Named_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3979
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::_environment0_Import_LiveBindings_Named_Lib
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3987
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_5FEC0676___jroc_esm_mark
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3996
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x399e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x39a1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x39a4
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_default::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x39b7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_default::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x39c6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_9468F934___jroc_esm_default
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x39d5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x39dd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x39e0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x39e3
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x39fd
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a13
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_F9B75BCD___jroc_esm_get
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Named_Lib/Scope _environment0_Import_LiveBindings_Named_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Named_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a22
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::_environment0_Import_LiveBindings_Named_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3a31
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3a34
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a37
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::_environment0_Import_LiveBindings_Named_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a50
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::_environment0_Import_LiveBindings_Named_Lib
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a65
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_6273282E___jroc_esm_namespace
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_F24EF04E_L38C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Named_Lib/Scope _environment0_Import_LiveBindings_Named_Lib
-	.field private initonly class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Named_Lib/Scope capture0,
-			class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a74
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_F24EF04E_L38C87::_environment0_Import_LiveBindings_Named_Lib
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_F24EF04E_L38C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_F24EF04E_L38C87::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_F24EF04E_L38C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3a91
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F24EF04E_L38C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3a94
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F24EF04E_L38C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a97
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_F24EF04E_L38C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_F24EF04E_L38C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3aa9
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_F24EF04E_L38C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_F24EF04E_L38C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ab7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F24EF04E_L38C87::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_F24EF04E_L38C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_04FB8F4B_L39C94
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Named_Lib/Scope _environment0_Import_LiveBindings_Named_Lib
-	.field private initonly class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Named_Lib/Scope capture0,
-			class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ac6
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_04FB8F4B_L39C94::_environment0_Import_LiveBindings_Named_Lib
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_04FB8F4B_L39C94::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_04FB8F4B_L39C94::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_04FB8F4B_L39C94::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3ae3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_04FB8F4B_L39C94::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3ae6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_04FB8F4B_L39C94::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ae9
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_04FB8F4B_L39C94::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_04FB8F4B_L39C94::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3afb
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_04FB8F4B_L39C94::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_04FB8F4B_L39C94::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b09
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_04FB8F4B_L39C94::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_04FB8F4B_L39C94
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_3B7B1C25_L48C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Named_Lib/Scope _environment0_Import_LiveBindings_Named_Lib
-	.field private initonly class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Named_Lib/Scope capture0,
-			class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b18
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_3B7B1C25_L48C10::_environment0_Import_LiveBindings_Named_Lib
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_3B7B1C25_L48C10::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_3B7B1C25_L48C10::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_3B7B1C25_L48C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3b35
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3B7B1C25_L48C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3b38
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3B7B1C25_L48C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b3b
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_3B7B1C25_L48C10::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_3B7B1C25_L48C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b54
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_3B7B1C25_L48C10::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_3B7B1C25_L48C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b69
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3B7B1C25_L48C10::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_3B7B1C25_L48C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_E975A0C8_L49C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Named_Lib/Scope _environment0_Import_LiveBindings_Named_Lib
-	.field private initonly class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/Scope _environment2_FunctionExpression_L48C9
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Named_Lib/Scope capture0,
-			class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope capture1,
-			class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b78
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_E975A0C8_L49C87::_environment0_Import_LiveBindings_Named_Lib
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/Scope FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_E975A0C8_L49C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/Scope FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_E975A0C8_L49C87::_environment2_FunctionExpression_L48C9
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_E975A0C8_L49C87::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_E975A0C8_L49C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3b9d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E975A0C8_L49C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3ba0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E975A0C8_L49C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ba3
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_E975A0C8_L49C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_E975A0C8_L49C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3bb5
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_E975A0C8_L49C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_E975A0C8_L49C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3bc3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E975A0C8_L49C87::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionExpression_E975A0C8_L49C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_LiveBindings_Named_Lib/Scope _environment0_Import_LiveBindings_Named_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_LiveBindings_Named_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3bd2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_LiveBindings_Named_Lib/Scope FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::_environment0_Import_LiveBindings_Named_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3be1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3be4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3be7
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::_environment0_Import_LiveBindings_Named_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0017: ldarg.2
-		IL_0018: ldc.i4.1
-		IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001e: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object, string, object)
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c0c
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_LiveBindings_Named_Lib/Scope FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::_environment0_Import_LiveBindings_Named_Lib
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.1
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.Import_LiveBindings_Named_Lib/__jroc_esm_export::__js_call__(class Modules.Import_LiveBindings_Named_Lib/Scope, object, string, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c2d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export::ConstructCore
-
-} // end of class FunctionObjects.Import_LiveBindings_Named_Lib_7A3B7183.FunctionObject_FunctionDeclaration_C9B8EF59___jroc_esm_export
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_Esm_Basic.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_Esm_Basic.verified.txt
@@ -53,6 +53,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_Namespace_Esm_Basic/Scope _environment0_Import_Namespace_Esm_Basic
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_Namespace_Esm_Basic/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3806
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::_environment0_Import_Namespace_Esm_Basic
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3815
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3818
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x381b
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::_environment0_Import_Namespace_Esm_Basic
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_Esm_Basic/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x382d
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::_environment0_Import_Namespace_Esm_Basic
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_Esm_Basic/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x383b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark
+
 
 		// Methods
 		.method public hidebysig static 
@@ -159,6 +266,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x384a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3852
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3855
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3858
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_default::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x386b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_default::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x387a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default
+
 
 		// Methods
 		.method public hidebysig static 
@@ -262,6 +470,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3889
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3891
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3894
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3897
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x38b1
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x38c7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get
+
 
 		// Methods
 		.method public hidebysig static 
@@ -320,6 +635,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_006DDFD4_L45C87
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_Namespace_Esm_Basic/Scope _environment0_Import_Namespace_Esm_Basic
+				.field private initonly class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_Namespace_Esm_Basic/Scope capture0,
+						class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3928
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86/FunctionObject_FunctionExpression_006DDFD4_L45C87::_environment0_Import_Namespace_Esm_Basic
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86/FunctionObject_FunctionExpression_006DDFD4_L45C87::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86/FunctionObject_FunctionExpression_006DDFD4_L45C87::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_006DDFD4_L45C87::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3945
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_006DDFD4_L45C87::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3948
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_006DDFD4_L45C87::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x394b
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86/FunctionObject_FunctionExpression_006DDFD4_L45C87::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_006DDFD4_L45C87::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x395d
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86/FunctionObject_FunctionExpression_006DDFD4_L45C87::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_006DDFD4_L45C87::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x396b
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_006DDFD4_L45C87::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_006DDFD4_L45C87
+
 
 			// Methods
 			.method public hidebysig static 
@@ -369,6 +801,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_61BBEADB_L46C94
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_Namespace_Esm_Basic/Scope _environment0_Import_Namespace_Esm_Basic
+				.field private initonly class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_Namespace_Esm_Basic/Scope capture0,
+						class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x397a
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93/FunctionObject_FunctionExpression_61BBEADB_L46C94::_environment0_Import_Namespace_Esm_Basic
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93/FunctionObject_FunctionExpression_61BBEADB_L46C94::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93/FunctionObject_FunctionExpression_61BBEADB_L46C94::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_61BBEADB_L46C94::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3997
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_61BBEADB_L46C94::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x399a
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_61BBEADB_L46C94::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x399d
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93/FunctionObject_FunctionExpression_61BBEADB_L46C94::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_61BBEADB_L46C94::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x39af
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93/FunctionObject_FunctionExpression_61BBEADB_L46C94::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_61BBEADB_L46C94::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x39bd
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_61BBEADB_L46C94::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_61BBEADB_L46C94
 
 
 			// Methods
@@ -423,6 +972,128 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7839B813_L56C87
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Import_Namespace_Esm_Basic/Scope _environment0_Import_Namespace_Esm_Basic
+					.field private initonly class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+					.field private initonly class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/Scope _environment2_FunctionExpression_L55C9
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Import_Namespace_Esm_Basic/Scope capture0,
+							class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope capture1,
+							class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x3a2c
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86/FunctionObject_FunctionExpression_7839B813_L56C87::_environment0_Import_Namespace_Esm_Basic
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86/FunctionObject_FunctionExpression_7839B813_L56C87::_environment1___jroc_esm_namespace
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86/FunctionObject_FunctionExpression_7839B813_L56C87::_environment2_FunctionExpression_L55C9
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86/FunctionObject_FunctionExpression_7839B813_L56C87::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_7839B813_L56C87::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x3a51
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_7839B813_L56C87::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x3a54
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_7839B813_L56C87::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x3a57
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86/FunctionObject_FunctionExpression_7839B813_L56C87::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_7839B813_L56C87::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x3a69
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86/FunctionObject_FunctionExpression_7839B813_L56C87::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_7839B813_L56C87::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x3a77
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_7839B813_L56C87::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_7839B813_L56C87
 
 
 				// Methods
@@ -489,6 +1160,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_CCE895B8_L55C10
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_Namespace_Esm_Basic/Scope _environment0_Import_Namespace_Esm_Basic
+				.field private initonly class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_Namespace_Esm_Basic/Scope capture0,
+						class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x39cc
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionObject_FunctionExpression_CCE895B8_L55C10::_environment0_Import_Namespace_Esm_Basic
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionObject_FunctionExpression_CCE895B8_L55C10::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionObject_FunctionExpression_CCE895B8_L55C10::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_CCE895B8_L55C10::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x39e9
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_CCE895B8_L55C10::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x39ec
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_CCE895B8_L55C10::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x39ef
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionObject_FunctionExpression_CCE895B8_L55C10::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_CCE895B8_L55C10::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3a08
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionObject_FunctionExpression_CCE895B8_L55C10::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_CCE895B8_L55C10::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3a1d
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_CCE895B8_L55C10::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_CCE895B8_L55C10
+
 
 			// Methods
 			.method public hidebysig static 
@@ -510,7 +1304,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_7839B813_L56C87,
+					[4] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86/FunctionObject_FunctionExpression_7839B813_L56C87,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -560,13 +1354,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_7839B813_L56C87::.ctor(class Modules.Import_Namespace_Esm_Basic/Scope, class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope, class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86/FunctionObject_FunctionExpression_7839B813_L56C87::.ctor(class Modules.Import_Namespace_Esm_Basic/Scope, class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope, class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_7839B813_L56C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86/FunctionObject_FunctionExpression_7839B813_L56C87>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -785,6 +1579,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_Namespace_Esm_Basic/Scope _environment0_Import_Namespace_Esm_Basic
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_Namespace_Esm_Basic/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x38d6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::_environment0_Import_Namespace_Esm_Basic
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x38e5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x38e8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x38eb
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::_environment0_Import_Namespace_Esm_Basic
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_Esm_Basic/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3904
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::_environment0_Import_Namespace_Esm_Basic
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_Esm_Basic/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3919
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace
+
 
 		// Methods
 		.method public hidebysig static 
@@ -824,12 +1731,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_006DDFD4_L45C87,
-				[21] class FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_61BBEADB_L46C94,
+				[20] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86/FunctionObject_FunctionExpression_006DDFD4_L45C87,
+				[21] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93/FunctionObject_FunctionExpression_61BBEADB_L46C94,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_CCE895B8_L55C10
+				[25] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionObject_FunctionExpression_CCE895B8_L55C10
 			)
 
 			IL_0000: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope::.ctor()
@@ -1035,13 +1942,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_006DDFD4_L45C87::.ctor(class Modules.Import_Namespace_Esm_Basic/Scope, class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86/FunctionObject_FunctionExpression_006DDFD4_L45C87::.ctor(class Modules.Import_Namespace_Esm_Basic/Scope, class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_006DDFD4_L45C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86/FunctionObject_FunctionExpression_006DDFD4_L45C87>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -1085,13 +1992,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_61BBEADB_L46C94::.ctor(class Modules.Import_Namespace_Esm_Basic/Scope, class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93/FunctionObject_FunctionExpression_61BBEADB_L46C94::.ctor(class Modules.Import_Namespace_Esm_Basic/Scope, class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_61BBEADB_L46C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93/FunctionObject_FunctionExpression_61BBEADB_L46C94>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -1261,13 +2168,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_CCE895B8_L55C10::.ctor(class Modules.Import_Namespace_Esm_Basic/Scope, class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionObject_FunctionExpression_CCE895B8_L55C10::.ctor(class Modules.Import_Namespace_Esm_Basic/Scope, class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_CCE895B8_L55C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionObject_FunctionExpression_CCE895B8_L55C10>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldc.i4.1
 				IL_0487: newarr [System.Runtime]System.Object
@@ -1386,6 +2293,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_Namespace_Esm_Basic/Scope _environment0_Import_Namespace_Esm_Basic
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_Namespace_Esm_Basic/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a86
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_export/FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::_environment0_Import_Namespace_Esm_Basic
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3a95
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3a98
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a9b
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_export/FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::_environment0_Import_Namespace_Esm_Basic
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_Esm_Basic/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3abb
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic/Scope Modules.Import_Namespace_Esm_Basic/__jroc_esm_export/FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::_environment0_Import_Namespace_Esm_Basic
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_Esm_Basic/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ad7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1499,14 +2525,14 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_Namespace_Esm_Basic/Scope,
-			[1] class FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default,
-			[2] class FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get,
-			[3] class FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace,
-			[4] class FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export,
+			[1] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_default/FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default,
+			[2] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_get/FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get,
+			[3] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace,
+			[4] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_export/FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export,
 			[5] object,
 			[6] object,
 			[7] object[],
-			[8] class FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark,
+			[8] class Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark,
 			[9] object,
 			[10] object
 		)
@@ -1527,13 +2553,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_Namespace_Esm_Basic/Scope
-		IL_0022: newobj instance void FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::.ctor(class Modules.Import_Namespace_Esm_Basic/Scope)
+		IL_0022: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::.ctor(class Modules.Import_Namespace_Esm_Basic/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 8
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 8
@@ -1545,13 +2571,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 7
-		IL_004b: newobj instance void FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_default/FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic/__jroc_esm_default/FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -1560,13 +2586,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 7
-		IL_006b: newobj instance void FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_get/FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic/__jroc_esm_get/FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -1579,13 +2605,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_Namespace_Esm_Basic/Scope
-		IL_0094: newobj instance void FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::.ctor(class Modules.Import_Namespace_Esm_Basic/Scope)
+		IL_0094: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::.ctor(class Modules.Import_Namespace_Esm_Basic/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -1598,13 +2624,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_Namespace_Esm_Basic/Scope
-		IL_00bd: newobj instance void FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::.ctor(class Modules.Import_Namespace_Esm_Basic/Scope)
+		IL_00bd: newobj instance void Modules.Import_Namespace_Esm_Basic/__jroc_esm_export/FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::.ctor(class Modules.Import_Namespace_Esm_Basic/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic/__jroc_esm_export/FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 4
 		IL_00d2: nop
 		IL_00d3: ldloc.0
@@ -1819,6 +2845,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_359263CA_L3C24
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/Scope _environment0_Import_Namespace_Esm_Basic_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_Namespace_Esm_Basic_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ae6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L3C23/FunctionObject_FunctionExpression_359263CA_L3C24::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_359263CA_L3C24::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3af5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_359263CA_L3C24::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3af8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_359263CA_L3C24::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3afb
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L3C23/FunctionObject_FunctionExpression_359263CA_L3C24::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L3C23::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_359263CA_L3C24::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b0d
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L3C23/FunctionObject_FunctionExpression_359263CA_L3C24::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L3C23::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_359263CA_L3C24::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b1b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_359263CA_L3C24::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_359263CA_L3C24
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1870,6 +3003,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6DC6BB6B_L4C26
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/Scope _environment0_Import_Namespace_Esm_Basic_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_Namespace_Esm_Basic_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b2a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_6DC6BB6B_L4C26::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_6DC6BB6B_L4C26::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3b39
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_6DC6BB6B_L4C26::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3b3c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_6DC6BB6B_L4C26::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b3f
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_6DC6BB6B_L4C26::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_6DC6BB6B_L4C26::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b51
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_6DC6BB6B_L4C26::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_6DC6BB6B_L4C26::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b5f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_6DC6BB6B_L4C26::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_6DC6BB6B_L4C26
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1919,6 +3159,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7ACDD46D_L5C30
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/Scope _environment0_Import_Namespace_Esm_Basic_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_Namespace_Esm_Basic_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b6e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L5C29/FunctionObject_FunctionExpression_7ACDD46D_L5C30::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_7ACDD46D_L5C30::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3b7d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7ACDD46D_L5C30::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3b80
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7ACDD46D_L5C30::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b83
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L5C29/FunctionObject_FunctionExpression_7ACDD46D_L5C30::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L5C29::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_7ACDD46D_L5C30::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b95
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L5C29/FunctionObject_FunctionExpression_7ACDD46D_L5C30::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L5C29::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_7ACDD46D_L5C30::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ba3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_7ACDD46D_L5C30::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_7ACDD46D_L5C30
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1967,6 +3314,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_AA155EE4_inc
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/Scope _environment0_Import_Namespace_Esm_Basic_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_Namespace_Esm_Basic_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3bb2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/inc/FunctionObject_FunctionDeclaration_AA155EE4_inc::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_AA155EE4_inc::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3bc1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_AA155EE4_inc::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3bc4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_AA155EE4_inc::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3bc7
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/inc/FunctionObject_FunctionDeclaration_AA155EE4_inc::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_Namespace_Esm_Basic_Lib/inc::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_AA155EE4_inc::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3bd9
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/inc/FunctionObject_FunctionDeclaration_AA155EE4_inc::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/inc::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_AA155EE4_inc::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3be7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_AA155EE4_inc::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_AA155EE4_inc
 
 
 		// Methods
@@ -2031,6 +3485,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6DC8C2FC_getX
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/Scope _environment0_Import_Namespace_Esm_Basic_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_Namespace_Esm_Basic_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3bf6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/getX/FunctionObject_FunctionDeclaration_6DC8C2FC_getX::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6DC8C2FC_getX::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3c05
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6DC8C2FC_getX::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3c08
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6DC8C2FC_getX::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3c0b
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/getX/FunctionObject_FunctionDeclaration_6DC8C2FC_getX::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_Namespace_Esm_Basic_Lib/getX::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_6DC8C2FC_getX::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3c1d
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/getX/FunctionObject_FunctionDeclaration_6DC8C2FC_getX::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/getX::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_6DC8C2FC_getX::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3c2b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6DC8C2FC_getX::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_6DC8C2FC_getX
 
 
 		// Methods
@@ -2104,6 +3665,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/Scope _environment0_Import_Namespace_Esm_Basic_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_Namespace_Esm_Basic_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3c3a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3c49
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3c4c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3c4f
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3c61
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3c6f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark
 
 
 		// Methods
@@ -2211,6 +3879,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3c7e
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3c86
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3c89
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3c8c
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_default::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3c9f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_default::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3cae
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2314,6 +4083,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_72668557___jroc_esm_get
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3cbd
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_72668557___jroc_esm_get::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3cc5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_72668557___jroc_esm_get::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3cc8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_72668557___jroc_esm_get::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ccb
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_72668557___jroc_esm_get::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ce5
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_72668557___jroc_esm_get::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3cfb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_72668557___jroc_esm_get::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_72668557___jroc_esm_get
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2372,6 +4248,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A97A51A2_L43C87
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/Scope _environment0_Import_Namespace_Esm_Basic_Lib
+				.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_Namespace_Esm_Basic_Lib/Scope capture0,
+						class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3d5c
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_A97A51A2_L43C87::_environment0_Import_Namespace_Esm_Basic_Lib
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_A97A51A2_L43C87::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_A97A51A2_L43C87::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_A97A51A2_L43C87::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3d79
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_A97A51A2_L43C87::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3d7c
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_A97A51A2_L43C87::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x3d7f
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_A97A51A2_L43C87::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_A97A51A2_L43C87::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3d91
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_A97A51A2_L43C87::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_A97A51A2_L43C87::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3d9f
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_A97A51A2_L43C87::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_A97A51A2_L43C87
+
 
 			// Methods
 			.method public hidebysig static 
@@ -2421,6 +4414,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3F83402D_L44C94
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/Scope _environment0_Import_Namespace_Esm_Basic_Lib
+				.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_Namespace_Esm_Basic_Lib/Scope capture0,
+						class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3dae
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_3F83402D_L44C94::_environment0_Import_Namespace_Esm_Basic_Lib
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_3F83402D_L44C94::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_3F83402D_L44C94::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_3F83402D_L44C94::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3dcb
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_3F83402D_L44C94::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3dce
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_3F83402D_L44C94::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x3dd1
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_3F83402D_L44C94::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_3F83402D_L44C94::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3de3
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_3F83402D_L44C94::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_3F83402D_L44C94::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3df1
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_3F83402D_L44C94::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_3F83402D_L44C94
 
 
 			// Methods
@@ -2475,6 +4585,128 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9C1A8725_L54C87
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/Scope _environment0_Import_Namespace_Esm_Basic_Lib
+					.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+					.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope _environment2_FunctionExpression_L53C9
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Import_Namespace_Esm_Basic_Lib/Scope capture0,
+							class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope capture1,
+							class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x3e60
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_9C1A8725_L54C87::_environment0_Import_Namespace_Esm_Basic_Lib
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_9C1A8725_L54C87::_environment1___jroc_esm_namespace
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_9C1A8725_L54C87::_environment2_FunctionExpression_L53C9
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_9C1A8725_L54C87::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_9C1A8725_L54C87::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x3e85
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_9C1A8725_L54C87::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x3e88
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_9C1A8725_L54C87::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x3e8b
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_9C1A8725_L54C87::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_9C1A8725_L54C87::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x3e9d
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_9C1A8725_L54C87::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_9C1A8725_L54C87::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x3eab
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_9C1A8725_L54C87::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_9C1A8725_L54C87
 
 
 				// Methods
@@ -2541,6 +4773,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_CBC7A6C8_L53C10
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/Scope _environment0_Import_Namespace_Esm_Basic_Lib
+				.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_Namespace_Esm_Basic_Lib/Scope capture0,
+						class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3e00
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_CBC7A6C8_L53C10::_environment0_Import_Namespace_Esm_Basic_Lib
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_CBC7A6C8_L53C10::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_CBC7A6C8_L53C10::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_CBC7A6C8_L53C10::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3e1d
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_CBC7A6C8_L53C10::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3e20
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_CBC7A6C8_L53C10::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x3e23
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_CBC7A6C8_L53C10::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_CBC7A6C8_L53C10::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3e3c
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_CBC7A6C8_L53C10::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_CBC7A6C8_L53C10::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3e51
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_CBC7A6C8_L53C10::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_CBC7A6C8_L53C10
+
 
 			// Methods
 			.method public hidebysig static 
@@ -2562,7 +4917,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_9C1A8725_L54C87,
+					[4] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_9C1A8725_L54C87,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -2612,13 +4967,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_9C1A8725_L54C87::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope, class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_9C1A8725_L54C87::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope, class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_9C1A8725_L54C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_9C1A8725_L54C87>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -2837,6 +5192,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/Scope _environment0_Import_Namespace_Esm_Basic_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_Namespace_Esm_Basic_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3d0a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3d19
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3d1c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3d1f
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3d38
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3d4d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2876,12 +5344,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_A97A51A2_L43C87,
-				[21] class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_3F83402D_L44C94,
+				[20] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_A97A51A2_L43C87,
+				[21] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_3F83402D_L44C94,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_CBC7A6C8_L53C10
+				[25] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_CBC7A6C8_L53C10
 			)
 
 			IL_0000: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope::.ctor()
@@ -3087,13 +5555,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_A97A51A2_L43C87::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_A97A51A2_L43C87::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_A97A51A2_L43C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_A97A51A2_L43C87>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -3137,13 +5605,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_3F83402D_L44C94::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_3F83402D_L44C94::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_3F83402D_L44C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_3F83402D_L44C94>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -3313,13 +5781,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_CBC7A6C8_L53C10::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_CBC7A6C8_L53C10::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_CBC7A6C8_L53C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_CBC7A6C8_L53C10>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldc.i4.1
 				IL_0487: newarr [System.Runtime]System.Object
@@ -3437,6 +5905,127 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/Scope _environment0_Import_Namespace_Esm_Basic_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_Namespace_Esm_Basic_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3eba
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3ec9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3ecc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ecf
+				// Header size: 1
+				// Code size: 36 (0x24)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0017: ldarg.2
+				IL_0018: ldc.i4.1
+				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001e: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object, string, object)
+				IL_0023: ret
+			} // end of method FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ef4
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::_environment0_Import_Namespace_Esm_Basic_Lib
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.1
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object, string, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3f15
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export
 
 
 		// Methods
@@ -3559,19 +6148,19 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_Namespace_Esm_Basic_Lib/Scope,
-			[1] class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default,
-			[2] class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_72668557___jroc_esm_get,
-			[3] class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace,
-			[4] class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export,
+			[1] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default,
+			[2] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_72668557___jroc_esm_get,
+			[3] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace,
+			[4] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export,
 			[5] object[],
-			[6] class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_AA155EE4_inc,
-			[7] class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_6DC8C2FC_getX,
-			[8] class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark,
+			[6] class Modules.Import_Namespace_Esm_Basic_Lib/inc/FunctionObject_FunctionDeclaration_AA155EE4_inc,
+			[7] class Modules.Import_Namespace_Esm_Basic_Lib/getX/FunctionObject_FunctionDeclaration_6DC8C2FC_getX,
+			[8] class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark,
 			[9] object,
 			[10] object[],
-			[11] class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_359263CA_L3C24,
-			[12] class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_6DC6BB6B_L4C26,
-			[13] class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_7ACDD46D_L5C30
+			[11] class Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L3C23/FunctionObject_FunctionExpression_359263CA_L3C24,
+			[12] class Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_6DC6BB6B_L4C26,
+			[13] class Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L5C29/FunctionObject_FunctionExpression_7ACDD46D_L5C30
 		)
 
 		IL_0000: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/Scope::.ctor()
@@ -3590,13 +6179,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_0022: newobj instance void FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_AA155EE4_inc::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
+		IL_0022: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/inc/FunctionObject_FunctionDeclaration_AA155EE4_inc::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "inc"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_AA155EE4_inc>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/inc/FunctionObject_FunctionDeclaration_AA155EE4_inc>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 6
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 6
@@ -3612,13 +6201,13 @@
 		IL_004d: ldc.i4.0
 		IL_004e: ldelem.ref
 		IL_004f: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_0054: newobj instance void FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_6DC8C2FC_getX::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
+		IL_0054: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/getX/FunctionObject_FunctionDeclaration_6DC8C2FC_getX::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
 		IL_0059: ldc.i4.0
 		IL_005a: conv.r8
 		IL_005b: ldstr "getX"
 		IL_0060: ldc.i4.0
 		IL_0061: ldc.i4.1
-		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_6DC8C2FC_getX>(!!0, float64, string, bool, bool)
+		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/getX/FunctionObject_FunctionDeclaration_6DC8C2FC_getX>(!!0, float64, string, bool, bool)
 		IL_0067: stloc.s 7
 		IL_0069: ldloc.0
 		IL_006a: ldloc.s 7
@@ -3634,13 +6223,13 @@
 		IL_007f: ldc.i4.0
 		IL_0080: ldelem.ref
 		IL_0081: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_0086: newobj instance void FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
+		IL_0086: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
 		IL_008b: ldc.i4.0
 		IL_008c: conv.r8
 		IL_008d: ldstr "__jroc_esm_mark"
 		IL_0092: ldc.i4.0
 		IL_0093: ldc.i4.1
-		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0094: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark>(!!0, float64, string, bool, bool)
 		IL_0099: stloc.s 8
 		IL_009b: ldloc.0
 		IL_009c: ldloc.s 8
@@ -3652,13 +6241,13 @@
 		IL_00ab: ldloc.0
 		IL_00ac: stelem.ref
 		IL_00ad: stloc.s 5
-		IL_00af: newobj instance void FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default::.ctor()
+		IL_00af: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default::.ctor()
 		IL_00b4: ldc.i4.1
 		IL_00b5: conv.r8
 		IL_00b6: ldstr "__jroc_esm_default"
 		IL_00bb: ldc.i4.0
 		IL_00bc: ldc.i4.1
-		IL_00bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_00bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default>(!!0, float64, string, bool, bool)
 		IL_00c2: stloc.1
 		IL_00c3: ldc.i4.1
 		IL_00c4: newarr [System.Runtime]System.Object
@@ -3667,13 +6256,13 @@
 		IL_00cb: ldloc.0
 		IL_00cc: stelem.ref
 		IL_00cd: stloc.s 5
-		IL_00cf: newobj instance void FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_72668557___jroc_esm_get::.ctor()
+		IL_00cf: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_72668557___jroc_esm_get::.ctor()
 		IL_00d4: ldc.i4.2
 		IL_00d5: conv.r8
 		IL_00d6: ldstr "__jroc_esm_get"
 		IL_00db: ldc.i4.0
 		IL_00dc: ldc.i4.1
-		IL_00dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_72668557___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_00dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_72668557___jroc_esm_get>(!!0, float64, string, bool, bool)
 		IL_00e2: stloc.2
 		IL_00e3: ldc.i4.1
 		IL_00e4: newarr [System.Runtime]System.Object
@@ -3686,13 +6275,13 @@
 		IL_00f1: ldc.i4.0
 		IL_00f2: ldelem.ref
 		IL_00f3: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_00f8: newobj instance void FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
+		IL_00f8: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
 		IL_00fd: ldc.i4.1
 		IL_00fe: conv.r8
 		IL_00ff: ldstr "__jroc_esm_namespace"
 		IL_0104: ldc.i4.0
 		IL_0105: ldc.i4.1
-		IL_0106: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_0106: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace>(!!0, float64, string, bool, bool)
 		IL_010b: stloc.3
 		IL_010c: ldc.i4.1
 		IL_010d: newarr [System.Runtime]System.Object
@@ -3705,13 +6294,13 @@
 		IL_011a: ldc.i4.0
 		IL_011b: ldelem.ref
 		IL_011c: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_0121: newobj instance void FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
+		IL_0121: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
 		IL_0126: ldc.i4.2
 		IL_0127: conv.r8
 		IL_0128: ldstr "__jroc_esm_export"
 		IL_012d: ldc.i4.0
 		IL_012e: ldc.i4.1
-		IL_012f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_012f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export>(!!0, float64, string, bool, bool)
 		IL_0134: stloc.s 4
 		IL_0136: nop
 		IL_0137: ldloc.0
@@ -3734,13 +6323,13 @@
 		IL_0161: ldc.i4.0
 		IL_0162: ldelem.ref
 		IL_0163: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_0168: newobj instance void FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_359263CA_L3C24::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
+		IL_0168: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L3C23/FunctionObject_FunctionExpression_359263CA_L3C24::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
 		IL_016d: ldc.i4.0
 		IL_016e: conv.r8
 		IL_016f: ldstr ""
 		IL_0174: ldc.i4.0
 		IL_0175: ldc.i4.1
-		IL_0176: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_359263CA_L3C24>(!!0, float64, string, bool, bool)
+		IL_0176: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L3C23/FunctionObject_FunctionExpression_359263CA_L3C24>(!!0, float64, string, bool, bool)
 		IL_017b: stloc.s 11
 		IL_017d: ldloc.s 4
 		IL_017f: ldloc.s 5
@@ -3761,13 +6350,13 @@
 		IL_01a3: ldc.i4.0
 		IL_01a4: ldelem.ref
 		IL_01a5: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_01aa: newobj instance void FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_6DC6BB6B_L4C26::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
+		IL_01aa: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_6DC6BB6B_L4C26::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
 		IL_01af: ldc.i4.0
 		IL_01b0: conv.r8
 		IL_01b1: ldstr ""
 		IL_01b6: ldc.i4.0
 		IL_01b7: ldc.i4.1
-		IL_01b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_6DC6BB6B_L4C26>(!!0, float64, string, bool, bool)
+		IL_01b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_6DC6BB6B_L4C26>(!!0, float64, string, bool, bool)
 		IL_01bd: stloc.s 12
 		IL_01bf: ldloc.s 4
 		IL_01c1: ldloc.s 5
@@ -3788,13 +6377,13 @@
 		IL_01e5: ldc.i4.0
 		IL_01e6: ldelem.ref
 		IL_01e7: castclass Modules.Import_Namespace_Esm_Basic_Lib/Scope
-		IL_01ec: newobj instance void FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_7ACDD46D_L5C30::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
+		IL_01ec: newobj instance void Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L5C29/FunctionObject_FunctionExpression_7ACDD46D_L5C30::.ctor(class Modules.Import_Namespace_Esm_Basic_Lib/Scope)
 		IL_01f1: ldc.i4.0
 		IL_01f2: conv.r8
 		IL_01f3: ldstr ""
 		IL_01f8: ldc.i4.0
 		IL_01f9: ldc.i4.1
-		IL_01fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_7ACDD46D_L5C30>(!!0, float64, string, bool, bool)
+		IL_01fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L5C29/FunctionObject_FunctionExpression_7ACDD46D_L5C30>(!!0, float64, string, bool, bool)
 		IL_01ff: stloc.s 13
 		IL_0201: ldloc.s 4
 		IL_0203: ldloc.s 5
@@ -3810,2595 +6399,6 @@
 	} // end of method Import_Namespace_Esm_Basic_Lib::__js_module_init__
 
 } // end of class Modules.Import_Namespace_Esm_Basic_Lib
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_Esm_Basic/Scope _environment0_Import_Namespace_Esm_Basic
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_Esm_Basic/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3806
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_Esm_Basic/Scope FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::_environment0_Import_Namespace_Esm_Basic
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3815
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3818
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x381b
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic/Scope FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::_environment0_Import_Namespace_Esm_Basic
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_Esm_Basic/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x382d
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic/Scope FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::_environment0_Import_Namespace_Esm_Basic
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_Esm_Basic/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x383b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_8F5924A8___jroc_esm_mark
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x384a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3852
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3855
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3858
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_default::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x386b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_default::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x387a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_BE49D806___jroc_esm_default
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3889
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3891
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3894
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3897
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x38b1
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x38c7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_D97025EF___jroc_esm_get
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_Esm_Basic/Scope _environment0_Import_Namespace_Esm_Basic
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_Esm_Basic/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x38d6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_Esm_Basic/Scope FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::_environment0_Import_Namespace_Esm_Basic
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x38e5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x38e8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x38eb
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic/Scope FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::_environment0_Import_Namespace_Esm_Basic
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_Esm_Basic/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3904
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic/Scope FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::_environment0_Import_Namespace_Esm_Basic
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_Esm_Basic/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3919
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_2DF4C078___jroc_esm_namespace
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_006DDFD4_L45C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_Esm_Basic/Scope _environment0_Import_Namespace_Esm_Basic
-	.field private initonly class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_Esm_Basic/Scope capture0,
-			class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3928
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_Esm_Basic/Scope FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_006DDFD4_L45C87::_environment0_Import_Namespace_Esm_Basic
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_006DDFD4_L45C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_006DDFD4_L45C87::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_006DDFD4_L45C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3945
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_006DDFD4_L45C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3948
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_006DDFD4_L45C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x394b
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_006DDFD4_L45C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_006DDFD4_L45C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x395d
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_006DDFD4_L45C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L45C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_006DDFD4_L45C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x396b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_006DDFD4_L45C87::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_006DDFD4_L45C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_61BBEADB_L46C94
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_Esm_Basic/Scope _environment0_Import_Namespace_Esm_Basic
-	.field private initonly class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_Esm_Basic/Scope capture0,
-			class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x397a
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_Esm_Basic/Scope FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_61BBEADB_L46C94::_environment0_Import_Namespace_Esm_Basic
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_61BBEADB_L46C94::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_61BBEADB_L46C94::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_61BBEADB_L46C94::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3997
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_61BBEADB_L46C94::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x399a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_61BBEADB_L46C94::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x399d
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_61BBEADB_L46C94::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_61BBEADB_L46C94::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x39af
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_61BBEADB_L46C94::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L46C93::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_61BBEADB_L46C94::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x39bd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_61BBEADB_L46C94::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_61BBEADB_L46C94
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_CCE895B8_L55C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_Esm_Basic/Scope _environment0_Import_Namespace_Esm_Basic
-	.field private initonly class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_Esm_Basic/Scope capture0,
-			class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x39cc
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_Esm_Basic/Scope FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_CCE895B8_L55C10::_environment0_Import_Namespace_Esm_Basic
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_CCE895B8_L55C10::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_CCE895B8_L55C10::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_CCE895B8_L55C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x39e9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_CCE895B8_L55C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x39ec
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_CCE895B8_L55C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x39ef
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_CCE895B8_L55C10::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_CCE895B8_L55C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a08
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_CCE895B8_L55C10::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_CCE895B8_L55C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a1d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_CCE895B8_L55C10::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_CCE895B8_L55C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_7839B813_L56C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_Esm_Basic/Scope _environment0_Import_Namespace_Esm_Basic
-	.field private initonly class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/Scope _environment2_FunctionExpression_L55C9
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_Esm_Basic/Scope capture0,
-			class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope capture1,
-			class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a2c
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_Esm_Basic/Scope FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_7839B813_L56C87::_environment0_Import_Namespace_Esm_Basic
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/Scope FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_7839B813_L56C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/Scope FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_7839B813_L56C87::_environment2_FunctionExpression_L55C9
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_7839B813_L56C87::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_7839B813_L56C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3a51
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7839B813_L56C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3a54
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7839B813_L56C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a57
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_7839B813_L56C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_7839B813_L56C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a69
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_7839B813_L56C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_namespace/FunctionExpression_L55C9/FunctionExpression_L56C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_7839B813_L56C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a77
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7839B813_L56C87::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionExpression_7839B813_L56C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_Esm_Basic/Scope _environment0_Import_Namespace_Esm_Basic
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_Esm_Basic/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a86
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_Esm_Basic/Scope FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::_environment0_Import_Namespace_Esm_Basic
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3a95
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3a98
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a9b
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic/Scope FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::_environment0_Import_Namespace_Esm_Basic
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_Esm_Basic/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3abb
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic/Scope FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::_environment0_Import_Namespace_Esm_Basic
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Import_Namespace_Esm_Basic/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_Esm_Basic/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ad7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_Esm_Basic_E0B498A5.FunctionObject_FunctionDeclaration_F5C5F89B___jroc_esm_export
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_359263CA_L3C24
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/Scope _environment0_Import_Namespace_Esm_Basic_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_Esm_Basic_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ae6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_359263CA_L3C24::_environment0_Import_Namespace_Esm_Basic_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_359263CA_L3C24::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3af5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_359263CA_L3C24::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3af8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_359263CA_L3C24::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3afb
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_359263CA_L3C24::_environment0_Import_Namespace_Esm_Basic_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L3C23::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_359263CA_L3C24::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b0d
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_359263CA_L3C24::_environment0_Import_Namespace_Esm_Basic_Lib
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L3C23::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_359263CA_L3C24::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b1b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_359263CA_L3C24::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_359263CA_L3C24
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_6DC6BB6B_L4C26
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/Scope _environment0_Import_Namespace_Esm_Basic_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_Esm_Basic_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b2a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_6DC6BB6B_L4C26::_environment0_Import_Namespace_Esm_Basic_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_6DC6BB6B_L4C26::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3b39
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6DC6BB6B_L4C26::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3b3c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6DC6BB6B_L4C26::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b3f
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_6DC6BB6B_L4C26::_environment0_Import_Namespace_Esm_Basic_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_6DC6BB6B_L4C26::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b51
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_6DC6BB6B_L4C26::_environment0_Import_Namespace_Esm_Basic_Lib
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_6DC6BB6B_L4C26::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b5f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_6DC6BB6B_L4C26::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_6DC6BB6B_L4C26
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_7ACDD46D_L5C30
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/Scope _environment0_Import_Namespace_Esm_Basic_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_Esm_Basic_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b6e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_7ACDD46D_L5C30::_environment0_Import_Namespace_Esm_Basic_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7ACDD46D_L5C30::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3b7d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7ACDD46D_L5C30::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3b80
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7ACDD46D_L5C30::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b83
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_7ACDD46D_L5C30::_environment0_Import_Namespace_Esm_Basic_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L5C29::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_7ACDD46D_L5C30::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b95
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_7ACDD46D_L5C30::_environment0_Import_Namespace_Esm_Basic_Lib
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/FunctionExpression_L5C29::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_7ACDD46D_L5C30::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ba3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7ACDD46D_L5C30::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_7ACDD46D_L5C30
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_AA155EE4_inc
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/Scope _environment0_Import_Namespace_Esm_Basic_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_Esm_Basic_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3bb2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_AA155EE4_inc::_environment0_Import_Namespace_Esm_Basic_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_AA155EE4_inc::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3bc1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_AA155EE4_inc::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3bc4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_AA155EE4_inc::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3bc7
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_AA155EE4_inc::_environment0_Import_Namespace_Esm_Basic_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_Namespace_Esm_Basic_Lib/inc::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_AA155EE4_inc::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3bd9
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_AA155EE4_inc::_environment0_Import_Namespace_Esm_Basic_Lib
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/inc::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_AA155EE4_inc::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3be7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_AA155EE4_inc::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_AA155EE4_inc
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_6DC8C2FC_getX
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/Scope _environment0_Import_Namespace_Esm_Basic_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_Esm_Basic_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3bf6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_6DC8C2FC_getX::_environment0_Import_Namespace_Esm_Basic_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6DC8C2FC_getX::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3c05
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6DC8C2FC_getX::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3c08
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6DC8C2FC_getX::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c0b
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_6DC8C2FC_getX::_environment0_Import_Namespace_Esm_Basic_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_Namespace_Esm_Basic_Lib/getX::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_6DC8C2FC_getX::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c1d
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_6DC8C2FC_getX::_environment0_Import_Namespace_Esm_Basic_Lib
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/getX::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_6DC8C2FC_getX::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c2b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6DC8C2FC_getX::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_6DC8C2FC_getX
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/Scope _environment0_Import_Namespace_Esm_Basic_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_Esm_Basic_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c3a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::_environment0_Import_Namespace_Esm_Basic_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3c49
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3c4c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c4f
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::_environment0_Import_Namespace_Esm_Basic_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c61
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::_environment0_Import_Namespace_Esm_Basic_Lib
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c6f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_8EF35EA0___jroc_esm_mark
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3c7e
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3c86
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3c89
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c8c
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_default::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c9f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_default::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3cae
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_DCD519DE___jroc_esm_default
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_72668557___jroc_esm_get
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3cbd
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_72668557___jroc_esm_get::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3cc5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_72668557___jroc_esm_get::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3cc8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_72668557___jroc_esm_get::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ccb
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_72668557___jroc_esm_get::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ce5
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_72668557___jroc_esm_get::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3cfb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_72668557___jroc_esm_get::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_72668557___jroc_esm_get
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/Scope _environment0_Import_Namespace_Esm_Basic_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_Esm_Basic_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3d0a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::_environment0_Import_Namespace_Esm_Basic_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3d19
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3d1c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3d1f
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::_environment0_Import_Namespace_Esm_Basic_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3d38
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::_environment0_Import_Namespace_Esm_Basic_Lib
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3d4d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_BB6968A0___jroc_esm_namespace
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_A97A51A2_L43C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/Scope _environment0_Import_Namespace_Esm_Basic_Lib
-	.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_Esm_Basic_Lib/Scope capture0,
-			class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3d5c
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_A97A51A2_L43C87::_environment0_Import_Namespace_Esm_Basic_Lib
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_A97A51A2_L43C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_A97A51A2_L43C87::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_A97A51A2_L43C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3d79
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A97A51A2_L43C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3d7c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A97A51A2_L43C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3d7f
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_A97A51A2_L43C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_A97A51A2_L43C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3d91
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_A97A51A2_L43C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L43C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_A97A51A2_L43C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3d9f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A97A51A2_L43C87::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_A97A51A2_L43C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_3F83402D_L44C94
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/Scope _environment0_Import_Namespace_Esm_Basic_Lib
-	.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_Esm_Basic_Lib/Scope capture0,
-			class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3dae
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_3F83402D_L44C94::_environment0_Import_Namespace_Esm_Basic_Lib
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_3F83402D_L44C94::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_3F83402D_L44C94::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_3F83402D_L44C94::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3dcb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3F83402D_L44C94::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3dce
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3F83402D_L44C94::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3dd1
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_3F83402D_L44C94::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_3F83402D_L44C94::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3de3
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_3F83402D_L44C94::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L44C93::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_3F83402D_L44C94::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3df1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3F83402D_L44C94::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_3F83402D_L44C94
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_CBC7A6C8_L53C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/Scope _environment0_Import_Namespace_Esm_Basic_Lib
-	.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_Esm_Basic_Lib/Scope capture0,
-			class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3e00
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_CBC7A6C8_L53C10::_environment0_Import_Namespace_Esm_Basic_Lib
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_CBC7A6C8_L53C10::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_CBC7A6C8_L53C10::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_CBC7A6C8_L53C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3e1d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_CBC7A6C8_L53C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3e20
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_CBC7A6C8_L53C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3e23
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_CBC7A6C8_L53C10::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_CBC7A6C8_L53C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3e3c
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_CBC7A6C8_L53C10::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_CBC7A6C8_L53C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3e51
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_CBC7A6C8_L53C10::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_CBC7A6C8_L53C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_9C1A8725_L54C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/Scope _environment0_Import_Namespace_Esm_Basic_Lib
-	.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope _environment2_FunctionExpression_L53C9
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_Esm_Basic_Lib/Scope capture0,
-			class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope capture1,
-			class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x3e60
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_9C1A8725_L54C87::_environment0_Import_Namespace_Esm_Basic_Lib
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_9C1A8725_L54C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_9C1A8725_L54C87::_environment2_FunctionExpression_L53C9
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_9C1A8725_L54C87::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_9C1A8725_L54C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3e85
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9C1A8725_L54C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3e88
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9C1A8725_L54C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3e8b
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_9C1A8725_L54C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_9C1A8725_L54C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3e9d
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_9C1A8725_L54C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_9C1A8725_L54C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3eab
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_9C1A8725_L54C87::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionExpression_9C1A8725_L54C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_Esm_Basic_Lib/Scope _environment0_Import_Namespace_Esm_Basic_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_Esm_Basic_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3eba
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::_environment0_Import_Namespace_Esm_Basic_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3ec9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3ecc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ecf
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::_environment0_Import_Namespace_Esm_Basic_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0017: ldarg.2
-		IL_0018: ldc.i4.1
-		IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001e: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object, string, object)
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ef4
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_Esm_Basic_Lib/Scope FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::_environment0_Import_Namespace_Esm_Basic_Lib
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.1
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.Import_Namespace_Esm_Basic_Lib/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_Esm_Basic_Lib/Scope, object, string, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3f15
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_Esm_Basic_Lib_06A11A6D.FunctionObject_FunctionDeclaration_299616B3___jroc_esm_export
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_FromCjs_Stable.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_Namespace_FromCjs_Stable.verified.txt
@@ -53,6 +53,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_Namespace_FromCjs_Stable/Scope _environment0_Import_Namespace_FromCjs_Stable
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_Namespace_FromCjs_Stable/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x413d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::_environment0_Import_Namespace_FromCjs_Stable
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x414c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x414f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4152
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::_environment0_Import_Namespace_FromCjs_Stable
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4164
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::_environment0_Import_Namespace_FromCjs_Stable
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4172
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark
+
 
 		// Methods
 		.method public hidebysig static 
@@ -159,6 +266,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4181
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4189
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x418c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x418f
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_default::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x41a2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_default::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x41b1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default
+
 
 		// Methods
 		.method public hidebysig static 
@@ -262,6 +470,115 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x41c0
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x41c8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x41cb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x41ce
+				// Header size: 1
+				// Code size: 30 (0x1e)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0018: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, string)
+				IL_001d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x41ed
+				// Header size: 1
+				// Code size: 26 (0x1a)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0014: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, string)
+				IL_0019: ret
+			} // end of method FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4208
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get
+
 
 		// Methods
 		.method public hidebysig static 
@@ -320,6 +637,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DC2ECB5E_L43C87
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_Namespace_FromCjs_Stable/Scope _environment0_Import_Namespace_FromCjs_Stable
+				.field private initonly class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_Namespace_FromCjs_Stable/Scope capture0,
+						class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x4269
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_DC2ECB5E_L43C87::_environment0_Import_Namespace_FromCjs_Stable
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_DC2ECB5E_L43C87::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_DC2ECB5E_L43C87::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_DC2ECB5E_L43C87::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x4286
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_DC2ECB5E_L43C87::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x4289
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_DC2ECB5E_L43C87::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x428c
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_DC2ECB5E_L43C87::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_DC2ECB5E_L43C87::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x429e
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_DC2ECB5E_L43C87::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_DC2ECB5E_L43C87::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x42ac
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_DC2ECB5E_L43C87::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_DC2ECB5E_L43C87
+
 
 			// Methods
 			.method public hidebysig static 
@@ -369,6 +803,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A8084EC1_L44C94
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_Namespace_FromCjs_Stable/Scope _environment0_Import_Namespace_FromCjs_Stable
+				.field private initonly class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_Namespace_FromCjs_Stable/Scope capture0,
+						class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x42bb
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_A8084EC1_L44C94::_environment0_Import_Namespace_FromCjs_Stable
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_A8084EC1_L44C94::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_A8084EC1_L44C94::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_A8084EC1_L44C94::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x42d8
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_A8084EC1_L44C94::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x42db
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_A8084EC1_L44C94::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x42de
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_A8084EC1_L44C94::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_A8084EC1_L44C94::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x42f0
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_A8084EC1_L44C94::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_A8084EC1_L44C94::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x42fe
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_A8084EC1_L44C94::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_A8084EC1_L44C94
 
 
 			// Methods
@@ -423,6 +974,128 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_4C2D45B9_L54C87
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Import_Namespace_FromCjs_Stable/Scope _environment0_Import_Namespace_FromCjs_Stable
+					.field private initonly class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+					.field private initonly class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/Scope _environment2_FunctionExpression_L53C9
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Import_Namespace_FromCjs_Stable/Scope capture0,
+							class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope capture1,
+							class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x436d
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_4C2D45B9_L54C87::_environment0_Import_Namespace_FromCjs_Stable
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_4C2D45B9_L54C87::_environment1___jroc_esm_namespace
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_4C2D45B9_L54C87::_environment2_FunctionExpression_L53C9
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_4C2D45B9_L54C87::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_4C2D45B9_L54C87::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x4392
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_4C2D45B9_L54C87::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x4395
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_4C2D45B9_L54C87::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x4398
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_4C2D45B9_L54C87::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_4C2D45B9_L54C87::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x43aa
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_4C2D45B9_L54C87::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_4C2D45B9_L54C87::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x43b8
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_4C2D45B9_L54C87::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_4C2D45B9_L54C87
 
 
 				// Methods
@@ -489,6 +1162,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9F4A7CF4_L53C10
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_Namespace_FromCjs_Stable/Scope _environment0_Import_Namespace_FromCjs_Stable
+				.field private initonly class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_Namespace_FromCjs_Stable/Scope capture0,
+						class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x430d
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_9F4A7CF4_L53C10::_environment0_Import_Namespace_FromCjs_Stable
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_9F4A7CF4_L53C10::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_9F4A7CF4_L53C10::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_9F4A7CF4_L53C10::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x432a
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_9F4A7CF4_L53C10::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x432d
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_9F4A7CF4_L53C10::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x4330
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_9F4A7CF4_L53C10::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_9F4A7CF4_L53C10::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x4349
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_9F4A7CF4_L53C10::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_9F4A7CF4_L53C10::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x435e
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_9F4A7CF4_L53C10::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_9F4A7CF4_L53C10
+
 
 			// Methods
 			.method public hidebysig static 
@@ -510,7 +1306,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_4C2D45B9_L54C87,
+					[4] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_4C2D45B9_L54C87,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -560,13 +1356,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_4C2D45B9_L54C87::.ctor(class Modules.Import_Namespace_FromCjs_Stable/Scope, class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope, class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_4C2D45B9_L54C87::.ctor(class Modules.Import_Namespace_FromCjs_Stable/Scope, class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope, class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_4C2D45B9_L54C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_4C2D45B9_L54C87>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -785,6 +1581,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_Namespace_FromCjs_Stable/Scope _environment0_Import_Namespace_FromCjs_Stable
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_Namespace_FromCjs_Stable/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4217
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::_environment0_Import_Namespace_FromCjs_Stable
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4226
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4229
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x422c
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::_environment0_Import_Namespace_FromCjs_Stable
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_FromCjs_Stable/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4245
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::_environment0_Import_Namespace_FromCjs_Stable
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_FromCjs_Stable/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x425a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace
+
 
 		// Methods
 		.method public hidebysig static 
@@ -824,12 +1733,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_DC2ECB5E_L43C87,
-				[21] class FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_A8084EC1_L44C94,
+				[20] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_DC2ECB5E_L43C87,
+				[21] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_A8084EC1_L44C94,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_9F4A7CF4_L53C10
+				[25] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_9F4A7CF4_L53C10
 			)
 
 			IL_0000: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope::.ctor()
@@ -1035,13 +1944,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_DC2ECB5E_L43C87::.ctor(class Modules.Import_Namespace_FromCjs_Stable/Scope, class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_DC2ECB5E_L43C87::.ctor(class Modules.Import_Namespace_FromCjs_Stable/Scope, class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_DC2ECB5E_L43C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_DC2ECB5E_L43C87>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -1085,13 +1994,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_A8084EC1_L44C94::.ctor(class Modules.Import_Namespace_FromCjs_Stable/Scope, class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_A8084EC1_L44C94::.ctor(class Modules.Import_Namespace_FromCjs_Stable/Scope, class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_A8084EC1_L44C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_A8084EC1_L44C94>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -1261,13 +2170,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_9F4A7CF4_L53C10::.ctor(class Modules.Import_Namespace_FromCjs_Stable/Scope, class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_9F4A7CF4_L53C10::.ctor(class Modules.Import_Namespace_FromCjs_Stable/Scope, class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_9F4A7CF4_L53C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_9F4A7CF4_L53C10>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldc.i4.1
 				IL_0487: newarr [System.Runtime]System.Object
@@ -1386,6 +2295,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_Namespace_FromCjs_Stable/Scope _environment0_Import_Namespace_FromCjs_Stable
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_Namespace_FromCjs_Stable/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x43c7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_export/FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::_environment0_Import_Namespace_FromCjs_Stable
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x43d6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x43d9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x43dc
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_export/FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::_environment0_Import_Namespace_FromCjs_Stable
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_FromCjs_Stable/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x43fc
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable/Scope Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_export/FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::_environment0_Import_Namespace_FromCjs_Stable
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_FromCjs_Stable/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4418
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1499,14 +2527,14 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_Namespace_FromCjs_Stable/Scope,
-			[1] class FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default,
-			[2] class FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get,
-			[3] class FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace,
-			[4] class FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export,
+			[1] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_default/FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default,
+			[2] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get/FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get,
+			[3] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace,
+			[4] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_export/FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export,
 			[5] object,
 			[6] object,
 			[7] object[],
-			[8] class FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark,
+			[8] class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark,
 			[9] object,
 			[10] object,
 			[11] object,
@@ -1530,13 +2558,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_Namespace_FromCjs_Stable/Scope
-		IL_0022: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::.ctor(class Modules.Import_Namespace_FromCjs_Stable/Scope)
+		IL_0022: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::.ctor(class Modules.Import_Namespace_FromCjs_Stable/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark/FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 8
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 8
@@ -1548,13 +2576,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 7
-		IL_004b: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_default/FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_default/FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -1563,13 +2591,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 7
-		IL_006b: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get/FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get/FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -1582,13 +2610,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_Namespace_FromCjs_Stable/Scope
-		IL_0094: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::.ctor(class Modules.Import_Namespace_FromCjs_Stable/Scope)
+		IL_0094: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::.ctor(class Modules.Import_Namespace_FromCjs_Stable/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -1601,13 +2629,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_Namespace_FromCjs_Stable/Scope
-		IL_00bd: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::.ctor(class Modules.Import_Namespace_FromCjs_Stable/Scope)
+		IL_00bd: newobj instance void Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_export/FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::.ctor(class Modules.Import_Namespace_FromCjs_Stable/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_export/FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 4
 		IL_00d2: nop
 		IL_00d3: ldloc.0
@@ -1821,6 +2849,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D865E319_L10C25
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_Namespace_FromCjs_Stable_A/Scope _environment0_Import_Namespace_FromCjs_Stable_A
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_Namespace_FromCjs_Stable_A/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4427
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/FunctionExpression_L10C24/FunctionObject_FunctionExpression_D865E319_L10C25::_environment0_Import_Namespace_FromCjs_Stable_A
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_D865E319_L10C25::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4436
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D865E319_L10C25::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4439
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D865E319_L10C25::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x443c
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/FunctionExpression_L10C24/FunctionObject_FunctionExpression_D865E319_L10C25::_environment0_Import_Namespace_FromCjs_Stable_A
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_A/FunctionExpression_L10C24::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_D865E319_L10C25::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x444e
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/FunctionExpression_L10C24/FunctionObject_FunctionExpression_D865E319_L10C25::_environment0_Import_Namespace_FromCjs_Stable_A
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_A/FunctionExpression_L10C24::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_D865E319_L10C25::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x445c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_D865E319_L10C25::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_D865E319_L10C25
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1891,6 +3026,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_Namespace_FromCjs_Stable_A/Scope _environment0_Import_Namespace_FromCjs_Stable_A
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_Namespace_FromCjs_Stable_A/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x446b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark/FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::_environment0_Import_Namespace_FromCjs_Stable_A
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x447a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x447d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4480
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark/FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::_environment0_Import_Namespace_FromCjs_Stable_A
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4492
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark/FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::_environment0_Import_Namespace_FromCjs_Stable_A
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x44a0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark
 
 
 		// Methods
@@ -1998,6 +3240,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x44af
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x44b7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x44ba
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x44bd
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_default::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x44d0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_default::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x44df
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2101,6 +3444,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x44ee
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x44f6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x44f9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x44fc
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4516
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x452c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2159,6 +3609,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_EC5DD978_L38C87
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_Namespace_FromCjs_Stable_A/Scope _environment0_Import_Namespace_FromCjs_Stable_A
+				.field private initonly class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_Namespace_FromCjs_Stable_A/Scope capture0,
+						class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x458d
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_EC5DD978_L38C87::_environment0_Import_Namespace_FromCjs_Stable_A
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_EC5DD978_L38C87::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_EC5DD978_L38C87::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_EC5DD978_L38C87::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x45aa
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_EC5DD978_L38C87::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x45ad
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_EC5DD978_L38C87::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x45b0
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_EC5DD978_L38C87::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_EC5DD978_L38C87::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x45c2
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_EC5DD978_L38C87::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_EC5DD978_L38C87::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x45d0
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_EC5DD978_L38C87::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_EC5DD978_L38C87
+
 
 			// Methods
 			.method public hidebysig static 
@@ -2208,6 +3775,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0C4BA5B9_L39C94
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_Namespace_FromCjs_Stable_A/Scope _environment0_Import_Namespace_FromCjs_Stable_A
+				.field private initonly class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_Namespace_FromCjs_Stable_A/Scope capture0,
+						class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x45df
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_0C4BA5B9_L39C94::_environment0_Import_Namespace_FromCjs_Stable_A
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_0C4BA5B9_L39C94::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_0C4BA5B9_L39C94::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_0C4BA5B9_L39C94::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x45fc
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_0C4BA5B9_L39C94::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x45ff
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_0C4BA5B9_L39C94::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x4602
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_0C4BA5B9_L39C94::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_0C4BA5B9_L39C94::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x4614
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_0C4BA5B9_L39C94::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_0C4BA5B9_L39C94::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x4622
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_0C4BA5B9_L39C94::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_0C4BA5B9_L39C94
 
 
 			// Methods
@@ -2262,6 +3946,128 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DC3B754A_L49C87
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Import_Namespace_FromCjs_Stable_A/Scope _environment0_Import_Namespace_FromCjs_Stable_A
+					.field private initonly class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+					.field private initonly class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/Scope _environment2_FunctionExpression_L48C9
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Import_Namespace_FromCjs_Stable_A/Scope capture0,
+							class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope capture1,
+							class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x4691
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DC3B754A_L49C87::_environment0_Import_Namespace_FromCjs_Stable_A
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DC3B754A_L49C87::_environment1___jroc_esm_namespace
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DC3B754A_L49C87::_environment2_FunctionExpression_L48C9
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DC3B754A_L49C87::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_DC3B754A_L49C87::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x46b6
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_DC3B754A_L49C87::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x46b9
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_DC3B754A_L49C87::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x46bc
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DC3B754A_L49C87::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_DC3B754A_L49C87::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x46ce
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DC3B754A_L49C87::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_DC3B754A_L49C87::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x46dc
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_DC3B754A_L49C87::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_DC3B754A_L49C87
 
 
 				// Methods
@@ -2328,6 +4134,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6078F843_L48C10
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_Namespace_FromCjs_Stable_A/Scope _environment0_Import_Namespace_FromCjs_Stable_A
+				.field private initonly class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_Namespace_FromCjs_Stable_A/Scope capture0,
+						class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x4631
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_6078F843_L48C10::_environment0_Import_Namespace_FromCjs_Stable_A
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_6078F843_L48C10::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_6078F843_L48C10::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_6078F843_L48C10::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x464e
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_6078F843_L48C10::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x4651
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_6078F843_L48C10::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x4654
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_6078F843_L48C10::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_6078F843_L48C10::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x466d
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_6078F843_L48C10::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_6078F843_L48C10::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x4682
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_6078F843_L48C10::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_6078F843_L48C10
+
 
 			// Methods
 			.method public hidebysig static 
@@ -2349,7 +4278,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_DC3B754A_L49C87,
+					[4] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DC3B754A_L49C87,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -2399,13 +4328,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_DC3B754A_L49C87::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope, class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DC3B754A_L49C87::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope, class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_DC3B754A_L49C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_DC3B754A_L49C87>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -2624,6 +4553,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_Namespace_FromCjs_Stable_A/Scope _environment0_Import_Namespace_FromCjs_Stable_A
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_Namespace_FromCjs_Stable_A/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x453b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::_environment0_Import_Namespace_FromCjs_Stable_A
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x454a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x454d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4550
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::_environment0_Import_Namespace_FromCjs_Stable_A
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4569
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::_environment0_Import_Namespace_FromCjs_Stable_A
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x457e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2663,12 +4705,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_EC5DD978_L38C87,
-				[21] class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_0C4BA5B9_L39C94,
+				[20] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_EC5DD978_L38C87,
+				[21] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_0C4BA5B9_L39C94,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_6078F843_L48C10
+				[25] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_6078F843_L48C10
 			)
 
 			IL_0000: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope::.ctor()
@@ -2874,13 +4916,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_EC5DD978_L38C87::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_EC5DD978_L38C87::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_EC5DD978_L38C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_EC5DD978_L38C87>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -2924,13 +4966,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_0C4BA5B9_L39C94::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_0C4BA5B9_L39C94::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_0C4BA5B9_L39C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_0C4BA5B9_L39C94>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -3100,13 +5142,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_6078F843_L48C10::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_6078F843_L48C10::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_6078F843_L48C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_6078F843_L48C10>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldc.i4.1
 				IL_0487: newarr [System.Runtime]System.Object
@@ -3225,6 +5267,127 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_Namespace_FromCjs_Stable_A/Scope _environment0_Import_Namespace_FromCjs_Stable_A
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_Namespace_FromCjs_Stable_A/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x46eb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export/FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::_environment0_Import_Namespace_FromCjs_Stable_A
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x46fa
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x46fd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4700
+				// Header size: 1
+				// Code size: 36 (0x24)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export/FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::_environment0_Import_Namespace_FromCjs_Stable_A
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0017: ldarg.2
+				IL_0018: ldc.i4.1
+				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001e: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object, string, object)
+				IL_0023: ret
+			} // end of method FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4725
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export/FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::_environment0_Import_Namespace_FromCjs_Stable_A
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.1
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object, string, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4746
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export
+
 
 		// Methods
 		.method public hidebysig static 
@@ -3340,16 +5503,16 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_Namespace_FromCjs_Stable_A/Scope,
-			[1] class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default,
-			[2] class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get,
-			[3] class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace,
-			[4] class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export,
+			[1] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_default/FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default,
+			[2] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_get/FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get,
+			[3] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace,
+			[4] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export/FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export,
 			[5] object,
 			[6] object[],
-			[7] class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark,
+			[7] class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark/FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark,
 			[8] object,
 			[9] object[],
-			[10] class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_D865E319_L10C25
+			[10] class Modules.Import_Namespace_FromCjs_Stable_A/FunctionExpression_L10C24/FunctionObject_FunctionExpression_D865E319_L10C25
 		)
 
 		IL_0000: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/Scope::.ctor()
@@ -3368,13 +5531,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_Namespace_FromCjs_Stable_A/Scope
-		IL_0022: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope)
+		IL_0022: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark/FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark/FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 7
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 7
@@ -3386,13 +5549,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 6
-		IL_004b: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_default/FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_default/FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -3401,13 +5564,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 6
-		IL_006b: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_get/FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_get/FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -3420,13 +5583,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_Namespace_FromCjs_Stable_A/Scope
-		IL_0094: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope)
+		IL_0094: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -3439,13 +5602,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_Namespace_FromCjs_Stable_A/Scope
-		IL_00bd: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope)
+		IL_00bd: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export/FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export/FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 4
 		IL_00d2: nop
 		IL_00d3: ldloc.0
@@ -3480,13 +5643,13 @@
 		IL_0121: ldc.i4.0
 		IL_0122: ldelem.ref
 		IL_0123: castclass Modules.Import_Namespace_FromCjs_Stable_A/Scope
-		IL_0128: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_D865E319_L10C25::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope)
+		IL_0128: newobj instance void Modules.Import_Namespace_FromCjs_Stable_A/FunctionExpression_L10C24/FunctionObject_FunctionExpression_D865E319_L10C25::.ctor(class Modules.Import_Namespace_FromCjs_Stable_A/Scope)
 		IL_012d: ldc.i4.0
 		IL_012e: conv.r8
 		IL_012f: ldstr ""
 		IL_0134: ldc.i4.0
 		IL_0135: ldc.i4.1
-		IL_0136: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_D865E319_L10C25>(!!0, float64, string, bool, bool)
+		IL_0136: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_A/FunctionExpression_L10C24/FunctionObject_FunctionExpression_D865E319_L10C25>(!!0, float64, string, bool, bool)
 		IL_013b: stloc.s 10
 		IL_013d: ldloc.s 4
 		IL_013f: ldloc.s 6
@@ -3526,6 +5689,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_23B80F39_L4C15
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_Namespace_FromCjs_Stable_Lib/Scope _environment0_Import_Namespace_FromCjs_Stable_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_Namespace_FromCjs_Stable_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4755
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_Lib/Scope Modules.Import_Namespace_FromCjs_Stable_Lib/FunctionExpression_L4C14/FunctionObject_FunctionExpression_23B80F39_L4C15::_environment0_Import_Namespace_FromCjs_Stable_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_23B80F39_L4C15::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4764
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_23B80F39_L4C15::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4767
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_23B80F39_L4C15::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x476a
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_Lib/Scope Modules.Import_Namespace_FromCjs_Stable_Lib/FunctionExpression_L4C14/FunctionObject_FunctionExpression_23B80F39_L4C15::_environment0_Import_Namespace_FromCjs_Stable_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_Lib/FunctionExpression_L4C14::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_Lib/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_23B80F39_L4C15::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x477c
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_Lib/Scope Modules.Import_Namespace_FromCjs_Stable_Lib/FunctionExpression_L4C14/FunctionObject_FunctionExpression_23B80F39_L4C15::_environment0_Import_Namespace_FromCjs_Stable_Lib
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_Lib/FunctionExpression_L4C14::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_Lib/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_23B80F39_L4C15::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x478a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_23B80F39_L4C15::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_23B80F39_L4C15
 
 
 		// Methods
@@ -3620,7 +5890,7 @@
 			[0] class Modules.Import_Namespace_FromCjs_Stable_Lib/Scope,
 			[1] object,
 			[2] object[],
-			[3] class FunctionObjects.Import_Namespace_FromCjs_Stable_Lib_A737D159.FunctionObject_FunctionExpression_23B80F39_L4C15
+			[3] class Modules.Import_Namespace_FromCjs_Stable_Lib/FunctionExpression_L4C14/FunctionObject_FunctionExpression_23B80F39_L4C15
 		)
 
 		IL_0000: newobj instance void Modules.Import_Namespace_FromCjs_Stable_Lib/Scope::.ctor()
@@ -3652,13 +5922,13 @@
 		IL_003e: ldc.i4.0
 		IL_003f: ldelem.ref
 		IL_0040: castclass Modules.Import_Namespace_FromCjs_Stable_Lib/Scope
-		IL_0045: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_Lib_A737D159.FunctionObject_FunctionExpression_23B80F39_L4C15::.ctor(class Modules.Import_Namespace_FromCjs_Stable_Lib/Scope)
+		IL_0045: newobj instance void Modules.Import_Namespace_FromCjs_Stable_Lib/FunctionExpression_L4C14/FunctionObject_FunctionExpression_23B80F39_L4C15::.ctor(class Modules.Import_Namespace_FromCjs_Stable_Lib/Scope)
 		IL_004a: ldc.i4.0
 		IL_004b: conv.r8
 		IL_004c: ldstr ""
 		IL_0051: ldc.i4.0
 		IL_0052: ldc.i4.1
-		IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_Lib_A737D159.FunctionObject_FunctionExpression_23B80F39_L4C15>(!!0, float64, string, bool, bool)
+		IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_Lib/FunctionExpression_L4C14/FunctionObject_FunctionExpression_23B80F39_L4C15>(!!0, float64, string, bool, bool)
 		IL_0058: stloc.3
 		IL_0059: ldloc.1
 		IL_005a: ldstr "inc"
@@ -3698,6 +5968,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_273665B4_L10C25
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_Namespace_FromCjs_Stable_B/Scope _environment0_Import_Namespace_FromCjs_Stable_B
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_Namespace_FromCjs_Stable_B/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4799
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/FunctionExpression_L10C24/FunctionObject_FunctionExpression_273665B4_L10C25::_environment0_Import_Namespace_FromCjs_Stable_B
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_273665B4_L10C25::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x47a8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_273665B4_L10C25::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x47ab
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_273665B4_L10C25::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x47ae
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/FunctionExpression_L10C24/FunctionObject_FunctionExpression_273665B4_L10C25::_environment0_Import_Namespace_FromCjs_Stable_B
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_B/FunctionExpression_L10C24::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_273665B4_L10C25::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x47c0
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/FunctionExpression_L10C24/FunctionObject_FunctionExpression_273665B4_L10C25::_environment0_Import_Namespace_FromCjs_Stable_B
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_B/FunctionExpression_L10C24::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_273665B4_L10C25::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x47ce
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_273665B4_L10C25::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_273665B4_L10C25
 
 
 		// Methods
@@ -3769,6 +6146,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_Namespace_FromCjs_Stable_B/Scope _environment0_Import_Namespace_FromCjs_Stable_B
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_Namespace_FromCjs_Stable_B/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x47dd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark/FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::_environment0_Import_Namespace_FromCjs_Stable_B
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x47ec
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x47ef
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x47f2
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark/FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::_environment0_Import_Namespace_FromCjs_Stable_B
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4804
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark/FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::_environment0_Import_Namespace_FromCjs_Stable_B
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4812
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark
 
 
 		// Methods
@@ -3876,6 +6360,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4821
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4829
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x482c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x482f
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_default::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4842
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_default::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4851
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default
+
 
 		// Methods
 		.method public hidebysig static 
@@ -3979,6 +6564,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4860
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4868
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x486b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x486e
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4888
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x489e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get
+
 
 		// Methods
 		.method public hidebysig static 
@@ -4037,6 +6729,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_BAD62F07_L38C87
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_Namespace_FromCjs_Stable_B/Scope _environment0_Import_Namespace_FromCjs_Stable_B
+				.field private initonly class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_Namespace_FromCjs_Stable_B/Scope capture0,
+						class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x48ff
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_BAD62F07_L38C87::_environment0_Import_Namespace_FromCjs_Stable_B
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_BAD62F07_L38C87::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_BAD62F07_L38C87::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_BAD62F07_L38C87::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x491c
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_BAD62F07_L38C87::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x491f
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_BAD62F07_L38C87::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x4922
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_BAD62F07_L38C87::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_BAD62F07_L38C87::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x4934
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_BAD62F07_L38C87::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_BAD62F07_L38C87::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x4942
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_BAD62F07_L38C87::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_BAD62F07_L38C87
+
 
 			// Methods
 			.method public hidebysig static 
@@ -4086,6 +6895,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2828C68A_L39C94
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_Namespace_FromCjs_Stable_B/Scope _environment0_Import_Namespace_FromCjs_Stable_B
+				.field private initonly class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_Namespace_FromCjs_Stable_B/Scope capture0,
+						class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x4951
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2828C68A_L39C94::_environment0_Import_Namespace_FromCjs_Stable_B
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2828C68A_L39C94::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2828C68A_L39C94::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_2828C68A_L39C94::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x496e
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_2828C68A_L39C94::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x4971
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_2828C68A_L39C94::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x4974
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2828C68A_L39C94::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_2828C68A_L39C94::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x4986
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2828C68A_L39C94::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_2828C68A_L39C94::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x4994
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_2828C68A_L39C94::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_2828C68A_L39C94
 
 
 			// Methods
@@ -4140,6 +7066,128 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3D876629_L49C87
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Import_Namespace_FromCjs_Stable_B/Scope _environment0_Import_Namespace_FromCjs_Stable_B
+					.field private initonly class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+					.field private initonly class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/Scope _environment2_FunctionExpression_L48C9
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Import_Namespace_FromCjs_Stable_B/Scope capture0,
+							class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope capture1,
+							class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x4a03
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_3D876629_L49C87::_environment0_Import_Namespace_FromCjs_Stable_B
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_3D876629_L49C87::_environment1___jroc_esm_namespace
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_3D876629_L49C87::_environment2_FunctionExpression_L48C9
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_3D876629_L49C87::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_3D876629_L49C87::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x4a28
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_3D876629_L49C87::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x4a2b
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_3D876629_L49C87::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x4a2e
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_3D876629_L49C87::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_3D876629_L49C87::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x4a40
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_3D876629_L49C87::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_3D876629_L49C87::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x4a4e
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_3D876629_L49C87::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_3D876629_L49C87
 
 
 				// Methods
@@ -4206,6 +7254,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_804B477E_L48C10
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_Namespace_FromCjs_Stable_B/Scope _environment0_Import_Namespace_FromCjs_Stable_B
+				.field private initonly class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_Namespace_FromCjs_Stable_B/Scope capture0,
+						class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x49a3
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_804B477E_L48C10::_environment0_Import_Namespace_FromCjs_Stable_B
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_804B477E_L48C10::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_804B477E_L48C10::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_804B477E_L48C10::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x49c0
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_804B477E_L48C10::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x49c3
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_804B477E_L48C10::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x49c6
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_804B477E_L48C10::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_804B477E_L48C10::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x49df
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_804B477E_L48C10::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_804B477E_L48C10::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x49f4
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_804B477E_L48C10::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_804B477E_L48C10
+
 
 			// Methods
 			.method public hidebysig static 
@@ -4227,7 +7398,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_3D876629_L49C87,
+					[4] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_3D876629_L49C87,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -4277,13 +7448,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_3D876629_L49C87::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope, class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_3D876629_L49C87::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope, class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_3D876629_L49C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86/FunctionObject_FunctionExpression_3D876629_L49C87>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -4502,6 +7673,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_Namespace_FromCjs_Stable_B/Scope _environment0_Import_Namespace_FromCjs_Stable_B
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_Namespace_FromCjs_Stable_B/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x48ad
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::_environment0_Import_Namespace_FromCjs_Stable_B
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x48bc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x48bf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x48c2
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::_environment0_Import_Namespace_FromCjs_Stable_B
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x48db
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::_environment0_Import_Namespace_FromCjs_Stable_B
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x48f0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace
+
 
 		// Methods
 		.method public hidebysig static 
@@ -4541,12 +7825,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_BAD62F07_L38C87,
-				[21] class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_2828C68A_L39C94,
+				[20] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_BAD62F07_L38C87,
+				[21] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2828C68A_L39C94,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_804B477E_L48C10
+				[25] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_804B477E_L48C10
 			)
 
 			IL_0000: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope::.ctor()
@@ -4752,13 +8036,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_BAD62F07_L38C87::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_BAD62F07_L38C87::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_BAD62F07_L38C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86/FunctionObject_FunctionExpression_BAD62F07_L38C87>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -4802,13 +8086,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_2828C68A_L39C94::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2828C68A_L39C94::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_2828C68A_L39C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93/FunctionObject_FunctionExpression_2828C68A_L39C94>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -4978,13 +8262,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_804B477E_L48C10::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_804B477E_L48C10::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_804B477E_L48C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionObject_FunctionExpression_804B477E_L48C10>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldc.i4.1
 				IL_0487: newarr [System.Runtime]System.Object
@@ -5103,6 +8387,127 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_Namespace_FromCjs_Stable_B/Scope _environment0_Import_Namespace_FromCjs_Stable_B
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_Namespace_FromCjs_Stable_B/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4a5d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export/FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::_environment0_Import_Namespace_FromCjs_Stable_B
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4a6c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4a6f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4a72
+				// Header size: 1
+				// Code size: 36 (0x24)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export/FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::_environment0_Import_Namespace_FromCjs_Stable_B
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0017: ldarg.2
+				IL_0018: ldc.i4.1
+				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001e: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object, string, object)
+				IL_0023: ret
+			} // end of method FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4a97
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export/FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::_environment0_Import_Namespace_FromCjs_Stable_B
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.1
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object, string, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4ab8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export
+
 
 		// Methods
 		.method public hidebysig static 
@@ -5218,16 +8623,16 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_Namespace_FromCjs_Stable_B/Scope,
-			[1] class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default,
-			[2] class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get,
-			[3] class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace,
-			[4] class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export,
+			[1] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_default/FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default,
+			[2] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_get/FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get,
+			[3] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace,
+			[4] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export/FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export,
 			[5] object,
 			[6] object[],
-			[7] class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark,
+			[7] class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark/FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark,
 			[8] object,
 			[9] object[],
-			[10] class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_273665B4_L10C25
+			[10] class Modules.Import_Namespace_FromCjs_Stable_B/FunctionExpression_L10C24/FunctionObject_FunctionExpression_273665B4_L10C25
 		)
 
 		IL_0000: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/Scope::.ctor()
@@ -5246,13 +8651,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_Namespace_FromCjs_Stable_B/Scope
-		IL_0022: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope)
+		IL_0022: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark/FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark/FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 7
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 7
@@ -5264,13 +8669,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 6
-		IL_004b: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_default/FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_default/FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -5279,13 +8684,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 6
-		IL_006b: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_get/FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_get/FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -5298,13 +8703,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_Namespace_FromCjs_Stable_B/Scope
-		IL_0094: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope)
+		IL_0094: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -5317,13 +8722,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_Namespace_FromCjs_Stable_B/Scope
-		IL_00bd: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope)
+		IL_00bd: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export/FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export/FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 4
 		IL_00d2: nop
 		IL_00d3: ldloc.0
@@ -5358,13 +8763,13 @@
 		IL_0121: ldc.i4.0
 		IL_0122: ldelem.ref
 		IL_0123: castclass Modules.Import_Namespace_FromCjs_Stable_B/Scope
-		IL_0128: newobj instance void FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_273665B4_L10C25::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope)
+		IL_0128: newobj instance void Modules.Import_Namespace_FromCjs_Stable_B/FunctionExpression_L10C24/FunctionObject_FunctionExpression_273665B4_L10C25::.ctor(class Modules.Import_Namespace_FromCjs_Stable_B/Scope)
 		IL_012d: ldc.i4.0
 		IL_012e: conv.r8
 		IL_012f: ldstr ""
 		IL_0134: ldc.i4.0
 		IL_0135: ldc.i4.1
-		IL_0136: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_273665B4_L10C25>(!!0, float64, string, bool, bool)
+		IL_0136: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_Namespace_FromCjs_Stable_B/FunctionExpression_L10C24/FunctionObject_FunctionExpression_273665B4_L10C25>(!!0, float64, string, bool, bool)
 		IL_013b: stloc.s 10
 		IL_013d: ldloc.s 4
 		IL_013f: ldloc.s 6
@@ -5376,3411 +8781,6 @@
 	} // end of method Import_Namespace_FromCjs_Stable_B::__js_module_init__
 
 } // end of class Modules.Import_Namespace_FromCjs_Stable_B
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable/Scope _environment0_Import_Namespace_FromCjs_Stable
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_FromCjs_Stable/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x413d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::_environment0_Import_Namespace_FromCjs_Stable
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x414c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x414f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4152
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::_environment0_Import_Namespace_FromCjs_Stable
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4164
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::_environment0_Import_Namespace_FromCjs_Stable
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4172
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_8648779C___jroc_esm_mark
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x4181
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4189
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x418c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x418f
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_default::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x41a2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_default::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x41b1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_149375FA___jroc_esm_default
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x41c0
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x41c8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x41cb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x41ce
-		// Header size: 1
-		// Code size: 30 (0x1e)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0018: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, string)
-		IL_001d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x41ed
-		// Header size: 1
-		// Code size: 26 (0x1a)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0014: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_get::__js_call__(object, object, string)
-		IL_0019: ret
-	} // end of method FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4208
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_0685F2CB___jroc_esm_get
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable/Scope _environment0_Import_Namespace_FromCjs_Stable
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_FromCjs_Stable/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4217
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::_environment0_Import_Namespace_FromCjs_Stable
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4226
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4229
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x422c
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::_environment0_Import_Namespace_FromCjs_Stable
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_FromCjs_Stable/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4245
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::_environment0_Import_Namespace_FromCjs_Stable
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_FromCjs_Stable/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x425a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_67C810AC___jroc_esm_namespace
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_DC2ECB5E_L43C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable/Scope _environment0_Import_Namespace_FromCjs_Stable
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_FromCjs_Stable/Scope capture0,
-			class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x4269
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_DC2ECB5E_L43C87::_environment0_Import_Namespace_FromCjs_Stable
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_DC2ECB5E_L43C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_DC2ECB5E_L43C87::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_DC2ECB5E_L43C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4286
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DC2ECB5E_L43C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4289
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DC2ECB5E_L43C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x428c
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_DC2ECB5E_L43C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_DC2ECB5E_L43C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x429e
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_DC2ECB5E_L43C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L43C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_DC2ECB5E_L43C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x42ac
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DC2ECB5E_L43C87::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_DC2ECB5E_L43C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_A8084EC1_L44C94
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable/Scope _environment0_Import_Namespace_FromCjs_Stable
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_FromCjs_Stable/Scope capture0,
-			class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x42bb
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_A8084EC1_L44C94::_environment0_Import_Namespace_FromCjs_Stable
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_A8084EC1_L44C94::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_A8084EC1_L44C94::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_A8084EC1_L44C94::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x42d8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A8084EC1_L44C94::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x42db
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A8084EC1_L44C94::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x42de
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_A8084EC1_L44C94::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_A8084EC1_L44C94::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x42f0
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_A8084EC1_L44C94::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L44C93::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_A8084EC1_L44C94::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x42fe
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A8084EC1_L44C94::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_A8084EC1_L44C94
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_9F4A7CF4_L53C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable/Scope _environment0_Import_Namespace_FromCjs_Stable
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_FromCjs_Stable/Scope capture0,
-			class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x430d
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_9F4A7CF4_L53C10::_environment0_Import_Namespace_FromCjs_Stable
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_9F4A7CF4_L53C10::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_9F4A7CF4_L53C10::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_9F4A7CF4_L53C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x432a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9F4A7CF4_L53C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x432d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9F4A7CF4_L53C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4330
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_9F4A7CF4_L53C10::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_9F4A7CF4_L53C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4349
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_9F4A7CF4_L53C10::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_9F4A7CF4_L53C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x435e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_9F4A7CF4_L53C10::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_9F4A7CF4_L53C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_4C2D45B9_L54C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable/Scope _environment0_Import_Namespace_FromCjs_Stable
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/Scope _environment2_FunctionExpression_L53C9
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_FromCjs_Stable/Scope capture0,
-			class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope capture1,
-			class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x436d
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_4C2D45B9_L54C87::_environment0_Import_Namespace_FromCjs_Stable
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_4C2D45B9_L54C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_4C2D45B9_L54C87::_environment2_FunctionExpression_L53C9
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_4C2D45B9_L54C87::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_4C2D45B9_L54C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4392
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_4C2D45B9_L54C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4395
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_4C2D45B9_L54C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4398
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_4C2D45B9_L54C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_4C2D45B9_L54C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x43aa
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_4C2D45B9_L54C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_4C2D45B9_L54C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x43b8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_4C2D45B9_L54C87::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionExpression_4C2D45B9_L54C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable/Scope _environment0_Import_Namespace_FromCjs_Stable
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_FromCjs_Stable/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x43c7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::_environment0_Import_Namespace_FromCjs_Stable
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x43d6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x43d9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x43dc
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::_environment0_Import_Namespace_FromCjs_Stable
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_FromCjs_Stable/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x43fc
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::_environment0_Import_Namespace_FromCjs_Stable
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Import_Namespace_FromCjs_Stable/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_FromCjs_Stable/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4418
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_F0F2A191.FunctionObject_FunctionDeclaration_9B4DEADF___jroc_esm_export
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_D865E319_L10C25
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable_A/Scope _environment0_Import_Namespace_FromCjs_Stable_A
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_FromCjs_Stable_A/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4427
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_D865E319_L10C25::_environment0_Import_Namespace_FromCjs_Stable_A
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D865E319_L10C25::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4436
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D865E319_L10C25::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4439
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D865E319_L10C25::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x443c
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_D865E319_L10C25::_environment0_Import_Namespace_FromCjs_Stable_A
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_A/FunctionExpression_L10C24::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_D865E319_L10C25::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x444e
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_D865E319_L10C25::_environment0_Import_Namespace_FromCjs_Stable_A
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_A/FunctionExpression_L10C24::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_D865E319_L10C25::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x445c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D865E319_L10C25::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_D865E319_L10C25
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable_A/Scope _environment0_Import_Namespace_FromCjs_Stable_A
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_FromCjs_Stable_A/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x446b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::_environment0_Import_Namespace_FromCjs_Stable_A
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x447a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x447d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4480
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::_environment0_Import_Namespace_FromCjs_Stable_A
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4492
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::_environment0_Import_Namespace_FromCjs_Stable_A
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x44a0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_629D275C___jroc_esm_mark
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x44af
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x44b7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x44ba
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x44bd
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_default::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x44d0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_default::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x44df
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_B318E4BA___jroc_esm_default
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x44ee
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x44f6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x44f9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x44fc
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4516
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x452c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_C7F5C58B___jroc_esm_get
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable_A/Scope _environment0_Import_Namespace_FromCjs_Stable_A
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_FromCjs_Stable_A/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x453b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::_environment0_Import_Namespace_FromCjs_Stable_A
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x454a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x454d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4550
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::_environment0_Import_Namespace_FromCjs_Stable_A
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4569
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::_environment0_Import_Namespace_FromCjs_Stable_A
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x457e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_8DA2CA6C___jroc_esm_namespace
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_EC5DD978_L38C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable_A/Scope _environment0_Import_Namespace_FromCjs_Stable_A
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_FromCjs_Stable_A/Scope capture0,
-			class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x458d
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_EC5DD978_L38C87::_environment0_Import_Namespace_FromCjs_Stable_A
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_EC5DD978_L38C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_EC5DD978_L38C87::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_EC5DD978_L38C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x45aa
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_EC5DD978_L38C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x45ad
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_EC5DD978_L38C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x45b0
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_EC5DD978_L38C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_EC5DD978_L38C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x45c2
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_EC5DD978_L38C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_EC5DD978_L38C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x45d0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_EC5DD978_L38C87::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_EC5DD978_L38C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_0C4BA5B9_L39C94
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable_A/Scope _environment0_Import_Namespace_FromCjs_Stable_A
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_FromCjs_Stable_A/Scope capture0,
-			class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x45df
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_0C4BA5B9_L39C94::_environment0_Import_Namespace_FromCjs_Stable_A
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_0C4BA5B9_L39C94::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_0C4BA5B9_L39C94::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_0C4BA5B9_L39C94::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x45fc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_0C4BA5B9_L39C94::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x45ff
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_0C4BA5B9_L39C94::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4602
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_0C4BA5B9_L39C94::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_0C4BA5B9_L39C94::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4614
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_0C4BA5B9_L39C94::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_0C4BA5B9_L39C94::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4622
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_0C4BA5B9_L39C94::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_0C4BA5B9_L39C94
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_6078F843_L48C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable_A/Scope _environment0_Import_Namespace_FromCjs_Stable_A
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_FromCjs_Stable_A/Scope capture0,
-			class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x4631
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_6078F843_L48C10::_environment0_Import_Namespace_FromCjs_Stable_A
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_6078F843_L48C10::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_6078F843_L48C10::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_6078F843_L48C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x464e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6078F843_L48C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4651
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6078F843_L48C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4654
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_6078F843_L48C10::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_6078F843_L48C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x466d
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_6078F843_L48C10::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_6078F843_L48C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4682
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_6078F843_L48C10::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_6078F843_L48C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_DC3B754A_L49C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable_A/Scope _environment0_Import_Namespace_FromCjs_Stable_A
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/Scope _environment2_FunctionExpression_L48C9
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_FromCjs_Stable_A/Scope capture0,
-			class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope capture1,
-			class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x4691
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_DC3B754A_L49C87::_environment0_Import_Namespace_FromCjs_Stable_A
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_DC3B754A_L49C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_DC3B754A_L49C87::_environment2_FunctionExpression_L48C9
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_DC3B754A_L49C87::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_DC3B754A_L49C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x46b6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DC3B754A_L49C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x46b9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DC3B754A_L49C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x46bc
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_DC3B754A_L49C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_DC3B754A_L49C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x46ce
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_DC3B754A_L49C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_DC3B754A_L49C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x46dc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DC3B754A_L49C87::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionExpression_DC3B754A_L49C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable_A/Scope _environment0_Import_Namespace_FromCjs_Stable_A
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_FromCjs_Stable_A/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x46eb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::_environment0_Import_Namespace_FromCjs_Stable_A
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x46fa
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x46fd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4700
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::_environment0_Import_Namespace_FromCjs_Stable_A
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0017: ldarg.2
-		IL_0018: ldc.i4.1
-		IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001e: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object, string, object)
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4725
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_A/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::_environment0_Import_Namespace_FromCjs_Stable_A
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.1
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.Import_Namespace_FromCjs_Stable_A/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_A/Scope, object, string, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4746
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_A_0D3C2651.FunctionObject_FunctionDeclaration_6E49349F___jroc_esm_export
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_Lib_A737D159.FunctionObject_FunctionExpression_23B80F39_L4C15
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable_Lib/Scope _environment0_Import_Namespace_FromCjs_Stable_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_FromCjs_Stable_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4755
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_Lib/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_Lib_A737D159.FunctionObject_FunctionExpression_23B80F39_L4C15::_environment0_Import_Namespace_FromCjs_Stable_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_23B80F39_L4C15::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4764
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_23B80F39_L4C15::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4767
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_23B80F39_L4C15::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x476a
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_Lib/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_Lib_A737D159.FunctionObject_FunctionExpression_23B80F39_L4C15::_environment0_Import_Namespace_FromCjs_Stable_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_Lib/FunctionExpression_L4C14::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_Lib/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_23B80F39_L4C15::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x477c
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_Lib/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_Lib_A737D159.FunctionObject_FunctionExpression_23B80F39_L4C15::_environment0_Import_Namespace_FromCjs_Stable_Lib
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_Lib/FunctionExpression_L4C14::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_Lib/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_23B80F39_L4C15::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x478a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_23B80F39_L4C15::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_Lib_A737D159.FunctionObject_FunctionExpression_23B80F39_L4C15
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_273665B4_L10C25
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable_B/Scope _environment0_Import_Namespace_FromCjs_Stable_B
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_FromCjs_Stable_B/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4799
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_273665B4_L10C25::_environment0_Import_Namespace_FromCjs_Stable_B
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_273665B4_L10C25::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x47a8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_273665B4_L10C25::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x47ab
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_273665B4_L10C25::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x47ae
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_273665B4_L10C25::_environment0_Import_Namespace_FromCjs_Stable_B
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_B/FunctionExpression_L10C24::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_273665B4_L10C25::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x47c0
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_273665B4_L10C25::_environment0_Import_Namespace_FromCjs_Stable_B
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_B/FunctionExpression_L10C24::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_273665B4_L10C25::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x47ce
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_273665B4_L10C25::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_273665B4_L10C25
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable_B/Scope _environment0_Import_Namespace_FromCjs_Stable_B
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_FromCjs_Stable_B/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x47dd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::_environment0_Import_Namespace_FromCjs_Stable_B
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x47ec
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x47ef
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x47f2
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::_environment0_Import_Namespace_FromCjs_Stable_B
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4804
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::_environment0_Import_Namespace_FromCjs_Stable_B
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_mark::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4812
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_1BBCA01D___jroc_esm_mark
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x4821
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4829
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x482c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x482f
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_default::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4842
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_default::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4851
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_0DAAB5B9___jroc_esm_default
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x4860
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4868
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x486b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x486e
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4888
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x489e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_D50ABD60___jroc_esm_get
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable_B/Scope _environment0_Import_Namespace_FromCjs_Stable_B
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_FromCjs_Stable_B/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x48ad
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::_environment0_Import_Namespace_FromCjs_Stable_B
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x48bc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x48bf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x48c2
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::_environment0_Import_Namespace_FromCjs_Stable_B
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x48db
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::_environment0_Import_Namespace_FromCjs_Stable_B
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x48f0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_4874C7EB___jroc_esm_namespace
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_BAD62F07_L38C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable_B/Scope _environment0_Import_Namespace_FromCjs_Stable_B
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_FromCjs_Stable_B/Scope capture0,
-			class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x48ff
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_BAD62F07_L38C87::_environment0_Import_Namespace_FromCjs_Stable_B
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_BAD62F07_L38C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_BAD62F07_L38C87::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_BAD62F07_L38C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x491c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_BAD62F07_L38C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x491f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_BAD62F07_L38C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4922
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_BAD62F07_L38C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_BAD62F07_L38C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4934
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_BAD62F07_L38C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L38C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_BAD62F07_L38C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4942
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_BAD62F07_L38C87::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_BAD62F07_L38C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_2828C68A_L39C94
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable_B/Scope _environment0_Import_Namespace_FromCjs_Stable_B
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_FromCjs_Stable_B/Scope capture0,
-			class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x4951
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_2828C68A_L39C94::_environment0_Import_Namespace_FromCjs_Stable_B
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_2828C68A_L39C94::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_2828C68A_L39C94::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_2828C68A_L39C94::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x496e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2828C68A_L39C94::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4971
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2828C68A_L39C94::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4974
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_2828C68A_L39C94::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_2828C68A_L39C94::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4986
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_2828C68A_L39C94::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L39C93::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_2828C68A_L39C94::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4994
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2828C68A_L39C94::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_2828C68A_L39C94
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_804B477E_L48C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable_B/Scope _environment0_Import_Namespace_FromCjs_Stable_B
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_FromCjs_Stable_B/Scope capture0,
-			class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x49a3
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_804B477E_L48C10::_environment0_Import_Namespace_FromCjs_Stable_B
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_804B477E_L48C10::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_804B477E_L48C10::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_804B477E_L48C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x49c0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_804B477E_L48C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x49c3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_804B477E_L48C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x49c6
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_804B477E_L48C10::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_804B477E_L48C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x49df
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_804B477E_L48C10::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_804B477E_L48C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x49f4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_804B477E_L48C10::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_804B477E_L48C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_3D876629_L49C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable_B/Scope _environment0_Import_Namespace_FromCjs_Stable_B
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/Scope _environment2_FunctionExpression_L48C9
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_FromCjs_Stable_B/Scope capture0,
-			class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope capture1,
-			class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x4a03
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_3D876629_L49C87::_environment0_Import_Namespace_FromCjs_Stable_B
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_3D876629_L49C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_3D876629_L49C87::_environment2_FunctionExpression_L48C9
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_3D876629_L49C87::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_3D876629_L49C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4a28
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3D876629_L49C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4a2b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3D876629_L49C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4a2e
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_3D876629_L49C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_3D876629_L49C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4a40
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_3D876629_L49C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_namespace/FunctionExpression_L48C9/FunctionExpression_L49C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_3D876629_L49C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4a4e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3D876629_L49C87::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionExpression_3D876629_L49C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_Namespace_FromCjs_Stable_B/Scope _environment0_Import_Namespace_FromCjs_Stable_B
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_Namespace_FromCjs_Stable_B/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4a5d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::_environment0_Import_Namespace_FromCjs_Stable_B
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4a6c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4a6f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4a72
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::_environment0_Import_Namespace_FromCjs_Stable_B
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0017: ldarg.2
-		IL_0018: ldc.i4.1
-		IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001e: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object, string, object)
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4a97
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_Namespace_FromCjs_Stable_B/Scope FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::_environment0_Import_Namespace_FromCjs_Stable_B
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.1
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.Import_Namespace_FromCjs_Stable_B/__jroc_esm_export::__js_call__(class Modules.Import_Namespace_FromCjs_Stable_B/Scope, object, string, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4ab8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export::ConstructCore
-
-} // end of class FunctionObjects.Import_Namespace_FromCjs_Stable_B_0A3C2198.FunctionObject_FunctionDeclaration_BB330332___jroc_esm_export
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_RequireEsmModule.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_RequireEsmModule.verified.txt
@@ -136,6 +136,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F4B3CAF0_L3C28
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_RequireEsmModule_Lib/Scope _environment0_Import_RequireEsmModule_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_RequireEsmModule_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c47
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/FunctionExpression_L3C27/FunctionObject_FunctionExpression_F4B3CAF0_L3C28::_environment0_Import_RequireEsmModule_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_F4B3CAF0_L3C28::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2c56
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F4B3CAF0_L3C28::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2c59
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F4B3CAF0_L3C28::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c5c
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/FunctionExpression_L3C27/FunctionObject_FunctionExpression_F4B3CAF0_L3C28::_environment0_Import_RequireEsmModule_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L3C27::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_F4B3CAF0_L3C28::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c6e
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/FunctionExpression_L3C27/FunctionObject_FunctionExpression_F4B3CAF0_L3C28::_environment0_Import_RequireEsmModule_Lib
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L3C27::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_F4B3CAF0_L3C28::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c7c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_F4B3CAF0_L3C28::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_F4B3CAF0_L3C28
+
 
 		// Methods
 		.method public hidebysig static 
@@ -187,6 +294,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_47065CFD_L4C26
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_RequireEsmModule_Lib/Scope _environment0_Import_RequireEsmModule_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_RequireEsmModule_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c8b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_47065CFD_L4C26::_environment0_Import_RequireEsmModule_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_47065CFD_L4C26::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2c9a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_47065CFD_L4C26::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2c9d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_47065CFD_L4C26::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ca0
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_47065CFD_L4C26::_environment0_Import_RequireEsmModule_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_47065CFD_L4C26::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2cb2
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_47065CFD_L4C26::_environment0_Import_RequireEsmModule_Lib
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_47065CFD_L4C26::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2cc0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_47065CFD_L4C26::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_47065CFD_L4C26
+
 
 		// Methods
 		.method public hidebysig static 
@@ -235,6 +449,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_66259425_sum
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2ccf
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_66259425_sum::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2cd7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_66259425_sum::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2cda
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_66259425_sum::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2cdd
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Import_RequireEsmModule_Lib/sum::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_66259425_sum::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2cf7
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Import_RequireEsmModule_Lib/sum::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_66259425_sum::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d0d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_66259425_sum::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_66259425_sum
 
 
 		// Methods
@@ -289,6 +610,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E6D9534C_L15C30
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_RequireEsmModule_Lib/Scope _environment0_Import_RequireEsmModule_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_RequireEsmModule_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d1c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/FunctionExpression_L15C29/FunctionObject_FunctionExpression_E6D9534C_L15C30::_environment0_Import_RequireEsmModule_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E6D9534C_L15C30::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2d2b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E6D9534C_L15C30::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2d2e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E6D9534C_L15C30::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d31
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/FunctionExpression_L15C29/FunctionObject_FunctionExpression_E6D9534C_L15C30::_environment0_Import_RequireEsmModule_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L15C29::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_E6D9534C_L15C30::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d43
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/FunctionExpression_L15C29/FunctionObject_FunctionExpression_E6D9534C_L15C30::_environment0_Import_RequireEsmModule_Lib
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L15C29::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_E6D9534C_L15C30::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d51
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E6D9534C_L15C30::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_E6D9534C_L15C30
 
 
 		// Methods
@@ -360,6 +788,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_RequireEsmModule_Lib/Scope _environment0_Import_RequireEsmModule_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_RequireEsmModule_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d60
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::_environment0_Import_RequireEsmModule_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2d6f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2d72
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d75
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::_environment0_Import_RequireEsmModule_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d87
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::_environment0_Import_RequireEsmModule_Lib
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d95
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark
 
 
 		// Methods
@@ -467,6 +1002,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2da4
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2dac
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2daf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2db2
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_default::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2dc5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_default::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2dd4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default
+
 
 		// Methods
 		.method public hidebysig static 
@@ -570,6 +1206,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2de3
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2deb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2dee
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2df1
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e0b
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_get::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e21
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get
+
 
 		// Methods
 		.method public hidebysig static 
@@ -628,6 +1371,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_CCED5EB8_L43C87
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_RequireEsmModule_Lib/Scope _environment0_Import_RequireEsmModule_Lib
+				.field private initonly class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_RequireEsmModule_Lib/Scope capture0,
+						class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2e82
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_CCED5EB8_L43C87::_environment0_Import_RequireEsmModule_Lib
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_CCED5EB8_L43C87::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_CCED5EB8_L43C87::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_CCED5EB8_L43C87::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2e9f
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_CCED5EB8_L43C87::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2ea2
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_CCED5EB8_L43C87::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2ea5
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_CCED5EB8_L43C87::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L43C86::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_CCED5EB8_L43C87::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2eb7
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_CCED5EB8_L43C87::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L43C86::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_CCED5EB8_L43C87::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2ec5
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_CCED5EB8_L43C87::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_CCED5EB8_L43C87
+
 
 			// Methods
 			.method public hidebysig static 
@@ -677,6 +1537,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A8452093_L44C94
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_RequireEsmModule_Lib/Scope _environment0_Import_RequireEsmModule_Lib
+				.field private initonly class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_RequireEsmModule_Lib/Scope capture0,
+						class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2ed4
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_A8452093_L44C94::_environment0_Import_RequireEsmModule_Lib
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_A8452093_L44C94::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_A8452093_L44C94::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_A8452093_L44C94::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2ef1
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_A8452093_L44C94::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2ef4
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_A8452093_L44C94::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2ef7
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_A8452093_L44C94::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L44C93::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_A8452093_L44C94::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2f09
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_A8452093_L44C94::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L44C93::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_A8452093_L44C94::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2f17
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_A8452093_L44C94::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_A8452093_L44C94
 
 
 			// Methods
@@ -731,6 +1708,128 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DFB4664B_L54C87
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Import_RequireEsmModule_Lib/Scope _environment0_Import_RequireEsmModule_Lib
+					.field private initonly class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+					.field private initonly class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope _environment2_FunctionExpression_L53C9
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Import_RequireEsmModule_Lib/Scope capture0,
+							class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope capture1,
+							class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x2f86
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_DFB4664B_L54C87::_environment0_Import_RequireEsmModule_Lib
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_DFB4664B_L54C87::_environment1___jroc_esm_namespace
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_DFB4664B_L54C87::_environment2_FunctionExpression_L53C9
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_DFB4664B_L54C87::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_DFB4664B_L54C87::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x2fab
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_DFB4664B_L54C87::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x2fae
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_DFB4664B_L54C87::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x2fb1
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_DFB4664B_L54C87::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_DFB4664B_L54C87::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x2fc3
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_DFB4664B_L54C87::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_DFB4664B_L54C87::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x2fd1
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_DFB4664B_L54C87::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_DFB4664B_L54C87
 
 
 				// Methods
@@ -797,6 +1896,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5F1A817A_L53C10
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_RequireEsmModule_Lib/Scope _environment0_Import_RequireEsmModule_Lib
+				.field private initonly class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_RequireEsmModule_Lib/Scope capture0,
+						class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2f26
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_5F1A817A_L53C10::_environment0_Import_RequireEsmModule_Lib
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_5F1A817A_L53C10::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_5F1A817A_L53C10::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_5F1A817A_L53C10::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2f43
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_5F1A817A_L53C10::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2f46
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_5F1A817A_L53C10::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2f49
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_5F1A817A_L53C10::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_5F1A817A_L53C10::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2f62
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_5F1A817A_L53C10::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_5F1A817A_L53C10::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2f77
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_5F1A817A_L53C10::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_5F1A817A_L53C10
+
 
 			// Methods
 			.method public hidebysig static 
@@ -818,7 +2040,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_DFB4664B_L54C87,
+					[4] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_DFB4664B_L54C87,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -868,13 +2090,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_DFB4664B_L54C87::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope, class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope, class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_DFB4664B_L54C87::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope, class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope, class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_DFB4664B_L54C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86/FunctionObject_FunctionExpression_DFB4664B_L54C87>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -1093,6 +2315,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_RequireEsmModule_Lib/Scope _environment0_Import_RequireEsmModule_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_RequireEsmModule_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e30
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::_environment0_Import_RequireEsmModule_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2e3f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2e42
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e45
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::_environment0_Import_RequireEsmModule_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e5e
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::_environment0_Import_RequireEsmModule_Lib
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e73
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1132,12 +2467,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_CCED5EB8_L43C87,
-				[21] class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_A8452093_L44C94,
+				[20] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_CCED5EB8_L43C87,
+				[21] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_A8452093_L44C94,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_5F1A817A_L53C10
+				[25] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_5F1A817A_L53C10
 			)
 
 			IL_0000: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope::.ctor()
@@ -1343,13 +2678,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_CCED5EB8_L43C87::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope, class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_CCED5EB8_L43C87::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope, class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_CCED5EB8_L43C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L43C86/FunctionObject_FunctionExpression_CCED5EB8_L43C87>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -1393,13 +2728,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_A8452093_L44C94::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope, class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_A8452093_L44C94::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope, class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_A8452093_L44C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L44C93/FunctionObject_FunctionExpression_A8452093_L44C94>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -1569,13 +2904,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_5F1A817A_L53C10::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope, class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_5F1A817A_L53C10::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope, class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_5F1A817A_L53C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionObject_FunctionExpression_5F1A817A_L53C10>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldc.i4.1
 				IL_0487: newarr [System.Runtime]System.Object
@@ -1693,6 +3028,127 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_RequireEsmModule_Lib/Scope _environment0_Import_RequireEsmModule_Lib
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_RequireEsmModule_Lib/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2fe0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::_environment0_Import_RequireEsmModule_Lib
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2fef
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2ff2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ff5
+				// Header size: 1
+				// Code size: 36 (0x24)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::_environment0_Import_RequireEsmModule_Lib
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0017: ldarg.2
+				IL_0018: ldc.i4.1
+				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001e: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_export::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object, string, object)
+				IL_0023: ret
+			} // end of method FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x301a
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope Modules.Import_RequireEsmModule_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::_environment0_Import_RequireEsmModule_Lib
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.1
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_export::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object, string, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x303b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export
 
 
 		// Methods
@@ -1815,18 +3271,18 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_RequireEsmModule_Lib/Scope,
-			[1] class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default,
-			[2] class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get,
-			[3] class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace,
-			[4] class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export,
+			[1] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default,
+			[2] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get,
+			[3] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace,
+			[4] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export,
 			[5] object[],
-			[6] class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_66259425_sum,
-			[7] class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark,
+			[6] class Modules.Import_RequireEsmModule_Lib/sum/FunctionObject_FunctionDeclaration_66259425_sum,
+			[7] class Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark,
 			[8] object,
 			[9] object[],
-			[10] class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_F4B3CAF0_L3C28,
-			[11] class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_47065CFD_L4C26,
-			[12] class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_E6D9534C_L15C30
+			[10] class Modules.Import_RequireEsmModule_Lib/FunctionExpression_L3C27/FunctionObject_FunctionExpression_F4B3CAF0_L3C28,
+			[11] class Modules.Import_RequireEsmModule_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_47065CFD_L4C26,
+			[12] class Modules.Import_RequireEsmModule_Lib/FunctionExpression_L15C29/FunctionObject_FunctionExpression_E6D9534C_L15C30
 		)
 
 		IL_0000: newobj instance void Modules.Import_RequireEsmModule_Lib/Scope::.ctor()
@@ -1841,13 +3297,13 @@
 		IL_0015: ldloc.0
 		IL_0016: stelem.ref
 		IL_0017: stloc.s 5
-		IL_0019: newobj instance void FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_66259425_sum::.ctor()
+		IL_0019: newobj instance void Modules.Import_RequireEsmModule_Lib/sum/FunctionObject_FunctionDeclaration_66259425_sum::.ctor()
 		IL_001e: ldc.i4.2
 		IL_001f: conv.r8
 		IL_0020: ldstr "sum"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_66259425_sum>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/sum/FunctionObject_FunctionDeclaration_66259425_sum>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.s 6
 		IL_002e: ldloc.0
 		IL_002f: ldloc.s 6
@@ -1863,13 +3319,13 @@
 		IL_0044: ldc.i4.0
 		IL_0045: ldelem.ref
 		IL_0046: castclass Modules.Import_RequireEsmModule_Lib/Scope
-		IL_004b: newobj instance void FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope)
+		IL_004b: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope)
 		IL_0050: ldc.i4.0
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_mark"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark/FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.s 7
 		IL_0060: ldloc.0
 		IL_0061: ldloc.s 7
@@ -1881,13 +3337,13 @@
 		IL_0070: ldloc.0
 		IL_0071: stelem.ref
 		IL_0072: stloc.s 5
-		IL_0074: newobj instance void FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default::.ctor()
+		IL_0074: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default::.ctor()
 		IL_0079: ldc.i4.1
 		IL_007a: conv.r8
 		IL_007b: ldstr "__jroc_esm_default"
 		IL_0080: ldc.i4.0
 		IL_0081: ldc.i4.1
-		IL_0082: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0082: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_default/FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default>(!!0, float64, string, bool, bool)
 		IL_0087: stloc.1
 		IL_0088: ldc.i4.1
 		IL_0089: newarr [System.Runtime]System.Object
@@ -1896,13 +3352,13 @@
 		IL_0090: ldloc.0
 		IL_0091: stelem.ref
 		IL_0092: stloc.s 5
-		IL_0094: newobj instance void FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get::.ctor()
+		IL_0094: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get::.ctor()
 		IL_0099: ldc.i4.2
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_get"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_get/FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.2
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -1915,13 +3371,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_RequireEsmModule_Lib/Scope
-		IL_00bd: newobj instance void FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope)
+		IL_00bd: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope)
 		IL_00c2: ldc.i4.1
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_namespace"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.3
 		IL_00d1: ldc.i4.1
 		IL_00d2: newarr [System.Runtime]System.Object
@@ -1934,13 +3390,13 @@
 		IL_00df: ldc.i4.0
 		IL_00e0: ldelem.ref
 		IL_00e1: castclass Modules.Import_RequireEsmModule_Lib/Scope
-		IL_00e6: newobj instance void FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope)
+		IL_00e6: newobj instance void Modules.Import_RequireEsmModule_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope)
 		IL_00eb: ldc.i4.2
 		IL_00ec: conv.r8
 		IL_00ed: ldstr "__jroc_esm_export"
 		IL_00f2: ldc.i4.0
 		IL_00f3: ldc.i4.1
-		IL_00f4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00f4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/__jroc_esm_export/FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export>(!!0, float64, string, bool, bool)
 		IL_00f9: stloc.s 4
 		IL_00fb: nop
 		IL_00fc: ldloc.0
@@ -1963,13 +3419,13 @@
 		IL_0126: ldc.i4.0
 		IL_0127: ldelem.ref
 		IL_0128: castclass Modules.Import_RequireEsmModule_Lib/Scope
-		IL_012d: newobj instance void FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_F4B3CAF0_L3C28::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope)
+		IL_012d: newobj instance void Modules.Import_RequireEsmModule_Lib/FunctionExpression_L3C27/FunctionObject_FunctionExpression_F4B3CAF0_L3C28::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope)
 		IL_0132: ldc.i4.0
 		IL_0133: conv.r8
 		IL_0134: ldstr ""
 		IL_0139: ldc.i4.0
 		IL_013a: ldc.i4.1
-		IL_013b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_F4B3CAF0_L3C28>(!!0, float64, string, bool, bool)
+		IL_013b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/FunctionExpression_L3C27/FunctionObject_FunctionExpression_F4B3CAF0_L3C28>(!!0, float64, string, bool, bool)
 		IL_0140: stloc.s 10
 		IL_0142: ldloc.s 4
 		IL_0144: ldloc.s 5
@@ -1990,13 +3446,13 @@
 		IL_0168: ldc.i4.0
 		IL_0169: ldelem.ref
 		IL_016a: castclass Modules.Import_RequireEsmModule_Lib/Scope
-		IL_016f: newobj instance void FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_47065CFD_L4C26::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope)
+		IL_016f: newobj instance void Modules.Import_RequireEsmModule_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_47065CFD_L4C26::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope)
 		IL_0174: ldc.i4.0
 		IL_0175: conv.r8
 		IL_0176: ldstr ""
 		IL_017b: ldc.i4.0
 		IL_017c: ldc.i4.1
-		IL_017d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_47065CFD_L4C26>(!!0, float64, string, bool, bool)
+		IL_017d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/FunctionExpression_L4C25/FunctionObject_FunctionExpression_47065CFD_L4C26>(!!0, float64, string, bool, bool)
 		IL_0182: stloc.s 11
 		IL_0184: ldloc.s 4
 		IL_0186: ldloc.s 5
@@ -2025,13 +3481,13 @@
 		IL_01ca: ldc.i4.0
 		IL_01cb: ldelem.ref
 		IL_01cc: castclass Modules.Import_RequireEsmModule_Lib/Scope
-		IL_01d1: newobj instance void FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_E6D9534C_L15C30::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope)
+		IL_01d1: newobj instance void Modules.Import_RequireEsmModule_Lib/FunctionExpression_L15C29/FunctionObject_FunctionExpression_E6D9534C_L15C30::.ctor(class Modules.Import_RequireEsmModule_Lib/Scope)
 		IL_01d6: ldc.i4.0
 		IL_01d7: conv.r8
 		IL_01d8: ldstr ""
 		IL_01dd: ldc.i4.0
 		IL_01de: ldc.i4.1
-		IL_01df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_E6D9534C_L15C30>(!!0, float64, string, bool, bool)
+		IL_01df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_RequireEsmModule_Lib/FunctionExpression_L15C29/FunctionObject_FunctionExpression_E6D9534C_L15C30>(!!0, float64, string, bool, bool)
 		IL_01e4: stloc.s 12
 		IL_01e6: ldloc.s 4
 		IL_01e8: ldloc.s 5
@@ -2043,1462 +3499,6 @@
 	} // end of method Import_RequireEsmModule_Lib::__js_module_init__
 
 } // end of class Modules.Import_RequireEsmModule_Lib
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_F4B3CAF0_L3C28
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_RequireEsmModule_Lib/Scope _environment0_Import_RequireEsmModule_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_RequireEsmModule_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c47
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_F4B3CAF0_L3C28::_environment0_Import_RequireEsmModule_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F4B3CAF0_L3C28::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2c56
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F4B3CAF0_L3C28::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2c59
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F4B3CAF0_L3C28::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c5c
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_F4B3CAF0_L3C28::_environment0_Import_RequireEsmModule_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L3C27::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_F4B3CAF0_L3C28::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c6e
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_F4B3CAF0_L3C28::_environment0_Import_RequireEsmModule_Lib
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L3C27::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_F4B3CAF0_L3C28::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c7c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F4B3CAF0_L3C28::ConstructCore
-
-} // end of class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_F4B3CAF0_L3C28
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_47065CFD_L4C26
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_RequireEsmModule_Lib/Scope _environment0_Import_RequireEsmModule_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_RequireEsmModule_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c8b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_47065CFD_L4C26::_environment0_Import_RequireEsmModule_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_47065CFD_L4C26::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2c9a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_47065CFD_L4C26::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2c9d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_47065CFD_L4C26::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ca0
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_47065CFD_L4C26::_environment0_Import_RequireEsmModule_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_47065CFD_L4C26::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cb2
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_47065CFD_L4C26::_environment0_Import_RequireEsmModule_Lib
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L4C25::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_47065CFD_L4C26::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cc0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_47065CFD_L4C26::ConstructCore
-
-} // end of class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_47065CFD_L4C26
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_66259425_sum
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2ccf
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_66259425_sum::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2cd7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_66259425_sum::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2cda
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_66259425_sum::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cdd
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Import_RequireEsmModule_Lib/sum::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_66259425_sum::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cf7
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Import_RequireEsmModule_Lib/sum::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_66259425_sum::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d0d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_66259425_sum::ConstructCore
-
-} // end of class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_66259425_sum
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_E6D9534C_L15C30
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_RequireEsmModule_Lib/Scope _environment0_Import_RequireEsmModule_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_RequireEsmModule_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d1c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_E6D9534C_L15C30::_environment0_Import_RequireEsmModule_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E6D9534C_L15C30::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2d2b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E6D9534C_L15C30::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2d2e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E6D9534C_L15C30::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d31
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_E6D9534C_L15C30::_environment0_Import_RequireEsmModule_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L15C29::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_E6D9534C_L15C30::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d43
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_E6D9534C_L15C30::_environment0_Import_RequireEsmModule_Lib
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_RequireEsmModule_Lib/FunctionExpression_L15C29::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_E6D9534C_L15C30::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d51
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E6D9534C_L15C30::ConstructCore
-
-} // end of class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_E6D9534C_L15C30
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_RequireEsmModule_Lib/Scope _environment0_Import_RequireEsmModule_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_RequireEsmModule_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d60
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::_environment0_Import_RequireEsmModule_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2d6f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2d72
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d75
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::_environment0_Import_RequireEsmModule_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d87
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::_environment0_Import_RequireEsmModule_Lib
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_mark::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d95
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark::ConstructCore
-
-} // end of class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_878CACC2___jroc_esm_mark
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2da4
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2dac
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2daf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2db2
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_default::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2dc5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_default::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2dd4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default::ConstructCore
-
-} // end of class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_AEA05920___jroc_esm_default
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2de3
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2deb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2dee
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2df1
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e0b
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_get::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e21
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get::ConstructCore
-
-} // end of class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_9E8D30C1___jroc_esm_get
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_RequireEsmModule_Lib/Scope _environment0_Import_RequireEsmModule_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_RequireEsmModule_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e30
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::_environment0_Import_RequireEsmModule_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2e3f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2e42
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e45
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::_environment0_Import_RequireEsmModule_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e5e
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::_environment0_Import_RequireEsmModule_Lib
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e73
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace::ConstructCore
-
-} // end of class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_7256C84A___jroc_esm_namespace
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_CCED5EB8_L43C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_RequireEsmModule_Lib/Scope _environment0_Import_RequireEsmModule_Lib
-	.field private initonly class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_RequireEsmModule_Lib/Scope capture0,
-			class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e82
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_CCED5EB8_L43C87::_environment0_Import_RequireEsmModule_Lib
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_CCED5EB8_L43C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_CCED5EB8_L43C87::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_CCED5EB8_L43C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2e9f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_CCED5EB8_L43C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2ea2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_CCED5EB8_L43C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ea5
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_CCED5EB8_L43C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L43C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_CCED5EB8_L43C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2eb7
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_CCED5EB8_L43C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L43C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_CCED5EB8_L43C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ec5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_CCED5EB8_L43C87::ConstructCore
-
-} // end of class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_CCED5EB8_L43C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_A8452093_L44C94
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_RequireEsmModule_Lib/Scope _environment0_Import_RequireEsmModule_Lib
-	.field private initonly class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_RequireEsmModule_Lib/Scope capture0,
-			class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ed4
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_A8452093_L44C94::_environment0_Import_RequireEsmModule_Lib
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_A8452093_L44C94::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_A8452093_L44C94::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_A8452093_L44C94::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2ef1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A8452093_L44C94::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2ef4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A8452093_L44C94::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ef7
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_A8452093_L44C94::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L44C93::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_A8452093_L44C94::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f09
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_A8452093_L44C94::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L44C93::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_A8452093_L44C94::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f17
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A8452093_L44C94::ConstructCore
-
-} // end of class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_A8452093_L44C94
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_5F1A817A_L53C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_RequireEsmModule_Lib/Scope _environment0_Import_RequireEsmModule_Lib
-	.field private initonly class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_RequireEsmModule_Lib/Scope capture0,
-			class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f26
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_5F1A817A_L53C10::_environment0_Import_RequireEsmModule_Lib
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_5F1A817A_L53C10::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_5F1A817A_L53C10::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_5F1A817A_L53C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2f43
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5F1A817A_L53C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2f46
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5F1A817A_L53C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f49
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_5F1A817A_L53C10::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_5F1A817A_L53C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f62
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_5F1A817A_L53C10::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_5F1A817A_L53C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f77
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5F1A817A_L53C10::ConstructCore
-
-} // end of class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_5F1A817A_L53C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_DFB4664B_L54C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_RequireEsmModule_Lib/Scope _environment0_Import_RequireEsmModule_Lib
-	.field private initonly class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope _environment2_FunctionExpression_L53C9
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_RequireEsmModule_Lib/Scope capture0,
-			class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope capture1,
-			class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f86
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_DFB4664B_L54C87::_environment0_Import_RequireEsmModule_Lib
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/Scope FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_DFB4664B_L54C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/Scope FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_DFB4664B_L54C87::_environment2_FunctionExpression_L53C9
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_DFB4664B_L54C87::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_DFB4664B_L54C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2fab
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DFB4664B_L54C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2fae
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DFB4664B_L54C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2fb1
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_DFB4664B_L54C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_DFB4664B_L54C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2fc3
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_DFB4664B_L54C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_namespace/FunctionExpression_L53C9/FunctionExpression_L54C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_DFB4664B_L54C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2fd1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DFB4664B_L54C87::ConstructCore
-
-} // end of class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionExpression_DFB4664B_L54C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_RequireEsmModule_Lib/Scope _environment0_Import_RequireEsmModule_Lib
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_RequireEsmModule_Lib/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2fe0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_RequireEsmModule_Lib/Scope FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::_environment0_Import_RequireEsmModule_Lib
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2fef
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2ff2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ff5
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::_environment0_Import_RequireEsmModule_Lib
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0017: ldarg.2
-		IL_0018: ldc.i4.1
-		IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001e: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_export::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object, string, object)
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x301a
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_RequireEsmModule_Lib/Scope FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::_environment0_Import_RequireEsmModule_Lib
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.1
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.Import_RequireEsmModule_Lib/__jroc_esm_export::__js_call__(class Modules.Import_RequireEsmModule_Lib/Scope, object, string, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x303b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export::ConstructCore
-
-} // end of class FunctionObjects.Import_RequireEsmModule_Lib_B293F467.FunctionObject_FunctionDeclaration_FE2F4B25___jroc_esm_export
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_StaticImport_FromCjs.verified.txt
+++ b/tests/Jroc.Tests/Import/Snapshots/GeneratorTests.Import_StaticImport_FromCjs.verified.txt
@@ -53,6 +53,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_StaticImport_FromCjs/Scope _environment0_Import_StaticImport_FromCjs
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_StaticImport_FromCjs/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b5c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_mark/FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::_environment0_Import_StaticImport_FromCjs
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2b6b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2b6e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b71
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_mark/FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::_environment0_Import_StaticImport_FromCjs
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_mark::__js_call__(class Modules.Import_StaticImport_FromCjs/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b83
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_mark/FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::_environment0_Import_StaticImport_FromCjs
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_mark::__js_call__(class Modules.Import_StaticImport_FromCjs/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b91
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark
+
 
 		// Methods
 		.method public hidebysig static 
@@ -159,6 +266,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2ba0
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2ba8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2bab
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bae
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_default::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bc1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_default::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bd0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default
+
 
 		// Methods
 		.method public hidebysig static 
@@ -262,6 +470,115 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2bdf
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2be7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2bea
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bed
+				// Header size: 1
+				// Code size: 30 (0x1e)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0018: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_get::__js_call__(object, object, string)
+				IL_001d: ret
+			} // end of method FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c0c
+				// Header size: 1
+				// Code size: 26 (0x1a)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0014: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_get::__js_call__(object, object, string)
+				IL_0019: ret
+			} // end of method FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c27
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get
+
 
 		// Methods
 		.method public hidebysig static 
@@ -320,6 +637,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C4FD07CD_L42C87
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_StaticImport_FromCjs/Scope _environment0_Import_StaticImport_FromCjs
+				.field private initonly class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_StaticImport_FromCjs/Scope capture0,
+						class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2c88
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86/FunctionObject_FunctionExpression_C4FD07CD_L42C87::_environment0_Import_StaticImport_FromCjs
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86/FunctionObject_FunctionExpression_C4FD07CD_L42C87::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86/FunctionObject_FunctionExpression_C4FD07CD_L42C87::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_C4FD07CD_L42C87::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2ca5
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_C4FD07CD_L42C87::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2ca8
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_C4FD07CD_L42C87::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2cab
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86/FunctionObject_FunctionExpression_C4FD07CD_L42C87::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_C4FD07CD_L42C87::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2cbd
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86/FunctionObject_FunctionExpression_C4FD07CD_L42C87::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_C4FD07CD_L42C87::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2ccb
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_C4FD07CD_L42C87::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_C4FD07CD_L42C87
+
 
 			// Methods
 			.method public hidebysig static 
@@ -369,6 +803,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F868AEAC_L43C94
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_StaticImport_FromCjs/Scope _environment0_Import_StaticImport_FromCjs
+				.field private initonly class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_StaticImport_FromCjs/Scope capture0,
+						class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2cda
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93/FunctionObject_FunctionExpression_F868AEAC_L43C94::_environment0_Import_StaticImport_FromCjs
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93/FunctionObject_FunctionExpression_F868AEAC_L43C94::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93/FunctionObject_FunctionExpression_F868AEAC_L43C94::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_F868AEAC_L43C94::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2cf7
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_F868AEAC_L43C94::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2cfa
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_F868AEAC_L43C94::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2cfd
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93/FunctionObject_FunctionExpression_F868AEAC_L43C94::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_F868AEAC_L43C94::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2d0f
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93/FunctionObject_FunctionExpression_F868AEAC_L43C94::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_F868AEAC_L43C94::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2d1d
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_F868AEAC_L43C94::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_F868AEAC_L43C94
 
 
 			// Methods
@@ -423,6 +974,128 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_69B7ACEA_L53C87
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Import_StaticImport_FromCjs/Scope _environment0_Import_StaticImport_FromCjs
+					.field private initonly class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+					.field private initonly class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/Scope _environment2_FunctionExpression_L52C9
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Import_StaticImport_FromCjs/Scope capture0,
+							class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope capture1,
+							class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x2d8c
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86/FunctionObject_FunctionExpression_69B7ACEA_L53C87::_environment0_Import_StaticImport_FromCjs
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86/FunctionObject_FunctionExpression_69B7ACEA_L53C87::_environment1___jroc_esm_namespace
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86/FunctionObject_FunctionExpression_69B7ACEA_L53C87::_environment2_FunctionExpression_L52C9
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86/FunctionObject_FunctionExpression_69B7ACEA_L53C87::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_69B7ACEA_L53C87::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x2db1
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_69B7ACEA_L53C87::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x2db4
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_69B7ACEA_L53C87::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x2db7
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86/FunctionObject_FunctionExpression_69B7ACEA_L53C87::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_69B7ACEA_L53C87::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x2dc9
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86/FunctionObject_FunctionExpression_69B7ACEA_L53C87::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_69B7ACEA_L53C87::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x2dd7
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_69B7ACEA_L53C87::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_69B7ACEA_L53C87
 
 
 				// Methods
@@ -489,6 +1162,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1A1351AC_L52C10
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Import_StaticImport_FromCjs/Scope _environment0_Import_StaticImport_FromCjs
+				.field private initonly class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Import_StaticImport_FromCjs/Scope capture0,
+						class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2d2c
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionObject_FunctionExpression_1A1351AC_L52C10::_environment0_Import_StaticImport_FromCjs
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionObject_FunctionExpression_1A1351AC_L52C10::_environment1___jroc_esm_namespace
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionObject_FunctionExpression_1A1351AC_L52C10::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_1A1351AC_L52C10::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2d49
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_1A1351AC_L52C10::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2d4c
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_1A1351AC_L52C10::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2d4f
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionObject_FunctionExpression_1A1351AC_L52C10::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_1A1351AC_L52C10::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2d68
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionObject_FunctionExpression_1A1351AC_L52C10::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_1A1351AC_L52C10::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2d7d
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_1A1351AC_L52C10::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_1A1351AC_L52C10
+
 
 			// Methods
 			.method public hidebysig static 
@@ -510,7 +1306,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_69B7ACEA_L53C87,
+					[4] class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86/FunctionObject_FunctionExpression_69B7ACEA_L53C87,
 					[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 				)
 
@@ -560,13 +1356,13 @@
 				IL_004b: ldelem.ref
 				IL_004c: castclass Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/Scope
 				IL_0051: ldloc.3
-				IL_0052: newobj instance void FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_69B7ACEA_L53C87::.ctor(class Modules.Import_StaticImport_FromCjs/Scope, class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope, class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/Scope, object[])
+				IL_0052: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86/FunctionObject_FunctionExpression_69B7ACEA_L53C87::.ctor(class Modules.Import_StaticImport_FromCjs/Scope, class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope, class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/Scope, object[])
 				IL_0057: ldc.i4.0
 				IL_0058: conv.r8
 				IL_0059: ldstr ""
 				IL_005e: ldc.i4.0
 				IL_005f: ldc.i4.1
-				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_69B7ACEA_L53C87>(!!0, float64, string, bool, bool)
+				IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86/FunctionObject_FunctionExpression_69B7ACEA_L53C87>(!!0, float64, string, bool, bool)
 				IL_0065: stloc.s 4
 				IL_0067: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 				IL_006c: dup
@@ -785,6 +1581,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_StaticImport_FromCjs/Scope _environment0_Import_StaticImport_FromCjs
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_StaticImport_FromCjs/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c36
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::_environment0_Import_StaticImport_FromCjs
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2c45
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2c48
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c4b
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::_environment0_Import_StaticImport_FromCjs
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace::__js_call__(class Modules.Import_StaticImport_FromCjs/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c64
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::_environment0_Import_StaticImport_FromCjs
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace::__js_call__(class Modules.Import_StaticImport_FromCjs/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c79
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace
+
 
 		// Methods
 		.method public hidebysig static 
@@ -824,12 +1733,12 @@
 				[17] object,
 				[18] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[19] object[],
-				[20] class FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_C4FD07CD_L42C87,
-				[21] class FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_F868AEAC_L43C94,
+				[20] class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86/FunctionObject_FunctionExpression_C4FD07CD_L42C87,
+				[21] class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93/FunctionObject_FunctionExpression_F868AEAC_L43C94,
 				[22] object,
 				[23] object,
 				[24] object,
-				[25] class FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_1A1351AC_L52C10
+				[25] class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionObject_FunctionExpression_1A1351AC_L52C10
 			)
 
 			IL_0000: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope::.ctor()
@@ -1035,13 +1944,13 @@
 			IL_021b: ldelem.ref
 			IL_021c: castclass Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope
 			IL_0221: ldloc.s 19
-			IL_0223: newobj instance void FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_C4FD07CD_L42C87::.ctor(class Modules.Import_StaticImport_FromCjs/Scope, class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope, object[])
+			IL_0223: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86/FunctionObject_FunctionExpression_C4FD07CD_L42C87::.ctor(class Modules.Import_StaticImport_FromCjs/Scope, class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope, object[])
 			IL_0228: ldc.i4.0
 			IL_0229: conv.r8
 			IL_022a: ldstr ""
 			IL_022f: ldc.i4.0
 			IL_0230: ldc.i4.1
-			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_C4FD07CD_L42C87>(!!0, float64, string, bool, bool)
+			IL_0231: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86/FunctionObject_FunctionExpression_C4FD07CD_L42C87>(!!0, float64, string, bool, bool)
 			IL_0236: stloc.s 20
 			IL_0238: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_023d: dup
@@ -1085,13 +1994,13 @@
 			IL_0297: ldelem.ref
 			IL_0298: castclass Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope
 			IL_029d: ldloc.s 19
-			IL_029f: newobj instance void FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_F868AEAC_L43C94::.ctor(class Modules.Import_StaticImport_FromCjs/Scope, class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope, object[])
+			IL_029f: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93/FunctionObject_FunctionExpression_F868AEAC_L43C94::.ctor(class Modules.Import_StaticImport_FromCjs/Scope, class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope, object[])
 			IL_02a4: ldc.i4.0
 			IL_02a5: conv.r8
 			IL_02a6: ldstr ""
 			IL_02ab: ldc.i4.0
 			IL_02ac: ldc.i4.1
-			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_F868AEAC_L43C94>(!!0, float64, string, bool, bool)
+			IL_02ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93/FunctionObject_FunctionExpression_F868AEAC_L43C94>(!!0, float64, string, bool, bool)
 			IL_02b2: stloc.s 21
 			IL_02b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_02b9: dup
@@ -1261,13 +2170,13 @@
 				IL_0469: ldelem.ref
 				IL_046a: castclass Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope
 				IL_046f: ldloc.s 19
-				IL_0471: newobj instance void FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_1A1351AC_L52C10::.ctor(class Modules.Import_StaticImport_FromCjs/Scope, class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope, object[])
+				IL_0471: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionObject_FunctionExpression_1A1351AC_L52C10::.ctor(class Modules.Import_StaticImport_FromCjs/Scope, class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope, object[])
 				IL_0476: ldc.i4.1
 				IL_0477: conv.r8
 				IL_0478: ldstr ""
 				IL_047d: ldc.i4.0
 				IL_047e: ldc.i4.1
-				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_1A1351AC_L52C10>(!!0, float64, string, bool, bool)
+				IL_047f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionObject_FunctionExpression_1A1351AC_L52C10>(!!0, float64, string, bool, bool)
 				IL_0484: stloc.s 25
 				IL_0486: ldc.i4.1
 				IL_0487: newarr [System.Runtime]System.Object
@@ -1386,6 +2295,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Import_StaticImport_FromCjs/Scope _environment0_Import_StaticImport_FromCjs
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Import_StaticImport_FromCjs/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2de6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_export/FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::_environment0_Import_StaticImport_FromCjs
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2df5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2df8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2dfb
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_export/FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::_environment0_Import_StaticImport_FromCjs
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_export::__js_call__(class Modules.Import_StaticImport_FromCjs/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e1b
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Import_StaticImport_FromCjs/Scope Modules.Import_StaticImport_FromCjs/__jroc_esm_export/FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::_environment0_Import_StaticImport_FromCjs
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_export::__js_call__(class Modules.Import_StaticImport_FromCjs/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e37
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1499,15 +2527,15 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Import_StaticImport_FromCjs/Scope,
-			[1] class FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default,
-			[2] class FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get,
-			[3] class FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace,
-			[4] class FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export,
+			[1] class Modules.Import_StaticImport_FromCjs/__jroc_esm_default/FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default,
+			[2] class Modules.Import_StaticImport_FromCjs/__jroc_esm_get/FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get,
+			[3] class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace,
+			[4] class Modules.Import_StaticImport_FromCjs/__jroc_esm_export/FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export,
 			[5] object,
 			[6] object,
 			[7] object,
 			[8] object[],
-			[9] class FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark,
+			[9] class Modules.Import_StaticImport_FromCjs/__jroc_esm_mark/FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark,
 			[10] object,
 			[11] object
 		)
@@ -1528,13 +2556,13 @@
 		IL_001b: ldc.i4.0
 		IL_001c: ldelem.ref
 		IL_001d: castclass Modules.Import_StaticImport_FromCjs/Scope
-		IL_0022: newobj instance void FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::.ctor(class Modules.Import_StaticImport_FromCjs/Scope)
+		IL_0022: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_mark/FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::.ctor(class Modules.Import_StaticImport_FromCjs/Scope)
 		IL_0027: ldc.i4.0
 		IL_0028: conv.r8
 		IL_0029: ldstr "__jroc_esm_mark"
 		IL_002e: ldc.i4.0
 		IL_002f: ldc.i4.1
-		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark>(!!0, float64, string, bool, bool)
+		IL_0030: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_StaticImport_FromCjs/__jroc_esm_mark/FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark>(!!0, float64, string, bool, bool)
 		IL_0035: stloc.s 9
 		IL_0037: ldloc.0
 		IL_0038: ldloc.s 9
@@ -1546,13 +2574,13 @@
 		IL_0047: ldloc.0
 		IL_0048: stelem.ref
 		IL_0049: stloc.s 8
-		IL_004b: newobj instance void FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default::.ctor()
+		IL_004b: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_default/FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default::.ctor()
 		IL_0050: ldc.i4.1
 		IL_0051: conv.r8
 		IL_0052: ldstr "__jroc_esm_default"
 		IL_0057: ldc.i4.0
 		IL_0058: ldc.i4.1
-		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default>(!!0, float64, string, bool, bool)
+		IL_0059: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_StaticImport_FromCjs/__jroc_esm_default/FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default>(!!0, float64, string, bool, bool)
 		IL_005e: stloc.1
 		IL_005f: ldc.i4.1
 		IL_0060: newarr [System.Runtime]System.Object
@@ -1561,13 +2589,13 @@
 		IL_0067: ldloc.0
 		IL_0068: stelem.ref
 		IL_0069: stloc.s 8
-		IL_006b: newobj instance void FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get::.ctor()
+		IL_006b: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_get/FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get::.ctor()
 		IL_0070: ldc.i4.2
 		IL_0071: conv.r8
 		IL_0072: ldstr "__jroc_esm_get"
 		IL_0077: ldc.i4.0
 		IL_0078: ldc.i4.1
-		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get>(!!0, float64, string, bool, bool)
+		IL_0079: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_StaticImport_FromCjs/__jroc_esm_get/FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get>(!!0, float64, string, bool, bool)
 		IL_007e: stloc.2
 		IL_007f: ldc.i4.1
 		IL_0080: newarr [System.Runtime]System.Object
@@ -1580,13 +2608,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Import_StaticImport_FromCjs/Scope
-		IL_0094: newobj instance void FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::.ctor(class Modules.Import_StaticImport_FromCjs/Scope)
+		IL_0094: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::.ctor(class Modules.Import_StaticImport_FromCjs/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr "__jroc_esm_namespace"
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.3
 		IL_00a8: ldc.i4.1
 		IL_00a9: newarr [System.Runtime]System.Object
@@ -1599,13 +2627,13 @@
 		IL_00b6: ldc.i4.0
 		IL_00b7: ldelem.ref
 		IL_00b8: castclass Modules.Import_StaticImport_FromCjs/Scope
-		IL_00bd: newobj instance void FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::.ctor(class Modules.Import_StaticImport_FromCjs/Scope)
+		IL_00bd: newobj instance void Modules.Import_StaticImport_FromCjs/__jroc_esm_export/FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::.ctor(class Modules.Import_StaticImport_FromCjs/Scope)
 		IL_00c2: ldc.i4.2
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "__jroc_esm_export"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.1
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Import_StaticImport_FromCjs/__jroc_esm_export/FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 4
 		IL_00d2: nop
 		IL_00d3: ldloc.0
@@ -1765,1034 +2793,6 @@
 	} // end of method Import_StaticImport_FromCjs_Lib::__js_module_init__
 
 } // end of class Modules.Import_StaticImport_FromCjs_Lib
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_StaticImport_FromCjs/Scope _environment0_Import_StaticImport_FromCjs
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_StaticImport_FromCjs/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b5c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_StaticImport_FromCjs/Scope FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::_environment0_Import_StaticImport_FromCjs
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2b6b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2b6e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b71
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_StaticImport_FromCjs/Scope FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::_environment0_Import_StaticImport_FromCjs
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_mark::__js_call__(class Modules.Import_StaticImport_FromCjs/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b83
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_StaticImport_FromCjs/Scope FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::_environment0_Import_StaticImport_FromCjs
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_mark::__js_call__(class Modules.Import_StaticImport_FromCjs/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b91
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark::ConstructCore
-
-} // end of class FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_FCB364A6___jroc_esm_mark
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2ba0
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2ba8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2bab
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bae
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_default::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bc1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_default::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bd0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default::ConstructCore
-
-} // end of class FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_4C8D77A4___jroc_esm_default
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2bdf
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2be7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2bea
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bed
-		// Header size: 1
-		// Code size: 30 (0x1e)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0018: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_get::__js_call__(object, object, string)
-		IL_001d: ret
-	} // end of method FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c0c
-		// Header size: 1
-		// Code size: 26 (0x1a)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0014: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_get::__js_call__(object, object, string)
-		IL_0019: ret
-	} // end of method FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c27
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get::ConstructCore
-
-} // end of class FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_30B2239D___jroc_esm_get
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_StaticImport_FromCjs/Scope _environment0_Import_StaticImport_FromCjs
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_StaticImport_FromCjs/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c36
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_StaticImport_FromCjs/Scope FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::_environment0_Import_StaticImport_FromCjs
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2c45
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2c48
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c4b
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_StaticImport_FromCjs/Scope FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::_environment0_Import_StaticImport_FromCjs
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace::__js_call__(class Modules.Import_StaticImport_FromCjs/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c64
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_StaticImport_FromCjs/Scope FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::_environment0_Import_StaticImport_FromCjs
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace::__js_call__(class Modules.Import_StaticImport_FromCjs/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c79
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace::ConstructCore
-
-} // end of class FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_920E5F1E___jroc_esm_namespace
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_C4FD07CD_L42C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_StaticImport_FromCjs/Scope _environment0_Import_StaticImport_FromCjs
-	.field private initonly class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_StaticImport_FromCjs/Scope capture0,
-			class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c88
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_StaticImport_FromCjs/Scope FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_C4FD07CD_L42C87::_environment0_Import_StaticImport_FromCjs
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_C4FD07CD_L42C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_C4FD07CD_L42C87::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_C4FD07CD_L42C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2ca5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C4FD07CD_L42C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2ca8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C4FD07CD_L42C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cab
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_C4FD07CD_L42C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_C4FD07CD_L42C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cbd
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_C4FD07CD_L42C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L42C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_C4FD07CD_L42C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ccb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C4FD07CD_L42C87::ConstructCore
-
-} // end of class FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_C4FD07CD_L42C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_F868AEAC_L43C94
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_StaticImport_FromCjs/Scope _environment0_Import_StaticImport_FromCjs
-	.field private initonly class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_StaticImport_FromCjs/Scope capture0,
-			class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cda
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_StaticImport_FromCjs/Scope FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_F868AEAC_L43C94::_environment0_Import_StaticImport_FromCjs
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_F868AEAC_L43C94::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_F868AEAC_L43C94::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_F868AEAC_L43C94::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2cf7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F868AEAC_L43C94::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2cfa
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F868AEAC_L43C94::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cfd
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_F868AEAC_L43C94::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_F868AEAC_L43C94::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d0f
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_F868AEAC_L43C94::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L43C93::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_F868AEAC_L43C94::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d1d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F868AEAC_L43C94::ConstructCore
-
-} // end of class FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_F868AEAC_L43C94
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_1A1351AC_L52C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_StaticImport_FromCjs/Scope _environment0_Import_StaticImport_FromCjs
-	.field private initonly class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_StaticImport_FromCjs/Scope capture0,
-			class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d2c
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_StaticImport_FromCjs/Scope FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_1A1351AC_L52C10::_environment0_Import_StaticImport_FromCjs
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_1A1351AC_L52C10::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_1A1351AC_L52C10::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_1A1351AC_L52C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2d49
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1A1351AC_L52C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2d4c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1A1351AC_L52C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d4f
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_1A1351AC_L52C10::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_1A1351AC_L52C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d68
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_1A1351AC_L52C10::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_1A1351AC_L52C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d7d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1A1351AC_L52C10::ConstructCore
-
-} // end of class FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_1A1351AC_L52C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_69B7ACEA_L53C87
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_StaticImport_FromCjs/Scope _environment0_Import_StaticImport_FromCjs
-	.field private initonly class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope _environment1___jroc_esm_namespace
-	.field private initonly class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/Scope _environment2_FunctionExpression_L52C9
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_StaticImport_FromCjs/Scope capture0,
-			class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope capture1,
-			class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d8c
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_StaticImport_FromCjs/Scope FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_69B7ACEA_L53C87::_environment0_Import_StaticImport_FromCjs
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/Scope FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_69B7ACEA_L53C87::_environment1___jroc_esm_namespace
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/Scope FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_69B7ACEA_L53C87::_environment2_FunctionExpression_L52C9
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_69B7ACEA_L53C87::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_69B7ACEA_L53C87::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2db1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_69B7ACEA_L53C87::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2db4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_69B7ACEA_L53C87::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2db7
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_69B7ACEA_L53C87::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_69B7ACEA_L53C87::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2dc9
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_69B7ACEA_L53C87::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_namespace/FunctionExpression_L52C9/FunctionExpression_L53C86::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_69B7ACEA_L53C87::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2dd7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_69B7ACEA_L53C87::ConstructCore
-
-} // end of class FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionExpression_69B7ACEA_L53C87
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Import_StaticImport_FromCjs/Scope _environment0_Import_StaticImport_FromCjs
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Import_StaticImport_FromCjs/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2de6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Import_StaticImport_FromCjs/Scope FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::_environment0_Import_StaticImport_FromCjs
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2df5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2df8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2dfb
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_StaticImport_FromCjs/Scope FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::_environment0_Import_StaticImport_FromCjs
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_export::__js_call__(class Modules.Import_StaticImport_FromCjs/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e1b
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Import_StaticImport_FromCjs/Scope FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::_environment0_Import_StaticImport_FromCjs
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Import_StaticImport_FromCjs/__jroc_esm_export::__js_call__(class Modules.Import_StaticImport_FromCjs/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e37
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export::ConstructCore
-
-} // end of class FunctionObjects.Import_StaticImport_FromCjs_827BEAB3.FunctionObject_FunctionDeclaration_9D2BB669___jroc_esm_export
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Integration/GeneratedFunctionObjectEmissionTests.cs
+++ b/tests/Jroc.Tests/Integration/GeneratedFunctionObjectEmissionTests.cs
@@ -122,6 +122,18 @@ public sealed class GeneratedFunctionObjectEmissionTests
             .ToArray();
 
         Assert.Empty(answerType.GetFields(BindingFlags.Instance | BindingFlags.NonPublic));
+        Assert.All(
+            emittedTypes,
+            type =>
+            {
+                Assert.NotNull(type.DeclaringType);
+                Assert.DoesNotContain(
+                    "FunctionObjects.",
+                    type.Namespace,
+                    StringComparison.Ordinal);
+            });
+        Assert.Equal("answer", answerType.DeclaringType!.Name);
+        Assert.Equal("inner", innerType.DeclaringType!.Name);
         Assert.NotEmpty(arrowTypes);
         Assert.All(
             arrowTypes,
@@ -206,6 +218,7 @@ public sealed class GeneratedFunctionObjectEmissionTests
             GetFunctionObjectTypes(compiled.Assembly),
             type => type.Name.Contains("ClassMethod", StringComparison.Ordinal)
                 && type.Name.EndsWith("_Echo_method", StringComparison.Ordinal));
+        Assert.Equal("Echo", methodFunctionType.DeclaringType!.Name);
         var methodFunction = Assert.IsAssignableFrom<JsFunctionObject>(
             Activator.CreateInstance(methodFunctionType));
         var echoType = compiled.Assembly.GetTypes().Single(type => type.Name == "Echo");

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Array_Modern.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Array_Modern.verified.txt
@@ -31,6 +31,117 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0503C5DA_startTest
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x27da
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_0503C5DA_startTest::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x27e2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0503C5DA_startTest::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x27e5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0503C5DA_startTest::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x27e8
+				// Header size: 1
+				// Code size: 35 (0x23)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_001d: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/startTest::__js_call__(object, string, string)
+				IL_0022: ret
+			} // end of method FunctionObject_FunctionDeclaration_0503C5DA_startTest::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x280c
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0019: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/startTest::__js_call__(object, string, string)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_0503C5DA_startTest::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x282c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0503C5DA_startTest::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_0503C5DA_startTest
+
 
 		// Methods
 		.method public hidebysig static 
@@ -77,6 +188,101 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3950DF5B_endTest
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x283b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_3950DF5B_endTest::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2843
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3950DF5B_endTest::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2846
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3950DF5B_endTest::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2849
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/endTest::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_3950DF5B_endTest::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2855
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/endTest::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_3950DF5B_endTest::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x285d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3950DF5B_endTest::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_3950DF5B_endTest
 
 
 		// Methods
@@ -144,6 +350,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5501B021_prep
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x286c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_5501B021_prep::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2874
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5501B021_prep::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2877
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5501B021_prep::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x287a
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/prep::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_5501B021_prep::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x288d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/prep::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5501B021_prep::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x289c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5501B021_prep::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_5501B021_prep
 
 
 		// Methods
@@ -231,6 +538,115 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_31AC3262_test
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x28ab
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_31AC3262_test::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x28b3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_31AC3262_test::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x28b6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_31AC3262_test::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x28b9
+				// Header size: 1
+				// Code size: 30 (0x1e)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, string, object)
+				IL_001d: ret
+			} // end of method FunctionObject_FunctionDeclaration_31AC3262_test::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x28d8
+				// Header size: 1
+				// Code size: 26 (0x1a)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, string, object)
+				IL_0019: ret
+			} // end of method FunctionObject_FunctionDeclaration_31AC3262_test::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x28f3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_31AC3262_test::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_31AC3262_test
 
 
 		// Methods
@@ -1740,10 +2156,10 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/Scope,
-			[1] class FunctionObjects.Compile_Performance_Dromaeo_Object_Array_Modern_93542E2F.FunctionObject_FunctionDeclaration_0503C5DA_startTest,
-			[2] class FunctionObjects.Compile_Performance_Dromaeo_Object_Array_Modern_93542E2F.FunctionObject_FunctionDeclaration_3950DF5B_endTest,
-			[3] class FunctionObjects.Compile_Performance_Dromaeo_Object_Array_Modern_93542E2F.FunctionObject_FunctionDeclaration_5501B021_prep,
-			[4] class FunctionObjects.Compile_Performance_Dromaeo_Object_Array_Modern_93542E2F.FunctionObject_FunctionDeclaration_31AC3262_test,
+			[1] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/startTest/FunctionObject_FunctionDeclaration_0503C5DA_startTest,
+			[2] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/endTest/FunctionObject_FunctionDeclaration_3950DF5B_endTest,
+			[3] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/prep/FunctionObject_FunctionDeclaration_5501B021_prep,
+			[4] class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test/FunctionObject_FunctionDeclaration_31AC3262_test,
 			[5] float64,
 			[6] object[],
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -1767,13 +2183,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 6
-		IL_0012: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Array_Modern_93542E2F.FunctionObject_FunctionDeclaration_0503C5DA_startTest::.ctor()
+		IL_0012: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/startTest/FunctionObject_FunctionDeclaration_0503C5DA_startTest::.ctor()
 		IL_0017: ldc.i4.2
 		IL_0018: conv.r8
 		IL_0019: ldstr "startTest"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Array_Modern_93542E2F.FunctionObject_FunctionDeclaration_0503C5DA_startTest>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/startTest/FunctionObject_FunctionDeclaration_0503C5DA_startTest>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -1782,13 +2198,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 6
-		IL_0032: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Array_Modern_93542E2F.FunctionObject_FunctionDeclaration_3950DF5B_endTest::.ctor()
+		IL_0032: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/endTest/FunctionObject_FunctionDeclaration_3950DF5B_endTest::.ctor()
 		IL_0037: ldc.i4.0
 		IL_0038: conv.r8
 		IL_0039: ldstr "endTest"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Array_Modern_93542E2F.FunctionObject_FunctionDeclaration_3950DF5B_endTest>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/endTest/FunctionObject_FunctionDeclaration_3950DF5B_endTest>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -1797,13 +2213,13 @@
 		IL_004e: ldloc.0
 		IL_004f: stelem.ref
 		IL_0050: stloc.s 6
-		IL_0052: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Array_Modern_93542E2F.FunctionObject_FunctionDeclaration_5501B021_prep::.ctor()
+		IL_0052: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/prep/FunctionObject_FunctionDeclaration_5501B021_prep::.ctor()
 		IL_0057: ldc.i4.1
 		IL_0058: conv.r8
 		IL_0059: ldstr "prep"
 		IL_005e: ldc.i4.0
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Array_Modern_93542E2F.FunctionObject_FunctionDeclaration_5501B021_prep>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/prep/FunctionObject_FunctionDeclaration_5501B021_prep>(!!0, float64, string, bool, bool)
 		IL_0065: stloc.3
 		IL_0066: ldc.i4.1
 		IL_0067: newarr [System.Runtime]System.Object
@@ -1812,13 +2228,13 @@
 		IL_006e: ldloc.0
 		IL_006f: stelem.ref
 		IL_0070: stloc.s 6
-		IL_0072: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Array_Modern_93542E2F.FunctionObject_FunctionDeclaration_31AC3262_test::.ctor()
+		IL_0072: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test/FunctionObject_FunctionDeclaration_31AC3262_test::.ctor()
 		IL_0077: ldc.i4.2
 		IL_0078: conv.r8
 		IL_0079: ldstr "test"
 		IL_007e: ldc.i4.0
 		IL_007f: ldc.i4.1
-		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Array_Modern_93542E2F.FunctionObject_FunctionDeclaration_31AC3262_test>(!!0, float64, string, bool, bool)
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test/FunctionObject_FunctionDeclaration_31AC3262_test>(!!0, float64, string, bool, bool)
 		IL_0085: stloc.s 4
 		IL_0087: nop
 		IL_0088: nop
@@ -2076,422 +2492,6 @@
 	} // end of method Compile_Performance_Dromaeo_Object_Array_Modern::__js_module_init__
 
 } // end of class Modules.Compile_Performance_Dromaeo_Object_Array_Modern
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Array_Modern_93542E2F.FunctionObject_FunctionDeclaration_0503C5DA_startTest
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x27da
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_0503C5DA_startTest::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x27e2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0503C5DA_startTest::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x27e5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0503C5DA_startTest::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x27e8
-		// Header size: 1
-		// Code size: 35 (0x23)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_001d: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/startTest::__js_call__(object, string, string)
-		IL_0022: ret
-	} // end of method FunctionObject_FunctionDeclaration_0503C5DA_startTest::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x280c
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0019: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/startTest::__js_call__(object, string, string)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_0503C5DA_startTest::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x282c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0503C5DA_startTest::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Array_Modern_93542E2F.FunctionObject_FunctionDeclaration_0503C5DA_startTest
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Array_Modern_93542E2F.FunctionObject_FunctionDeclaration_3950DF5B_endTest
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x283b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_3950DF5B_endTest::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2843
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3950DF5B_endTest::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2846
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3950DF5B_endTest::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2849
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/endTest::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_3950DF5B_endTest::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2855
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/endTest::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_3950DF5B_endTest::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x285d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3950DF5B_endTest::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Array_Modern_93542E2F.FunctionObject_FunctionDeclaration_3950DF5B_endTest
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Array_Modern_93542E2F.FunctionObject_FunctionDeclaration_5501B021_prep
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x286c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_5501B021_prep::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2874
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5501B021_prep::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2877
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5501B021_prep::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x287a
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/prep::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_5501B021_prep::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x288d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/prep::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5501B021_prep::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x289c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5501B021_prep::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Array_Modern_93542E2F.FunctionObject_FunctionDeclaration_5501B021_prep
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Array_Modern_93542E2F.FunctionObject_FunctionDeclaration_31AC3262_test
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x28ab
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_31AC3262_test::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x28b3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_31AC3262_test::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x28b6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_31AC3262_test::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x28b9
-		// Header size: 1
-		// Code size: 30 (0x1e)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, string, object)
-		IL_001d: ret
-	} // end of method FunctionObject_FunctionDeclaration_31AC3262_test::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28d8
-		// Header size: 1
-		// Code size: 26 (0x1a)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call object Modules.Compile_Performance_Dromaeo_Object_Array_Modern/test::__js_call__(object, string, object)
-		IL_0019: ret
-	} // end of method FunctionObject_FunctionDeclaration_31AC3262_test::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28f3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_31AC3262_test::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Array_Modern_93542E2F.FunctionObject_FunctionDeclaration_31AC3262_test
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_Dromaeo_Object_Regexp.verified.txt
@@ -31,6 +31,117 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6CF2F656_startTest
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5363
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_6CF2F656_startTest::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x536b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6CF2F656_startTest::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x536e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6CF2F656_startTest::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5371
+				// Header size: 1
+				// Code size: 35 (0x23)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_001d: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/startTest::__js_call__(object, string, string)
+				IL_0022: ret
+			} // end of method FunctionObject_FunctionDeclaration_6CF2F656_startTest::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5395
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0019: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/startTest::__js_call__(object, string, string)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_6CF2F656_startTest::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x53b5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6CF2F656_startTest::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_6CF2F656_startTest
+
 
 		// Methods
 		.method public hidebysig static 
@@ -77,6 +188,101 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B7494A8F_endTest
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x53c4
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_B7494A8F_endTest::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x53cc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B7494A8F_endTest::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x53cf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B7494A8F_endTest::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x53d2
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/endTest::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_B7494A8F_endTest::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x53de
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/endTest::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_B7494A8F_endTest::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x53e6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B7494A8F_endTest::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_B7494A8F_endTest
 
 
 		// Methods
@@ -144,6 +350,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6F708165_prep
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x53f5
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_6F708165_prep::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x53fd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6F708165_prep::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5400
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6F708165_prep::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5403
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_6F708165_prep::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5416
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6F708165_prep::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5425
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6F708165_prep::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_6F708165_prep
 
 
 		// Methods
@@ -232,6 +539,115 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F3312FC6_test
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5434
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_F3312FC6_test::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x543c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F3312FC6_test::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x543f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F3312FC6_test::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5442
+				// Header size: 1
+				// Code size: 30 (0x1e)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+				IL_001d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F3312FC6_test::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5461
+				// Header size: 1
+				// Code size: 26 (0x1a)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
+				IL_0019: ret
+			} // end of method FunctionObject_FunctionDeclaration_F3312FC6_test::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x547c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F3312FC6_test::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_F3312FC6_test
+
 
 		// Methods
 		.method public hidebysig static 
@@ -297,6 +713,101 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7C555EF1_randomChar
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x548b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_7C555EF1_randomChar::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5493
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7C555EF1_randomChar::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5496
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7C555EF1_randomChar::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5499
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call string Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_7C555EF1_randomChar::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x54a5
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call string Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_7C555EF1_randomChar::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x54ad
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_7C555EF1_randomChar::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_7C555EF1_randomChar
 
 
 		// Methods
@@ -412,6 +923,121 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_244F5225_generateTestStrings
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x54bc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x54cb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x54ce
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x54d1
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+				IL_001c: ret
+			} // end of method FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x54ef
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0013: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5509
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_244F5225_generateTestStrings
 
 
 		// Methods
@@ -675,6 +1301,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_84CD8439_L48C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5518
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject_FunctionExpression_84CD8439_L48C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_84CD8439_L48C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5527
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_84CD8439_L48C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x552a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_84CD8439_L48C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x552d
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject_FunctionExpression_84CD8439_L48C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_84CD8439_L48C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x553f
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject_FunctionExpression_84CD8439_L48C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_84CD8439_L48C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x554d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_84CD8439_L48C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_84CD8439_L48C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -752,6 +1485,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_40DF050A_L56C37
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x555c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject_FunctionExpression_40DF050A_L56C37::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_40DF050A_L56C37::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x556b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_40DF050A_L56C37::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x556e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_40DF050A_L56C37::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5571
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject_FunctionExpression_40DF050A_L56C37::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_40DF050A_L56C37::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5583
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject_FunctionExpression_40DF050A_L56C37::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_40DF050A_L56C37::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5591
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_40DF050A_L56C37::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_40DF050A_L56C37
 
 
 		// Methods
@@ -845,6 +1685,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_367F8A10_L61C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x55a0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject_FunctionExpression_367F8A10_L61C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_367F8A10_L61C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x55af
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_367F8A10_L61C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x55b2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_367F8A10_L61C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x55b5
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject_FunctionExpression_367F8A10_L61C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_367F8A10_L61C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x55c7
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject_FunctionExpression_367F8A10_L61C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_367F8A10_L61C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x55d5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_367F8A10_L61C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_367F8A10_L61C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -922,6 +1869,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_048224EC_L66C36
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x55e4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject_FunctionExpression_048224EC_L66C36::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_048224EC_L66C36::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x55f3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_048224EC_L66C36::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x55f6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_048224EC_L66C36::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x55f9
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject_FunctionExpression_048224EC_L66C36::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_048224EC_L66C36::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x560b
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject_FunctionExpression_048224EC_L66C36::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_048224EC_L66C36::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5619
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_048224EC_L66C36::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_048224EC_L66C36
 
 
 		// Methods
@@ -1015,6 +2069,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7C0CF449_L71C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5628
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject_FunctionExpression_7C0CF449_L71C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_7C0CF449_L71C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5637
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7C0CF449_L71C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x563a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7C0CF449_L71C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x563d
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject_FunctionExpression_7C0CF449_L71C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_7C0CF449_L71C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x564f
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject_FunctionExpression_7C0CF449_L71C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_7C0CF449_L71C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x565d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_7C0CF449_L71C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_7C0CF449_L71C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1092,6 +2253,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_99D19962_L76C40
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x566c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject_FunctionExpression_99D19962_L76C40::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_99D19962_L76C40::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x567b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_99D19962_L76C40::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x567e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_99D19962_L76C40::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5681
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject_FunctionExpression_99D19962_L76C40::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_99D19962_L76C40::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5693
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject_FunctionExpression_99D19962_L76C40::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_99D19962_L76C40::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x56a1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_99D19962_L76C40::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_99D19962_L76C40
 
 
 		// Methods
@@ -1185,6 +2453,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F1E0E698_L83C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x56b0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject_FunctionExpression_F1E0E698_L83C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_F1E0E698_L83C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x56bf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F1E0E698_L83C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x56c2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F1E0E698_L83C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x56c5
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject_FunctionExpression_F1E0E698_L83C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_F1E0E698_L83C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x56d7
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject_FunctionExpression_F1E0E698_L83C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_F1E0E698_L83C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x56e5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_F1E0E698_L83C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_F1E0E698_L83C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1262,6 +2637,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E322D6B7_L88C24
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x56f4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject_FunctionExpression_E322D6B7_L88C24::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E322D6B7_L88C24::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5703
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E322D6B7_L88C24::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5706
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E322D6B7_L88C24::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5709
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject_FunctionExpression_E322D6B7_L88C24::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_E322D6B7_L88C24::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x571b
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject_FunctionExpression_E322D6B7_L88C24::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_E322D6B7_L88C24::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5729
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E322D6B7_L88C24::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_E322D6B7_L88C24
 
 
 		// Methods
@@ -1355,6 +2837,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_83D3F4FD_L93C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5738
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject_FunctionExpression_83D3F4FD_L93C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_83D3F4FD_L93C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5747
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_83D3F4FD_L93C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x574a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_83D3F4FD_L93C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x574d
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject_FunctionExpression_83D3F4FD_L93C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_83D3F4FD_L93C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x575f
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject_FunctionExpression_83D3F4FD_L93C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_83D3F4FD_L93C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x576d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_83D3F4FD_L93C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_83D3F4FD_L93C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1424,6 +3013,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_300CE2EA_L97C23
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x577c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject_FunctionExpression_300CE2EA_L97C23::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_300CE2EA_L97C23::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x578b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_300CE2EA_L97C23::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x578e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_300CE2EA_L97C23::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5791
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject_FunctionExpression_300CE2EA_L97C23::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_300CE2EA_L97C23::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x57a3
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject_FunctionExpression_300CE2EA_L97C23::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_300CE2EA_L97C23::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x57b1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_300CE2EA_L97C23::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_300CE2EA_L97C23
 
 
 		// Methods
@@ -1515,6 +3211,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_15168718_L102C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x57c0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject_FunctionExpression_15168718_L102C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_15168718_L102C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x57cf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_15168718_L102C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x57d2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_15168718_L102C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x57d5
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject_FunctionExpression_15168718_L102C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_15168718_L102C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x57e7
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject_FunctionExpression_15168718_L102C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_15168718_L102C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x57f5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_15168718_L102C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_15168718_L102C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1584,6 +3387,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_AADD4623_L106C32
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5804
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject_FunctionExpression_AADD4623_L106C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_AADD4623_L106C32::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5813
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_AADD4623_L106C32::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5816
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_AADD4623_L106C32::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5819
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject_FunctionExpression_AADD4623_L106C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_AADD4623_L106C32::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x582b
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject_FunctionExpression_AADD4623_L106C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_AADD4623_L106C32::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5839
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_AADD4623_L106C32::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_AADD4623_L106C32
 
 
 		// Methods
@@ -1678,6 +3588,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_35949A34_L111C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5848
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject_FunctionExpression_35949A34_L111C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_35949A34_L111C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5857
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_35949A34_L111C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x585a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_35949A34_L111C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x585d
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject_FunctionExpression_35949A34_L111C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_35949A34_L111C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x586f
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject_FunctionExpression_35949A34_L111C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_35949A34_L111C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x587d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_35949A34_L111C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_35949A34_L111C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1747,6 +3764,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_123E59E1_L115C34
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x588c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject_FunctionExpression_123E59E1_L115C34::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_123E59E1_L115C34::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x589b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_123E59E1_L115C34::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x589e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_123E59E1_L115C34::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x58a1
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject_FunctionExpression_123E59E1_L115C34::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_123E59E1_L115C34::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x58b3
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject_FunctionExpression_123E59E1_L115C34::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_123E59E1_L115C34::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x58c1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_123E59E1_L115C34::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_123E59E1_L115C34
 
 
 		// Methods
@@ -1841,6 +3965,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1A1A3900_L120C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x58d0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject_FunctionExpression_1A1A3900_L120C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_1A1A3900_L120C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x58df
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_1A1A3900_L120C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x58e2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_1A1A3900_L120C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x58e5
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject_FunctionExpression_1A1A3900_L120C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_1A1A3900_L120C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x58f7
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject_FunctionExpression_1A1A3900_L120C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_1A1A3900_L120C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5905
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_1A1A3900_L120C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_1A1A3900_L120C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1918,6 +4149,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A14DF61B_L125C31
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5914
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject_FunctionExpression_A14DF61B_L125C31::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_A14DF61B_L125C31::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5923
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A14DF61B_L125C31::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5926
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A14DF61B_L125C31::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5929
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject_FunctionExpression_A14DF61B_L125C31::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_A14DF61B_L125C31::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x593b
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject_FunctionExpression_A14DF61B_L125C31::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_A14DF61B_L125C31::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5949
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_A14DF61B_L125C31::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_A14DF61B_L125C31
 
 
 		// Methods
@@ -2011,6 +4349,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FEC96B05_L130C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5958
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject_FunctionExpression_FEC96B05_L130C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_FEC96B05_L130C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5967
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_FEC96B05_L130C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x596a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_FEC96B05_L130C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x596d
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject_FunctionExpression_FEC96B05_L130C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_FEC96B05_L130C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x597f
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject_FunctionExpression_FEC96B05_L130C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_FEC96B05_L130C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x598d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_FEC96B05_L130C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_FEC96B05_L130C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2080,6 +4525,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A2B06A06_L134C30
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x599c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject_FunctionExpression_A2B06A06_L134C30::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_A2B06A06_L134C30::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x59ab
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A2B06A06_L134C30::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x59ae
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A2B06A06_L134C30::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x59b1
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject_FunctionExpression_A2B06A06_L134C30::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_A2B06A06_L134C30::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x59c3
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject_FunctionExpression_A2B06A06_L134C30::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_A2B06A06_L134C30::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x59d1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_A2B06A06_L134C30::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_A2B06A06_L134C30
 
 
 		// Methods
@@ -2171,6 +4723,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_826BD7E2_L139C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x59e0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject_FunctionExpression_826BD7E2_L139C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_826BD7E2_L139C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x59ef
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_826BD7E2_L139C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x59f2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_826BD7E2_L139C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x59f5
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject_FunctionExpression_826BD7E2_L139C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_826BD7E2_L139C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5a07
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject_FunctionExpression_826BD7E2_L139C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_826BD7E2_L139C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5a15
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_826BD7E2_L139C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_826BD7E2_L139C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2240,6 +4899,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_52BFD713_L143C39
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5a24
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject_FunctionExpression_52BFD713_L143C39::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_52BFD713_L143C39::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5a33
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_52BFD713_L143C39::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5a36
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_52BFD713_L143C39::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5a39
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject_FunctionExpression_52BFD713_L143C39::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_52BFD713_L143C39::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5a4b
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject_FunctionExpression_52BFD713_L143C39::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_52BFD713_L143C39::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5a59
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_52BFD713_L143C39::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_52BFD713_L143C39
 
 
 		// Methods
@@ -2334,6 +5100,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_ADF86AB6_L148C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5a68
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject_FunctionExpression_ADF86AB6_L148C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_ADF86AB6_L148C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5a77
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_ADF86AB6_L148C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5a7a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_ADF86AB6_L148C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5a7d
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject_FunctionExpression_ADF86AB6_L148C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_ADF86AB6_L148C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5a8f
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject_FunctionExpression_ADF86AB6_L148C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_ADF86AB6_L148C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5a9d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_ADF86AB6_L148C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_ADF86AB6_L148C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2403,6 +5276,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6A51803A_L152C41
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5aac
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject_FunctionExpression_6A51803A_L152C41::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_6A51803A_L152C41::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5abb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_6A51803A_L152C41::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5abe
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_6A51803A_L152C41::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5ac1
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject_FunctionExpression_6A51803A_L152C41::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_6A51803A_L152C41::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5ad3
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject_FunctionExpression_6A51803A_L152C41::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_6A51803A_L152C41::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5ae1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_6A51803A_L152C41::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_6A51803A_L152C41
 
 
 		// Methods
@@ -2497,6 +5477,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_59F53CDE_L157C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5af0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject_FunctionExpression_59F53CDE_L157C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_59F53CDE_L157C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5aff
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_59F53CDE_L157C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5b02
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_59F53CDE_L157C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5b05
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject_FunctionExpression_59F53CDE_L157C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_59F53CDE_L157C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5b17
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject_FunctionExpression_59F53CDE_L157C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_59F53CDE_L157C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5b25
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_59F53CDE_L157C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_59F53CDE_L157C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2571,6 +5658,107 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D2F1EA44_L163C34
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x5b78
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_D2F1EA44_L163C34::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x5b80
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_D2F1EA44_L163C34::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x5b83
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_D2F1EA44_L163C34::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x5b86
+					// Header size: 1
+					// Code size: 18 (0x12)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: ldarg.2
+					IL_0006: ldc.i4.0
+					IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000c: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionExpression_L163C33::__js_call__(object, object)
+					IL_0011: ret
+				} // end of method FunctionObject_FunctionExpression_D2F1EA44_L163C34::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x5b99
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: ldarg.2
+					IL_0002: ldc.i4.0
+					IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0008: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionExpression_L163C33::__js_call__(object, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_D2F1EA44_L163C34::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x5ba8
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_D2F1EA44_L163C34::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_D2F1EA44_L163C34
+
 
 			// Methods
 			.method public hidebysig static 
@@ -2613,6 +5801,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F7D2F9E6_L161C50
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5b34
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject_FunctionExpression_F7D2F9E6_L161C50::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_F7D2F9E6_L161C50::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5b43
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F7D2F9E6_L161C50::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5b46
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F7D2F9E6_L161C50::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5b49
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject_FunctionExpression_F7D2F9E6_L161C50::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_F7D2F9E6_L161C50::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5b5b
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject_FunctionExpression_F7D2F9E6_L161C50::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_F7D2F9E6_L161C50::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5b69
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_F7D2F9E6_L161C50::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_F7D2F9E6_L161C50
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2637,7 +5932,7 @@
 				[3] string,
 				[4] object,
 				[5] object[],
-				[6] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_D2F1EA44_L163C34
+				[6] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionExpression_L163C33/FunctionObject_FunctionExpression_D2F1EA44_L163C34
 			)
 
 			IL_0000: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/Scope::.ctor()
@@ -2672,13 +5967,13 @@
 				IL_0051: ldarg.0
 				IL_0052: stelem.ref
 				IL_0053: stloc.s 5
-				IL_0055: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_D2F1EA44_L163C34::.ctor()
+				IL_0055: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionExpression_L163C33/FunctionObject_FunctionExpression_D2F1EA44_L163C34::.ctor()
 				IL_005a: ldc.i4.1
 				IL_005b: conv.r8
 				IL_005c: ldstr ""
 				IL_0061: ldc.i4.0
 				IL_0062: ldc.i4.1
-				IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_D2F1EA44_L163C34>(!!0, float64, string, bool, bool)
+				IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionExpression_L163C33/FunctionObject_FunctionExpression_D2F1EA44_L163C34>(!!0, float64, string, bool, bool)
 				IL_0068: stloc.s 6
 				IL_006a: ldloc.3
 				IL_006b: ldstr "replace"
@@ -2725,6 +6020,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5BE125D1_L170C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5bb7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject_FunctionExpression_5BE125D1_L170C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_5BE125D1_L170C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5bc6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5BE125D1_L170C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5bc9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5BE125D1_L170C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5bcc
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject_FunctionExpression_5BE125D1_L170C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_5BE125D1_L170C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5bde
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject_FunctionExpression_5BE125D1_L170C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_5BE125D1_L170C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5bec
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_5BE125D1_L170C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_5BE125D1_L170C6
 
 
 		// Methods
@@ -2803,6 +6205,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E6D30A9E_L175C33
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5bfb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject_FunctionExpression_E6D30A9E_L175C33::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E6D30A9E_L175C33::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5c0a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E6D30A9E_L175C33::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5c0d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E6D30A9E_L175C33::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5c10
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject_FunctionExpression_E6D30A9E_L175C33::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_E6D30A9E_L175C33::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5c22
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject_FunctionExpression_E6D30A9E_L175C33::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_E6D30A9E_L175C33::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5c30
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E6D30A9E_L175C33::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_E6D30A9E_L175C33
 
 
 		// Methods
@@ -2896,6 +6405,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_316E4A1A_L180C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5c3f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject_FunctionExpression_316E4A1A_L180C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_316E4A1A_L180C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5c4e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_316E4A1A_L180C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5c51
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_316E4A1A_L180C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5c54
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject_FunctionExpression_316E4A1A_L180C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_316E4A1A_L180C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5c66
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject_FunctionExpression_316E4A1A_L180C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_316E4A1A_L180C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5c74
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_316E4A1A_L180C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_316E4A1A_L180C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2965,6 +6581,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F75042ED_L184C32
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5c83
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject_FunctionExpression_F75042ED_L184C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_F75042ED_L184C32::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5c92
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F75042ED_L184C32::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5c95
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F75042ED_L184C32::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5c98
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject_FunctionExpression_F75042ED_L184C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_F75042ED_L184C32::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5caa
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject_FunctionExpression_F75042ED_L184C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_F75042ED_L184C32::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5cb8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_F75042ED_L184C32::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_F75042ED_L184C32
 
 
 		// Methods
@@ -3056,6 +6779,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DE23A66D_L189C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5cc7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject_FunctionExpression_DE23A66D_L189C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_DE23A66D_L189C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5cd6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_DE23A66D_L189C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5cd9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_DE23A66D_L189C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5cdc
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject_FunctionExpression_DE23A66D_L189C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_DE23A66D_L189C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5cee
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject_FunctionExpression_DE23A66D_L189C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_DE23A66D_L189C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5cfc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_DE23A66D_L189C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_DE23A66D_L189C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -3125,6 +6955,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_59F2FA63_L193C41
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5d0b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject_FunctionExpression_59F2FA63_L193C41::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_59F2FA63_L193C41::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5d1a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_59F2FA63_L193C41::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5d1d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_59F2FA63_L193C41::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5d20
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject_FunctionExpression_59F2FA63_L193C41::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_59F2FA63_L193C41::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5d32
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject_FunctionExpression_59F2FA63_L193C41::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_59F2FA63_L193C41::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5d40
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_59F2FA63_L193C41::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_59F2FA63_L193C41
 
 
 		// Methods
@@ -3219,6 +7156,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FD52FD47_L198C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5d4f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject_FunctionExpression_FD52FD47_L198C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_FD52FD47_L198C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5d5e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_FD52FD47_L198C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5d61
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_FD52FD47_L198C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5d64
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject_FunctionExpression_FD52FD47_L198C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_FD52FD47_L198C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5d76
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject_FunctionExpression_FD52FD47_L198C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_FD52FD47_L198C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5d84
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_FD52FD47_L198C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_FD52FD47_L198C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -3288,6 +7332,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_AB7296C4_L202C43
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5d93
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject_FunctionExpression_AB7296C4_L202C43::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_AB7296C4_L202C43::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5da2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_AB7296C4_L202C43::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5da5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_AB7296C4_L202C43::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5da8
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject_FunctionExpression_AB7296C4_L202C43::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_AB7296C4_L202C43::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5dba
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject_FunctionExpression_AB7296C4_L202C43::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_AB7296C4_L202C43::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5dc8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_AB7296C4_L202C43::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_AB7296C4_L202C43
 
 
 		// Methods
@@ -3382,6 +7533,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6250884E_L207C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5dd7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject_FunctionExpression_6250884E_L207C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_6250884E_L207C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5de6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_6250884E_L207C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5de9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_6250884E_L207C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5dec
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject_FunctionExpression_6250884E_L207C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_6250884E_L207C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5dfe
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject_FunctionExpression_6250884E_L207C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_6250884E_L207C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5e0c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_6250884E_L207C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_6250884E_L207C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -3459,6 +7717,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9FBA592E_L212C40
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5e1b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject_FunctionExpression_9FBA592E_L212C40::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_9FBA592E_L212C40::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5e2a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_9FBA592E_L212C40::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5e2d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_9FBA592E_L212C40::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5e30
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject_FunctionExpression_9FBA592E_L212C40::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_9FBA592E_L212C40::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5e42
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject_FunctionExpression_9FBA592E_L212C40::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_9FBA592E_L212C40::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5e50
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_9FBA592E_L212C40::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_9FBA592E_L212C40
 
 
 		// Methods
@@ -3552,6 +7917,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6442B403_L217C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5e5f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject_FunctionExpression_6442B403_L217C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_6442B403_L217C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5e6e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_6442B403_L217C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5e71
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_6442B403_L217C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5e74
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject_FunctionExpression_6442B403_L217C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_6442B403_L217C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5e86
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject_FunctionExpression_6442B403_L217C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_6442B403_L217C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5e94
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_6442B403_L217C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_6442B403_L217C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -3621,6 +8093,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7B23A4A4_L221C39
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5ea3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject_FunctionExpression_7B23A4A4_L221C39::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_7B23A4A4_L221C39::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5eb2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7B23A4A4_L221C39::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5eb5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7B23A4A4_L221C39::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5eb8
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject_FunctionExpression_7B23A4A4_L221C39::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_7B23A4A4_L221C39::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5eca
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject_FunctionExpression_7B23A4A4_L221C39::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_7B23A4A4_L221C39::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5ed8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_7B23A4A4_L221C39::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_7B23A4A4_L221C39
 
 
 		// Methods
@@ -3712,6 +8291,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_15CEA57B_L226C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5ee7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject_FunctionExpression_15CEA57B_L226C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_15CEA57B_L226C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5ef6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_15CEA57B_L226C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5ef9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_15CEA57B_L226C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5efc
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject_FunctionExpression_15CEA57B_L226C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_15CEA57B_L226C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5f0e
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject_FunctionExpression_15CEA57B_L226C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_15CEA57B_L226C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5f1c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_15CEA57B_L226C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_15CEA57B_L226C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -3781,6 +8467,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_CE64C73E_L230C48
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5f2b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject_FunctionExpression_CE64C73E_L230C48::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_CE64C73E_L230C48::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5f3a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_CE64C73E_L230C48::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5f3d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_CE64C73E_L230C48::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5f40
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject_FunctionExpression_CE64C73E_L230C48::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_CE64C73E_L230C48::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5f52
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject_FunctionExpression_CE64C73E_L230C48::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_CE64C73E_L230C48::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5f60
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_CE64C73E_L230C48::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_CE64C73E_L230C48
 
 
 		// Methods
@@ -3875,6 +8668,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6B3295AB_L235C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5f6f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject_FunctionExpression_6B3295AB_L235C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_6B3295AB_L235C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5f7e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_6B3295AB_L235C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5f81
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_6B3295AB_L235C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5f84
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject_FunctionExpression_6B3295AB_L235C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_6B3295AB_L235C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5f96
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject_FunctionExpression_6B3295AB_L235C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_6B3295AB_L235C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5fa4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_6B3295AB_L235C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_6B3295AB_L235C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -3944,6 +8844,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1419E03E_L239C50
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5fb3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject_FunctionExpression_1419E03E_L239C50::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_1419E03E_L239C50::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5fc2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_1419E03E_L239C50::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5fc5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_1419E03E_L239C50::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5fc8
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject_FunctionExpression_1419E03E_L239C50::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_1419E03E_L239C50::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5fda
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject_FunctionExpression_1419E03E_L239C50::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_1419E03E_L239C50::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5fe8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_1419E03E_L239C50::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_1419E03E_L239C50
 
 
 		// Methods
@@ -4038,6 +9045,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1AD25763_L244C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x5ff7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject_FunctionExpression_1AD25763_L244C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_1AD25763_L244C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6006
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_1AD25763_L244C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6009
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_1AD25763_L244C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x600c
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject_FunctionExpression_1AD25763_L244C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_1AD25763_L244C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x601e
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject_FunctionExpression_1AD25763_L244C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_1AD25763_L244C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x602c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_1AD25763_L244C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_1AD25763_L244C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -4112,6 +9226,107 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_44DC3DAF_L250C34
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x607f
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_44DC3DAF_L250C34::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x6087
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_44DC3DAF_L250C34::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x608a
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_44DC3DAF_L250C34::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x608d
+					// Header size: 1
+					// Code size: 18 (0x12)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: ldarg.2
+					IL_0006: ldc.i4.0
+					IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000c: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionExpression_L250C33::__js_call__(object, object)
+					IL_0011: ret
+				} // end of method FunctionObject_FunctionExpression_44DC3DAF_L250C34::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x60a0
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: ldarg.2
+					IL_0002: ldc.i4.0
+					IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0008: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionExpression_L250C33::__js_call__(object, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_44DC3DAF_L250C34::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x60af
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_44DC3DAF_L250C34::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_44DC3DAF_L250C34
+
 
 			// Methods
 			.method public hidebysig static 
@@ -4154,6 +9369,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B68C9781_L248C59
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x603b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject_FunctionExpression_B68C9781_L248C59::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_B68C9781_L248C59::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x604a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_B68C9781_L248C59::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x604d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_B68C9781_L248C59::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6050
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject_FunctionExpression_B68C9781_L248C59::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_B68C9781_L248C59::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6062
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject_FunctionExpression_B68C9781_L248C59::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_B68C9781_L248C59::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6070
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_B68C9781_L248C59::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_B68C9781_L248C59
+
 
 		// Methods
 		.method public hidebysig static 
@@ -4178,7 +9500,7 @@
 				[3] string,
 				[4] object,
 				[5] object[],
-				[6] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_44DC3DAF_L250C34
+				[6] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionExpression_L250C33/FunctionObject_FunctionExpression_44DC3DAF_L250C34
 			)
 
 			IL_0000: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/Scope::.ctor()
@@ -4213,13 +9535,13 @@
 				IL_0051: ldarg.0
 				IL_0052: stelem.ref
 				IL_0053: stloc.s 5
-				IL_0055: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_44DC3DAF_L250C34::.ctor()
+				IL_0055: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionExpression_L250C33/FunctionObject_FunctionExpression_44DC3DAF_L250C34::.ctor()
 				IL_005a: ldc.i4.1
 				IL_005b: conv.r8
 				IL_005c: ldstr ""
 				IL_0061: ldc.i4.0
 				IL_0062: ldc.i4.1
-				IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_44DC3DAF_L250C34>(!!0, float64, string, bool, bool)
+				IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionExpression_L250C33/FunctionObject_FunctionExpression_44DC3DAF_L250C34>(!!0, float64, string, bool, bool)
 				IL_0068: stloc.s 6
 				IL_006a: ldloc.3
 				IL_006b: ldstr "replace"
@@ -4266,6 +9588,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_62C7C36F_L257C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x60be
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject_FunctionExpression_62C7C36F_L257C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_62C7C36F_L257C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x60cd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_62C7C36F_L257C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x60d0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_62C7C36F_L257C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x60d3
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject_FunctionExpression_62C7C36F_L257C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_62C7C36F_L257C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x60e5
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject_FunctionExpression_62C7C36F_L257C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_62C7C36F_L257C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x60f3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_62C7C36F_L257C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_62C7C36F_L257C6
 
 
 		// Methods
@@ -4344,6 +9773,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_BE52CC8A_L262C32
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6102
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject_FunctionExpression_BE52CC8A_L262C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_BE52CC8A_L262C32::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6111
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_BE52CC8A_L262C32::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6114
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_BE52CC8A_L262C32::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6117
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject_FunctionExpression_BE52CC8A_L262C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_BE52CC8A_L262C32::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6129
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject_FunctionExpression_BE52CC8A_L262C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_BE52CC8A_L262C32::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6137
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_BE52CC8A_L262C32::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_BE52CC8A_L262C32
 
 
 		// Methods
@@ -4437,6 +9973,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1AD7FAC4_L267C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6146
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject_FunctionExpression_1AD7FAC4_L267C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_1AD7FAC4_L267C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6155
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_1AD7FAC4_L267C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6158
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_1AD7FAC4_L267C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x615b
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject_FunctionExpression_1AD7FAC4_L267C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_1AD7FAC4_L267C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x616d
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject_FunctionExpression_1AD7FAC4_L267C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_1AD7FAC4_L267C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x617b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_1AD7FAC4_L267C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_1AD7FAC4_L267C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -4506,6 +10149,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_75E34588_L271C34
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x618a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject_FunctionExpression_75E34588_L271C34::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_75E34588_L271C34::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6199
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_75E34588_L271C34::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x619c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_75E34588_L271C34::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x619f
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject_FunctionExpression_75E34588_L271C34::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_75E34588_L271C34::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x61b1
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject_FunctionExpression_75E34588_L271C34::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_75E34588_L271C34::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x61bf
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_75E34588_L271C34::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_75E34588_L271C34
 
 
 		// Methods
@@ -4600,6 +10350,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_98DF622E_L276C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x61ce
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject_FunctionExpression_98DF622E_L276C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_98DF622E_L276C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x61dd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_98DF622E_L276C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x61e0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_98DF622E_L276C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x61e3
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject_FunctionExpression_98DF622E_L276C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_98DF622E_L276C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x61f5
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject_FunctionExpression_98DF622E_L276C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_98DF622E_L276C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6203
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_98DF622E_L276C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_98DF622E_L276C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -4669,6 +10526,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6EF0F712_L280C47
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6212
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject_FunctionExpression_6EF0F712_L280C47::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_6EF0F712_L280C47::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6221
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_6EF0F712_L280C47::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6224
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_6EF0F712_L280C47::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6227
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject_FunctionExpression_6EF0F712_L280C47::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_6EF0F712_L280C47::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6239
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject_FunctionExpression_6EF0F712_L280C47::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_6EF0F712_L280C47::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6247
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_6EF0F712_L280C47::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_6EF0F712_L280C47
 
 
 		// Methods
@@ -4763,6 +10727,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0304DE8C_L285C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6256
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject_FunctionExpression_0304DE8C_L285C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_0304DE8C_L285C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6265
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_0304DE8C_L285C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6268
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_0304DE8C_L285C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x626b
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject_FunctionExpression_0304DE8C_L285C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_0304DE8C_L285C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x627d
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject_FunctionExpression_0304DE8C_L285C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_0304DE8C_L285C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x628b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_0304DE8C_L285C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_0304DE8C_L285C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -4837,6 +10908,113 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_561F59BC_L291C34
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x62de
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_561F59BC_L291C34::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x62e6
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_561F59BC_L291C34::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x62e9
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_561F59BC_L291C34::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x62ec
+					// Header size: 1
+					// Code size: 25 (0x19)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: ldarg.2
+					IL_0006: ldc.i4.0
+					IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000c: ldarg.2
+					IL_000d: ldc.i4.1
+					IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0013: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionExpression_L291C33::__js_call__(object, object, object)
+					IL_0018: ret
+				} // end of method FunctionObject_FunctionExpression_561F59BC_L291C34::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x6306
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: ldarg.2
+					IL_0002: ldc.i4.0
+					IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0008: ldarg.2
+					IL_0009: ldc.i4.1
+					IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000f: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionExpression_L291C33::__js_call__(object, object, object)
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionExpression_561F59BC_L291C34::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x631c
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_561F59BC_L291C34::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_561F59BC_L291C34
+
 
 			// Methods
 			.method public hidebysig static 
@@ -4891,6 +11069,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D94750FD_L289C56
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x629a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject_FunctionExpression_D94750FD_L289C56::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_D94750FD_L289C56::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x62a9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D94750FD_L289C56::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x62ac
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D94750FD_L289C56::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x62af
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject_FunctionExpression_D94750FD_L289C56::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_D94750FD_L289C56::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x62c1
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject_FunctionExpression_D94750FD_L289C56::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_D94750FD_L289C56::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x62cf
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_D94750FD_L289C56::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_D94750FD_L289C56
+
 
 		// Methods
 		.method public hidebysig static 
@@ -4915,7 +11200,7 @@
 				[3] string,
 				[4] object,
 				[5] object[],
-				[6] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_561F59BC_L291C34
+				[6] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionExpression_L291C33/FunctionObject_FunctionExpression_561F59BC_L291C34
 			)
 
 			IL_0000: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/Scope::.ctor()
@@ -4950,13 +11235,13 @@
 				IL_0051: ldarg.0
 				IL_0052: stelem.ref
 				IL_0053: stloc.s 5
-				IL_0055: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_561F59BC_L291C34::.ctor()
+				IL_0055: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionExpression_L291C33/FunctionObject_FunctionExpression_561F59BC_L291C34::.ctor()
 				IL_005a: ldc.i4.2
 				IL_005b: conv.r8
 				IL_005c: ldstr ""
 				IL_0061: ldc.i4.0
 				IL_0062: ldc.i4.1
-				IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_561F59BC_L291C34>(!!0, float64, string, bool, bool)
+				IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionExpression_L291C33/FunctionObject_FunctionExpression_561F59BC_L291C34>(!!0, float64, string, bool, bool)
 				IL_0068: stloc.s 6
 				IL_006a: ldloc.3
 				IL_006b: ldstr "replace"
@@ -5003,6 +11288,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_29656618_L296C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x632b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject_FunctionExpression_29656618_L296C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_29656618_L296C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x633a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_29656618_L296C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x633d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_29656618_L296C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6340
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject_FunctionExpression_29656618_L296C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_29656618_L296C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6352
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject_FunctionExpression_29656618_L296C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_29656618_L296C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6360
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_29656618_L296C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_29656618_L296C6
 
 
 		// Methods
@@ -5078,6 +11470,113 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_691C8819_L302C34
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x63b3
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_691C8819_L302C34::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x63bb
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_691C8819_L302C34::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x63be
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_691C8819_L302C34::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x63c1
+					// Header size: 1
+					// Code size: 25 (0x19)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: ldarg.2
+					IL_0006: ldc.i4.0
+					IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000c: ldarg.2
+					IL_000d: ldc.i4.1
+					IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0013: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionExpression_L302C33::__js_call__(object, object, object)
+					IL_0018: ret
+				} // end of method FunctionObject_FunctionExpression_691C8819_L302C34::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x63db
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: ldarg.2
+					IL_0002: ldc.i4.0
+					IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0008: ldarg.2
+					IL_0009: ldc.i4.1
+					IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000f: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionExpression_L302C33::__js_call__(object, object, object)
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionExpression_691C8819_L302C34::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x63f1
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_691C8819_L302C34::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_691C8819_L302C34
+
 
 			// Methods
 			.method public hidebysig static 
@@ -5129,6 +11628,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1062EA27_L300C65
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x636f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject_FunctionExpression_1062EA27_L300C65::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_1062EA27_L300C65::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x637e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_1062EA27_L300C65::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6381
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_1062EA27_L300C65::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6384
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject_FunctionExpression_1062EA27_L300C65::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_1062EA27_L300C65::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6396
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject_FunctionExpression_1062EA27_L300C65::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_1062EA27_L300C65::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x63a4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_1062EA27_L300C65::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_1062EA27_L300C65
+
 
 		// Methods
 		.method public hidebysig static 
@@ -5153,7 +11759,7 @@
 				[3] string,
 				[4] object,
 				[5] object[],
-				[6] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_691C8819_L302C34
+				[6] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionExpression_L302C33/FunctionObject_FunctionExpression_691C8819_L302C34
 			)
 
 			IL_0000: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/Scope::.ctor()
@@ -5188,13 +11794,13 @@
 				IL_0051: ldarg.0
 				IL_0052: stelem.ref
 				IL_0053: stloc.s 5
-				IL_0055: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_691C8819_L302C34::.ctor()
+				IL_0055: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionExpression_L302C33/FunctionObject_FunctionExpression_691C8819_L302C34::.ctor()
 				IL_005a: ldc.i4.2
 				IL_005b: conv.r8
 				IL_005c: ldstr ""
 				IL_0061: ldc.i4.0
 				IL_0062: ldc.i4.1
-				IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_691C8819_L302C34>(!!0, float64, string, bool, bool)
+				IL_0063: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionExpression_L302C33/FunctionObject_FunctionExpression_691C8819_L302C34>(!!0, float64, string, bool, bool)
 				IL_0068: stloc.s 6
 				IL_006a: ldloc.3
 				IL_006b: ldstr "replace"
@@ -5241,6 +11847,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_612413E3_L309C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6400
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject_FunctionExpression_612413E3_L309C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_612413E3_L309C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x640f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_612413E3_L309C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6412
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_612413E3_L309C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6415
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject_FunctionExpression_612413E3_L309C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_612413E3_L309C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6427
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject_FunctionExpression_612413E3_L309C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_612413E3_L309C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6435
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_612413E3_L309C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_612413E3_L309C6
 
 
 		// Methods
@@ -5311,6 +12024,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5D299276_L313C26
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6444
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject_FunctionExpression_5D299276_L313C26::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_5D299276_L313C26::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6453
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5D299276_L313C26::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6456
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5D299276_L313C26::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6459
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject_FunctionExpression_5D299276_L313C26::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_5D299276_L313C26::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x646b
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject_FunctionExpression_5D299276_L313C26::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_5D299276_L313C26::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6479
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_5D299276_L313C26::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_5D299276_L313C26
 
 
 		// Methods
@@ -5406,6 +12226,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_AF818725_L318C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6488
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject_FunctionExpression_AF818725_L318C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_AF818725_L318C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6497
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_AF818725_L318C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x649a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_AF818725_L318C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x649d
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject_FunctionExpression_AF818725_L318C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_AF818725_L318C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x64af
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject_FunctionExpression_AF818725_L318C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_AF818725_L318C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x64bd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_AF818725_L318C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_AF818725_L318C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -5475,6 +12402,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_64DC70FB_L322C25
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x64cc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject_FunctionExpression_64DC70FB_L322C25::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_64DC70FB_L322C25::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x64db
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_64DC70FB_L322C25::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x64de
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_64DC70FB_L322C25::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x64e1
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject_FunctionExpression_64DC70FB_L322C25::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_64DC70FB_L322C25::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x64f3
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject_FunctionExpression_64DC70FB_L322C25::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_64DC70FB_L322C25::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6501
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_64DC70FB_L322C25::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_64DC70FB_L322C25
 
 
 		// Methods
@@ -5566,6 +12600,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_455C0AC7_L327C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6510
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject_FunctionExpression_455C0AC7_L327C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_455C0AC7_L327C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x651f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_455C0AC7_L327C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6522
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_455C0AC7_L327C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6525
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject_FunctionExpression_455C0AC7_L327C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_455C0AC7_L327C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6537
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject_FunctionExpression_455C0AC7_L327C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_455C0AC7_L327C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6545
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_455C0AC7_L327C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_455C0AC7_L327C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -5635,6 +12776,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C0E29ED5_L331C34
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6554
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject_FunctionExpression_C0E29ED5_L331C34::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_C0E29ED5_L331C34::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6563
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C0E29ED5_L331C34::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6566
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C0E29ED5_L331C34::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6569
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject_FunctionExpression_C0E29ED5_L331C34::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_C0E29ED5_L331C34::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x657b
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject_FunctionExpression_C0E29ED5_L331C34::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_C0E29ED5_L331C34::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6589
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_C0E29ED5_L331C34::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_C0E29ED5_L331C34
 
 
 		// Methods
@@ -5731,6 +12979,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_78E8D78D_L336C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6598
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject_FunctionExpression_78E8D78D_L336C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_78E8D78D_L336C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x65a7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_78E8D78D_L336C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x65aa
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_78E8D78D_L336C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x65ad
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject_FunctionExpression_78E8D78D_L336C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_78E8D78D_L336C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x65bf
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject_FunctionExpression_78E8D78D_L336C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_78E8D78D_L336C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x65cd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_78E8D78D_L336C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_78E8D78D_L336C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -5800,6 +13155,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_31C4DBA7_L340C36
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x65dc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject_FunctionExpression_31C4DBA7_L340C36::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_31C4DBA7_L340C36::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x65eb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_31C4DBA7_L340C36::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x65ee
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_31C4DBA7_L340C36::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x65f1
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject_FunctionExpression_31C4DBA7_L340C36::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_31C4DBA7_L340C36::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6603
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject_FunctionExpression_31C4DBA7_L340C36::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_31C4DBA7_L340C36::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6611
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_31C4DBA7_L340C36::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_31C4DBA7_L340C36
 
 
 		// Methods
@@ -5896,6 +13358,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_ADC77423_L345C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6620
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject_FunctionExpression_ADC77423_L345C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_ADC77423_L345C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x662f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_ADC77423_L345C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6632
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_ADC77423_L345C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6635
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject_FunctionExpression_ADC77423_L345C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_ADC77423_L345C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6647
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject_FunctionExpression_ADC77423_L345C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_ADC77423_L345C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6655
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_ADC77423_L345C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_ADC77423_L345C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -5965,6 +13534,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_AB0D0A79_L349C33
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6664
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject_FunctionExpression_AB0D0A79_L349C33::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_AB0D0A79_L349C33::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6673
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_AB0D0A79_L349C33::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6676
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_AB0D0A79_L349C33::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6679
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject_FunctionExpression_AB0D0A79_L349C33::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_AB0D0A79_L349C33::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x668b
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject_FunctionExpression_AB0D0A79_L349C33::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_AB0D0A79_L349C33::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6699
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_AB0D0A79_L349C33::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_AB0D0A79_L349C33
 
 
 		// Methods
@@ -6060,6 +13736,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FE9F5065_L354C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x66a8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject_FunctionExpression_FE9F5065_L354C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_FE9F5065_L354C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x66b7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_FE9F5065_L354C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x66ba
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_FE9F5065_L354C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x66bd
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject_FunctionExpression_FE9F5065_L354C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_FE9F5065_L354C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x66cf
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject_FunctionExpression_FE9F5065_L354C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_FE9F5065_L354C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x66dd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_FE9F5065_L354C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_FE9F5065_L354C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -6129,6 +13912,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_48BE92D8_L358C32
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x66ec
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject_FunctionExpression_48BE92D8_L358C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_48BE92D8_L358C32::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x66fb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_48BE92D8_L358C32::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x66fe
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_48BE92D8_L358C32::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6701
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject_FunctionExpression_48BE92D8_L358C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_48BE92D8_L358C32::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6713
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject_FunctionExpression_48BE92D8_L358C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_48BE92D8_L358C32::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6721
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_48BE92D8_L358C32::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_48BE92D8_L358C32
 
 
 		// Methods
@@ -6220,6 +14110,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_4D9B395F_L363C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6730
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject_FunctionExpression_4D9B395F_L363C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_4D9B395F_L363C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x673f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_4D9B395F_L363C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6742
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_4D9B395F_L363C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6745
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject_FunctionExpression_4D9B395F_L363C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_4D9B395F_L363C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6757
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject_FunctionExpression_4D9B395F_L363C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_4D9B395F_L363C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6765
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_4D9B395F_L363C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_4D9B395F_L363C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -6289,6 +14286,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_222F9CF0_L367C41
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6774
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject_FunctionExpression_222F9CF0_L367C41::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_222F9CF0_L367C41::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6783
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_222F9CF0_L367C41::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6786
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_222F9CF0_L367C41::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6789
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject_FunctionExpression_222F9CF0_L367C41::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_222F9CF0_L367C41::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x679b
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject_FunctionExpression_222F9CF0_L367C41::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_222F9CF0_L367C41::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x67a9
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_222F9CF0_L367C41::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_222F9CF0_L367C41
 
 
 		// Methods
@@ -6385,6 +14489,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F85E69FD_L372C6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x67b8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject_FunctionExpression_F85E69FD_L372C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_F85E69FD_L372C6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x67c7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F85E69FD_L372C6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x67ca
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F85E69FD_L372C6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x67cd
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject_FunctionExpression_F85E69FD_L372C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_F85E69FD_L372C6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x67df
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject_FunctionExpression_F85E69FD_L372C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_F85E69FD_L372C6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x67ed
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_F85E69FD_L372C6::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_F85E69FD_L372C6
+
 
 		// Methods
 		.method public hidebysig static 
@@ -6454,6 +14665,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9DF3FAC8_L376C43
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x67fc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject_FunctionExpression_9DF3FAC8_L376C43::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_9DF3FAC8_L376C43::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x680b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_9DF3FAC8_L376C43::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x680e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_9DF3FAC8_L376C43::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6811
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject_FunctionExpression_9DF3FAC8_L376C43::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_9DF3FAC8_L376C43::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6823
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject_FunctionExpression_9DF3FAC8_L376C43::_environment0_Compile_Performance_Dromaeo_Object_Regexp
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_9DF3FAC8_L376C43::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6831
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_9DF3FAC8_L376C43::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_9DF3FAC8_L376C43
 
 
 		// Methods
@@ -6586,88 +14904,88 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope,
-			[1] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_6CF2F656_startTest,
-			[2] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_B7494A8F_endTest,
-			[3] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_6F708165_prep,
-			[4] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_F3312FC6_test,
+			[1] class Modules.Compile_Performance_Dromaeo_Object_Regexp/startTest/FunctionObject_FunctionDeclaration_6CF2F656_startTest,
+			[2] class Modules.Compile_Performance_Dromaeo_Object_Regexp/endTest/FunctionObject_FunctionDeclaration_B7494A8F_endTest,
+			[3] class Modules.Compile_Performance_Dromaeo_Object_Regexp/prep/FunctionObject_FunctionDeclaration_6F708165_prep,
+			[4] class Modules.Compile_Performance_Dromaeo_Object_Regexp/test/FunctionObject_FunctionDeclaration_F3312FC6_test,
 			[5] float64,
 			[6] object[],
-			[7] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_7C555EF1_randomChar,
-			[8] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_244F5225_generateTestStrings,
+			[7] class Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar/FunctionObject_FunctionDeclaration_7C555EF1_randomChar,
+			[8] class Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/FunctionObject_FunctionDeclaration_244F5225_generateTestStrings,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[10] float64,
 			[11] object,
 			[12] object,
 			[13] object,
 			[14] object[],
-			[15] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_84CD8439_L48C6,
-			[16] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_40DF050A_L56C37,
-			[17] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_367F8A10_L61C6,
-			[18] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_048224EC_L66C36,
-			[19] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_7C0CF449_L71C6,
-			[20] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_99D19962_L76C40,
-			[21] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F1E0E698_L83C6,
-			[22] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_E322D6B7_L88C24,
-			[23] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_83D3F4FD_L93C6,
-			[24] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_300CE2EA_L97C23,
-			[25] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_15168718_L102C6,
-			[26] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AADD4623_L106C32,
-			[27] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_35949A34_L111C6,
-			[28] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_123E59E1_L115C34,
-			[29] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1A1A3900_L120C6,
-			[30] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_A14DF61B_L125C31,
-			[31] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_FEC96B05_L130C6,
-			[32] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_A2B06A06_L134C30,
-			[33] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_826BD7E2_L139C6,
-			[34] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_52BFD713_L143C39,
-			[35] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_ADF86AB6_L148C6,
-			[36] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6A51803A_L152C41,
-			[37] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_59F53CDE_L157C6,
-			[38] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F7D2F9E6_L161C50,
-			[39] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_5BE125D1_L170C6,
-			[40] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_E6D30A9E_L175C33,
-			[41] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_316E4A1A_L180C6,
-			[42] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F75042ED_L184C32,
-			[43] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_DE23A66D_L189C6,
-			[44] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_59F2FA63_L193C41,
-			[45] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_FD52FD47_L198C6,
-			[46] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AB7296C4_L202C43,
-			[47] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6250884E_L207C6,
-			[48] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_9FBA592E_L212C40,
-			[49] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6442B403_L217C6,
-			[50] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_7B23A4A4_L221C39,
-			[51] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_15CEA57B_L226C6,
-			[52] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_CE64C73E_L230C48,
-			[53] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6B3295AB_L235C6,
-			[54] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1419E03E_L239C50,
-			[55] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1AD25763_L244C6,
-			[56] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_B68C9781_L248C59,
-			[57] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_62C7C36F_L257C6,
-			[58] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_BE52CC8A_L262C32,
-			[59] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1AD7FAC4_L267C6,
-			[60] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_75E34588_L271C34,
-			[61] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_98DF622E_L276C6,
-			[62] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6EF0F712_L280C47,
-			[63] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_0304DE8C_L285C6,
-			[64] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_D94750FD_L289C56,
-			[65] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_29656618_L296C6,
-			[66] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1062EA27_L300C65,
-			[67] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_612413E3_L309C6,
-			[68] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_5D299276_L313C26,
-			[69] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AF818725_L318C6,
-			[70] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_64DC70FB_L322C25,
-			[71] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_455C0AC7_L327C6,
-			[72] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_C0E29ED5_L331C34,
-			[73] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_78E8D78D_L336C6,
-			[74] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_31C4DBA7_L340C36,
-			[75] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_ADC77423_L345C6,
-			[76] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AB0D0A79_L349C33,
-			[77] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_FE9F5065_L354C6,
-			[78] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_48BE92D8_L358C32,
-			[79] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_4D9B395F_L363C6,
-			[80] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_222F9CF0_L367C41,
-			[81] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F85E69FD_L372C6,
-			[82] class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_9DF3FAC8_L376C43
+			[15] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject_FunctionExpression_84CD8439_L48C6,
+			[16] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject_FunctionExpression_40DF050A_L56C37,
+			[17] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject_FunctionExpression_367F8A10_L61C6,
+			[18] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject_FunctionExpression_048224EC_L66C36,
+			[19] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject_FunctionExpression_7C0CF449_L71C6,
+			[20] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject_FunctionExpression_99D19962_L76C40,
+			[21] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject_FunctionExpression_F1E0E698_L83C6,
+			[22] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject_FunctionExpression_E322D6B7_L88C24,
+			[23] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject_FunctionExpression_83D3F4FD_L93C6,
+			[24] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject_FunctionExpression_300CE2EA_L97C23,
+			[25] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject_FunctionExpression_15168718_L102C6,
+			[26] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject_FunctionExpression_AADD4623_L106C32,
+			[27] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject_FunctionExpression_35949A34_L111C6,
+			[28] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject_FunctionExpression_123E59E1_L115C34,
+			[29] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject_FunctionExpression_1A1A3900_L120C6,
+			[30] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject_FunctionExpression_A14DF61B_L125C31,
+			[31] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject_FunctionExpression_FEC96B05_L130C6,
+			[32] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject_FunctionExpression_A2B06A06_L134C30,
+			[33] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject_FunctionExpression_826BD7E2_L139C6,
+			[34] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject_FunctionExpression_52BFD713_L143C39,
+			[35] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject_FunctionExpression_ADF86AB6_L148C6,
+			[36] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject_FunctionExpression_6A51803A_L152C41,
+			[37] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject_FunctionExpression_59F53CDE_L157C6,
+			[38] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject_FunctionExpression_F7D2F9E6_L161C50,
+			[39] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject_FunctionExpression_5BE125D1_L170C6,
+			[40] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject_FunctionExpression_E6D30A9E_L175C33,
+			[41] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject_FunctionExpression_316E4A1A_L180C6,
+			[42] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject_FunctionExpression_F75042ED_L184C32,
+			[43] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject_FunctionExpression_DE23A66D_L189C6,
+			[44] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject_FunctionExpression_59F2FA63_L193C41,
+			[45] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject_FunctionExpression_FD52FD47_L198C6,
+			[46] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject_FunctionExpression_AB7296C4_L202C43,
+			[47] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject_FunctionExpression_6250884E_L207C6,
+			[48] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject_FunctionExpression_9FBA592E_L212C40,
+			[49] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject_FunctionExpression_6442B403_L217C6,
+			[50] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject_FunctionExpression_7B23A4A4_L221C39,
+			[51] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject_FunctionExpression_15CEA57B_L226C6,
+			[52] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject_FunctionExpression_CE64C73E_L230C48,
+			[53] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject_FunctionExpression_6B3295AB_L235C6,
+			[54] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject_FunctionExpression_1419E03E_L239C50,
+			[55] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject_FunctionExpression_1AD25763_L244C6,
+			[56] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject_FunctionExpression_B68C9781_L248C59,
+			[57] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject_FunctionExpression_62C7C36F_L257C6,
+			[58] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject_FunctionExpression_BE52CC8A_L262C32,
+			[59] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject_FunctionExpression_1AD7FAC4_L267C6,
+			[60] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject_FunctionExpression_75E34588_L271C34,
+			[61] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject_FunctionExpression_98DF622E_L276C6,
+			[62] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject_FunctionExpression_6EF0F712_L280C47,
+			[63] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject_FunctionExpression_0304DE8C_L285C6,
+			[64] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject_FunctionExpression_D94750FD_L289C56,
+			[65] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject_FunctionExpression_29656618_L296C6,
+			[66] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject_FunctionExpression_1062EA27_L300C65,
+			[67] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject_FunctionExpression_612413E3_L309C6,
+			[68] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject_FunctionExpression_5D299276_L313C26,
+			[69] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject_FunctionExpression_AF818725_L318C6,
+			[70] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject_FunctionExpression_64DC70FB_L322C25,
+			[71] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject_FunctionExpression_455C0AC7_L327C6,
+			[72] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject_FunctionExpression_C0E29ED5_L331C34,
+			[73] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject_FunctionExpression_78E8D78D_L336C6,
+			[74] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject_FunctionExpression_31C4DBA7_L340C36,
+			[75] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject_FunctionExpression_ADC77423_L345C6,
+			[76] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject_FunctionExpression_AB0D0A79_L349C33,
+			[77] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject_FunctionExpression_FE9F5065_L354C6,
+			[78] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject_FunctionExpression_48BE92D8_L358C32,
+			[79] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject_FunctionExpression_4D9B395F_L363C6,
+			[80] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject_FunctionExpression_222F9CF0_L367C41,
+			[81] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject_FunctionExpression_F85E69FD_L372C6,
+			[82] class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject_FunctionExpression_9DF3FAC8_L376C43
 		)
 
 		IL_0000: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope::.ctor()
@@ -6679,13 +14997,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 6
-		IL_0012: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_6CF2F656_startTest::.ctor()
+		IL_0012: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/startTest/FunctionObject_FunctionDeclaration_6CF2F656_startTest::.ctor()
 		IL_0017: ldc.i4.2
 		IL_0018: conv.r8
 		IL_0019: ldstr "startTest"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_6CF2F656_startTest>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/startTest/FunctionObject_FunctionDeclaration_6CF2F656_startTest>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -6694,13 +15012,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 6
-		IL_0032: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_B7494A8F_endTest::.ctor()
+		IL_0032: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/endTest/FunctionObject_FunctionDeclaration_B7494A8F_endTest::.ctor()
 		IL_0037: ldc.i4.0
 		IL_0038: conv.r8
 		IL_0039: ldstr "endTest"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_B7494A8F_endTest>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/endTest/FunctionObject_FunctionDeclaration_B7494A8F_endTest>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -6709,13 +15027,13 @@
 		IL_004e: ldloc.0
 		IL_004f: stelem.ref
 		IL_0050: stloc.s 6
-		IL_0052: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_6F708165_prep::.ctor()
+		IL_0052: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/prep/FunctionObject_FunctionDeclaration_6F708165_prep::.ctor()
 		IL_0057: ldc.i4.1
 		IL_0058: conv.r8
 		IL_0059: ldstr "prep"
 		IL_005e: ldc.i4.0
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_6F708165_prep>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/prep/FunctionObject_FunctionDeclaration_6F708165_prep>(!!0, float64, string, bool, bool)
 		IL_0065: stloc.3
 		IL_0066: ldc.i4.1
 		IL_0067: newarr [System.Runtime]System.Object
@@ -6724,13 +15042,13 @@
 		IL_006e: ldloc.0
 		IL_006f: stelem.ref
 		IL_0070: stloc.s 6
-		IL_0072: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_F3312FC6_test::.ctor()
+		IL_0072: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/test/FunctionObject_FunctionDeclaration_F3312FC6_test::.ctor()
 		IL_0077: ldc.i4.2
 		IL_0078: conv.r8
 		IL_0079: ldstr "test"
 		IL_007e: ldc.i4.0
 		IL_007f: ldc.i4.1
-		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_F3312FC6_test>(!!0, float64, string, bool, bool)
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/test/FunctionObject_FunctionDeclaration_F3312FC6_test>(!!0, float64, string, bool, bool)
 		IL_0085: stloc.s 4
 		IL_0087: ldc.i4.1
 		IL_0088: newarr [System.Runtime]System.Object
@@ -6739,13 +15057,13 @@
 		IL_008f: ldloc.0
 		IL_0090: stelem.ref
 		IL_0091: stloc.s 6
-		IL_0093: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_7C555EF1_randomChar::.ctor()
+		IL_0093: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar/FunctionObject_FunctionDeclaration_7C555EF1_randomChar::.ctor()
 		IL_0098: ldc.i4.0
 		IL_0099: conv.r8
 		IL_009a: ldstr "randomChar"
 		IL_009f: ldc.i4.0
 		IL_00a0: ldc.i4.1
-		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_7C555EF1_randomChar>(!!0, float64, string, bool, bool)
+		IL_00a1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar/FunctionObject_FunctionDeclaration_7C555EF1_randomChar>(!!0, float64, string, bool, bool)
 		IL_00a6: stloc.s 7
 		IL_00a8: ldloc.0
 		IL_00a9: ldloc.s 7
@@ -6761,13 +15079,13 @@
 		IL_00be: ldc.i4.0
 		IL_00bf: ldelem.ref
 		IL_00c0: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_00c5: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_00c5: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_00ca: ldc.i4.1
 		IL_00cb: conv.r8
 		IL_00cc: ldstr "generateTestStrings"
 		IL_00d1: ldc.i4.0
 		IL_00d2: ldc.i4.1
-		IL_00d3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_244F5225_generateTestStrings>(!!0, float64, string, bool, bool)
+		IL_00d3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings/FunctionObject_FunctionDeclaration_244F5225_generateTestStrings>(!!0, float64, string, bool, bool)
 		IL_00d8: stloc.s 8
 		IL_00da: ldloc.0
 		IL_00db: ldloc.s 8
@@ -6892,13 +15210,13 @@
 		IL_022e: ldc.i4.0
 		IL_022f: ldelem.ref
 		IL_0230: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0235: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_84CD8439_L48C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0235: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject_FunctionExpression_84CD8439_L48C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_023a: ldc.i4.0
 		IL_023b: conv.r8
 		IL_023c: ldstr ""
 		IL_0241: ldc.i4.0
 		IL_0242: ldc.i4.1
-		IL_0243: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_84CD8439_L48C6>(!!0, float64, string, bool, bool)
+		IL_0243: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5/FunctionObject_FunctionExpression_84CD8439_L48C6>(!!0, float64, string, bool, bool)
 		IL_0248: stloc.s 15
 		IL_024a: ldloc.3
 		IL_024b: ldloc.s 6
@@ -6918,13 +15236,13 @@
 		IL_026a: ldc.i4.0
 		IL_026b: ldelem.ref
 		IL_026c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0271: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_40DF050A_L56C37::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0271: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject_FunctionExpression_40DF050A_L56C37::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0276: ldc.i4.0
 		IL_0277: conv.r8
 		IL_0278: ldstr ""
 		IL_027d: ldc.i4.0
 		IL_027e: ldc.i4.1
-		IL_027f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_40DF050A_L56C37>(!!0, float64, string, bool, bool)
+		IL_027f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36/FunctionObject_FunctionExpression_40DF050A_L56C37>(!!0, float64, string, bool, bool)
 		IL_0284: stloc.s 16
 		IL_0286: ldloc.s 4
 		IL_0288: ldloc.s 6
@@ -6945,13 +15263,13 @@
 		IL_02ac: ldc.i4.0
 		IL_02ad: ldelem.ref
 		IL_02ae: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_02b3: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_367F8A10_L61C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_02b3: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject_FunctionExpression_367F8A10_L61C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_02b8: ldc.i4.0
 		IL_02b9: conv.r8
 		IL_02ba: ldstr ""
 		IL_02bf: ldc.i4.0
 		IL_02c0: ldc.i4.1
-		IL_02c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_367F8A10_L61C6>(!!0, float64, string, bool, bool)
+		IL_02c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5/FunctionObject_FunctionExpression_367F8A10_L61C6>(!!0, float64, string, bool, bool)
 		IL_02c6: stloc.s 17
 		IL_02c8: ldloc.3
 		IL_02c9: ldloc.s 6
@@ -6971,13 +15289,13 @@
 		IL_02e8: ldc.i4.0
 		IL_02e9: ldelem.ref
 		IL_02ea: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_02ef: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_048224EC_L66C36::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_02ef: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject_FunctionExpression_048224EC_L66C36::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_02f4: ldc.i4.0
 		IL_02f5: conv.r8
 		IL_02f6: ldstr ""
 		IL_02fb: ldc.i4.0
 		IL_02fc: ldc.i4.1
-		IL_02fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_048224EC_L66C36>(!!0, float64, string, bool, bool)
+		IL_02fd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35/FunctionObject_FunctionExpression_048224EC_L66C36>(!!0, float64, string, bool, bool)
 		IL_0302: stloc.s 18
 		IL_0304: ldloc.s 4
 		IL_0306: ldloc.s 6
@@ -6998,13 +15316,13 @@
 		IL_032a: ldc.i4.0
 		IL_032b: ldelem.ref
 		IL_032c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0331: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_7C0CF449_L71C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0331: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject_FunctionExpression_7C0CF449_L71C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0336: ldc.i4.0
 		IL_0337: conv.r8
 		IL_0338: ldstr ""
 		IL_033d: ldc.i4.0
 		IL_033e: ldc.i4.1
-		IL_033f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_7C0CF449_L71C6>(!!0, float64, string, bool, bool)
+		IL_033f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5/FunctionObject_FunctionExpression_7C0CF449_L71C6>(!!0, float64, string, bool, bool)
 		IL_0344: stloc.s 19
 		IL_0346: ldloc.3
 		IL_0347: ldloc.s 6
@@ -7024,13 +15342,13 @@
 		IL_0366: ldc.i4.0
 		IL_0367: ldelem.ref
 		IL_0368: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_036d: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_99D19962_L76C40::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_036d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject_FunctionExpression_99D19962_L76C40::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0372: ldc.i4.0
 		IL_0373: conv.r8
 		IL_0374: ldstr ""
 		IL_0379: ldc.i4.0
 		IL_037a: ldc.i4.1
-		IL_037b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_99D19962_L76C40>(!!0, float64, string, bool, bool)
+		IL_037b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39/FunctionObject_FunctionExpression_99D19962_L76C40>(!!0, float64, string, bool, bool)
 		IL_0380: stloc.s 20
 		IL_0382: ldloc.s 4
 		IL_0384: ldloc.s 6
@@ -7051,13 +15369,13 @@
 		IL_03a8: ldc.i4.0
 		IL_03a9: ldelem.ref
 		IL_03aa: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_03af: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F1E0E698_L83C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_03af: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject_FunctionExpression_F1E0E698_L83C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_03b4: ldc.i4.0
 		IL_03b5: conv.r8
 		IL_03b6: ldstr ""
 		IL_03bb: ldc.i4.0
 		IL_03bc: ldc.i4.1
-		IL_03bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F1E0E698_L83C6>(!!0, float64, string, bool, bool)
+		IL_03bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5/FunctionObject_FunctionExpression_F1E0E698_L83C6>(!!0, float64, string, bool, bool)
 		IL_03c2: stloc.s 21
 		IL_03c4: ldloc.3
 		IL_03c5: ldloc.s 6
@@ -7077,13 +15395,13 @@
 		IL_03e4: ldc.i4.0
 		IL_03e5: ldelem.ref
 		IL_03e6: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_03eb: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_E322D6B7_L88C24::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_03eb: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject_FunctionExpression_E322D6B7_L88C24::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_03f0: ldc.i4.0
 		IL_03f1: conv.r8
 		IL_03f2: ldstr ""
 		IL_03f7: ldc.i4.0
 		IL_03f8: ldc.i4.1
-		IL_03f9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_E322D6B7_L88C24>(!!0, float64, string, bool, bool)
+		IL_03f9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23/FunctionObject_FunctionExpression_E322D6B7_L88C24>(!!0, float64, string, bool, bool)
 		IL_03fe: stloc.s 22
 		IL_0400: ldloc.s 4
 		IL_0402: ldloc.s 6
@@ -7104,13 +15422,13 @@
 		IL_0426: ldc.i4.0
 		IL_0427: ldelem.ref
 		IL_0428: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_042d: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_83D3F4FD_L93C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_042d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject_FunctionExpression_83D3F4FD_L93C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0432: ldc.i4.0
 		IL_0433: conv.r8
 		IL_0434: ldstr ""
 		IL_0439: ldc.i4.0
 		IL_043a: ldc.i4.1
-		IL_043b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_83D3F4FD_L93C6>(!!0, float64, string, bool, bool)
+		IL_043b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5/FunctionObject_FunctionExpression_83D3F4FD_L93C6>(!!0, float64, string, bool, bool)
 		IL_0440: stloc.s 23
 		IL_0442: ldloc.3
 		IL_0443: ldloc.s 6
@@ -7130,13 +15448,13 @@
 		IL_0462: ldc.i4.0
 		IL_0463: ldelem.ref
 		IL_0464: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0469: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_300CE2EA_L97C23::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0469: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject_FunctionExpression_300CE2EA_L97C23::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_046e: ldc.i4.0
 		IL_046f: conv.r8
 		IL_0470: ldstr ""
 		IL_0475: ldc.i4.0
 		IL_0476: ldc.i4.1
-		IL_0477: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_300CE2EA_L97C23>(!!0, float64, string, bool, bool)
+		IL_0477: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22/FunctionObject_FunctionExpression_300CE2EA_L97C23>(!!0, float64, string, bool, bool)
 		IL_047c: stloc.s 24
 		IL_047e: ldloc.s 4
 		IL_0480: ldloc.s 6
@@ -7157,13 +15475,13 @@
 		IL_04a4: ldc.i4.0
 		IL_04a5: ldelem.ref
 		IL_04a6: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_04ab: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_15168718_L102C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_04ab: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject_FunctionExpression_15168718_L102C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_04b0: ldc.i4.0
 		IL_04b1: conv.r8
 		IL_04b2: ldstr ""
 		IL_04b7: ldc.i4.0
 		IL_04b8: ldc.i4.1
-		IL_04b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_15168718_L102C6>(!!0, float64, string, bool, bool)
+		IL_04b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5/FunctionObject_FunctionExpression_15168718_L102C6>(!!0, float64, string, bool, bool)
 		IL_04be: stloc.s 25
 		IL_04c0: ldloc.3
 		IL_04c1: ldloc.s 6
@@ -7183,13 +15501,13 @@
 		IL_04e0: ldc.i4.0
 		IL_04e1: ldelem.ref
 		IL_04e2: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_04e7: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AADD4623_L106C32::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_04e7: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject_FunctionExpression_AADD4623_L106C32::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_04ec: ldc.i4.0
 		IL_04ed: conv.r8
 		IL_04ee: ldstr ""
 		IL_04f3: ldc.i4.0
 		IL_04f4: ldc.i4.1
-		IL_04f5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AADD4623_L106C32>(!!0, float64, string, bool, bool)
+		IL_04f5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31/FunctionObject_FunctionExpression_AADD4623_L106C32>(!!0, float64, string, bool, bool)
 		IL_04fa: stloc.s 26
 		IL_04fc: ldloc.s 4
 		IL_04fe: ldloc.s 6
@@ -7210,13 +15528,13 @@
 		IL_0522: ldc.i4.0
 		IL_0523: ldelem.ref
 		IL_0524: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0529: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_35949A34_L111C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0529: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject_FunctionExpression_35949A34_L111C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_052e: ldc.i4.0
 		IL_052f: conv.r8
 		IL_0530: ldstr ""
 		IL_0535: ldc.i4.0
 		IL_0536: ldc.i4.1
-		IL_0537: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_35949A34_L111C6>(!!0, float64, string, bool, bool)
+		IL_0537: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5/FunctionObject_FunctionExpression_35949A34_L111C6>(!!0, float64, string, bool, bool)
 		IL_053c: stloc.s 27
 		IL_053e: ldloc.3
 		IL_053f: ldloc.s 6
@@ -7236,13 +15554,13 @@
 		IL_055e: ldc.i4.0
 		IL_055f: ldelem.ref
 		IL_0560: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0565: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_123E59E1_L115C34::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0565: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject_FunctionExpression_123E59E1_L115C34::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_056a: ldc.i4.0
 		IL_056b: conv.r8
 		IL_056c: ldstr ""
 		IL_0571: ldc.i4.0
 		IL_0572: ldc.i4.1
-		IL_0573: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_123E59E1_L115C34>(!!0, float64, string, bool, bool)
+		IL_0573: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33/FunctionObject_FunctionExpression_123E59E1_L115C34>(!!0, float64, string, bool, bool)
 		IL_0578: stloc.s 28
 		IL_057a: ldloc.s 4
 		IL_057c: ldloc.s 6
@@ -7263,13 +15581,13 @@
 		IL_05a0: ldc.i4.0
 		IL_05a1: ldelem.ref
 		IL_05a2: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_05a7: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1A1A3900_L120C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_05a7: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject_FunctionExpression_1A1A3900_L120C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_05ac: ldc.i4.0
 		IL_05ad: conv.r8
 		IL_05ae: ldstr ""
 		IL_05b3: ldc.i4.0
 		IL_05b4: ldc.i4.1
-		IL_05b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1A1A3900_L120C6>(!!0, float64, string, bool, bool)
+		IL_05b5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5/FunctionObject_FunctionExpression_1A1A3900_L120C6>(!!0, float64, string, bool, bool)
 		IL_05ba: stloc.s 29
 		IL_05bc: ldloc.3
 		IL_05bd: ldloc.s 6
@@ -7289,13 +15607,13 @@
 		IL_05dc: ldc.i4.0
 		IL_05dd: ldelem.ref
 		IL_05de: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_05e3: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_A14DF61B_L125C31::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_05e3: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject_FunctionExpression_A14DF61B_L125C31::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_05e8: ldc.i4.0
 		IL_05e9: conv.r8
 		IL_05ea: ldstr ""
 		IL_05ef: ldc.i4.0
 		IL_05f0: ldc.i4.1
-		IL_05f1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_A14DF61B_L125C31>(!!0, float64, string, bool, bool)
+		IL_05f1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30/FunctionObject_FunctionExpression_A14DF61B_L125C31>(!!0, float64, string, bool, bool)
 		IL_05f6: stloc.s 30
 		IL_05f8: ldloc.s 4
 		IL_05fa: ldloc.s 6
@@ -7316,13 +15634,13 @@
 		IL_061e: ldc.i4.0
 		IL_061f: ldelem.ref
 		IL_0620: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0625: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_FEC96B05_L130C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0625: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject_FunctionExpression_FEC96B05_L130C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_062a: ldc.i4.0
 		IL_062b: conv.r8
 		IL_062c: ldstr ""
 		IL_0631: ldc.i4.0
 		IL_0632: ldc.i4.1
-		IL_0633: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_FEC96B05_L130C6>(!!0, float64, string, bool, bool)
+		IL_0633: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5/FunctionObject_FunctionExpression_FEC96B05_L130C6>(!!0, float64, string, bool, bool)
 		IL_0638: stloc.s 31
 		IL_063a: ldloc.3
 		IL_063b: ldloc.s 6
@@ -7342,13 +15660,13 @@
 		IL_065a: ldc.i4.0
 		IL_065b: ldelem.ref
 		IL_065c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0661: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_A2B06A06_L134C30::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0661: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject_FunctionExpression_A2B06A06_L134C30::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0666: ldc.i4.0
 		IL_0667: conv.r8
 		IL_0668: ldstr ""
 		IL_066d: ldc.i4.0
 		IL_066e: ldc.i4.1
-		IL_066f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_A2B06A06_L134C30>(!!0, float64, string, bool, bool)
+		IL_066f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29/FunctionObject_FunctionExpression_A2B06A06_L134C30>(!!0, float64, string, bool, bool)
 		IL_0674: stloc.s 32
 		IL_0676: ldloc.s 4
 		IL_0678: ldloc.s 6
@@ -7369,13 +15687,13 @@
 		IL_069c: ldc.i4.0
 		IL_069d: ldelem.ref
 		IL_069e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_06a3: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_826BD7E2_L139C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_06a3: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject_FunctionExpression_826BD7E2_L139C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_06a8: ldc.i4.0
 		IL_06a9: conv.r8
 		IL_06aa: ldstr ""
 		IL_06af: ldc.i4.0
 		IL_06b0: ldc.i4.1
-		IL_06b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_826BD7E2_L139C6>(!!0, float64, string, bool, bool)
+		IL_06b1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5/FunctionObject_FunctionExpression_826BD7E2_L139C6>(!!0, float64, string, bool, bool)
 		IL_06b6: stloc.s 33
 		IL_06b8: ldloc.3
 		IL_06b9: ldloc.s 6
@@ -7395,13 +15713,13 @@
 		IL_06d8: ldc.i4.0
 		IL_06d9: ldelem.ref
 		IL_06da: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_06df: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_52BFD713_L143C39::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_06df: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject_FunctionExpression_52BFD713_L143C39::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_06e4: ldc.i4.0
 		IL_06e5: conv.r8
 		IL_06e6: ldstr ""
 		IL_06eb: ldc.i4.0
 		IL_06ec: ldc.i4.1
-		IL_06ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_52BFD713_L143C39>(!!0, float64, string, bool, bool)
+		IL_06ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38/FunctionObject_FunctionExpression_52BFD713_L143C39>(!!0, float64, string, bool, bool)
 		IL_06f2: stloc.s 34
 		IL_06f4: ldloc.s 4
 		IL_06f6: ldloc.s 6
@@ -7422,13 +15740,13 @@
 		IL_071a: ldc.i4.0
 		IL_071b: ldelem.ref
 		IL_071c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0721: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_ADF86AB6_L148C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0721: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject_FunctionExpression_ADF86AB6_L148C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0726: ldc.i4.0
 		IL_0727: conv.r8
 		IL_0728: ldstr ""
 		IL_072d: ldc.i4.0
 		IL_072e: ldc.i4.1
-		IL_072f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_ADF86AB6_L148C6>(!!0, float64, string, bool, bool)
+		IL_072f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5/FunctionObject_FunctionExpression_ADF86AB6_L148C6>(!!0, float64, string, bool, bool)
 		IL_0734: stloc.s 35
 		IL_0736: ldloc.3
 		IL_0737: ldloc.s 6
@@ -7448,13 +15766,13 @@
 		IL_0756: ldc.i4.0
 		IL_0757: ldelem.ref
 		IL_0758: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_075d: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6A51803A_L152C41::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_075d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject_FunctionExpression_6A51803A_L152C41::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0762: ldc.i4.0
 		IL_0763: conv.r8
 		IL_0764: ldstr ""
 		IL_0769: ldc.i4.0
 		IL_076a: ldc.i4.1
-		IL_076b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6A51803A_L152C41>(!!0, float64, string, bool, bool)
+		IL_076b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40/FunctionObject_FunctionExpression_6A51803A_L152C41>(!!0, float64, string, bool, bool)
 		IL_0770: stloc.s 36
 		IL_0772: ldloc.s 4
 		IL_0774: ldloc.s 6
@@ -7475,13 +15793,13 @@
 		IL_0798: ldc.i4.0
 		IL_0799: ldelem.ref
 		IL_079a: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_079f: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_59F53CDE_L157C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_079f: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject_FunctionExpression_59F53CDE_L157C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_07a4: ldc.i4.0
 		IL_07a5: conv.r8
 		IL_07a6: ldstr ""
 		IL_07ab: ldc.i4.0
 		IL_07ac: ldc.i4.1
-		IL_07ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_59F53CDE_L157C6>(!!0, float64, string, bool, bool)
+		IL_07ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5/FunctionObject_FunctionExpression_59F53CDE_L157C6>(!!0, float64, string, bool, bool)
 		IL_07b2: stloc.s 37
 		IL_07b4: ldloc.3
 		IL_07b5: ldloc.s 6
@@ -7501,13 +15819,13 @@
 		IL_07d4: ldc.i4.0
 		IL_07d5: ldelem.ref
 		IL_07d6: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_07db: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F7D2F9E6_L161C50::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_07db: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject_FunctionExpression_F7D2F9E6_L161C50::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_07e0: ldc.i4.0
 		IL_07e1: conv.r8
 		IL_07e2: ldstr ""
 		IL_07e7: ldc.i4.0
 		IL_07e8: ldc.i4.1
-		IL_07e9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F7D2F9E6_L161C50>(!!0, float64, string, bool, bool)
+		IL_07e9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionObject_FunctionExpression_F7D2F9E6_L161C50>(!!0, float64, string, bool, bool)
 		IL_07ee: stloc.s 38
 		IL_07f0: ldloc.s 4
 		IL_07f2: ldloc.s 6
@@ -7528,13 +15846,13 @@
 		IL_0816: ldc.i4.0
 		IL_0817: ldelem.ref
 		IL_0818: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_081d: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_5BE125D1_L170C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_081d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject_FunctionExpression_5BE125D1_L170C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0822: ldc.i4.0
 		IL_0823: conv.r8
 		IL_0824: ldstr ""
 		IL_0829: ldc.i4.0
 		IL_082a: ldc.i4.1
-		IL_082b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_5BE125D1_L170C6>(!!0, float64, string, bool, bool)
+		IL_082b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5/FunctionObject_FunctionExpression_5BE125D1_L170C6>(!!0, float64, string, bool, bool)
 		IL_0830: stloc.s 39
 		IL_0832: ldloc.3
 		IL_0833: ldloc.s 6
@@ -7554,13 +15872,13 @@
 		IL_0852: ldc.i4.0
 		IL_0853: ldelem.ref
 		IL_0854: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0859: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_E6D30A9E_L175C33::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0859: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject_FunctionExpression_E6D30A9E_L175C33::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_085e: ldc.i4.0
 		IL_085f: conv.r8
 		IL_0860: ldstr ""
 		IL_0865: ldc.i4.0
 		IL_0866: ldc.i4.1
-		IL_0867: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_E6D30A9E_L175C33>(!!0, float64, string, bool, bool)
+		IL_0867: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32/FunctionObject_FunctionExpression_E6D30A9E_L175C33>(!!0, float64, string, bool, bool)
 		IL_086c: stloc.s 40
 		IL_086e: ldloc.s 4
 		IL_0870: ldloc.s 6
@@ -7581,13 +15899,13 @@
 		IL_0894: ldc.i4.0
 		IL_0895: ldelem.ref
 		IL_0896: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_089b: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_316E4A1A_L180C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_089b: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject_FunctionExpression_316E4A1A_L180C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_08a0: ldc.i4.0
 		IL_08a1: conv.r8
 		IL_08a2: ldstr ""
 		IL_08a7: ldc.i4.0
 		IL_08a8: ldc.i4.1
-		IL_08a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_316E4A1A_L180C6>(!!0, float64, string, bool, bool)
+		IL_08a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5/FunctionObject_FunctionExpression_316E4A1A_L180C6>(!!0, float64, string, bool, bool)
 		IL_08ae: stloc.s 41
 		IL_08b0: ldloc.3
 		IL_08b1: ldloc.s 6
@@ -7607,13 +15925,13 @@
 		IL_08d0: ldc.i4.0
 		IL_08d1: ldelem.ref
 		IL_08d2: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_08d7: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F75042ED_L184C32::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_08d7: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject_FunctionExpression_F75042ED_L184C32::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_08dc: ldc.i4.0
 		IL_08dd: conv.r8
 		IL_08de: ldstr ""
 		IL_08e3: ldc.i4.0
 		IL_08e4: ldc.i4.1
-		IL_08e5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F75042ED_L184C32>(!!0, float64, string, bool, bool)
+		IL_08e5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31/FunctionObject_FunctionExpression_F75042ED_L184C32>(!!0, float64, string, bool, bool)
 		IL_08ea: stloc.s 42
 		IL_08ec: ldloc.s 4
 		IL_08ee: ldloc.s 6
@@ -7634,13 +15952,13 @@
 		IL_0912: ldc.i4.0
 		IL_0913: ldelem.ref
 		IL_0914: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0919: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_DE23A66D_L189C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0919: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject_FunctionExpression_DE23A66D_L189C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_091e: ldc.i4.0
 		IL_091f: conv.r8
 		IL_0920: ldstr ""
 		IL_0925: ldc.i4.0
 		IL_0926: ldc.i4.1
-		IL_0927: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_DE23A66D_L189C6>(!!0, float64, string, bool, bool)
+		IL_0927: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5/FunctionObject_FunctionExpression_DE23A66D_L189C6>(!!0, float64, string, bool, bool)
 		IL_092c: stloc.s 43
 		IL_092e: ldloc.3
 		IL_092f: ldloc.s 6
@@ -7660,13 +15978,13 @@
 		IL_094e: ldc.i4.0
 		IL_094f: ldelem.ref
 		IL_0950: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0955: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_59F2FA63_L193C41::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0955: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject_FunctionExpression_59F2FA63_L193C41::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_095a: ldc.i4.0
 		IL_095b: conv.r8
 		IL_095c: ldstr ""
 		IL_0961: ldc.i4.0
 		IL_0962: ldc.i4.1
-		IL_0963: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_59F2FA63_L193C41>(!!0, float64, string, bool, bool)
+		IL_0963: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40/FunctionObject_FunctionExpression_59F2FA63_L193C41>(!!0, float64, string, bool, bool)
 		IL_0968: stloc.s 44
 		IL_096a: ldloc.s 4
 		IL_096c: ldloc.s 6
@@ -7687,13 +16005,13 @@
 		IL_0990: ldc.i4.0
 		IL_0991: ldelem.ref
 		IL_0992: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0997: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_FD52FD47_L198C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0997: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject_FunctionExpression_FD52FD47_L198C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_099c: ldc.i4.0
 		IL_099d: conv.r8
 		IL_099e: ldstr ""
 		IL_09a3: ldc.i4.0
 		IL_09a4: ldc.i4.1
-		IL_09a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_FD52FD47_L198C6>(!!0, float64, string, bool, bool)
+		IL_09a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5/FunctionObject_FunctionExpression_FD52FD47_L198C6>(!!0, float64, string, bool, bool)
 		IL_09aa: stloc.s 45
 		IL_09ac: ldloc.3
 		IL_09ad: ldloc.s 6
@@ -7713,13 +16031,13 @@
 		IL_09cc: ldc.i4.0
 		IL_09cd: ldelem.ref
 		IL_09ce: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_09d3: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AB7296C4_L202C43::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_09d3: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject_FunctionExpression_AB7296C4_L202C43::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_09d8: ldc.i4.0
 		IL_09d9: conv.r8
 		IL_09da: ldstr ""
 		IL_09df: ldc.i4.0
 		IL_09e0: ldc.i4.1
-		IL_09e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AB7296C4_L202C43>(!!0, float64, string, bool, bool)
+		IL_09e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42/FunctionObject_FunctionExpression_AB7296C4_L202C43>(!!0, float64, string, bool, bool)
 		IL_09e6: stloc.s 46
 		IL_09e8: ldloc.s 4
 		IL_09ea: ldloc.s 6
@@ -7740,13 +16058,13 @@
 		IL_0a0e: ldc.i4.0
 		IL_0a0f: ldelem.ref
 		IL_0a10: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0a15: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6250884E_L207C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0a15: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject_FunctionExpression_6250884E_L207C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0a1a: ldc.i4.0
 		IL_0a1b: conv.r8
 		IL_0a1c: ldstr ""
 		IL_0a21: ldc.i4.0
 		IL_0a22: ldc.i4.1
-		IL_0a23: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6250884E_L207C6>(!!0, float64, string, bool, bool)
+		IL_0a23: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5/FunctionObject_FunctionExpression_6250884E_L207C6>(!!0, float64, string, bool, bool)
 		IL_0a28: stloc.s 47
 		IL_0a2a: ldloc.3
 		IL_0a2b: ldloc.s 6
@@ -7766,13 +16084,13 @@
 		IL_0a4a: ldc.i4.0
 		IL_0a4b: ldelem.ref
 		IL_0a4c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0a51: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_9FBA592E_L212C40::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0a51: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject_FunctionExpression_9FBA592E_L212C40::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0a56: ldc.i4.0
 		IL_0a57: conv.r8
 		IL_0a58: ldstr ""
 		IL_0a5d: ldc.i4.0
 		IL_0a5e: ldc.i4.1
-		IL_0a5f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_9FBA592E_L212C40>(!!0, float64, string, bool, bool)
+		IL_0a5f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39/FunctionObject_FunctionExpression_9FBA592E_L212C40>(!!0, float64, string, bool, bool)
 		IL_0a64: stloc.s 48
 		IL_0a66: ldloc.s 4
 		IL_0a68: ldloc.s 6
@@ -7793,13 +16111,13 @@
 		IL_0a8c: ldc.i4.0
 		IL_0a8d: ldelem.ref
 		IL_0a8e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0a93: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6442B403_L217C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0a93: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject_FunctionExpression_6442B403_L217C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0a98: ldc.i4.0
 		IL_0a99: conv.r8
 		IL_0a9a: ldstr ""
 		IL_0a9f: ldc.i4.0
 		IL_0aa0: ldc.i4.1
-		IL_0aa1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6442B403_L217C6>(!!0, float64, string, bool, bool)
+		IL_0aa1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5/FunctionObject_FunctionExpression_6442B403_L217C6>(!!0, float64, string, bool, bool)
 		IL_0aa6: stloc.s 49
 		IL_0aa8: ldloc.3
 		IL_0aa9: ldloc.s 6
@@ -7819,13 +16137,13 @@
 		IL_0ac8: ldc.i4.0
 		IL_0ac9: ldelem.ref
 		IL_0aca: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0acf: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_7B23A4A4_L221C39::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0acf: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject_FunctionExpression_7B23A4A4_L221C39::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0ad4: ldc.i4.0
 		IL_0ad5: conv.r8
 		IL_0ad6: ldstr ""
 		IL_0adb: ldc.i4.0
 		IL_0adc: ldc.i4.1
-		IL_0add: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_7B23A4A4_L221C39>(!!0, float64, string, bool, bool)
+		IL_0add: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38/FunctionObject_FunctionExpression_7B23A4A4_L221C39>(!!0, float64, string, bool, bool)
 		IL_0ae2: stloc.s 50
 		IL_0ae4: ldloc.s 4
 		IL_0ae6: ldloc.s 6
@@ -7846,13 +16164,13 @@
 		IL_0b0a: ldc.i4.0
 		IL_0b0b: ldelem.ref
 		IL_0b0c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0b11: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_15CEA57B_L226C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0b11: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject_FunctionExpression_15CEA57B_L226C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0b16: ldc.i4.0
 		IL_0b17: conv.r8
 		IL_0b18: ldstr ""
 		IL_0b1d: ldc.i4.0
 		IL_0b1e: ldc.i4.1
-		IL_0b1f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_15CEA57B_L226C6>(!!0, float64, string, bool, bool)
+		IL_0b1f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5/FunctionObject_FunctionExpression_15CEA57B_L226C6>(!!0, float64, string, bool, bool)
 		IL_0b24: stloc.s 51
 		IL_0b26: ldloc.3
 		IL_0b27: ldloc.s 6
@@ -7872,13 +16190,13 @@
 		IL_0b46: ldc.i4.0
 		IL_0b47: ldelem.ref
 		IL_0b48: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0b4d: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_CE64C73E_L230C48::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0b4d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject_FunctionExpression_CE64C73E_L230C48::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0b52: ldc.i4.0
 		IL_0b53: conv.r8
 		IL_0b54: ldstr ""
 		IL_0b59: ldc.i4.0
 		IL_0b5a: ldc.i4.1
-		IL_0b5b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_CE64C73E_L230C48>(!!0, float64, string, bool, bool)
+		IL_0b5b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47/FunctionObject_FunctionExpression_CE64C73E_L230C48>(!!0, float64, string, bool, bool)
 		IL_0b60: stloc.s 52
 		IL_0b62: ldloc.s 4
 		IL_0b64: ldloc.s 6
@@ -7899,13 +16217,13 @@
 		IL_0b88: ldc.i4.0
 		IL_0b89: ldelem.ref
 		IL_0b8a: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0b8f: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6B3295AB_L235C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0b8f: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject_FunctionExpression_6B3295AB_L235C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0b94: ldc.i4.0
 		IL_0b95: conv.r8
 		IL_0b96: ldstr ""
 		IL_0b9b: ldc.i4.0
 		IL_0b9c: ldc.i4.1
-		IL_0b9d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6B3295AB_L235C6>(!!0, float64, string, bool, bool)
+		IL_0b9d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5/FunctionObject_FunctionExpression_6B3295AB_L235C6>(!!0, float64, string, bool, bool)
 		IL_0ba2: stloc.s 53
 		IL_0ba4: ldloc.3
 		IL_0ba5: ldloc.s 6
@@ -7925,13 +16243,13 @@
 		IL_0bc4: ldc.i4.0
 		IL_0bc5: ldelem.ref
 		IL_0bc6: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0bcb: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1419E03E_L239C50::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0bcb: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject_FunctionExpression_1419E03E_L239C50::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0bd0: ldc.i4.0
 		IL_0bd1: conv.r8
 		IL_0bd2: ldstr ""
 		IL_0bd7: ldc.i4.0
 		IL_0bd8: ldc.i4.1
-		IL_0bd9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1419E03E_L239C50>(!!0, float64, string, bool, bool)
+		IL_0bd9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49/FunctionObject_FunctionExpression_1419E03E_L239C50>(!!0, float64, string, bool, bool)
 		IL_0bde: stloc.s 54
 		IL_0be0: ldloc.s 4
 		IL_0be2: ldloc.s 6
@@ -7952,13 +16270,13 @@
 		IL_0c06: ldc.i4.0
 		IL_0c07: ldelem.ref
 		IL_0c08: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0c0d: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1AD25763_L244C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0c0d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject_FunctionExpression_1AD25763_L244C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0c12: ldc.i4.0
 		IL_0c13: conv.r8
 		IL_0c14: ldstr ""
 		IL_0c19: ldc.i4.0
 		IL_0c1a: ldc.i4.1
-		IL_0c1b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1AD25763_L244C6>(!!0, float64, string, bool, bool)
+		IL_0c1b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5/FunctionObject_FunctionExpression_1AD25763_L244C6>(!!0, float64, string, bool, bool)
 		IL_0c20: stloc.s 55
 		IL_0c22: ldloc.3
 		IL_0c23: ldloc.s 6
@@ -7978,13 +16296,13 @@
 		IL_0c42: ldc.i4.0
 		IL_0c43: ldelem.ref
 		IL_0c44: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0c49: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_B68C9781_L248C59::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0c49: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject_FunctionExpression_B68C9781_L248C59::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0c4e: ldc.i4.0
 		IL_0c4f: conv.r8
 		IL_0c50: ldstr ""
 		IL_0c55: ldc.i4.0
 		IL_0c56: ldc.i4.1
-		IL_0c57: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_B68C9781_L248C59>(!!0, float64, string, bool, bool)
+		IL_0c57: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionObject_FunctionExpression_B68C9781_L248C59>(!!0, float64, string, bool, bool)
 		IL_0c5c: stloc.s 56
 		IL_0c5e: ldloc.s 4
 		IL_0c60: ldloc.s 6
@@ -8005,13 +16323,13 @@
 		IL_0c84: ldc.i4.0
 		IL_0c85: ldelem.ref
 		IL_0c86: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0c8b: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_62C7C36F_L257C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0c8b: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject_FunctionExpression_62C7C36F_L257C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0c90: ldc.i4.0
 		IL_0c91: conv.r8
 		IL_0c92: ldstr ""
 		IL_0c97: ldc.i4.0
 		IL_0c98: ldc.i4.1
-		IL_0c99: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_62C7C36F_L257C6>(!!0, float64, string, bool, bool)
+		IL_0c99: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5/FunctionObject_FunctionExpression_62C7C36F_L257C6>(!!0, float64, string, bool, bool)
 		IL_0c9e: stloc.s 57
 		IL_0ca0: ldloc.3
 		IL_0ca1: ldloc.s 6
@@ -8031,13 +16349,13 @@
 		IL_0cc0: ldc.i4.0
 		IL_0cc1: ldelem.ref
 		IL_0cc2: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0cc7: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_BE52CC8A_L262C32::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0cc7: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject_FunctionExpression_BE52CC8A_L262C32::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0ccc: ldc.i4.0
 		IL_0ccd: conv.r8
 		IL_0cce: ldstr ""
 		IL_0cd3: ldc.i4.0
 		IL_0cd4: ldc.i4.1
-		IL_0cd5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_BE52CC8A_L262C32>(!!0, float64, string, bool, bool)
+		IL_0cd5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31/FunctionObject_FunctionExpression_BE52CC8A_L262C32>(!!0, float64, string, bool, bool)
 		IL_0cda: stloc.s 58
 		IL_0cdc: ldloc.s 4
 		IL_0cde: ldloc.s 6
@@ -8058,13 +16376,13 @@
 		IL_0d02: ldc.i4.0
 		IL_0d03: ldelem.ref
 		IL_0d04: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0d09: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1AD7FAC4_L267C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0d09: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject_FunctionExpression_1AD7FAC4_L267C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0d0e: ldc.i4.0
 		IL_0d0f: conv.r8
 		IL_0d10: ldstr ""
 		IL_0d15: ldc.i4.0
 		IL_0d16: ldc.i4.1
-		IL_0d17: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1AD7FAC4_L267C6>(!!0, float64, string, bool, bool)
+		IL_0d17: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5/FunctionObject_FunctionExpression_1AD7FAC4_L267C6>(!!0, float64, string, bool, bool)
 		IL_0d1c: stloc.s 59
 		IL_0d1e: ldloc.3
 		IL_0d1f: ldloc.s 6
@@ -8084,13 +16402,13 @@
 		IL_0d3e: ldc.i4.0
 		IL_0d3f: ldelem.ref
 		IL_0d40: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0d45: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_75E34588_L271C34::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0d45: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject_FunctionExpression_75E34588_L271C34::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0d4a: ldc.i4.0
 		IL_0d4b: conv.r8
 		IL_0d4c: ldstr ""
 		IL_0d51: ldc.i4.0
 		IL_0d52: ldc.i4.1
-		IL_0d53: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_75E34588_L271C34>(!!0, float64, string, bool, bool)
+		IL_0d53: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33/FunctionObject_FunctionExpression_75E34588_L271C34>(!!0, float64, string, bool, bool)
 		IL_0d58: stloc.s 60
 		IL_0d5a: ldloc.s 4
 		IL_0d5c: ldloc.s 6
@@ -8111,13 +16429,13 @@
 		IL_0d80: ldc.i4.0
 		IL_0d81: ldelem.ref
 		IL_0d82: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0d87: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_98DF622E_L276C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0d87: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject_FunctionExpression_98DF622E_L276C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0d8c: ldc.i4.0
 		IL_0d8d: conv.r8
 		IL_0d8e: ldstr ""
 		IL_0d93: ldc.i4.0
 		IL_0d94: ldc.i4.1
-		IL_0d95: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_98DF622E_L276C6>(!!0, float64, string, bool, bool)
+		IL_0d95: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5/FunctionObject_FunctionExpression_98DF622E_L276C6>(!!0, float64, string, bool, bool)
 		IL_0d9a: stloc.s 61
 		IL_0d9c: ldloc.3
 		IL_0d9d: ldloc.s 6
@@ -8137,13 +16455,13 @@
 		IL_0dbc: ldc.i4.0
 		IL_0dbd: ldelem.ref
 		IL_0dbe: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0dc3: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6EF0F712_L280C47::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0dc3: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject_FunctionExpression_6EF0F712_L280C47::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0dc8: ldc.i4.0
 		IL_0dc9: conv.r8
 		IL_0dca: ldstr ""
 		IL_0dcf: ldc.i4.0
 		IL_0dd0: ldc.i4.1
-		IL_0dd1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6EF0F712_L280C47>(!!0, float64, string, bool, bool)
+		IL_0dd1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46/FunctionObject_FunctionExpression_6EF0F712_L280C47>(!!0, float64, string, bool, bool)
 		IL_0dd6: stloc.s 62
 		IL_0dd8: ldloc.s 4
 		IL_0dda: ldloc.s 6
@@ -8164,13 +16482,13 @@
 		IL_0dfe: ldc.i4.0
 		IL_0dff: ldelem.ref
 		IL_0e00: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0e05: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_0304DE8C_L285C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0e05: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject_FunctionExpression_0304DE8C_L285C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0e0a: ldc.i4.0
 		IL_0e0b: conv.r8
 		IL_0e0c: ldstr ""
 		IL_0e11: ldc.i4.0
 		IL_0e12: ldc.i4.1
-		IL_0e13: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_0304DE8C_L285C6>(!!0, float64, string, bool, bool)
+		IL_0e13: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5/FunctionObject_FunctionExpression_0304DE8C_L285C6>(!!0, float64, string, bool, bool)
 		IL_0e18: stloc.s 63
 		IL_0e1a: ldloc.3
 		IL_0e1b: ldloc.s 6
@@ -8190,13 +16508,13 @@
 		IL_0e3a: ldc.i4.0
 		IL_0e3b: ldelem.ref
 		IL_0e3c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0e41: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_D94750FD_L289C56::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0e41: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject_FunctionExpression_D94750FD_L289C56::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0e46: ldc.i4.0
 		IL_0e47: conv.r8
 		IL_0e48: ldstr ""
 		IL_0e4d: ldc.i4.0
 		IL_0e4e: ldc.i4.1
-		IL_0e4f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_D94750FD_L289C56>(!!0, float64, string, bool, bool)
+		IL_0e4f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionObject_FunctionExpression_D94750FD_L289C56>(!!0, float64, string, bool, bool)
 		IL_0e54: stloc.s 64
 		IL_0e56: ldloc.s 4
 		IL_0e58: ldloc.s 6
@@ -8217,13 +16535,13 @@
 		IL_0e7c: ldc.i4.0
 		IL_0e7d: ldelem.ref
 		IL_0e7e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0e83: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_29656618_L296C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0e83: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject_FunctionExpression_29656618_L296C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0e88: ldc.i4.0
 		IL_0e89: conv.r8
 		IL_0e8a: ldstr ""
 		IL_0e8f: ldc.i4.0
 		IL_0e90: ldc.i4.1
-		IL_0e91: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_29656618_L296C6>(!!0, float64, string, bool, bool)
+		IL_0e91: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5/FunctionObject_FunctionExpression_29656618_L296C6>(!!0, float64, string, bool, bool)
 		IL_0e96: stloc.s 65
 		IL_0e98: ldloc.3
 		IL_0e99: ldloc.s 6
@@ -8243,13 +16561,13 @@
 		IL_0eb8: ldc.i4.0
 		IL_0eb9: ldelem.ref
 		IL_0eba: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0ebf: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1062EA27_L300C65::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0ebf: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject_FunctionExpression_1062EA27_L300C65::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0ec4: ldc.i4.0
 		IL_0ec5: conv.r8
 		IL_0ec6: ldstr ""
 		IL_0ecb: ldc.i4.0
 		IL_0ecc: ldc.i4.1
-		IL_0ecd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1062EA27_L300C65>(!!0, float64, string, bool, bool)
+		IL_0ecd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionObject_FunctionExpression_1062EA27_L300C65>(!!0, float64, string, bool, bool)
 		IL_0ed2: stloc.s 66
 		IL_0ed4: ldloc.s 4
 		IL_0ed6: ldloc.s 6
@@ -8270,13 +16588,13 @@
 		IL_0efa: ldc.i4.0
 		IL_0efb: ldelem.ref
 		IL_0efc: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0f01: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_612413E3_L309C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0f01: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject_FunctionExpression_612413E3_L309C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0f06: ldc.i4.0
 		IL_0f07: conv.r8
 		IL_0f08: ldstr ""
 		IL_0f0d: ldc.i4.0
 		IL_0f0e: ldc.i4.1
-		IL_0f0f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_612413E3_L309C6>(!!0, float64, string, bool, bool)
+		IL_0f0f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5/FunctionObject_FunctionExpression_612413E3_L309C6>(!!0, float64, string, bool, bool)
 		IL_0f14: stloc.s 67
 		IL_0f16: ldloc.3
 		IL_0f17: ldloc.s 6
@@ -8296,13 +16614,13 @@
 		IL_0f36: ldc.i4.0
 		IL_0f37: ldelem.ref
 		IL_0f38: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0f3d: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_5D299276_L313C26::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0f3d: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject_FunctionExpression_5D299276_L313C26::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0f42: ldc.i4.0
 		IL_0f43: conv.r8
 		IL_0f44: ldstr ""
 		IL_0f49: ldc.i4.0
 		IL_0f4a: ldc.i4.1
-		IL_0f4b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_5D299276_L313C26>(!!0, float64, string, bool, bool)
+		IL_0f4b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25/FunctionObject_FunctionExpression_5D299276_L313C26>(!!0, float64, string, bool, bool)
 		IL_0f50: stloc.s 68
 		IL_0f52: ldloc.s 4
 		IL_0f54: ldloc.s 6
@@ -8323,13 +16641,13 @@
 		IL_0f78: ldc.i4.0
 		IL_0f79: ldelem.ref
 		IL_0f7a: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0f7f: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AF818725_L318C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0f7f: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject_FunctionExpression_AF818725_L318C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0f84: ldc.i4.0
 		IL_0f85: conv.r8
 		IL_0f86: ldstr ""
 		IL_0f8b: ldc.i4.0
 		IL_0f8c: ldc.i4.1
-		IL_0f8d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AF818725_L318C6>(!!0, float64, string, bool, bool)
+		IL_0f8d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5/FunctionObject_FunctionExpression_AF818725_L318C6>(!!0, float64, string, bool, bool)
 		IL_0f92: stloc.s 69
 		IL_0f94: ldloc.3
 		IL_0f95: ldloc.s 6
@@ -8349,13 +16667,13 @@
 		IL_0fb4: ldc.i4.0
 		IL_0fb5: ldelem.ref
 		IL_0fb6: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0fbb: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_64DC70FB_L322C25::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0fbb: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject_FunctionExpression_64DC70FB_L322C25::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_0fc0: ldc.i4.0
 		IL_0fc1: conv.r8
 		IL_0fc2: ldstr ""
 		IL_0fc7: ldc.i4.0
 		IL_0fc8: ldc.i4.1
-		IL_0fc9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_64DC70FB_L322C25>(!!0, float64, string, bool, bool)
+		IL_0fc9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24/FunctionObject_FunctionExpression_64DC70FB_L322C25>(!!0, float64, string, bool, bool)
 		IL_0fce: stloc.s 70
 		IL_0fd0: ldloc.s 4
 		IL_0fd2: ldloc.s 6
@@ -8376,13 +16694,13 @@
 		IL_0ff6: ldc.i4.0
 		IL_0ff7: ldelem.ref
 		IL_0ff8: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_0ffd: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_455C0AC7_L327C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_0ffd: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject_FunctionExpression_455C0AC7_L327C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_1002: ldc.i4.0
 		IL_1003: conv.r8
 		IL_1004: ldstr ""
 		IL_1009: ldc.i4.0
 		IL_100a: ldc.i4.1
-		IL_100b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_455C0AC7_L327C6>(!!0, float64, string, bool, bool)
+		IL_100b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5/FunctionObject_FunctionExpression_455C0AC7_L327C6>(!!0, float64, string, bool, bool)
 		IL_1010: stloc.s 71
 		IL_1012: ldloc.3
 		IL_1013: ldloc.s 6
@@ -8402,13 +16720,13 @@
 		IL_1032: ldc.i4.0
 		IL_1033: ldelem.ref
 		IL_1034: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1039: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_C0E29ED5_L331C34::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_1039: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject_FunctionExpression_C0E29ED5_L331C34::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_103e: ldc.i4.0
 		IL_103f: conv.r8
 		IL_1040: ldstr ""
 		IL_1045: ldc.i4.0
 		IL_1046: ldc.i4.1
-		IL_1047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_C0E29ED5_L331C34>(!!0, float64, string, bool, bool)
+		IL_1047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33/FunctionObject_FunctionExpression_C0E29ED5_L331C34>(!!0, float64, string, bool, bool)
 		IL_104c: stloc.s 72
 		IL_104e: ldloc.s 4
 		IL_1050: ldloc.s 6
@@ -8429,13 +16747,13 @@
 		IL_1074: ldc.i4.0
 		IL_1075: ldelem.ref
 		IL_1076: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_107b: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_78E8D78D_L336C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_107b: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject_FunctionExpression_78E8D78D_L336C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_1080: ldc.i4.0
 		IL_1081: conv.r8
 		IL_1082: ldstr ""
 		IL_1087: ldc.i4.0
 		IL_1088: ldc.i4.1
-		IL_1089: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_78E8D78D_L336C6>(!!0, float64, string, bool, bool)
+		IL_1089: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5/FunctionObject_FunctionExpression_78E8D78D_L336C6>(!!0, float64, string, bool, bool)
 		IL_108e: stloc.s 73
 		IL_1090: ldloc.3
 		IL_1091: ldloc.s 6
@@ -8455,13 +16773,13 @@
 		IL_10b0: ldc.i4.0
 		IL_10b1: ldelem.ref
 		IL_10b2: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_10b7: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_31C4DBA7_L340C36::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_10b7: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject_FunctionExpression_31C4DBA7_L340C36::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_10bc: ldc.i4.0
 		IL_10bd: conv.r8
 		IL_10be: ldstr ""
 		IL_10c3: ldc.i4.0
 		IL_10c4: ldc.i4.1
-		IL_10c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_31C4DBA7_L340C36>(!!0, float64, string, bool, bool)
+		IL_10c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35/FunctionObject_FunctionExpression_31C4DBA7_L340C36>(!!0, float64, string, bool, bool)
 		IL_10ca: stloc.s 74
 		IL_10cc: ldloc.s 4
 		IL_10ce: ldloc.s 6
@@ -8482,13 +16800,13 @@
 		IL_10f2: ldc.i4.0
 		IL_10f3: ldelem.ref
 		IL_10f4: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_10f9: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_ADC77423_L345C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_10f9: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject_FunctionExpression_ADC77423_L345C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_10fe: ldc.i4.0
 		IL_10ff: conv.r8
 		IL_1100: ldstr ""
 		IL_1105: ldc.i4.0
 		IL_1106: ldc.i4.1
-		IL_1107: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_ADC77423_L345C6>(!!0, float64, string, bool, bool)
+		IL_1107: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5/FunctionObject_FunctionExpression_ADC77423_L345C6>(!!0, float64, string, bool, bool)
 		IL_110c: stloc.s 75
 		IL_110e: ldloc.3
 		IL_110f: ldloc.s 6
@@ -8508,13 +16826,13 @@
 		IL_112e: ldc.i4.0
 		IL_112f: ldelem.ref
 		IL_1130: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1135: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AB0D0A79_L349C33::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_1135: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject_FunctionExpression_AB0D0A79_L349C33::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_113a: ldc.i4.0
 		IL_113b: conv.r8
 		IL_113c: ldstr ""
 		IL_1141: ldc.i4.0
 		IL_1142: ldc.i4.1
-		IL_1143: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AB0D0A79_L349C33>(!!0, float64, string, bool, bool)
+		IL_1143: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32/FunctionObject_FunctionExpression_AB0D0A79_L349C33>(!!0, float64, string, bool, bool)
 		IL_1148: stloc.s 76
 		IL_114a: ldloc.s 4
 		IL_114c: ldloc.s 6
@@ -8535,13 +16853,13 @@
 		IL_1170: ldc.i4.0
 		IL_1171: ldelem.ref
 		IL_1172: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1177: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_FE9F5065_L354C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_1177: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject_FunctionExpression_FE9F5065_L354C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_117c: ldc.i4.0
 		IL_117d: conv.r8
 		IL_117e: ldstr ""
 		IL_1183: ldc.i4.0
 		IL_1184: ldc.i4.1
-		IL_1185: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_FE9F5065_L354C6>(!!0, float64, string, bool, bool)
+		IL_1185: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5/FunctionObject_FunctionExpression_FE9F5065_L354C6>(!!0, float64, string, bool, bool)
 		IL_118a: stloc.s 77
 		IL_118c: ldloc.3
 		IL_118d: ldloc.s 6
@@ -8561,13 +16879,13 @@
 		IL_11ac: ldc.i4.0
 		IL_11ad: ldelem.ref
 		IL_11ae: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_11b3: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_48BE92D8_L358C32::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_11b3: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject_FunctionExpression_48BE92D8_L358C32::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_11b8: ldc.i4.0
 		IL_11b9: conv.r8
 		IL_11ba: ldstr ""
 		IL_11bf: ldc.i4.0
 		IL_11c0: ldc.i4.1
-		IL_11c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_48BE92D8_L358C32>(!!0, float64, string, bool, bool)
+		IL_11c1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31/FunctionObject_FunctionExpression_48BE92D8_L358C32>(!!0, float64, string, bool, bool)
 		IL_11c6: stloc.s 78
 		IL_11c8: ldloc.s 4
 		IL_11ca: ldloc.s 6
@@ -8588,13 +16906,13 @@
 		IL_11ee: ldc.i4.0
 		IL_11ef: ldelem.ref
 		IL_11f0: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_11f5: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_4D9B395F_L363C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_11f5: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject_FunctionExpression_4D9B395F_L363C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_11fa: ldc.i4.0
 		IL_11fb: conv.r8
 		IL_11fc: ldstr ""
 		IL_1201: ldc.i4.0
 		IL_1202: ldc.i4.1
-		IL_1203: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_4D9B395F_L363C6>(!!0, float64, string, bool, bool)
+		IL_1203: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5/FunctionObject_FunctionExpression_4D9B395F_L363C6>(!!0, float64, string, bool, bool)
 		IL_1208: stloc.s 79
 		IL_120a: ldloc.3
 		IL_120b: ldloc.s 6
@@ -8614,13 +16932,13 @@
 		IL_122a: ldc.i4.0
 		IL_122b: ldelem.ref
 		IL_122c: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1231: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_222F9CF0_L367C41::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_1231: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject_FunctionExpression_222F9CF0_L367C41::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_1236: ldc.i4.0
 		IL_1237: conv.r8
 		IL_1238: ldstr ""
 		IL_123d: ldc.i4.0
 		IL_123e: ldc.i4.1
-		IL_123f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_222F9CF0_L367C41>(!!0, float64, string, bool, bool)
+		IL_123f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40/FunctionObject_FunctionExpression_222F9CF0_L367C41>(!!0, float64, string, bool, bool)
 		IL_1244: stloc.s 80
 		IL_1246: ldloc.s 4
 		IL_1248: ldloc.s 6
@@ -8641,13 +16959,13 @@
 		IL_126c: ldc.i4.0
 		IL_126d: ldelem.ref
 		IL_126e: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_1273: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F85E69FD_L372C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_1273: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject_FunctionExpression_F85E69FD_L372C6::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_1278: ldc.i4.0
 		IL_1279: conv.r8
 		IL_127a: ldstr ""
 		IL_127f: ldc.i4.0
 		IL_1280: ldc.i4.1
-		IL_1281: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F85E69FD_L372C6>(!!0, float64, string, bool, bool)
+		IL_1281: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5/FunctionObject_FunctionExpression_F85E69FD_L372C6>(!!0, float64, string, bool, bool)
 		IL_1286: stloc.s 81
 		IL_1288: ldloc.3
 		IL_1289: ldloc.s 6
@@ -8667,13 +16985,13 @@
 		IL_12a8: ldc.i4.0
 		IL_12a9: ldelem.ref
 		IL_12aa: castclass Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope
-		IL_12af: newobj instance void FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_9DF3FAC8_L376C43::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
+		IL_12af: newobj instance void Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject_FunctionExpression_9DF3FAC8_L376C43::.ctor(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope)
 		IL_12b4: ldc.i4.0
 		IL_12b5: conv.r8
 		IL_12b6: ldstr ""
 		IL_12bb: ldc.i4.0
 		IL_12bc: ldc.i4.1
-		IL_12bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_9DF3FAC8_L376C43>(!!0, float64, string, bool, bool)
+		IL_12bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42/FunctionObject_FunctionExpression_9DF3FAC8_L376C43>(!!0, float64, string, bool, bool)
 		IL_12c2: stloc.s 82
 		IL_12c4: ldloc.s 4
 		IL_12c6: ldloc.s 6
@@ -8689,8324 +17007,6 @@
 	} // end of method Compile_Performance_Dromaeo_Object_Regexp::__js_module_init__
 
 } // end of class Modules.Compile_Performance_Dromaeo_Object_Regexp
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_6CF2F656_startTest
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x5363
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_6CF2F656_startTest::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x536b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6CF2F656_startTest::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x536e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6CF2F656_startTest::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5371
-		// Header size: 1
-		// Code size: 35 (0x23)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_001d: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/startTest::__js_call__(object, string, string)
-		IL_0022: ret
-	} // end of method FunctionObject_FunctionDeclaration_6CF2F656_startTest::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5395
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0019: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/startTest::__js_call__(object, string, string)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_6CF2F656_startTest::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x53b5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6CF2F656_startTest::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_6CF2F656_startTest
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_B7494A8F_endTest
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x53c4
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_B7494A8F_endTest::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x53cc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B7494A8F_endTest::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x53cf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B7494A8F_endTest::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x53d2
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/endTest::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_B7494A8F_endTest::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x53de
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/endTest::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_B7494A8F_endTest::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x53e6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B7494A8F_endTest::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_B7494A8F_endTest
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_6F708165_prep
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x53f5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_6F708165_prep::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x53fd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6F708165_prep::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5400
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6F708165_prep::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5403
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_6F708165_prep::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5416
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/prep::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6F708165_prep::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5425
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6F708165_prep::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_6F708165_prep
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_F3312FC6_test
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x5434
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_F3312FC6_test::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x543c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F3312FC6_test::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x543f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F3312FC6_test::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5442
-		// Header size: 1
-		// Code size: 30 (0x1e)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
-		IL_001d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F3312FC6_test::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5461
-		// Header size: 1
-		// Code size: 26 (0x1a)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/test::__js_call__(object, string, object)
-		IL_0019: ret
-	} // end of method FunctionObject_FunctionDeclaration_F3312FC6_test::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x547c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F3312FC6_test::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_F3312FC6_test
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_7C555EF1_randomChar
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x548b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_7C555EF1_randomChar::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5493
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7C555EF1_randomChar::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5496
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7C555EF1_randomChar::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5499
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call string Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_7C555EF1_randomChar::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x54a5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call string Modules.Compile_Performance_Dromaeo_Object_Regexp/randomChar::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_7C555EF1_randomChar::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x54ad
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_7C555EF1_randomChar::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_7C555EF1_randomChar
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_244F5225_generateTestStrings
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x54bc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x54cb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x54ce
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x54d1
-		// Header size: 1
-		// Code size: 29 (0x1d)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0017: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-		IL_001c: ret
-	} // end of method FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x54ef
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0013: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Performance_Dromaeo_Object_Regexp/generateTestStrings::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object, float64)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5509
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_244F5225_generateTestStrings::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionDeclaration_244F5225_generateTestStrings
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_84CD8439_L48C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5518
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_84CD8439_L48C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_84CD8439_L48C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5527
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_84CD8439_L48C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x552a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_84CD8439_L48C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x552d
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_84CD8439_L48C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_84CD8439_L48C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x553f
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_84CD8439_L48C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L48C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_84CD8439_L48C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x554d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_84CD8439_L48C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_84CD8439_L48C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_40DF050A_L56C37
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x555c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_40DF050A_L56C37::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_40DF050A_L56C37::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x556b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_40DF050A_L56C37::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x556e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_40DF050A_L56C37::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5571
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_40DF050A_L56C37::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_40DF050A_L56C37::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5583
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_40DF050A_L56C37::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L56C36::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_40DF050A_L56C37::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5591
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_40DF050A_L56C37::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_40DF050A_L56C37
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_367F8A10_L61C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x55a0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_367F8A10_L61C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_367F8A10_L61C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x55af
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_367F8A10_L61C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x55b2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_367F8A10_L61C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x55b5
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_367F8A10_L61C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_367F8A10_L61C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x55c7
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_367F8A10_L61C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L61C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_367F8A10_L61C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x55d5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_367F8A10_L61C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_367F8A10_L61C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_048224EC_L66C36
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x55e4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_048224EC_L66C36::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_048224EC_L66C36::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x55f3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_048224EC_L66C36::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x55f6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_048224EC_L66C36::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x55f9
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_048224EC_L66C36::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_048224EC_L66C36::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x560b
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_048224EC_L66C36::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L66C35::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_048224EC_L66C36::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5619
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_048224EC_L66C36::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_048224EC_L66C36
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_7C0CF449_L71C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5628
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_7C0CF449_L71C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7C0CF449_L71C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5637
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7C0CF449_L71C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x563a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7C0CF449_L71C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x563d
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_7C0CF449_L71C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_7C0CF449_L71C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x564f
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_7C0CF449_L71C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L71C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_7C0CF449_L71C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x565d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7C0CF449_L71C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_7C0CF449_L71C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_99D19962_L76C40
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x566c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_99D19962_L76C40::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_99D19962_L76C40::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x567b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_99D19962_L76C40::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x567e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_99D19962_L76C40::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5681
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_99D19962_L76C40::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_99D19962_L76C40::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5693
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_99D19962_L76C40::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L76C39::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_99D19962_L76C40::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x56a1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_99D19962_L76C40::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_99D19962_L76C40
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F1E0E698_L83C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x56b0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F1E0E698_L83C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F1E0E698_L83C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x56bf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F1E0E698_L83C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x56c2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F1E0E698_L83C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x56c5
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F1E0E698_L83C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_F1E0E698_L83C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x56d7
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F1E0E698_L83C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L83C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_F1E0E698_L83C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x56e5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F1E0E698_L83C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F1E0E698_L83C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_E322D6B7_L88C24
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x56f4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_E322D6B7_L88C24::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E322D6B7_L88C24::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5703
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E322D6B7_L88C24::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5706
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E322D6B7_L88C24::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5709
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_E322D6B7_L88C24::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_E322D6B7_L88C24::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x571b
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_E322D6B7_L88C24::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L88C23::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_E322D6B7_L88C24::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5729
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E322D6B7_L88C24::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_E322D6B7_L88C24
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_83D3F4FD_L93C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5738
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_83D3F4FD_L93C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_83D3F4FD_L93C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5747
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_83D3F4FD_L93C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x574a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_83D3F4FD_L93C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x574d
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_83D3F4FD_L93C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_83D3F4FD_L93C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x575f
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_83D3F4FD_L93C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L93C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_83D3F4FD_L93C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x576d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_83D3F4FD_L93C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_83D3F4FD_L93C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_300CE2EA_L97C23
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x577c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_300CE2EA_L97C23::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_300CE2EA_L97C23::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x578b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_300CE2EA_L97C23::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x578e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_300CE2EA_L97C23::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5791
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_300CE2EA_L97C23::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_300CE2EA_L97C23::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x57a3
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_300CE2EA_L97C23::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L97C22::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_300CE2EA_L97C23::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x57b1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_300CE2EA_L97C23::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_300CE2EA_L97C23
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_15168718_L102C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x57c0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_15168718_L102C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_15168718_L102C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x57cf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_15168718_L102C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x57d2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_15168718_L102C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x57d5
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_15168718_L102C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_15168718_L102C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x57e7
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_15168718_L102C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L102C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_15168718_L102C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x57f5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_15168718_L102C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_15168718_L102C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AADD4623_L106C32
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5804
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AADD4623_L106C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_AADD4623_L106C32::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5813
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_AADD4623_L106C32::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5816
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_AADD4623_L106C32::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5819
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AADD4623_L106C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_AADD4623_L106C32::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x582b
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AADD4623_L106C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L106C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_AADD4623_L106C32::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5839
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_AADD4623_L106C32::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AADD4623_L106C32
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_35949A34_L111C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5848
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_35949A34_L111C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_35949A34_L111C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5857
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_35949A34_L111C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x585a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_35949A34_L111C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x585d
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_35949A34_L111C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_35949A34_L111C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x586f
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_35949A34_L111C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L111C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_35949A34_L111C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x587d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_35949A34_L111C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_35949A34_L111C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_123E59E1_L115C34
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x588c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_123E59E1_L115C34::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_123E59E1_L115C34::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x589b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_123E59E1_L115C34::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x589e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_123E59E1_L115C34::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x58a1
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_123E59E1_L115C34::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_123E59E1_L115C34::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x58b3
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_123E59E1_L115C34::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L115C33::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_123E59E1_L115C34::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x58c1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_123E59E1_L115C34::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_123E59E1_L115C34
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1A1A3900_L120C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x58d0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1A1A3900_L120C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1A1A3900_L120C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x58df
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1A1A3900_L120C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x58e2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1A1A3900_L120C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x58e5
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1A1A3900_L120C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_1A1A3900_L120C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x58f7
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1A1A3900_L120C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L120C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_1A1A3900_L120C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5905
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1A1A3900_L120C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1A1A3900_L120C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_A14DF61B_L125C31
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5914
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_A14DF61B_L125C31::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A14DF61B_L125C31::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5923
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A14DF61B_L125C31::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5926
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A14DF61B_L125C31::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5929
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_A14DF61B_L125C31::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_A14DF61B_L125C31::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x593b
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_A14DF61B_L125C31::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L125C30::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_A14DF61B_L125C31::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5949
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A14DF61B_L125C31::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_A14DF61B_L125C31
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_FEC96B05_L130C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5958
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_FEC96B05_L130C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_FEC96B05_L130C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5967
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FEC96B05_L130C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x596a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FEC96B05_L130C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x596d
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_FEC96B05_L130C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_FEC96B05_L130C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x597f
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_FEC96B05_L130C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L130C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_FEC96B05_L130C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x598d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_FEC96B05_L130C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_FEC96B05_L130C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_A2B06A06_L134C30
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x599c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_A2B06A06_L134C30::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A2B06A06_L134C30::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x59ab
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A2B06A06_L134C30::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x59ae
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A2B06A06_L134C30::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x59b1
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_A2B06A06_L134C30::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_A2B06A06_L134C30::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x59c3
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_A2B06A06_L134C30::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L134C29::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_A2B06A06_L134C30::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x59d1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A2B06A06_L134C30::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_A2B06A06_L134C30
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_826BD7E2_L139C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x59e0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_826BD7E2_L139C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_826BD7E2_L139C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x59ef
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_826BD7E2_L139C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x59f2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_826BD7E2_L139C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x59f5
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_826BD7E2_L139C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_826BD7E2_L139C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5a07
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_826BD7E2_L139C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L139C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_826BD7E2_L139C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5a15
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_826BD7E2_L139C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_826BD7E2_L139C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_52BFD713_L143C39
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5a24
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_52BFD713_L143C39::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_52BFD713_L143C39::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5a33
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_52BFD713_L143C39::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5a36
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_52BFD713_L143C39::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5a39
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_52BFD713_L143C39::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_52BFD713_L143C39::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5a4b
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_52BFD713_L143C39::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L143C38::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_52BFD713_L143C39::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5a59
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_52BFD713_L143C39::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_52BFD713_L143C39
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_ADF86AB6_L148C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5a68
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_ADF86AB6_L148C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_ADF86AB6_L148C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5a77
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_ADF86AB6_L148C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5a7a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_ADF86AB6_L148C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5a7d
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_ADF86AB6_L148C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_ADF86AB6_L148C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5a8f
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_ADF86AB6_L148C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L148C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_ADF86AB6_L148C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5a9d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_ADF86AB6_L148C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_ADF86AB6_L148C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6A51803A_L152C41
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5aac
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6A51803A_L152C41::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_6A51803A_L152C41::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5abb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6A51803A_L152C41::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5abe
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6A51803A_L152C41::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5ac1
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6A51803A_L152C41::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_6A51803A_L152C41::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5ad3
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6A51803A_L152C41::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L152C40::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_6A51803A_L152C41::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5ae1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_6A51803A_L152C41::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6A51803A_L152C41
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_59F53CDE_L157C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5af0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_59F53CDE_L157C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_59F53CDE_L157C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5aff
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_59F53CDE_L157C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5b02
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_59F53CDE_L157C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5b05
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_59F53CDE_L157C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_59F53CDE_L157C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5b17
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_59F53CDE_L157C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L157C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_59F53CDE_L157C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5b25
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_59F53CDE_L157C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_59F53CDE_L157C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F7D2F9E6_L161C50
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5b34
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F7D2F9E6_L161C50::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F7D2F9E6_L161C50::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5b43
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F7D2F9E6_L161C50::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5b46
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F7D2F9E6_L161C50::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5b49
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F7D2F9E6_L161C50::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_F7D2F9E6_L161C50::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5b5b
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F7D2F9E6_L161C50::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_F7D2F9E6_L161C50::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5b69
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F7D2F9E6_L161C50::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F7D2F9E6_L161C50
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_D2F1EA44_L163C34
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x5b78
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_D2F1EA44_L163C34::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5b80
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D2F1EA44_L163C34::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5b83
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D2F1EA44_L163C34::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5b86
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionExpression_L163C33::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_D2F1EA44_L163C34::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5b99
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L161C49/FunctionExpression_L163C33::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D2F1EA44_L163C34::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5ba8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D2F1EA44_L163C34::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_D2F1EA44_L163C34
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_5BE125D1_L170C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5bb7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_5BE125D1_L170C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5BE125D1_L170C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5bc6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5BE125D1_L170C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5bc9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5BE125D1_L170C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5bcc
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_5BE125D1_L170C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_5BE125D1_L170C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5bde
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_5BE125D1_L170C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L170C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_5BE125D1_L170C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5bec
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5BE125D1_L170C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_5BE125D1_L170C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_E6D30A9E_L175C33
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5bfb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_E6D30A9E_L175C33::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E6D30A9E_L175C33::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5c0a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E6D30A9E_L175C33::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5c0d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E6D30A9E_L175C33::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5c10
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_E6D30A9E_L175C33::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_E6D30A9E_L175C33::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5c22
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_E6D30A9E_L175C33::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L175C32::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_E6D30A9E_L175C33::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5c30
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E6D30A9E_L175C33::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_E6D30A9E_L175C33
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_316E4A1A_L180C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5c3f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_316E4A1A_L180C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_316E4A1A_L180C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5c4e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_316E4A1A_L180C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5c51
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_316E4A1A_L180C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5c54
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_316E4A1A_L180C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_316E4A1A_L180C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5c66
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_316E4A1A_L180C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L180C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_316E4A1A_L180C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5c74
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_316E4A1A_L180C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_316E4A1A_L180C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F75042ED_L184C32
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5c83
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F75042ED_L184C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F75042ED_L184C32::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5c92
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F75042ED_L184C32::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5c95
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F75042ED_L184C32::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5c98
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F75042ED_L184C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_F75042ED_L184C32::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5caa
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F75042ED_L184C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L184C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_F75042ED_L184C32::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5cb8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F75042ED_L184C32::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F75042ED_L184C32
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_DE23A66D_L189C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5cc7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_DE23A66D_L189C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DE23A66D_L189C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5cd6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DE23A66D_L189C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5cd9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DE23A66D_L189C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5cdc
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_DE23A66D_L189C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_DE23A66D_L189C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5cee
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_DE23A66D_L189C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L189C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_DE23A66D_L189C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5cfc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DE23A66D_L189C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_DE23A66D_L189C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_59F2FA63_L193C41
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5d0b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_59F2FA63_L193C41::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_59F2FA63_L193C41::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5d1a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_59F2FA63_L193C41::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5d1d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_59F2FA63_L193C41::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5d20
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_59F2FA63_L193C41::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_59F2FA63_L193C41::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5d32
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_59F2FA63_L193C41::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L193C40::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_59F2FA63_L193C41::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5d40
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_59F2FA63_L193C41::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_59F2FA63_L193C41
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_FD52FD47_L198C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5d4f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_FD52FD47_L198C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_FD52FD47_L198C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5d5e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FD52FD47_L198C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5d61
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FD52FD47_L198C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5d64
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_FD52FD47_L198C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_FD52FD47_L198C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5d76
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_FD52FD47_L198C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L198C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_FD52FD47_L198C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5d84
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_FD52FD47_L198C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_FD52FD47_L198C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AB7296C4_L202C43
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5d93
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AB7296C4_L202C43::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_AB7296C4_L202C43::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5da2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_AB7296C4_L202C43::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5da5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_AB7296C4_L202C43::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5da8
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AB7296C4_L202C43::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_AB7296C4_L202C43::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5dba
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AB7296C4_L202C43::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L202C42::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_AB7296C4_L202C43::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5dc8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_AB7296C4_L202C43::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AB7296C4_L202C43
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6250884E_L207C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5dd7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6250884E_L207C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_6250884E_L207C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5de6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6250884E_L207C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5de9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6250884E_L207C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5dec
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6250884E_L207C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_6250884E_L207C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5dfe
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6250884E_L207C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L207C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_6250884E_L207C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5e0c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_6250884E_L207C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6250884E_L207C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_9FBA592E_L212C40
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5e1b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_9FBA592E_L212C40::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_9FBA592E_L212C40::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5e2a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9FBA592E_L212C40::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5e2d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9FBA592E_L212C40::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5e30
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_9FBA592E_L212C40::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_9FBA592E_L212C40::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5e42
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_9FBA592E_L212C40::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L212C39::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_9FBA592E_L212C40::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5e50
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_9FBA592E_L212C40::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_9FBA592E_L212C40
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6442B403_L217C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5e5f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6442B403_L217C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_6442B403_L217C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5e6e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6442B403_L217C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5e71
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6442B403_L217C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5e74
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6442B403_L217C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_6442B403_L217C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5e86
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6442B403_L217C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L217C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_6442B403_L217C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5e94
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_6442B403_L217C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6442B403_L217C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_7B23A4A4_L221C39
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5ea3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_7B23A4A4_L221C39::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7B23A4A4_L221C39::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5eb2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7B23A4A4_L221C39::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5eb5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7B23A4A4_L221C39::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5eb8
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_7B23A4A4_L221C39::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_7B23A4A4_L221C39::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5eca
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_7B23A4A4_L221C39::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L221C38::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_7B23A4A4_L221C39::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5ed8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7B23A4A4_L221C39::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_7B23A4A4_L221C39
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_15CEA57B_L226C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5ee7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_15CEA57B_L226C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_15CEA57B_L226C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5ef6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_15CEA57B_L226C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5ef9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_15CEA57B_L226C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5efc
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_15CEA57B_L226C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_15CEA57B_L226C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5f0e
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_15CEA57B_L226C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L226C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_15CEA57B_L226C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5f1c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_15CEA57B_L226C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_15CEA57B_L226C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_CE64C73E_L230C48
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5f2b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_CE64C73E_L230C48::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_CE64C73E_L230C48::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5f3a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_CE64C73E_L230C48::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5f3d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_CE64C73E_L230C48::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5f40
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_CE64C73E_L230C48::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_CE64C73E_L230C48::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5f52
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_CE64C73E_L230C48::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L230C47::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_CE64C73E_L230C48::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5f60
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_CE64C73E_L230C48::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_CE64C73E_L230C48
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6B3295AB_L235C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5f6f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6B3295AB_L235C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_6B3295AB_L235C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5f7e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6B3295AB_L235C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5f81
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6B3295AB_L235C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5f84
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6B3295AB_L235C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_6B3295AB_L235C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5f96
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6B3295AB_L235C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L235C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_6B3295AB_L235C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5fa4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_6B3295AB_L235C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6B3295AB_L235C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1419E03E_L239C50
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5fb3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1419E03E_L239C50::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1419E03E_L239C50::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5fc2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1419E03E_L239C50::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5fc5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1419E03E_L239C50::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5fc8
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1419E03E_L239C50::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_1419E03E_L239C50::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5fda
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1419E03E_L239C50::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L239C49::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_1419E03E_L239C50::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5fe8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1419E03E_L239C50::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1419E03E_L239C50
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1AD25763_L244C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x5ff7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1AD25763_L244C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1AD25763_L244C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6006
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1AD25763_L244C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6009
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1AD25763_L244C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x600c
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1AD25763_L244C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_1AD25763_L244C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x601e
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1AD25763_L244C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L244C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_1AD25763_L244C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x602c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1AD25763_L244C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1AD25763_L244C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_B68C9781_L248C59
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x603b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_B68C9781_L248C59::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_B68C9781_L248C59::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x604a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_B68C9781_L248C59::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x604d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_B68C9781_L248C59::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6050
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_B68C9781_L248C59::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_B68C9781_L248C59::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6062
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_B68C9781_L248C59::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_B68C9781_L248C59::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6070
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_B68C9781_L248C59::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_B68C9781_L248C59
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_44DC3DAF_L250C34
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x607f
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_44DC3DAF_L250C34::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6087
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_44DC3DAF_L250C34::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x608a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_44DC3DAF_L250C34::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x608d
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionExpression_L250C33::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_44DC3DAF_L250C34::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x60a0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L248C58/FunctionExpression_L250C33::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_44DC3DAF_L250C34::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x60af
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_44DC3DAF_L250C34::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_44DC3DAF_L250C34
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_62C7C36F_L257C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x60be
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_62C7C36F_L257C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_62C7C36F_L257C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x60cd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_62C7C36F_L257C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x60d0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_62C7C36F_L257C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x60d3
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_62C7C36F_L257C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_62C7C36F_L257C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x60e5
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_62C7C36F_L257C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L257C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_62C7C36F_L257C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x60f3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_62C7C36F_L257C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_62C7C36F_L257C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_BE52CC8A_L262C32
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6102
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_BE52CC8A_L262C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_BE52CC8A_L262C32::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6111
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_BE52CC8A_L262C32::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6114
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_BE52CC8A_L262C32::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6117
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_BE52CC8A_L262C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_BE52CC8A_L262C32::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6129
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_BE52CC8A_L262C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L262C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_BE52CC8A_L262C32::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6137
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_BE52CC8A_L262C32::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_BE52CC8A_L262C32
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1AD7FAC4_L267C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6146
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1AD7FAC4_L267C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1AD7FAC4_L267C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6155
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1AD7FAC4_L267C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6158
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1AD7FAC4_L267C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x615b
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1AD7FAC4_L267C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_1AD7FAC4_L267C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x616d
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1AD7FAC4_L267C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L267C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_1AD7FAC4_L267C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x617b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1AD7FAC4_L267C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1AD7FAC4_L267C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_75E34588_L271C34
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x618a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_75E34588_L271C34::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_75E34588_L271C34::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6199
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_75E34588_L271C34::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x619c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_75E34588_L271C34::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x619f
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_75E34588_L271C34::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_75E34588_L271C34::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x61b1
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_75E34588_L271C34::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L271C33::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_75E34588_L271C34::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x61bf
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_75E34588_L271C34::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_75E34588_L271C34
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_98DF622E_L276C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x61ce
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_98DF622E_L276C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_98DF622E_L276C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x61dd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_98DF622E_L276C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x61e0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_98DF622E_L276C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x61e3
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_98DF622E_L276C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_98DF622E_L276C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x61f5
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_98DF622E_L276C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L276C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_98DF622E_L276C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6203
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_98DF622E_L276C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_98DF622E_L276C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6EF0F712_L280C47
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6212
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6EF0F712_L280C47::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_6EF0F712_L280C47::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6221
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6EF0F712_L280C47::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6224
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6EF0F712_L280C47::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6227
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6EF0F712_L280C47::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_6EF0F712_L280C47::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6239
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6EF0F712_L280C47::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L280C46::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_6EF0F712_L280C47::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6247
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_6EF0F712_L280C47::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_6EF0F712_L280C47
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_0304DE8C_L285C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6256
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_0304DE8C_L285C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_0304DE8C_L285C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6265
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_0304DE8C_L285C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6268
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_0304DE8C_L285C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x626b
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_0304DE8C_L285C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_0304DE8C_L285C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x627d
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_0304DE8C_L285C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L285C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_0304DE8C_L285C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x628b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_0304DE8C_L285C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_0304DE8C_L285C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_D94750FD_L289C56
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x629a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_D94750FD_L289C56::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D94750FD_L289C56::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x62a9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D94750FD_L289C56::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x62ac
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D94750FD_L289C56::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x62af
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_D94750FD_L289C56::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_D94750FD_L289C56::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x62c1
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_D94750FD_L289C56::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_D94750FD_L289C56::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x62cf
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D94750FD_L289C56::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_D94750FD_L289C56
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_561F59BC_L291C34
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x62de
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_561F59BC_L291C34::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x62e6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_561F59BC_L291C34::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x62e9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_561F59BC_L291C34::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x62ec
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionExpression_L291C33::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_561F59BC_L291C34::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6306
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L289C55/FunctionExpression_L291C33::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_561F59BC_L291C34::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x631c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_561F59BC_L291C34::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_561F59BC_L291C34
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_29656618_L296C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x632b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_29656618_L296C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_29656618_L296C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x633a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_29656618_L296C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x633d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_29656618_L296C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6340
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_29656618_L296C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_29656618_L296C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6352
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_29656618_L296C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L296C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_29656618_L296C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6360
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_29656618_L296C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_29656618_L296C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1062EA27_L300C65
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x636f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1062EA27_L300C65::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1062EA27_L300C65::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x637e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1062EA27_L300C65::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6381
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1062EA27_L300C65::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6384
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1062EA27_L300C65::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_1062EA27_L300C65::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6396
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1062EA27_L300C65::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_1062EA27_L300C65::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x63a4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1062EA27_L300C65::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_1062EA27_L300C65
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_691C8819_L302C34
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x63b3
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_691C8819_L302C34::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x63bb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_691C8819_L302C34::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x63be
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_691C8819_L302C34::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x63c1
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionExpression_L302C33::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_691C8819_L302C34::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x63db
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L300C64/FunctionExpression_L302C33::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_691C8819_L302C34::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x63f1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_691C8819_L302C34::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_691C8819_L302C34
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_612413E3_L309C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6400
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_612413E3_L309C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_612413E3_L309C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x640f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_612413E3_L309C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6412
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_612413E3_L309C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6415
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_612413E3_L309C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_612413E3_L309C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6427
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_612413E3_L309C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L309C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_612413E3_L309C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6435
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_612413E3_L309C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_612413E3_L309C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_5D299276_L313C26
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6444
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_5D299276_L313C26::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5D299276_L313C26::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6453
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5D299276_L313C26::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6456
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5D299276_L313C26::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6459
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_5D299276_L313C26::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_5D299276_L313C26::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x646b
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_5D299276_L313C26::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L313C25::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_5D299276_L313C26::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6479
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5D299276_L313C26::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_5D299276_L313C26
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AF818725_L318C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6488
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AF818725_L318C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_AF818725_L318C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6497
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_AF818725_L318C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x649a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_AF818725_L318C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x649d
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AF818725_L318C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_AF818725_L318C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x64af
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AF818725_L318C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L318C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_AF818725_L318C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x64bd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_AF818725_L318C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AF818725_L318C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_64DC70FB_L322C25
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x64cc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_64DC70FB_L322C25::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_64DC70FB_L322C25::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x64db
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_64DC70FB_L322C25::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x64de
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_64DC70FB_L322C25::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x64e1
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_64DC70FB_L322C25::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_64DC70FB_L322C25::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x64f3
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_64DC70FB_L322C25::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L322C24::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_64DC70FB_L322C25::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6501
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_64DC70FB_L322C25::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_64DC70FB_L322C25
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_455C0AC7_L327C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6510
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_455C0AC7_L327C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_455C0AC7_L327C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x651f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_455C0AC7_L327C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6522
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_455C0AC7_L327C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6525
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_455C0AC7_L327C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_455C0AC7_L327C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6537
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_455C0AC7_L327C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L327C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_455C0AC7_L327C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6545
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_455C0AC7_L327C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_455C0AC7_L327C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_C0E29ED5_L331C34
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6554
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_C0E29ED5_L331C34::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C0E29ED5_L331C34::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6563
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C0E29ED5_L331C34::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6566
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C0E29ED5_L331C34::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6569
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_C0E29ED5_L331C34::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_C0E29ED5_L331C34::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x657b
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_C0E29ED5_L331C34::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L331C33::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_C0E29ED5_L331C34::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6589
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C0E29ED5_L331C34::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_C0E29ED5_L331C34
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_78E8D78D_L336C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6598
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_78E8D78D_L336C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_78E8D78D_L336C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x65a7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_78E8D78D_L336C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x65aa
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_78E8D78D_L336C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x65ad
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_78E8D78D_L336C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_78E8D78D_L336C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x65bf
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_78E8D78D_L336C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L336C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_78E8D78D_L336C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x65cd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_78E8D78D_L336C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_78E8D78D_L336C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_31C4DBA7_L340C36
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x65dc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_31C4DBA7_L340C36::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_31C4DBA7_L340C36::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x65eb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_31C4DBA7_L340C36::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x65ee
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_31C4DBA7_L340C36::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x65f1
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_31C4DBA7_L340C36::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_31C4DBA7_L340C36::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6603
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_31C4DBA7_L340C36::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L340C35::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_31C4DBA7_L340C36::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6611
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_31C4DBA7_L340C36::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_31C4DBA7_L340C36
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_ADC77423_L345C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6620
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_ADC77423_L345C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_ADC77423_L345C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x662f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_ADC77423_L345C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6632
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_ADC77423_L345C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6635
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_ADC77423_L345C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_ADC77423_L345C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6647
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_ADC77423_L345C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L345C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_ADC77423_L345C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6655
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_ADC77423_L345C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_ADC77423_L345C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AB0D0A79_L349C33
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6664
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AB0D0A79_L349C33::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_AB0D0A79_L349C33::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6673
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_AB0D0A79_L349C33::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6676
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_AB0D0A79_L349C33::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6679
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AB0D0A79_L349C33::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_AB0D0A79_L349C33::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x668b
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AB0D0A79_L349C33::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L349C32::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_AB0D0A79_L349C33::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6699
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_AB0D0A79_L349C33::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_AB0D0A79_L349C33
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_FE9F5065_L354C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x66a8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_FE9F5065_L354C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_FE9F5065_L354C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x66b7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FE9F5065_L354C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x66ba
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FE9F5065_L354C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x66bd
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_FE9F5065_L354C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_FE9F5065_L354C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x66cf
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_FE9F5065_L354C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L354C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_FE9F5065_L354C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x66dd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_FE9F5065_L354C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_FE9F5065_L354C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_48BE92D8_L358C32
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x66ec
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_48BE92D8_L358C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_48BE92D8_L358C32::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x66fb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_48BE92D8_L358C32::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x66fe
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_48BE92D8_L358C32::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6701
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_48BE92D8_L358C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_48BE92D8_L358C32::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6713
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_48BE92D8_L358C32::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L358C31::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_48BE92D8_L358C32::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6721
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_48BE92D8_L358C32::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_48BE92D8_L358C32
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_4D9B395F_L363C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6730
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_4D9B395F_L363C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_4D9B395F_L363C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x673f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_4D9B395F_L363C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6742
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_4D9B395F_L363C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6745
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_4D9B395F_L363C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_4D9B395F_L363C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6757
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_4D9B395F_L363C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L363C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_4D9B395F_L363C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6765
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_4D9B395F_L363C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_4D9B395F_L363C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_222F9CF0_L367C41
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6774
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_222F9CF0_L367C41::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_222F9CF0_L367C41::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6783
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_222F9CF0_L367C41::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6786
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_222F9CF0_L367C41::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6789
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_222F9CF0_L367C41::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_222F9CF0_L367C41::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x679b
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_222F9CF0_L367C41::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L367C40::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_222F9CF0_L367C41::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x67a9
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_222F9CF0_L367C41::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_222F9CF0_L367C41
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F85E69FD_L372C6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x67b8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F85E69FD_L372C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F85E69FD_L372C6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x67c7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F85E69FD_L372C6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x67ca
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F85E69FD_L372C6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x67cd
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F85E69FD_L372C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_F85E69FD_L372C6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x67df
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F85E69FD_L372C6::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L372C5::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_F85E69FD_L372C6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x67ed
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F85E69FD_L372C6::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_F85E69FD_L372C6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_9DF3FAC8_L376C43
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope _environment0_Compile_Performance_Dromaeo_Object_Regexp
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x67fc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_9DF3FAC8_L376C43::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_9DF3FAC8_L376C43::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x680b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9DF3FAC8_L376C43::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x680e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9DF3FAC8_L376C43::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6811
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_9DF3FAC8_L376C43::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_9DF3FAC8_L376C43::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6823
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_9DF3FAC8_L376C43::_environment0_Compile_Performance_Dromaeo_Object_Regexp
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Performance_Dromaeo_Object_Regexp/FunctionExpression_L376C42::__js_call__(class Modules.Compile_Performance_Dromaeo_Object_Regexp/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_9DF3FAC8_L376C43::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6831
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_9DF3FAC8_L376C43::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_Dromaeo_Object_Regexp_850693FB.FunctionObject_FunctionExpression_9DF3FAC8_L376C43
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Performance_PrimeJavaScript.verified.txt
@@ -952,6 +952,355 @@
 
 		} // end of class Scope_searchBitFalse
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_29DE0AB5_BitArray
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3119
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Compile_Performance_PrimeJavaScript/BitArray/FunctionObject_ClassConstructor_29DE0AB5_BitArray::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_29DE0AB5_BitArray::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3128
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_29DE0AB5_BitArray::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x312b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_29DE0AB5_BitArray::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x312e
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_29DE0AB5_BitArray::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x313a
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_29DE0AB5_BitArray::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_29DE0AB5_BitArray
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_64943931_BitArray_setBitTrue
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3146
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_64943931_BitArray_setBitTrue::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x314e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_64943931_BitArray_setBitTrue::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3151
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_64943931_BitArray_setBitTrue::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3154
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Compile_Performance_PrimeJavaScript/BitArray
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0012: call instance object Modules.Compile_Performance_PrimeJavaScript/BitArray::setBitTrue(float64)
+				IL_0017: ret
+			} // end of method FunctionObject_ClassMethod_64943931_BitArray_setBitTrue::CallCore
+
+		} // end of class FunctionObject_ClassMethod_64943931_BitArray_setBitTrue
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x316d
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3175
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3178
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x317b
+				// Header size: 1
+				// Code size: 48 (0x30)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Compile_Performance_PrimeJavaScript/BitArray
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001e: ldarg.2
+				IL_001f: ldc.i4.2
+				IL_0020: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0025: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_002a: call instance object Modules.Compile_Performance_PrimeJavaScript/BitArray::setBitsTrue(float64, float64, float64)
+				IL_002f: ret
+			} // end of method FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue::CallCore
+
+		} // end of class FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x31ac
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x31b4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x31b7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x31ba
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Compile_Performance_PrimeJavaScript/BitArray
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0012: call instance float64 Modules.Compile_Performance_PrimeJavaScript/BitArray::testBitTrue(float64)
+				IL_0017: box [System.Runtime]System.Double
+				IL_001c: ret
+			} // end of method FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue::CallCore
+
+		} // end of class FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x31d8
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x31e0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x31e3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x31e6
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Compile_Performance_PrimeJavaScript/BitArray
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0012: call instance float64 Modules.Compile_Performance_PrimeJavaScript/BitArray::searchBitFalse(float64)
+				IL_0017: box [System.Runtime]System.Double
+				IL_001c: ret
+			} // end of method FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse::CallCore
+
+		} // end of class FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse
+
 
 		// Fields
 		.field private object[] _scopes
@@ -1732,6 +2081,342 @@
 			} // end of method Scope_validatePrimeCount::.ctor
 
 		} // end of class Scope_validatePrimeCount
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_CC015EE2_PrimeSieve
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Performance_PrimeJavaScript/Scope _environment0_Compile_Performance_PrimeJavaScript
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Performance_PrimeJavaScript/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x3204
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Performance_PrimeJavaScript/Scope Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/FunctionObject_ClassConstructor_CC015EE2_PrimeSieve::_environment0_Compile_Performance_PrimeJavaScript
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.Compile_Performance_PrimeJavaScript/PrimeSieve/FunctionObject_ClassConstructor_CC015EE2_PrimeSieve::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_ClassConstructor_CC015EE2_PrimeSieve::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x321a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_CC015EE2_PrimeSieve::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x321d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_CC015EE2_PrimeSieve::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3220
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_CC015EE2_PrimeSieve::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x322c
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_CC015EE2_PrimeSieve::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_CC015EE2_PrimeSieve
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_95B40C02_PrimeSieve_runSieve
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3238
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_95B40C02_PrimeSieve_runSieve::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3240
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_95B40C02_PrimeSieve_runSieve::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3243
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_95B40C02_PrimeSieve_runSieve::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3246
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
+				IL_0006: call instance class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::runSieve()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_95B40C02_PrimeSieve_runSieve::CallCore
+
+		} // end of class FunctionObject_ClassMethod_95B40C02_PrimeSieve_runSieve
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_ACB840E2_PrimeSieve_countPrimes
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3253
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_ACB840E2_PrimeSieve_countPrimes::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x325b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_ACB840E2_PrimeSieve_countPrimes::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x325e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_ACB840E2_PrimeSieve_countPrimes::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3261
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
+				IL_0006: call instance float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::countPrimes()
+				IL_000b: box [System.Runtime]System.Double
+				IL_0010: ret
+			} // end of method FunctionObject_ClassMethod_ACB840E2_PrimeSieve_countPrimes::CallCore
+
+		} // end of class FunctionObject_ClassMethod_ACB840E2_PrimeSieve_countPrimes
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_3CB2830D_PrimeSieve_getPrimes
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3273
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_3CB2830D_PrimeSieve_getPrimes::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x327b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_3CB2830D_PrimeSieve_getPrimes::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x327e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_3CB2830D_PrimeSieve_getPrimes::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3281
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::getPrimes(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassMethod_3CB2830D_PrimeSieve_getPrimes::CallCore
+
+		} // end of class FunctionObject_ClassMethod_3CB2830D_PrimeSieve_getPrimes
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_35212B1B_PrimeSieve_validatePrimeCount
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3295
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_35212B1B_PrimeSieve_validatePrimeCount::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x329d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_35212B1B_PrimeSieve_validatePrimeCount::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x32a0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_35212B1B_PrimeSieve_validatePrimeCount::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x32a3
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance bool Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::validatePrimeCount(object)
+				IL_0012: box [System.Runtime]System.Boolean
+				IL_0017: ret
+			} // end of method FunctionObject_ClassMethod_35212B1B_PrimeSieve_validatePrimeCount::CallCore
+
+		} // end of class FunctionObject_ClassMethod_35212B1B_PrimeSieve_validatePrimeCount
 
 
 		// Fields
@@ -2888,691 +3573,6 @@
 	} // end of method Compile_Performance_PrimeJavaScript::__js_module_init__
 
 } // end of class Modules.Compile_Performance_PrimeJavaScript
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_PrimeJavaScript_54D45068.FunctionObject_ClassConstructor_29DE0AB5_BitArray
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3119
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Compile_Performance_PrimeJavaScript_54D45068.FunctionObject_ClassConstructor_29DE0AB5_BitArray::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_29DE0AB5_BitArray::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3128
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_29DE0AB5_BitArray::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x312b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_29DE0AB5_BitArray::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x312e
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_29DE0AB5_BitArray::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x313a
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_29DE0AB5_BitArray::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_PrimeJavaScript_54D45068.FunctionObject_ClassConstructor_29DE0AB5_BitArray
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_PrimeJavaScript_54D45068.FunctionObject_ClassMethod_64943931_BitArray_setBitTrue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3146
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_64943931_BitArray_setBitTrue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x314e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_64943931_BitArray_setBitTrue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3151
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_64943931_BitArray_setBitTrue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3154
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Compile_Performance_PrimeJavaScript/BitArray
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0012: call instance object Modules.Compile_Performance_PrimeJavaScript/BitArray::setBitTrue(float64)
-		IL_0017: ret
-	} // end of method FunctionObject_ClassMethod_64943931_BitArray_setBitTrue::CallCore
-
-} // end of class FunctionObjects.Compile_Performance_PrimeJavaScript_54D45068.FunctionObject_ClassMethod_64943931_BitArray_setBitTrue
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_PrimeJavaScript_54D45068.FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x316d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3175
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3178
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x317b
-		// Header size: 1
-		// Code size: 48 (0x30)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Compile_Performance_PrimeJavaScript/BitArray
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001e: ldarg.2
-		IL_001f: ldc.i4.2
-		IL_0020: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0025: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_002a: call instance object Modules.Compile_Performance_PrimeJavaScript/BitArray::setBitsTrue(float64, float64, float64)
-		IL_002f: ret
-	} // end of method FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue::CallCore
-
-} // end of class FunctionObjects.Compile_Performance_PrimeJavaScript_54D45068.FunctionObject_ClassMethod_9D7610E2_BitArray_setBitsTrue
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_PrimeJavaScript_54D45068.FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x31ac
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x31b4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x31b7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x31ba
-		// Header size: 1
-		// Code size: 29 (0x1d)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Compile_Performance_PrimeJavaScript/BitArray
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0012: call instance float64 Modules.Compile_Performance_PrimeJavaScript/BitArray::testBitTrue(float64)
-		IL_0017: box [System.Runtime]System.Double
-		IL_001c: ret
-	} // end of method FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue::CallCore
-
-} // end of class FunctionObjects.Compile_Performance_PrimeJavaScript_54D45068.FunctionObject_ClassMethod_F5DAB081_BitArray_testBitTrue
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_PrimeJavaScript_54D45068.FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x31d8
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x31e0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x31e3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x31e6
-		// Header size: 1
-		// Code size: 29 (0x1d)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Compile_Performance_PrimeJavaScript/BitArray
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0012: call instance float64 Modules.Compile_Performance_PrimeJavaScript/BitArray::searchBitFalse(float64)
-		IL_0017: box [System.Runtime]System.Double
-		IL_001c: ret
-	} // end of method FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse::CallCore
-
-} // end of class FunctionObjects.Compile_Performance_PrimeJavaScript_54D45068.FunctionObject_ClassMethod_93DC7074_BitArray_searchBitFalse
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_PrimeJavaScript_54D45068.FunctionObject_ClassConstructor_CC015EE2_PrimeSieve
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Performance_PrimeJavaScript/Scope _environment0_Compile_Performance_PrimeJavaScript
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Performance_PrimeJavaScript/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x3204
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Performance_PrimeJavaScript/Scope FunctionObjects.Compile_Performance_PrimeJavaScript_54D45068.FunctionObject_ClassConstructor_CC015EE2_PrimeSieve::_environment0_Compile_Performance_PrimeJavaScript
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Compile_Performance_PrimeJavaScript_54D45068.FunctionObject_ClassConstructor_CC015EE2_PrimeSieve::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_ClassConstructor_CC015EE2_PrimeSieve::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x321a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_CC015EE2_PrimeSieve::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x321d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_CC015EE2_PrimeSieve::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3220
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_CC015EE2_PrimeSieve::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x322c
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_CC015EE2_PrimeSieve::ConstructCore
-
-} // end of class FunctionObjects.Compile_Performance_PrimeJavaScript_54D45068.FunctionObject_ClassConstructor_CC015EE2_PrimeSieve
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_PrimeJavaScript_54D45068.FunctionObject_ClassMethod_95B40C02_PrimeSieve_runSieve
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3238
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_95B40C02_PrimeSieve_runSieve::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3240
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_95B40C02_PrimeSieve_runSieve::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3243
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_95B40C02_PrimeSieve_runSieve::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3246
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
-		IL_0006: call instance class Modules.Compile_Performance_PrimeJavaScript/PrimeSieve Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::runSieve()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_95B40C02_PrimeSieve_runSieve::CallCore
-
-} // end of class FunctionObjects.Compile_Performance_PrimeJavaScript_54D45068.FunctionObject_ClassMethod_95B40C02_PrimeSieve_runSieve
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_PrimeJavaScript_54D45068.FunctionObject_ClassMethod_ACB840E2_PrimeSieve_countPrimes
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3253
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_ACB840E2_PrimeSieve_countPrimes::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x325b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_ACB840E2_PrimeSieve_countPrimes::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x325e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_ACB840E2_PrimeSieve_countPrimes::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3261
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
-		IL_0006: call instance float64 Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::countPrimes()
-		IL_000b: box [System.Runtime]System.Double
-		IL_0010: ret
-	} // end of method FunctionObject_ClassMethod_ACB840E2_PrimeSieve_countPrimes::CallCore
-
-} // end of class FunctionObjects.Compile_Performance_PrimeJavaScript_54D45068.FunctionObject_ClassMethod_ACB840E2_PrimeSieve_countPrimes
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_PrimeJavaScript_54D45068.FunctionObject_ClassMethod_3CB2830D_PrimeSieve_getPrimes
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3273
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_3CB2830D_PrimeSieve_getPrimes::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x327b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_3CB2830D_PrimeSieve_getPrimes::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x327e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_3CB2830D_PrimeSieve_getPrimes::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3281
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::getPrimes(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassMethod_3CB2830D_PrimeSieve_getPrimes::CallCore
-
-} // end of class FunctionObjects.Compile_Performance_PrimeJavaScript_54D45068.FunctionObject_ClassMethod_3CB2830D_PrimeSieve_getPrimes
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Performance_PrimeJavaScript_54D45068.FunctionObject_ClassMethod_35212B1B_PrimeSieve_validatePrimeCount
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3295
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_35212B1B_PrimeSieve_validatePrimeCount::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x329d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_35212B1B_PrimeSieve_validatePrimeCount::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x32a0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_35212B1B_PrimeSieve_validatePrimeCount::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x32a3
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Compile_Performance_PrimeJavaScript/PrimeSieve
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance bool Modules.Compile_Performance_PrimeJavaScript/PrimeSieve::validatePrimeCount(object)
-		IL_0012: box [System.Runtime]System.Boolean
-		IL_0017: ret
-	} // end of method FunctionObject_ClassMethod_35212B1B_PrimeSieve_validatePrimeCount::CallCore
-
-} // end of class FunctionObjects.Compile_Performance_PrimeJavaScript_54D45068.FunctionObject_ClassMethod_35212B1B_PrimeSieve_validatePrimeCount
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Resources_Dromaeo_3d_Cube.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Resources_Dromaeo_3d_Cube.verified.txt
@@ -31,6 +31,117 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3AA9AEF9_startTest
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5f4d
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_3AA9AEF9_startTest::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5f55
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3AA9AEF9_startTest::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5f58
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3AA9AEF9_startTest::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5f5b
+				// Header size: 1
+				// Code size: 35 (0x23)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_001d: call object Modules.Compile_Resources_Dromaeo_3d_Cube/startTest::__js_call__(object, string, string)
+				IL_0022: ret
+			} // end of method FunctionObject_FunctionDeclaration_3AA9AEF9_startTest::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5f7f
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0019: call object Modules.Compile_Resources_Dromaeo_3d_Cube/startTest::__js_call__(object, string, string)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_3AA9AEF9_startTest::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5f9f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3AA9AEF9_startTest::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_3AA9AEF9_startTest
+
 
 		// Methods
 		.method public hidebysig static 
@@ -77,6 +188,101 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_118F8B84_endTest
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5fae
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_118F8B84_endTest::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5fb6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_118F8B84_endTest::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5fb9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_118F8B84_endTest::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5fbc
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Compile_Resources_Dromaeo_3d_Cube/endTest::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_118F8B84_endTest::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5fc8
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Compile_Resources_Dromaeo_3d_Cube/endTest::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_118F8B84_endTest::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x5fd0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_118F8B84_endTest::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_118F8B84_endTest
 
 
 		// Methods
@@ -144,6 +350,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D89CEA64_prep
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x5fdf
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_D89CEA64_prep::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x5fe7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D89CEA64_prep::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x5fea
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D89CEA64_prep::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x5fed
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Compile_Resources_Dromaeo_3d_Cube/prep::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_D89CEA64_prep::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6000
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Compile_Resources_Dromaeo_3d_Cube/prep::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D89CEA64_prep::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x600f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D89CEA64_prep::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_D89CEA64_prep
 
 
 		// Methods
@@ -231,6 +538,115 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E8689847_test
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x601e
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_E8689847_test::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6026
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E8689847_test::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6029
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E8689847_test::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x602c
+				// Header size: 1
+				// Code size: 30 (0x1e)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call object Modules.Compile_Resources_Dromaeo_3d_Cube/test::__js_call__(object, string, object)
+				IL_001d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E8689847_test::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x604b
+				// Header size: 1
+				// Code size: 26 (0x1a)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call object Modules.Compile_Resources_Dromaeo_3d_Cube/test::__js_call__(object, string, object)
+				IL_0019: ret
+			} // end of method FunctionObject_FunctionDeclaration_E8689847_test::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6066
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E8689847_test::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E8689847_test
 
 
 		// Methods
@@ -461,6 +877,125 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope _environment0_Compile_Resources_Dromaeo_3d_Cube
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6075
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine/FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6084
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6087
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x608a
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine/FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x60aa
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine/FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x60c6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine
 
 
 		// Methods
@@ -799,6 +1334,117 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D57260FA_CalcCross
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x60d5
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_D57260FA_CalcCross::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x60dd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D57260FA_CalcCross::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x60e0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D57260FA_CalcCross::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x60e3
+				// Header size: 1
+				// Code size: 35 (0x23)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_001d: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/CalcCross::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+				IL_0022: ret
+			} // end of method FunctionObject_FunctionDeclaration_D57260FA_CalcCross::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6107
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0019: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/CalcCross::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_D57260FA_CalcCross::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6127
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D57260FA_CalcCross::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_D57260FA_CalcCross
+
 
 		// Methods
 		.method public hidebysig static 
@@ -977,6 +1623,131 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_828AC649_CalcNormal
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope _environment0_Compile_Resources_Dromaeo_3d_Cube
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6136
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/CalcNormal/FunctionObject_FunctionDeclaration_828AC649_CalcNormal::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_828AC649_CalcNormal::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6145
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_828AC649_CalcNormal::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6148
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_828AC649_CalcNormal::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x614b
+				// Header size: 1
+				// Code size: 38 (0x26)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/CalcNormal/FunctionObject_FunctionDeclaration_828AC649_CalcNormal::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/CalcNormal::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object, object)
+				IL_0025: ret
+			} // end of method FunctionObject_FunctionDeclaration_828AC649_CalcNormal::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6172
+				// Header size: 1
+				// Code size: 34 (0x22)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/CalcNormal/FunctionObject_FunctionDeclaration_828AC649_CalcNormal::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: ldarg.2
+				IL_0016: ldc.i4.2
+				IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001c: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/CalcNormal::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object, object)
+				IL_0021: ret
+			} // end of method FunctionObject_FunctionDeclaration_828AC649_CalcNormal::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6195
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_828AC649_CalcNormal::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_828AC649_CalcNormal
 
 
 		// Methods
@@ -1205,6 +1976,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_437DD829_CreateP
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x61a4
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_437DD829_CreateP::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x61ac
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_437DD829_CreateP::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x61af
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_437DD829_CreateP::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x61b2
+				// Header size: 1
+				// Code size: 47 (0x2f)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001d: ldarg.2
+				IL_001e: ldc.i4.2
+				IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0029: call object Modules.Compile_Resources_Dromaeo_3d_Cube/CreateP::__js_call__(object, float64, float64, float64)
+				IL_002e: ret
+			} // end of method FunctionObject_FunctionDeclaration_437DD829_CreateP::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x61e2
+				// Header size: 1
+				// Code size: 43 (0x2b)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0025: call object Modules.Compile_Resources_Dromaeo_3d_Cube/CreateP::__js_call__(object, float64, float64, float64)
+				IL_002a: ret
+			} // end of method FunctionObject_FunctionDeclaration_437DD829_CreateP::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x620e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_437DD829_CreateP::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_437DD829_CreateP
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1299,6 +2189,117 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_ABC69D1B_MMulti
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x621d
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_ABC69D1B_MMulti::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6225
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_ABC69D1B_MMulti::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6228
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_ABC69D1B_MMulti::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x622b
+				// Header size: 1
+				// Code size: 35 (0x23)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_001d: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+				IL_0022: ret
+			} // end of method FunctionObject_FunctionDeclaration_ABC69D1B_MMulti::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x624f
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0019: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_ABC69D1B_MMulti::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x626f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_ABC69D1B_MMulti::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_ABC69D1B_MMulti
 
 
 		// Methods
@@ -1505,6 +2506,115 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8F6544F8_VMulti
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x627e
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_8F6544F8_VMulti::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6286
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8F6544F8_VMulti::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6289
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8F6544F8_VMulti::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x628c
+				// Header size: 1
+				// Code size: 30 (0x1e)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object)
+				IL_001d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8F6544F8_VMulti::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x62ab
+				// Header size: 1
+				// Code size: 26 (0x1a)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object)
+				IL_0019: ret
+			} // end of method FunctionObject_FunctionDeclaration_8F6544F8_VMulti::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x62c6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8F6544F8_VMulti::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_8F6544F8_VMulti
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1662,6 +2772,115 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_866B49FE_VMulti2
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x62d5
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_866B49FE_VMulti2::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x62dd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_866B49FE_VMulti2::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x62e0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_866B49FE_VMulti2::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x62e3
+				// Header size: 1
+				// Code size: 30 (0x1e)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti2::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object)
+				IL_001d: ret
+			} // end of method FunctionObject_FunctionDeclaration_866B49FE_VMulti2::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6302
+				// Header size: 1
+				// Code size: 26 (0x1a)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti2::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object)
+				IL_0019: ret
+			} // end of method FunctionObject_FunctionDeclaration_866B49FE_VMulti2::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x631d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_866B49FE_VMulti2::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_866B49FE_VMulti2
 
 
 		// Methods
@@ -1823,6 +3042,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0DAEB721_MAdd
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x632c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_0DAEB721_MAdd::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6334
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0DAEB721_MAdd::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6337
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0DAEB721_MAdd::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x633a
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MAdd::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_0DAEB721_MAdd::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6354
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MAdd::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_0DAEB721_MAdd::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x636a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0DAEB721_MAdd::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_0DAEB721_MAdd
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1965,6 +3291,139 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_EE9ED553_Translate
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope _environment0_Compile_Resources_Dromaeo_3d_Cube
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6379
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/Translate/FunctionObject_FunctionDeclaration_EE9ED553_Translate::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_EE9ED553_Translate::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6388
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_EE9ED553_Translate::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x638b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_EE9ED553_Translate::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x638e
+				// Header size: 1
+				// Code size: 50 (0x32)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/Translate/FunctionObject_FunctionDeclaration_EE9ED553_Translate::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0017: ldarg.2
+				IL_0018: ldc.i4.1
+				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001e: ldarg.2
+				IL_001f: ldc.i4.2
+				IL_0020: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0025: ldarg.2
+				IL_0026: ldc.i4.3
+				IL_0027: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Translate::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object, object, object)
+				IL_0031: ret
+			} // end of method FunctionObject_FunctionDeclaration_EE9ED553_Translate::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x63c1
+				// Header size: 1
+				// Code size: 46 (0x2e)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/Translate/FunctionObject_FunctionDeclaration_EE9ED553_Translate::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.1
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: ldarg.2
+				IL_001b: ldc.i4.2
+				IL_001c: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0021: ldarg.2
+				IL_0022: ldc.i4.3
+				IL_0023: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0028: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Translate::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object, object, object)
+				IL_002d: ret
+			} // end of method FunctionObject_FunctionDeclaration_EE9ED553_Translate::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x63f0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_EE9ED553_Translate::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_EE9ED553_Translate
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2103,6 +3562,129 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5E4252E8_RotateX
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope _environment0_Compile_Resources_Dromaeo_3d_Cube
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x63ff
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/RotateX/FunctionObject_FunctionDeclaration_5E4252E8_RotateX::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E4252E8_RotateX::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x640e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E4252E8_RotateX::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6411
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E4252E8_RotateX::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6414
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/RotateX/FunctionObject_FunctionDeclaration_5E4252E8_RotateX::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0017: ldarg.2
+				IL_0018: ldc.i4.1
+				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0023: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/RotateX::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
+				IL_0028: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E4252E8_RotateX::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x643e
+				// Header size: 1
+				// Code size: 37 (0x25)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/RotateX/FunctionObject_FunctionDeclaration_5E4252E8_RotateX::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.1
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/RotateX::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
+				IL_0024: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E4252E8_RotateX::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6464
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5E4252E8_RotateX::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_5E4252E8_RotateX
 
 
 		// Methods
@@ -2268,6 +3850,129 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5F42547B_RotateY
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope _environment0_Compile_Resources_Dromaeo_3d_Cube
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x6473
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/RotateY/FunctionObject_FunctionDeclaration_5F42547B_RotateY::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5F42547B_RotateY::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x6482
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5F42547B_RotateY::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6485
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5F42547B_RotateY::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6488
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/RotateY/FunctionObject_FunctionDeclaration_5F42547B_RotateY::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0017: ldarg.2
+				IL_0018: ldc.i4.1
+				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0023: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/RotateY::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
+				IL_0028: ret
+			} // end of method FunctionObject_FunctionDeclaration_5F42547B_RotateY::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x64b2
+				// Header size: 1
+				// Code size: 37 (0x25)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/RotateY/FunctionObject_FunctionDeclaration_5F42547B_RotateY::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.1
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/RotateY::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
+				IL_0024: ret
+			} // end of method FunctionObject_FunctionDeclaration_5F42547B_RotateY::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x64d8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5F42547B_RotateY::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_5F42547B_RotateY
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2431,6 +4136,129 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6042560E_RotateZ
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope _environment0_Compile_Resources_Dromaeo_3d_Cube
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x64e7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/RotateZ/FunctionObject_FunctionDeclaration_6042560E_RotateZ::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6042560E_RotateZ::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x64f6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6042560E_RotateZ::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x64f9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6042560E_RotateZ::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x64fc
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/RotateZ/FunctionObject_FunctionDeclaration_6042560E_RotateZ::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0017: ldarg.2
+				IL_0018: ldc.i4.1
+				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0023: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/RotateZ::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
+				IL_0028: ret
+			} // end of method FunctionObject_FunctionDeclaration_6042560E_RotateZ::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6526
+				// Header size: 1
+				// Code size: 37 (0x25)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/RotateZ/FunctionObject_FunctionDeclaration_6042560E_RotateZ::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.1
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/RotateZ::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
+				IL_0024: ret
+			} // end of method FunctionObject_FunctionDeclaration_6042560E_RotateZ::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x654c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6042560E_RotateZ::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_6042560E_RotateZ
 
 
 		// Methods
@@ -3209,6 +5037,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B9CB8406_DrawQube
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope _environment0_Compile_Resources_Dromaeo_3d_Cube
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x655b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x656a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x656d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6570
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6582
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6590
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_B9CB8406_DrawQube
 
 
 		// Methods
@@ -4902,6 +6837,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C322C861_Loop
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope _environment0_Compile_Resources_Dromaeo_3d_Cube
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x659f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/Loop/FunctionObject_FunctionDeclaration_C322C861_Loop::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C322C861_Loop::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x65ae
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C322C861_Loop::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x65b1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C322C861_Loop::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x65b4
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/Loop/FunctionObject_FunctionDeclaration_C322C861_Loop::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Resources_Dromaeo_3d_Cube/Loop::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_C322C861_Loop::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x65c6
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/Loop/FunctionObject_FunctionDeclaration_C322C861_Loop::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Resources_Dromaeo_3d_Cube/Loop::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_C322C861_Loop::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x65d4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C322C861_Loop::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C322C861_Loop
+
 
 		// Methods
 		.method public hidebysig static 
@@ -5374,6 +7416,121 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A3F3852D_Init
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope _environment0_Compile_Resources_Dromaeo_3d_Cube
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x65e3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/Init/FunctionObject_FunctionDeclaration_A3F3852D_Init::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A3F3852D_Init::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x65f2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A3F3852D_Init::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x65f5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A3F3852D_Init::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x65f8
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/Init/FunctionObject_FunctionDeclaration_A3F3852D_Init::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: call object Modules.Compile_Resources_Dromaeo_3d_Cube/Init::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, float64)
+				IL_001c: ret
+			} // end of method FunctionObject_FunctionDeclaration_A3F3852D_Init::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6616
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/Init/FunctionObject_FunctionDeclaration_A3F3852D_Init::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0013: call object Modules.Compile_Resources_Dromaeo_3d_Cube/Init::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, float64)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_A3F3852D_Init::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6630
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A3F3852D_Init::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_A3F3852D_Init
 
 
 		// Methods
@@ -6559,6 +8716,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_144008FC_L334C24
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope _environment0_Compile_Resources_Dromaeo_3d_Cube
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x663f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23/FunctionObject_FunctionExpression_144008FC_L334C24::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_144008FC_L334C24::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x664e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_144008FC_L334C24::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x6651
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_144008FC_L334C24::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x6654
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23/FunctionObject_FunctionExpression_144008FC_L334C24::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_144008FC_L334C24::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6666
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23/FunctionObject_FunctionExpression_144008FC_L334C24::_environment0_Compile_Resources_Dromaeo_3d_Cube
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_144008FC_L334C24::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x6674
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_144008FC_L334C24::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_144008FC_L334C24
+
 
 		// Methods
 		.method public hidebysig static 
@@ -6691,31 +8955,31 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope,
-			[1] class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_3AA9AEF9_startTest,
-			[2] class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_118F8B84_endTest,
-			[3] class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_D89CEA64_prep,
-			[4] class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_E8689847_test,
-			[5] class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_0DAEB721_MAdd,
+			[1] class Modules.Compile_Resources_Dromaeo_3d_Cube/startTest/FunctionObject_FunctionDeclaration_3AA9AEF9_startTest,
+			[2] class Modules.Compile_Resources_Dromaeo_3d_Cube/endTest/FunctionObject_FunctionDeclaration_118F8B84_endTest,
+			[3] class Modules.Compile_Resources_Dromaeo_3d_Cube/prep/FunctionObject_FunctionDeclaration_D89CEA64_prep,
+			[4] class Modules.Compile_Resources_Dromaeo_3d_Cube/test/FunctionObject_FunctionDeclaration_E8689847_test,
+			[5] class Modules.Compile_Resources_Dromaeo_3d_Cube/MAdd/FunctionObject_FunctionDeclaration_0DAEB721_MAdd,
 			[6] object,
 			[7] object,
 			[8] object[],
-			[9] class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine,
-			[10] class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_D57260FA_CalcCross,
-			[11] class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_828AC649_CalcNormal,
-			[12] class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_437DD829_CreateP,
-			[13] class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_ABC69D1B_MMulti,
-			[14] class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_8F6544F8_VMulti,
-			[15] class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_866B49FE_VMulti2,
-			[16] class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_EE9ED553_Translate,
-			[17] class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_5E4252E8_RotateX,
-			[18] class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_5F42547B_RotateY,
-			[19] class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_6042560E_RotateZ,
-			[20] class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_B9CB8406_DrawQube,
-			[21] class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_C322C861_Loop,
-			[22] class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_A3F3852D_Init,
+			[9] class Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine/FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine,
+			[10] class Modules.Compile_Resources_Dromaeo_3d_Cube/CalcCross/FunctionObject_FunctionDeclaration_D57260FA_CalcCross,
+			[11] class Modules.Compile_Resources_Dromaeo_3d_Cube/CalcNormal/FunctionObject_FunctionDeclaration_828AC649_CalcNormal,
+			[12] class Modules.Compile_Resources_Dromaeo_3d_Cube/CreateP/FunctionObject_FunctionDeclaration_437DD829_CreateP,
+			[13] class Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti/FunctionObject_FunctionDeclaration_ABC69D1B_MMulti,
+			[14] class Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti/FunctionObject_FunctionDeclaration_8F6544F8_VMulti,
+			[15] class Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti2/FunctionObject_FunctionDeclaration_866B49FE_VMulti2,
+			[16] class Modules.Compile_Resources_Dromaeo_3d_Cube/Translate/FunctionObject_FunctionDeclaration_EE9ED553_Translate,
+			[17] class Modules.Compile_Resources_Dromaeo_3d_Cube/RotateX/FunctionObject_FunctionDeclaration_5E4252E8_RotateX,
+			[18] class Modules.Compile_Resources_Dromaeo_3d_Cube/RotateY/FunctionObject_FunctionDeclaration_5F42547B_RotateY,
+			[19] class Modules.Compile_Resources_Dromaeo_3d_Cube/RotateZ/FunctionObject_FunctionDeclaration_6042560E_RotateZ,
+			[20] class Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/FunctionObject_FunctionDeclaration_B9CB8406_DrawQube,
+			[21] class Modules.Compile_Resources_Dromaeo_3d_Cube/Loop/FunctionObject_FunctionDeclaration_C322C861_Loop,
+			[22] class Modules.Compile_Resources_Dromaeo_3d_Cube/Init/FunctionObject_FunctionDeclaration_A3F3852D_Init,
 			[23] object,
 			[24] object[],
-			[25] class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionExpression_144008FC_L334C24
+			[25] class Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23/FunctionObject_FunctionExpression_144008FC_L334C24
 		)
 
 		IL_0000: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/Scope::.ctor()
@@ -6727,13 +8991,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 8
-		IL_0012: newobj instance void FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_3AA9AEF9_startTest::.ctor()
+		IL_0012: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/startTest/FunctionObject_FunctionDeclaration_3AA9AEF9_startTest::.ctor()
 		IL_0017: ldc.i4.2
 		IL_0018: conv.r8
 		IL_0019: ldstr "startTest"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_3AA9AEF9_startTest>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/startTest/FunctionObject_FunctionDeclaration_3AA9AEF9_startTest>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -6742,13 +9006,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 8
-		IL_0032: newobj instance void FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_118F8B84_endTest::.ctor()
+		IL_0032: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/endTest/FunctionObject_FunctionDeclaration_118F8B84_endTest::.ctor()
 		IL_0037: ldc.i4.0
 		IL_0038: conv.r8
 		IL_0039: ldstr "endTest"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_118F8B84_endTest>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/endTest/FunctionObject_FunctionDeclaration_118F8B84_endTest>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -6757,13 +9021,13 @@
 		IL_004e: ldloc.0
 		IL_004f: stelem.ref
 		IL_0050: stloc.s 8
-		IL_0052: newobj instance void FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_D89CEA64_prep::.ctor()
+		IL_0052: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/prep/FunctionObject_FunctionDeclaration_D89CEA64_prep::.ctor()
 		IL_0057: ldc.i4.1
 		IL_0058: conv.r8
 		IL_0059: ldstr "prep"
 		IL_005e: ldc.i4.0
 		IL_005f: ldc.i4.1
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_D89CEA64_prep>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/prep/FunctionObject_FunctionDeclaration_D89CEA64_prep>(!!0, float64, string, bool, bool)
 		IL_0065: stloc.3
 		IL_0066: ldc.i4.1
 		IL_0067: newarr [System.Runtime]System.Object
@@ -6772,13 +9036,13 @@
 		IL_006e: ldloc.0
 		IL_006f: stelem.ref
 		IL_0070: stloc.s 8
-		IL_0072: newobj instance void FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_E8689847_test::.ctor()
+		IL_0072: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/test/FunctionObject_FunctionDeclaration_E8689847_test::.ctor()
 		IL_0077: ldc.i4.2
 		IL_0078: conv.r8
 		IL_0079: ldstr "test"
 		IL_007e: ldc.i4.0
 		IL_007f: ldc.i4.1
-		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_E8689847_test>(!!0, float64, string, bool, bool)
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/test/FunctionObject_FunctionDeclaration_E8689847_test>(!!0, float64, string, bool, bool)
 		IL_0085: stloc.s 4
 		IL_0087: ldc.i4.1
 		IL_0088: newarr [System.Runtime]System.Object
@@ -6791,13 +9055,13 @@
 		IL_0095: ldc.i4.0
 		IL_0096: ldelem.ref
 		IL_0097: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-		IL_009c: newobj instance void FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
+		IL_009c: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine/FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
 		IL_00a1: ldc.i4.2
 		IL_00a2: conv.r8
 		IL_00a3: ldstr "DrawLine"
 		IL_00a8: ldc.i4.0
 		IL_00a9: ldc.i4.1
-		IL_00aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine>(!!0, float64, string, bool, bool)
+		IL_00aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine/FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine>(!!0, float64, string, bool, bool)
 		IL_00af: stloc.s 9
 		IL_00b1: ldloc.0
 		IL_00b2: ldloc.s 9
@@ -6809,13 +9073,13 @@
 		IL_00c1: ldloc.0
 		IL_00c2: stelem.ref
 		IL_00c3: stloc.s 8
-		IL_00c5: newobj instance void FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_D57260FA_CalcCross::.ctor()
+		IL_00c5: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/CalcCross/FunctionObject_FunctionDeclaration_D57260FA_CalcCross::.ctor()
 		IL_00ca: ldc.i4.2
 		IL_00cb: conv.r8
 		IL_00cc: ldstr "CalcCross"
 		IL_00d1: ldc.i4.0
 		IL_00d2: ldc.i4.1
-		IL_00d3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_D57260FA_CalcCross>(!!0, float64, string, bool, bool)
+		IL_00d3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/CalcCross/FunctionObject_FunctionDeclaration_D57260FA_CalcCross>(!!0, float64, string, bool, bool)
 		IL_00d8: stloc.s 10
 		IL_00da: ldloc.0
 		IL_00db: ldloc.s 10
@@ -6831,13 +9095,13 @@
 		IL_00f0: ldc.i4.0
 		IL_00f1: ldelem.ref
 		IL_00f2: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-		IL_00f7: newobj instance void FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_828AC649_CalcNormal::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
+		IL_00f7: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/CalcNormal/FunctionObject_FunctionDeclaration_828AC649_CalcNormal::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
 		IL_00fc: ldc.i4.3
 		IL_00fd: conv.r8
 		IL_00fe: ldstr "CalcNormal"
 		IL_0103: ldc.i4.0
 		IL_0104: ldc.i4.1
-		IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_828AC649_CalcNormal>(!!0, float64, string, bool, bool)
+		IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/CalcNormal/FunctionObject_FunctionDeclaration_828AC649_CalcNormal>(!!0, float64, string, bool, bool)
 		IL_010a: stloc.s 11
 		IL_010c: ldloc.0
 		IL_010d: ldloc.s 11
@@ -6849,13 +9113,13 @@
 		IL_011c: ldloc.0
 		IL_011d: stelem.ref
 		IL_011e: stloc.s 8
-		IL_0120: newobj instance void FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_437DD829_CreateP::.ctor()
+		IL_0120: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/CreateP/FunctionObject_FunctionDeclaration_437DD829_CreateP::.ctor()
 		IL_0125: ldc.i4.3
 		IL_0126: conv.r8
 		IL_0127: ldstr "CreateP"
 		IL_012c: ldc.i4.1
 		IL_012d: ldc.i4.1
-		IL_012e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_437DD829_CreateP>(!!0, float64, string, bool, bool)
+		IL_012e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/CreateP/FunctionObject_FunctionDeclaration_437DD829_CreateP>(!!0, float64, string, bool, bool)
 		IL_0133: stloc.s 12
 		IL_0135: ldloc.0
 		IL_0136: ldloc.s 12
@@ -6867,13 +9131,13 @@
 		IL_0145: ldloc.0
 		IL_0146: stelem.ref
 		IL_0147: stloc.s 8
-		IL_0149: newobj instance void FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_ABC69D1B_MMulti::.ctor()
+		IL_0149: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti/FunctionObject_FunctionDeclaration_ABC69D1B_MMulti::.ctor()
 		IL_014e: ldc.i4.2
 		IL_014f: conv.r8
 		IL_0150: ldstr "MMulti"
 		IL_0155: ldc.i4.0
 		IL_0156: ldc.i4.1
-		IL_0157: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_ABC69D1B_MMulti>(!!0, float64, string, bool, bool)
+		IL_0157: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti/FunctionObject_FunctionDeclaration_ABC69D1B_MMulti>(!!0, float64, string, bool, bool)
 		IL_015c: stloc.s 13
 		IL_015e: ldloc.0
 		IL_015f: ldloc.s 13
@@ -6885,13 +9149,13 @@
 		IL_016e: ldloc.0
 		IL_016f: stelem.ref
 		IL_0170: stloc.s 8
-		IL_0172: newobj instance void FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_8F6544F8_VMulti::.ctor()
+		IL_0172: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti/FunctionObject_FunctionDeclaration_8F6544F8_VMulti::.ctor()
 		IL_0177: ldc.i4.2
 		IL_0178: conv.r8
 		IL_0179: ldstr "VMulti"
 		IL_017e: ldc.i4.0
 		IL_017f: ldc.i4.1
-		IL_0180: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_8F6544F8_VMulti>(!!0, float64, string, bool, bool)
+		IL_0180: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti/FunctionObject_FunctionDeclaration_8F6544F8_VMulti>(!!0, float64, string, bool, bool)
 		IL_0185: stloc.s 14
 		IL_0187: ldloc.0
 		IL_0188: ldloc.s 14
@@ -6903,13 +9167,13 @@
 		IL_0197: ldloc.0
 		IL_0198: stelem.ref
 		IL_0199: stloc.s 8
-		IL_019b: newobj instance void FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_866B49FE_VMulti2::.ctor()
+		IL_019b: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti2/FunctionObject_FunctionDeclaration_866B49FE_VMulti2::.ctor()
 		IL_01a0: ldc.i4.2
 		IL_01a1: conv.r8
 		IL_01a2: ldstr "VMulti2"
 		IL_01a7: ldc.i4.0
 		IL_01a8: ldc.i4.1
-		IL_01a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_866B49FE_VMulti2>(!!0, float64, string, bool, bool)
+		IL_01a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti2/FunctionObject_FunctionDeclaration_866B49FE_VMulti2>(!!0, float64, string, bool, bool)
 		IL_01ae: stloc.s 15
 		IL_01b0: ldloc.0
 		IL_01b1: ldloc.s 15
@@ -6921,13 +9185,13 @@
 		IL_01c0: ldloc.0
 		IL_01c1: stelem.ref
 		IL_01c2: stloc.s 8
-		IL_01c4: newobj instance void FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_0DAEB721_MAdd::.ctor()
+		IL_01c4: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/MAdd/FunctionObject_FunctionDeclaration_0DAEB721_MAdd::.ctor()
 		IL_01c9: ldc.i4.2
 		IL_01ca: conv.r8
 		IL_01cb: ldstr "MAdd"
 		IL_01d0: ldc.i4.0
 		IL_01d1: ldc.i4.1
-		IL_01d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_0DAEB721_MAdd>(!!0, float64, string, bool, bool)
+		IL_01d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/MAdd/FunctionObject_FunctionDeclaration_0DAEB721_MAdd>(!!0, float64, string, bool, bool)
 		IL_01d7: stloc.s 5
 		IL_01d9: ldc.i4.1
 		IL_01da: newarr [System.Runtime]System.Object
@@ -6940,13 +9204,13 @@
 		IL_01e7: ldc.i4.0
 		IL_01e8: ldelem.ref
 		IL_01e9: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-		IL_01ee: newobj instance void FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_EE9ED553_Translate::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
+		IL_01ee: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/Translate/FunctionObject_FunctionDeclaration_EE9ED553_Translate::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
 		IL_01f3: ldc.i4.4
 		IL_01f4: conv.r8
 		IL_01f5: ldstr "Translate"
 		IL_01fa: ldc.i4.0
 		IL_01fb: ldc.i4.1
-		IL_01fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_EE9ED553_Translate>(!!0, float64, string, bool, bool)
+		IL_01fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/Translate/FunctionObject_FunctionDeclaration_EE9ED553_Translate>(!!0, float64, string, bool, bool)
 		IL_0201: stloc.s 16
 		IL_0203: ldloc.0
 		IL_0204: ldloc.s 16
@@ -6962,13 +9226,13 @@
 		IL_0219: ldc.i4.0
 		IL_021a: ldelem.ref
 		IL_021b: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-		IL_0220: newobj instance void FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_5E4252E8_RotateX::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
+		IL_0220: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/RotateX/FunctionObject_FunctionDeclaration_5E4252E8_RotateX::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
 		IL_0225: ldc.i4.2
 		IL_0226: conv.r8
 		IL_0227: ldstr "RotateX"
 		IL_022c: ldc.i4.0
 		IL_022d: ldc.i4.1
-		IL_022e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_5E4252E8_RotateX>(!!0, float64, string, bool, bool)
+		IL_022e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/RotateX/FunctionObject_FunctionDeclaration_5E4252E8_RotateX>(!!0, float64, string, bool, bool)
 		IL_0233: stloc.s 17
 		IL_0235: ldloc.0
 		IL_0236: ldloc.s 17
@@ -6984,13 +9248,13 @@
 		IL_024b: ldc.i4.0
 		IL_024c: ldelem.ref
 		IL_024d: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-		IL_0252: newobj instance void FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_5F42547B_RotateY::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
+		IL_0252: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/RotateY/FunctionObject_FunctionDeclaration_5F42547B_RotateY::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
 		IL_0257: ldc.i4.2
 		IL_0258: conv.r8
 		IL_0259: ldstr "RotateY"
 		IL_025e: ldc.i4.0
 		IL_025f: ldc.i4.1
-		IL_0260: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_5F42547B_RotateY>(!!0, float64, string, bool, bool)
+		IL_0260: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/RotateY/FunctionObject_FunctionDeclaration_5F42547B_RotateY>(!!0, float64, string, bool, bool)
 		IL_0265: stloc.s 18
 		IL_0267: ldloc.0
 		IL_0268: ldloc.s 18
@@ -7006,13 +9270,13 @@
 		IL_027d: ldc.i4.0
 		IL_027e: ldelem.ref
 		IL_027f: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-		IL_0284: newobj instance void FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_6042560E_RotateZ::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
+		IL_0284: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/RotateZ/FunctionObject_FunctionDeclaration_6042560E_RotateZ::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
 		IL_0289: ldc.i4.2
 		IL_028a: conv.r8
 		IL_028b: ldstr "RotateZ"
 		IL_0290: ldc.i4.0
 		IL_0291: ldc.i4.1
-		IL_0292: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_6042560E_RotateZ>(!!0, float64, string, bool, bool)
+		IL_0292: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/RotateZ/FunctionObject_FunctionDeclaration_6042560E_RotateZ>(!!0, float64, string, bool, bool)
 		IL_0297: stloc.s 19
 		IL_0299: ldloc.0
 		IL_029a: ldloc.s 19
@@ -7028,13 +9292,13 @@
 		IL_02af: ldc.i4.0
 		IL_02b0: ldelem.ref
 		IL_02b1: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-		IL_02b6: newobj instance void FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
+		IL_02b6: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
 		IL_02bb: ldc.i4.0
 		IL_02bc: conv.r8
 		IL_02bd: ldstr "DrawQube"
 		IL_02c2: ldc.i4.0
 		IL_02c3: ldc.i4.1
-		IL_02c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_B9CB8406_DrawQube>(!!0, float64, string, bool, bool)
+		IL_02c4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube/FunctionObject_FunctionDeclaration_B9CB8406_DrawQube>(!!0, float64, string, bool, bool)
 		IL_02c9: stloc.s 20
 		IL_02cb: ldloc.0
 		IL_02cc: ldloc.s 20
@@ -7050,13 +9314,13 @@
 		IL_02e1: ldc.i4.0
 		IL_02e2: ldelem.ref
 		IL_02e3: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-		IL_02e8: newobj instance void FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_C322C861_Loop::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
+		IL_02e8: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/Loop/FunctionObject_FunctionDeclaration_C322C861_Loop::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
 		IL_02ed: ldc.i4.0
 		IL_02ee: conv.r8
 		IL_02ef: ldstr "Loop"
 		IL_02f4: ldc.i4.0
 		IL_02f5: ldc.i4.1
-		IL_02f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_C322C861_Loop>(!!0, float64, string, bool, bool)
+		IL_02f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/Loop/FunctionObject_FunctionDeclaration_C322C861_Loop>(!!0, float64, string, bool, bool)
 		IL_02fb: stloc.s 21
 		IL_02fd: ldloc.0
 		IL_02fe: ldloc.s 21
@@ -7072,13 +9336,13 @@
 		IL_0313: ldc.i4.0
 		IL_0314: ldelem.ref
 		IL_0315: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-		IL_031a: newobj instance void FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_A3F3852D_Init::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
+		IL_031a: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/Init/FunctionObject_FunctionDeclaration_A3F3852D_Init::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
 		IL_031f: ldc.i4.1
 		IL_0320: conv.r8
 		IL_0321: ldstr "Init"
 		IL_0326: ldc.i4.0
 		IL_0327: ldc.i4.1
-		IL_0328: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_A3F3852D_Init>(!!0, float64, string, bool, bool)
+		IL_0328: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/Init/FunctionObject_FunctionDeclaration_A3F3852D_Init>(!!0, float64, string, bool, bool)
 		IL_032d: stloc.s 22
 		IL_032f: ldloc.0
 		IL_0330: ldloc.s 22
@@ -7200,13 +9464,13 @@
 		IL_0474: ldc.i4.0
 		IL_0475: ldelem.ref
 		IL_0476: castclass Modules.Compile_Resources_Dromaeo_3d_Cube/Scope
-		IL_047b: newobj instance void FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionExpression_144008FC_L334C24::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
+		IL_047b: newobj instance void Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23/FunctionObject_FunctionExpression_144008FC_L334C24::.ctor(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope)
 		IL_0480: ldc.i4.0
 		IL_0481: conv.r8
 		IL_0482: ldstr ""
 		IL_0487: ldc.i4.0
 		IL_0488: ldc.i4.1
-		IL_0489: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionExpression_144008FC_L334C24>(!!0, float64, string, bool, bool)
+		IL_0489: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23/FunctionObject_FunctionExpression_144008FC_L334C24>(!!0, float64, string, bool, bool)
 		IL_048e: stloc.s 25
 		IL_0490: ldloc.s 4
 		IL_0492: ldloc.s 8
@@ -7222,2270 +9486,6 @@
 	} // end of method Compile_Resources_Dromaeo_3d_Cube::__js_module_init__
 
 } // end of class Modules.Compile_Resources_Dromaeo_3d_Cube
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_3AA9AEF9_startTest
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x5f4d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_3AA9AEF9_startTest::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5f55
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3AA9AEF9_startTest::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5f58
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3AA9AEF9_startTest::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5f5b
-		// Header size: 1
-		// Code size: 35 (0x23)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_001d: call object Modules.Compile_Resources_Dromaeo_3d_Cube/startTest::__js_call__(object, string, string)
-		IL_0022: ret
-	} // end of method FunctionObject_FunctionDeclaration_3AA9AEF9_startTest::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5f7f
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0019: call object Modules.Compile_Resources_Dromaeo_3d_Cube/startTest::__js_call__(object, string, string)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_3AA9AEF9_startTest::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5f9f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3AA9AEF9_startTest::ConstructCore
-
-} // end of class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_3AA9AEF9_startTest
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_118F8B84_endTest
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x5fae
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_118F8B84_endTest::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5fb6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_118F8B84_endTest::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5fb9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_118F8B84_endTest::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5fbc
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Compile_Resources_Dromaeo_3d_Cube/endTest::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_118F8B84_endTest::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5fc8
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Compile_Resources_Dromaeo_3d_Cube/endTest::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_118F8B84_endTest::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x5fd0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_118F8B84_endTest::ConstructCore
-
-} // end of class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_118F8B84_endTest
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_D89CEA64_prep
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x5fdf
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_D89CEA64_prep::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x5fe7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D89CEA64_prep::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x5fea
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D89CEA64_prep::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x5fed
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Compile_Resources_Dromaeo_3d_Cube/prep::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_D89CEA64_prep::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6000
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Compile_Resources_Dromaeo_3d_Cube/prep::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D89CEA64_prep::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x600f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D89CEA64_prep::ConstructCore
-
-} // end of class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_D89CEA64_prep
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_E8689847_test
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x601e
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_E8689847_test::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6026
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E8689847_test::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6029
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E8689847_test::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x602c
-		// Header size: 1
-		// Code size: 30 (0x1e)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call object Modules.Compile_Resources_Dromaeo_3d_Cube/test::__js_call__(object, string, object)
-		IL_001d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E8689847_test::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x604b
-		// Header size: 1
-		// Code size: 26 (0x1a)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call object Modules.Compile_Resources_Dromaeo_3d_Cube/test::__js_call__(object, string, object)
-		IL_0019: ret
-	} // end of method FunctionObject_FunctionDeclaration_E8689847_test::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6066
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E8689847_test::ConstructCore
-
-} // end of class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_E8689847_test
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope _environment0_Compile_Resources_Dromaeo_3d_Cube
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6075
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6084
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6087
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x608a
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x60aa
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawLine::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x60c6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine::ConstructCore
-
-} // end of class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_EB7DA09B_DrawLine
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_D57260FA_CalcCross
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x60d5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_D57260FA_CalcCross::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x60dd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D57260FA_CalcCross::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x60e0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D57260FA_CalcCross::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x60e3
-		// Header size: 1
-		// Code size: 35 (0x23)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_001d: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/CalcCross::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-		IL_0022: ret
-	} // end of method FunctionObject_FunctionDeclaration_D57260FA_CalcCross::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6107
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0019: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/CalcCross::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_D57260FA_CalcCross::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6127
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D57260FA_CalcCross::ConstructCore
-
-} // end of class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_D57260FA_CalcCross
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_828AC649_CalcNormal
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope _environment0_Compile_Resources_Dromaeo_3d_Cube
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6136
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_828AC649_CalcNormal::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_828AC649_CalcNormal::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6145
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_828AC649_CalcNormal::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6148
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_828AC649_CalcNormal::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x614b
-		// Header size: 1
-		// Code size: 38 (0x26)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_828AC649_CalcNormal::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/CalcNormal::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object, object)
-		IL_0025: ret
-	} // end of method FunctionObject_FunctionDeclaration_828AC649_CalcNormal::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6172
-		// Header size: 1
-		// Code size: 34 (0x22)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_828AC649_CalcNormal::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: ldarg.2
-		IL_0016: ldc.i4.2
-		IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001c: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/CalcNormal::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, object, object, object)
-		IL_0021: ret
-	} // end of method FunctionObject_FunctionDeclaration_828AC649_CalcNormal::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6195
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_828AC649_CalcNormal::ConstructCore
-
-} // end of class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_828AC649_CalcNormal
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_437DD829_CreateP
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x61a4
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_437DD829_CreateP::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x61ac
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_437DD829_CreateP::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x61af
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_437DD829_CreateP::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x61b2
-		// Header size: 1
-		// Code size: 47 (0x2f)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001d: ldarg.2
-		IL_001e: ldc.i4.2
-		IL_001f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0024: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0029: call object Modules.Compile_Resources_Dromaeo_3d_Cube/CreateP::__js_call__(object, float64, float64, float64)
-		IL_002e: ret
-	} // end of method FunctionObject_FunctionDeclaration_437DD829_CreateP::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x61e2
-		// Header size: 1
-		// Code size: 43 (0x2b)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0025: call object Modules.Compile_Resources_Dromaeo_3d_Cube/CreateP::__js_call__(object, float64, float64, float64)
-		IL_002a: ret
-	} // end of method FunctionObject_FunctionDeclaration_437DD829_CreateP::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x620e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_437DD829_CreateP::ConstructCore
-
-} // end of class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_437DD829_CreateP
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_ABC69D1B_MMulti
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x621d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_ABC69D1B_MMulti::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6225
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_ABC69D1B_MMulti::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6228
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_ABC69D1B_MMulti::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x622b
-		// Header size: 1
-		// Code size: 35 (0x23)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_001d: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-		IL_0022: ret
-	} // end of method FunctionObject_FunctionDeclaration_ABC69D1B_MMulti::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x624f
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0019: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MMulti::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, class [JavaScriptRuntime]JavaScriptRuntime.Array)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_ABC69D1B_MMulti::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x626f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_ABC69D1B_MMulti::ConstructCore
-
-} // end of class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_ABC69D1B_MMulti
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_8F6544F8_VMulti
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x627e
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_8F6544F8_VMulti::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6286
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8F6544F8_VMulti::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6289
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8F6544F8_VMulti::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x628c
-		// Header size: 1
-		// Code size: 30 (0x1e)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object)
-		IL_001d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8F6544F8_VMulti::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x62ab
-		// Header size: 1
-		// Code size: 26 (0x1a)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object)
-		IL_0019: ret
-	} // end of method FunctionObject_FunctionDeclaration_8F6544F8_VMulti::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x62c6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8F6544F8_VMulti::ConstructCore
-
-} // end of class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_8F6544F8_VMulti
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_866B49FE_VMulti2
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x62d5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_866B49FE_VMulti2::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x62dd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_866B49FE_VMulti2::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x62e0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_866B49FE_VMulti2::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x62e3
-		// Header size: 1
-		// Code size: 30 (0x1e)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti2::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object)
-		IL_001d: ret
-	} // end of method FunctionObject_FunctionDeclaration_866B49FE_VMulti2::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6302
-		// Header size: 1
-		// Code size: 26 (0x1a)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/VMulti2::__js_call__(object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object)
-		IL_0019: ret
-	} // end of method FunctionObject_FunctionDeclaration_866B49FE_VMulti2::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x631d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_866B49FE_VMulti2::ConstructCore
-
-} // end of class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_866B49FE_VMulti2
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_0DAEB721_MAdd
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x632c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_0DAEB721_MAdd::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6334
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0DAEB721_MAdd::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6337
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0DAEB721_MAdd::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x633a
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MAdd::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_0DAEB721_MAdd::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6354
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/MAdd::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_0DAEB721_MAdd::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x636a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0DAEB721_MAdd::ConstructCore
-
-} // end of class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_0DAEB721_MAdd
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_EE9ED553_Translate
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope _environment0_Compile_Resources_Dromaeo_3d_Cube
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6379
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_EE9ED553_Translate::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_EE9ED553_Translate::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6388
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_EE9ED553_Translate::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x638b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_EE9ED553_Translate::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x638e
-		// Header size: 1
-		// Code size: 50 (0x32)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_EE9ED553_Translate::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0017: ldarg.2
-		IL_0018: ldc.i4.1
-		IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001e: ldarg.2
-		IL_001f: ldc.i4.2
-		IL_0020: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0025: ldarg.2
-		IL_0026: ldc.i4.3
-		IL_0027: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_002c: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Translate::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object, object, object)
-		IL_0031: ret
-	} // end of method FunctionObject_FunctionDeclaration_EE9ED553_Translate::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x63c1
-		// Header size: 1
-		// Code size: 46 (0x2e)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_EE9ED553_Translate::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.1
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: ldarg.2
-		IL_001b: ldc.i4.2
-		IL_001c: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0021: ldarg.2
-		IL_0022: ldc.i4.3
-		IL_0023: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0028: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/Translate::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, object, object, object)
-		IL_002d: ret
-	} // end of method FunctionObject_FunctionDeclaration_EE9ED553_Translate::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x63f0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_EE9ED553_Translate::ConstructCore
-
-} // end of class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_EE9ED553_Translate
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_5E4252E8_RotateX
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope _environment0_Compile_Resources_Dromaeo_3d_Cube
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x63ff
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_5E4252E8_RotateX::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E4252E8_RotateX::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x640e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E4252E8_RotateX::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6411
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E4252E8_RotateX::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6414
-		// Header size: 1
-		// Code size: 41 (0x29)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_5E4252E8_RotateX::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0017: ldarg.2
-		IL_0018: ldc.i4.1
-		IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0023: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/RotateX::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
-		IL_0028: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E4252E8_RotateX::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x643e
-		// Header size: 1
-		// Code size: 37 (0x25)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_5E4252E8_RotateX::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.1
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/RotateX::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
-		IL_0024: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E4252E8_RotateX::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6464
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5E4252E8_RotateX::ConstructCore
-
-} // end of class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_5E4252E8_RotateX
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_5F42547B_RotateY
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope _environment0_Compile_Resources_Dromaeo_3d_Cube
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x6473
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_5F42547B_RotateY::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5F42547B_RotateY::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x6482
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5F42547B_RotateY::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6485
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5F42547B_RotateY::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6488
-		// Header size: 1
-		// Code size: 41 (0x29)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_5F42547B_RotateY::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0017: ldarg.2
-		IL_0018: ldc.i4.1
-		IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0023: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/RotateY::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
-		IL_0028: ret
-	} // end of method FunctionObject_FunctionDeclaration_5F42547B_RotateY::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x64b2
-		// Header size: 1
-		// Code size: 37 (0x25)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_5F42547B_RotateY::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.1
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/RotateY::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
-		IL_0024: ret
-	} // end of method FunctionObject_FunctionDeclaration_5F42547B_RotateY::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x64d8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5F42547B_RotateY::ConstructCore
-
-} // end of class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_5F42547B_RotateY
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_6042560E_RotateZ
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope _environment0_Compile_Resources_Dromaeo_3d_Cube
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x64e7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_6042560E_RotateZ::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6042560E_RotateZ::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x64f6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6042560E_RotateZ::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x64f9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6042560E_RotateZ::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x64fc
-		// Header size: 1
-		// Code size: 41 (0x29)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_6042560E_RotateZ::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0017: ldarg.2
-		IL_0018: ldc.i4.1
-		IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0023: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/RotateZ::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
-		IL_0028: ret
-	} // end of method FunctionObject_FunctionDeclaration_6042560E_RotateZ::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6526
-		// Header size: 1
-		// Code size: 37 (0x25)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_6042560E_RotateZ::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: castclass [JavaScriptRuntime]JavaScriptRuntime.Array
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.1
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001f: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Resources_Dromaeo_3d_Cube/RotateZ::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, class [JavaScriptRuntime]JavaScriptRuntime.Array, float64)
-		IL_0024: ret
-	} // end of method FunctionObject_FunctionDeclaration_6042560E_RotateZ::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x654c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6042560E_RotateZ::ConstructCore
-
-} // end of class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_6042560E_RotateZ
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_B9CB8406_DrawQube
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope _environment0_Compile_Resources_Dromaeo_3d_Cube
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x655b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x656a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x656d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6570
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6582
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Resources_Dromaeo_3d_Cube/DrawQube::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6590
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B9CB8406_DrawQube::ConstructCore
-
-} // end of class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_B9CB8406_DrawQube
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_C322C861_Loop
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope _environment0_Compile_Resources_Dromaeo_3d_Cube
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x659f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_C322C861_Loop::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C322C861_Loop::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x65ae
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C322C861_Loop::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x65b1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C322C861_Loop::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x65b4
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_C322C861_Loop::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Resources_Dromaeo_3d_Cube/Loop::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_C322C861_Loop::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x65c6
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_C322C861_Loop::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Resources_Dromaeo_3d_Cube/Loop::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_C322C861_Loop::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x65d4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C322C861_Loop::ConstructCore
-
-} // end of class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_C322C861_Loop
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_A3F3852D_Init
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope _environment0_Compile_Resources_Dromaeo_3d_Cube
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x65e3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_A3F3852D_Init::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A3F3852D_Init::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x65f2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A3F3852D_Init::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x65f5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A3F3852D_Init::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x65f8
-		// Header size: 1
-		// Code size: 29 (0x1d)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_A3F3852D_Init::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0017: call object Modules.Compile_Resources_Dromaeo_3d_Cube/Init::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, float64)
-		IL_001c: ret
-	} // end of method FunctionObject_FunctionDeclaration_A3F3852D_Init::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6616
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_A3F3852D_Init::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0013: call object Modules.Compile_Resources_Dromaeo_3d_Cube/Init::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object, float64)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_A3F3852D_Init::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6630
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A3F3852D_Init::ConstructCore
-
-} // end of class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionDeclaration_A3F3852D_Init
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionExpression_144008FC_L334C24
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope _environment0_Compile_Resources_Dromaeo_3d_Cube
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x663f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionExpression_144008FC_L334C24::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_144008FC_L334C24::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x664e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_144008FC_L334C24::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x6651
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_144008FC_L334C24::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x6654
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionExpression_144008FC_L334C24::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_144008FC_L334C24::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6666
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionExpression_144008FC_L334C24::_environment0_Compile_Resources_Dromaeo_3d_Cube
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Resources_Dromaeo_3d_Cube/FunctionExpression_L334C23::__js_call__(class Modules.Compile_Resources_Dromaeo_3d_Cube/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_144008FC_L334C24::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x6674
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_144008FC_L334C24::ConstructCore
-
-} // end of class FunctionObjects.Compile_Resources_Dromaeo_3d_Cube_CE9C71EC.FunctionObject_FunctionExpression_144008FC_L334C24
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_BumpVersion.verified.txt
@@ -31,6 +31,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E165DCE7_readFile
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_BumpVersion/Scope _environment0_Compile_Scripts_BumpVersion
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_BumpVersion/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3865
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/readFile/FunctionObject_FunctionDeclaration_E165DCE7_readFile::_environment0_Compile_Scripts_BumpVersion
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E165DCE7_readFile::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3874
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E165DCE7_readFile::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3877
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E165DCE7_readFile::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x387a
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/readFile/FunctionObject_FunctionDeclaration_E165DCE7_readFile::_environment0_Compile_Scripts_BumpVersion
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_E165DCE7_readFile::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3893
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/readFile/FunctionObject_FunctionDeclaration_E165DCE7_readFile::_environment0_Compile_Scripts_BumpVersion
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_E165DCE7_readFile::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x38a8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E165DCE7_readFile::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E165DCE7_readFile
+
 
 		// Methods
 		.method public hidebysig static 
@@ -92,6 +205,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9E2A195E_writeFile
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_BumpVersion/Scope _environment0_Compile_Scripts_BumpVersion
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_BumpVersion/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x38b7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/writeFile/FunctionObject_FunctionDeclaration_9E2A195E_writeFile::_environment0_Compile_Scripts_BumpVersion
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9E2A195E_writeFile::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x38c6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9E2A195E_writeFile::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x38c9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9E2A195E_writeFile::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x38cc
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/writeFile/FunctionObject_FunctionDeclaration_9E2A195E_writeFile::_environment0_Compile_Scripts_BumpVersion
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_9E2A195E_writeFile::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x38ec
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/writeFile/FunctionObject_FunctionDeclaration_9E2A195E_writeFile::_environment0_Compile_Scripts_BumpVersion
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_9E2A195E_writeFile::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3908
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9E2A195E_writeFile::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9E2A195E_writeFile
+
 
 		// Methods
 		.method public hidebysig static 
@@ -152,6 +384,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3917
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x391f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3922
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3925
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Compile_Scripts_BumpVersion/parseCurrentVersion::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3938
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Compile_Scripts_BumpVersion/parseCurrentVersion::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3947
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion
 
 
 		// Methods
@@ -510,6 +843,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_37FCF14D_incVersion
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3956
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_37FCF14D_incVersion::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x395e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_37FCF14D_incVersion::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3961
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_37FCF14D_incVersion::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3964
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Compile_Scripts_BumpVersion/incVersion::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_37FCF14D_incVersion::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x397e
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Compile_Scripts_BumpVersion/incVersion::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_37FCF14D_incVersion::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3994
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_37FCF14D_incVersion::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_37FCF14D_incVersion
 
 
 		// Methods
@@ -900,6 +1340,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_BumpVersion/Scope _environment0_Compile_Scripts_BumpVersion
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_BumpVersion/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x39dd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/resolveTargetVersion/FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::_environment0_Compile_Scripts_BumpVersion
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x39ec
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x39ef
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x39f2
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/resolveTargetVersion/FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::_environment0_Compile_Scripts_BumpVersion
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Compile_Scripts_BumpVersion/resolveTargetVersion::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a12
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/resolveTargetVersion/FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::_environment0_Compile_Scripts_BumpVersion
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Compile_Scripts_BumpVersion/resolveTargetVersion::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a2e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1062,6 +1621,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3a3d
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3a45
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3a48
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a4b
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a65
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a7b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1196,6 +1862,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3a8a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3a92
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3a95
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a98
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Compile_Scripts_BumpVersion/updateSamplesPropsVersion::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ab2
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Compile_Scripts_BumpVersion/updateSamplesPropsVersion::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ac8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1320,6 +2093,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_BumpVersion/Scope _environment0_Compile_Scripts_BumpVersion
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_BumpVersion/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ad7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/extractUnreleased/FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::_environment0_Compile_Scripts_BumpVersion
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3ae6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3ae9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3aec
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/extractUnreleased/FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::_environment0_Compile_Scripts_BumpVersion
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Compile_Scripts_BumpVersion/extractUnreleased::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b05
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/extractUnreleased/FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::_environment0_Compile_Scripts_BumpVersion
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Compile_Scripts_BumpVersion/extractUnreleased::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b1a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased
 
 
 		// Methods
@@ -1556,6 +2442,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3b29
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3b31
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3b34
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b37
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Compile_Scripts_BumpVersion/isPlaceholder::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b4a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Compile_Scripts_BumpVersion/isPlaceholder::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b59
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder
 
 
 		// Methods
@@ -1811,6 +2798,125 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_BumpVersion/Scope _environment0_Compile_Scripts_BumpVersion
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_BumpVersion/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b68
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/generateReleaseSection/FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::_environment0_Compile_Scripts_BumpVersion
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3b77
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3b7a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b7d
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/generateReleaseSection/FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::_environment0_Compile_Scripts_BumpVersion
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Compile_Scripts_BumpVersion/generateReleaseSection::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b9d
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/generateReleaseSection/FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::_environment0_Compile_Scripts_BumpVersion
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Compile_Scripts_BumpVersion/generateReleaseSection::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3bb9
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection
 
 
 		// Methods
@@ -2204,6 +3310,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F66C72E6_perform
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_BumpVersion/Scope _environment0_Compile_Scripts_BumpVersion
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_BumpVersion/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3bf9
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/perform/FunctionObject_FunctionDeclaration_F66C72E6_perform::_environment0_Compile_Scripts_BumpVersion
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F66C72E6_perform::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3c08
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F66C72E6_perform::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3c0b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F66C72E6_perform::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3c0e
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/perform/FunctionObject_FunctionDeclaration_F66C72E6_perform::_environment0_Compile_Scripts_BumpVersion
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Scripts_BumpVersion/perform::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_F66C72E6_perform::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3c20
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope Modules.Compile_Scripts_BumpVersion/perform/FunctionObject_FunctionDeclaration_F66C72E6_perform::_environment0_Compile_Scripts_BumpVersion
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Scripts_BumpVersion/perform::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_F66C72E6_perform::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3c2e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F66C72E6_perform::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_F66C72E6_perform
 
 
 		// Methods
@@ -3144,7 +4357,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_BumpVersion/Scope,
-			[1] class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_F66C72E6_perform,
+			[1] class Modules.Compile_Scripts_BumpVersion/perform/FunctionObject_FunctionDeclaration_F66C72E6_perform,
 			[2] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule,
 			[3] object,
 			[4] class [System.Runtime]System.Exception,
@@ -3152,16 +4365,16 @@
 			[6] object,
 			[7] object,
 			[8] object[],
-			[9] class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_E165DCE7_readFile,
-			[10] class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_9E2A195E_writeFile,
-			[11] class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion,
-			[12] class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_37FCF14D_incVersion,
-			[13] class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion,
-			[14] class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion,
-			[15] class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion,
-			[16] class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased,
-			[17] class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder,
-			[18] class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection,
+			[9] class Modules.Compile_Scripts_BumpVersion/readFile/FunctionObject_FunctionDeclaration_E165DCE7_readFile,
+			[10] class Modules.Compile_Scripts_BumpVersion/writeFile/FunctionObject_FunctionDeclaration_9E2A195E_writeFile,
+			[11] class Modules.Compile_Scripts_BumpVersion/parseCurrentVersion/FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion,
+			[12] class Modules.Compile_Scripts_BumpVersion/incVersion/FunctionObject_FunctionDeclaration_37FCF14D_incVersion,
+			[13] class Modules.Compile_Scripts_BumpVersion/resolveTargetVersion/FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion,
+			[14] class Modules.Compile_Scripts_BumpVersion/updateCsprojVersion/FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion,
+			[15] class Modules.Compile_Scripts_BumpVersion/updateSamplesPropsVersion/FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion,
+			[16] class Modules.Compile_Scripts_BumpVersion/extractUnreleased/FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased,
+			[17] class Modules.Compile_Scripts_BumpVersion/isPlaceholder/FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder,
+			[18] class Modules.Compile_Scripts_BumpVersion/generateReleaseSection/FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection,
 			[19] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
 			[20] object,
 			[21] object
@@ -3180,13 +4393,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Compile_Scripts_BumpVersion/Scope
-		IL_001b: newobj instance void FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_E165DCE7_readFile::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope)
+		IL_001b: newobj instance void Modules.Compile_Scripts_BumpVersion/readFile/FunctionObject_FunctionDeclaration_E165DCE7_readFile::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope)
 		IL_0020: ldc.i4.1
 		IL_0021: conv.r8
 		IL_0022: ldstr "readFile"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_E165DCE7_readFile>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/readFile/FunctionObject_FunctionDeclaration_E165DCE7_readFile>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.s 9
 		IL_0030: ldloc.0
 		IL_0031: ldloc.s 9
@@ -3202,13 +4415,13 @@
 		IL_0046: ldc.i4.0
 		IL_0047: ldelem.ref
 		IL_0048: castclass Modules.Compile_Scripts_BumpVersion/Scope
-		IL_004d: newobj instance void FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_9E2A195E_writeFile::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope)
+		IL_004d: newobj instance void Modules.Compile_Scripts_BumpVersion/writeFile/FunctionObject_FunctionDeclaration_9E2A195E_writeFile::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope)
 		IL_0052: ldc.i4.2
 		IL_0053: conv.r8
 		IL_0054: ldstr "writeFile"
 		IL_0059: ldc.i4.0
 		IL_005a: ldc.i4.1
-		IL_005b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_9E2A195E_writeFile>(!!0, float64, string, bool, bool)
+		IL_005b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/writeFile/FunctionObject_FunctionDeclaration_9E2A195E_writeFile>(!!0, float64, string, bool, bool)
 		IL_0060: stloc.s 10
 		IL_0062: ldloc.0
 		IL_0063: ldloc.s 10
@@ -3220,13 +4433,13 @@
 		IL_0072: ldloc.0
 		IL_0073: stelem.ref
 		IL_0074: stloc.s 8
-		IL_0076: newobj instance void FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion::.ctor()
+		IL_0076: newobj instance void Modules.Compile_Scripts_BumpVersion/parseCurrentVersion/FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion::.ctor()
 		IL_007b: ldc.i4.1
 		IL_007c: conv.r8
 		IL_007d: ldstr "parseCurrentVersion"
 		IL_0082: ldc.i4.0
 		IL_0083: ldc.i4.1
-		IL_0084: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion>(!!0, float64, string, bool, bool)
+		IL_0084: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/parseCurrentVersion/FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion>(!!0, float64, string, bool, bool)
 		IL_0089: stloc.s 11
 		IL_008b: ldloc.0
 		IL_008c: ldloc.s 11
@@ -3238,13 +4451,13 @@
 		IL_009b: ldloc.0
 		IL_009c: stelem.ref
 		IL_009d: stloc.s 8
-		IL_009f: newobj instance void FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_37FCF14D_incVersion::.ctor()
+		IL_009f: newobj instance void Modules.Compile_Scripts_BumpVersion/incVersion/FunctionObject_FunctionDeclaration_37FCF14D_incVersion::.ctor()
 		IL_00a4: ldc.i4.2
 		IL_00a5: conv.r8
 		IL_00a6: ldstr "incVersion"
 		IL_00ab: ldc.i4.0
 		IL_00ac: ldc.i4.1
-		IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_37FCF14D_incVersion>(!!0, float64, string, bool, bool)
+		IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/incVersion/FunctionObject_FunctionDeclaration_37FCF14D_incVersion>(!!0, float64, string, bool, bool)
 		IL_00b2: stloc.s 12
 		IL_00b4: ldloc.0
 		IL_00b5: ldloc.s 12
@@ -3260,13 +4473,13 @@
 		IL_00ca: ldc.i4.0
 		IL_00cb: ldelem.ref
 		IL_00cc: castclass Modules.Compile_Scripts_BumpVersion/Scope
-		IL_00d1: newobj instance void FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope)
+		IL_00d1: newobj instance void Modules.Compile_Scripts_BumpVersion/resolveTargetVersion/FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope)
 		IL_00d6: ldc.i4.2
 		IL_00d7: conv.r8
 		IL_00d8: ldstr "resolveTargetVersion"
 		IL_00dd: ldc.i4.0
 		IL_00de: ldc.i4.1
-		IL_00df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion>(!!0, float64, string, bool, bool)
+		IL_00df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/resolveTargetVersion/FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion>(!!0, float64, string, bool, bool)
 		IL_00e4: stloc.s 13
 		IL_00e6: ldloc.0
 		IL_00e7: ldloc.s 13
@@ -3278,13 +4491,13 @@
 		IL_00f6: ldloc.0
 		IL_00f7: stelem.ref
 		IL_00f8: stloc.s 8
-		IL_00fa: newobj instance void FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion::.ctor()
+		IL_00fa: newobj instance void Modules.Compile_Scripts_BumpVersion/updateCsprojVersion/FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion::.ctor()
 		IL_00ff: ldc.i4.2
 		IL_0100: conv.r8
 		IL_0101: ldstr "updateCsprojVersion"
 		IL_0106: ldc.i4.0
 		IL_0107: ldc.i4.1
-		IL_0108: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion>(!!0, float64, string, bool, bool)
+		IL_0108: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/updateCsprojVersion/FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion>(!!0, float64, string, bool, bool)
 		IL_010d: stloc.s 14
 		IL_010f: ldloc.0
 		IL_0110: ldloc.s 14
@@ -3296,13 +4509,13 @@
 		IL_011f: ldloc.0
 		IL_0120: stelem.ref
 		IL_0121: stloc.s 8
-		IL_0123: newobj instance void FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion::.ctor()
+		IL_0123: newobj instance void Modules.Compile_Scripts_BumpVersion/updateSamplesPropsVersion/FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion::.ctor()
 		IL_0128: ldc.i4.2
 		IL_0129: conv.r8
 		IL_012a: ldstr "updateSamplesPropsVersion"
 		IL_012f: ldc.i4.0
 		IL_0130: ldc.i4.1
-		IL_0131: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion>(!!0, float64, string, bool, bool)
+		IL_0131: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/updateSamplesPropsVersion/FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion>(!!0, float64, string, bool, bool)
 		IL_0136: stloc.s 15
 		IL_0138: ldloc.0
 		IL_0139: ldloc.s 15
@@ -3318,13 +4531,13 @@
 		IL_014e: ldc.i4.0
 		IL_014f: ldelem.ref
 		IL_0150: castclass Modules.Compile_Scripts_BumpVersion/Scope
-		IL_0155: newobj instance void FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope)
+		IL_0155: newobj instance void Modules.Compile_Scripts_BumpVersion/extractUnreleased/FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope)
 		IL_015a: ldc.i4.1
 		IL_015b: conv.r8
 		IL_015c: ldstr "extractUnreleased"
 		IL_0161: ldc.i4.0
 		IL_0162: ldc.i4.1
-		IL_0163: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased>(!!0, float64, string, bool, bool)
+		IL_0163: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/extractUnreleased/FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased>(!!0, float64, string, bool, bool)
 		IL_0168: stloc.s 16
 		IL_016a: ldloc.0
 		IL_016b: ldloc.s 16
@@ -3336,13 +4549,13 @@
 		IL_017a: ldloc.0
 		IL_017b: stelem.ref
 		IL_017c: stloc.s 8
-		IL_017e: newobj instance void FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder::.ctor()
+		IL_017e: newobj instance void Modules.Compile_Scripts_BumpVersion/isPlaceholder/FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder::.ctor()
 		IL_0183: ldc.i4.1
 		IL_0184: conv.r8
 		IL_0185: ldstr "isPlaceholder"
 		IL_018a: ldc.i4.0
 		IL_018b: ldc.i4.1
-		IL_018c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder>(!!0, float64, string, bool, bool)
+		IL_018c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/isPlaceholder/FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder>(!!0, float64, string, bool, bool)
 		IL_0191: stloc.s 17
 		IL_0193: ldloc.0
 		IL_0194: ldloc.s 17
@@ -3358,13 +4571,13 @@
 		IL_01a9: ldc.i4.0
 		IL_01aa: ldelem.ref
 		IL_01ab: castclass Modules.Compile_Scripts_BumpVersion/Scope
-		IL_01b0: newobj instance void FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope)
+		IL_01b0: newobj instance void Modules.Compile_Scripts_BumpVersion/generateReleaseSection/FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope)
 		IL_01b5: ldc.i4.2
 		IL_01b6: conv.r8
 		IL_01b7: ldstr "generateReleaseSection"
 		IL_01bc: ldc.i4.0
 		IL_01bd: ldc.i4.1
-		IL_01be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection>(!!0, float64, string, bool, bool)
+		IL_01be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/generateReleaseSection/FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection>(!!0, float64, string, bool, bool)
 		IL_01c3: stloc.s 18
 		IL_01c5: ldloc.0
 		IL_01c6: ldloc.s 18
@@ -3380,13 +4593,13 @@
 		IL_01db: ldc.i4.0
 		IL_01dc: ldelem.ref
 		IL_01dd: castclass Modules.Compile_Scripts_BumpVersion/Scope
-		IL_01e2: newobj instance void FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_F66C72E6_perform::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope)
+		IL_01e2: newobj instance void Modules.Compile_Scripts_BumpVersion/perform/FunctionObject_FunctionDeclaration_F66C72E6_perform::.ctor(class Modules.Compile_Scripts_BumpVersion/Scope)
 		IL_01e7: ldc.i4.0
 		IL_01e8: conv.r8
 		IL_01e9: ldstr "perform"
 		IL_01ee: ldc.i4.0
 		IL_01ef: ldc.i4.1
-		IL_01f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_F66C72E6_perform>(!!0, float64, string, bool, bool)
+		IL_01f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_BumpVersion/perform/FunctionObject_FunctionDeclaration_F66C72E6_perform>(!!0, float64, string, bool, bool)
 		IL_01f5: stloc.1
 		IL_01f6: nop
 		IL_01f7: ldarg.1
@@ -3621,1219 +4834,6 @@
 	} // end of method Compile_Scripts_BumpVersion::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_BumpVersion
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_E165DCE7_readFile
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_BumpVersion/Scope _environment0_Compile_Scripts_BumpVersion
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_BumpVersion/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3865
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_BumpVersion/Scope FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_E165DCE7_readFile::_environment0_Compile_Scripts_BumpVersion
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E165DCE7_readFile::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3874
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E165DCE7_readFile::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3877
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E165DCE7_readFile::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x387a
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_E165DCE7_readFile::_environment0_Compile_Scripts_BumpVersion
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_E165DCE7_readFile::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3893
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_E165DCE7_readFile::_environment0_Compile_Scripts_BumpVersion
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Compile_Scripts_BumpVersion/readFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_E165DCE7_readFile::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x38a8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E165DCE7_readFile::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_E165DCE7_readFile
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_9E2A195E_writeFile
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_BumpVersion/Scope _environment0_Compile_Scripts_BumpVersion
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_BumpVersion/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x38b7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_BumpVersion/Scope FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_9E2A195E_writeFile::_environment0_Compile_Scripts_BumpVersion
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9E2A195E_writeFile::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x38c6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9E2A195E_writeFile::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x38c9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9E2A195E_writeFile::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x38cc
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_9E2A195E_writeFile::_environment0_Compile_Scripts_BumpVersion
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_9E2A195E_writeFile::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x38ec
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_9E2A195E_writeFile::_environment0_Compile_Scripts_BumpVersion
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Compile_Scripts_BumpVersion/writeFile::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_9E2A195E_writeFile::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3908
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9E2A195E_writeFile::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_9E2A195E_writeFile
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3917
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x391f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3922
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3925
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Compile_Scripts_BumpVersion/parseCurrentVersion::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3938
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Compile_Scripts_BumpVersion/parseCurrentVersion::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3947
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_5D7C735F_parseCurrentVersion
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_37FCF14D_incVersion
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3956
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_37FCF14D_incVersion::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x395e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_37FCF14D_incVersion::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3961
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_37FCF14D_incVersion::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3964
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Compile_Scripts_BumpVersion/incVersion::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_37FCF14D_incVersion::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x397e
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Compile_Scripts_BumpVersion/incVersion::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_37FCF14D_incVersion::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3994
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_37FCF14D_incVersion::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_37FCF14D_incVersion
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_BumpVersion/Scope _environment0_Compile_Scripts_BumpVersion
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_BumpVersion/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x39dd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_BumpVersion/Scope FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::_environment0_Compile_Scripts_BumpVersion
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x39ec
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x39ef
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x39f2
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::_environment0_Compile_Scripts_BumpVersion
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Compile_Scripts_BumpVersion/resolveTargetVersion::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a12
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::_environment0_Compile_Scripts_BumpVersion
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Compile_Scripts_BumpVersion/resolveTargetVersion::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a2e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_BF8A917E_resolveTargetVersion
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3a3d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3a45
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3a48
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a4b
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a65
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Compile_Scripts_BumpVersion/updateCsprojVersion::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a7b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_13D2794F_updateCsprojVersion
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3a8a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3a92
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3a95
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a98
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Compile_Scripts_BumpVersion/updateSamplesPropsVersion::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ab2
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Compile_Scripts_BumpVersion/updateSamplesPropsVersion::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ac8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_B3C7C189_updateSamplesPropsVersion
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_BumpVersion/Scope _environment0_Compile_Scripts_BumpVersion
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_BumpVersion/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ad7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_BumpVersion/Scope FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::_environment0_Compile_Scripts_BumpVersion
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3ae6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3ae9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3aec
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::_environment0_Compile_Scripts_BumpVersion
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Compile_Scripts_BumpVersion/extractUnreleased::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b05
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::_environment0_Compile_Scripts_BumpVersion
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Compile_Scripts_BumpVersion/extractUnreleased::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b1a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_9AD51CCA_extractUnreleased
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3b29
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3b31
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3b34
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b37
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Compile_Scripts_BumpVersion/isPlaceholder::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b4a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Compile_Scripts_BumpVersion/isPlaceholder::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b59
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_7A26CC3E_isPlaceholder
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_BumpVersion/Scope _environment0_Compile_Scripts_BumpVersion
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_BumpVersion/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b68
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_BumpVersion/Scope FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::_environment0_Compile_Scripts_BumpVersion
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3b77
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3b7a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b7d
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::_environment0_Compile_Scripts_BumpVersion
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Compile_Scripts_BumpVersion/generateReleaseSection::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b9d
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::_environment0_Compile_Scripts_BumpVersion
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Compile_Scripts_BumpVersion/generateReleaseSection::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3bb9
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_4495EAE2_generateReleaseSection
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_F66C72E6_perform
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_BumpVersion/Scope _environment0_Compile_Scripts_BumpVersion
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_BumpVersion/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3bf9
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_BumpVersion/Scope FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_F66C72E6_perform::_environment0_Compile_Scripts_BumpVersion
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F66C72E6_perform::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3c08
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F66C72E6_perform::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3c0b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F66C72E6_perform::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c0e
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_F66C72E6_perform::_environment0_Compile_Scripts_BumpVersion
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Scripts_BumpVersion/perform::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_F66C72E6_perform::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c20
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_BumpVersion/Scope FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_F66C72E6_perform::_environment0_Compile_Scripts_BumpVersion
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Scripts_BumpVersion/perform::__js_call__(class Modules.Compile_Scripts_BumpVersion/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_F66C72E6_perform::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3c2e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F66C72E6_perform::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_BumpVersion_CEF50B12.FunctionObject_FunctionDeclaration_F66C72E6_perform
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown.verified.txt
@@ -155,6 +155,119 @@
 
 		} // end of class Scope_For_L21C7
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0544688E_parseArgs
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope _environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3253
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs/FunctionObject_FunctionDeclaration_0544688E_parseArgs::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0544688E_parseArgs::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3262
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0544688E_parseArgs::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3265
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0544688E_parseArgs::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3268
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs/FunctionObject_FunctionDeclaration_0544688E_parseArgs::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_0544688E_parseArgs::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3281
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs/FunctionObject_FunctionDeclaration_0544688E_parseArgs::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_0544688E_parseArgs::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3296
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0544688E_parseArgs::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_0544688E_parseArgs
+
 
 		// Methods
 		.method public hidebysig static 
@@ -458,6 +571,113 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_15C44BEA_L61C16
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x32f7
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_15C44BEA_L61C16::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x32ff
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_15C44BEA_L61C16::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3302
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_15C44BEA_L61C16::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x3305
+					// Header size: 1
+					// Code size: 25 (0x19)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: ldarg.2
+					IL_0006: ldc.i4.0
+					IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000c: ldarg.2
+					IL_000d: ldc.i4.1
+					IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0013: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L61C15::__js_call__(object, object, object)
+					IL_0018: ret
+				} // end of method FunctionObject_FunctionExpression_15C44BEA_L61C16::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x331f
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: ldarg.2
+					IL_0002: ldc.i4.0
+					IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0008: ldarg.2
+					IL_0009: ldc.i4.1
+					IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000f: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L61C15::__js_call__(object, object, object)
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionExpression_15C44BEA_L61C16::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3335
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_15C44BEA_L61C16::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_15C44BEA_L61C16
+
 
 			// Methods
 			.method public hidebysig static 
@@ -649,6 +869,107 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8A5C527C_L74C16
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x3344
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_8A5C527C_L74C16::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x334c
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_8A5C527C_L74C16::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x334f
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_8A5C527C_L74C16::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x3352
+					// Header size: 1
+					// Code size: 18 (0x12)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: ldarg.2
+					IL_0006: ldc.i4.0
+					IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000c: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L74C15::__js_call__(object, object)
+					IL_0011: ret
+				} // end of method FunctionObject_FunctionExpression_8A5C527C_L74C16::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3365
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: ldarg.2
+					IL_0002: ldc.i4.0
+					IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0008: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L74C15::__js_call__(object, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_8A5C527C_L74C16::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3374
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_8A5C527C_L74C16::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_8A5C527C_L74C16
+
 
 			// Methods
 			.method public hidebysig static 
@@ -750,6 +1071,107 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DD415412_L82C11
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x3383
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_DD415412_L82C11::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x338b
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_DD415412_L82C11::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x338e
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_DD415412_L82C11::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x3391
+					// Header size: 1
+					// Code size: 18 (0x12)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: ldarg.2
+					IL_0006: ldc.i4.0
+					IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000c: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L82C10::__js_call__(object, object)
+					IL_0011: ret
+				} // end of method FunctionObject_FunctionExpression_DD415412_L82C11::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x33a4
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: ldarg.2
+					IL_0002: ldc.i4.0
+					IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0008: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L82C10::__js_call__(object, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_DD415412_L82C11::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x33b3
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_DD415412_L82C11::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_DD415412_L82C11
 
 
 			// Methods
@@ -1047,6 +1469,130 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8E7AE75C_L85C16
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope _environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x33c2
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/FunctionObject_FunctionExpression_8E7AE75C_L85C16::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/FunctionObject_FunctionExpression_8E7AE75C_L85C16::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionExpression_8E7AE75C_L85C16::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x33d8
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_8E7AE75C_L85C16::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x33db
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_8E7AE75C_L85C16::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x33de
+					// Header size: 1
+					// Code size: 31 (0x1f)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/FunctionObject_FunctionExpression_8E7AE75C_L85C16::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: ldarg.2
+					IL_0013: ldc.i4.1
+					IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0019: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15::__js_call__(object[], object, object, object)
+					IL_001e: ret
+				} // end of method FunctionObject_FunctionExpression_8E7AE75C_L85C16::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x33fe
+					// Header size: 1
+					// Code size: 27 (0x1b)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15/FunctionObject_FunctionExpression_8E7AE75C_L85C16::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: ldarg.2
+					IL_000f: ldc.i4.1
+					IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0015: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15::__js_call__(object[], object, object, object)
+					IL_001a: ret
+				} // end of method FunctionObject_FunctionExpression_8E7AE75C_L85C16::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x341a
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_8E7AE75C_L85C16::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_8E7AE75C_L85C16
+
 
 			// Methods
 			.method public hidebysig static 
@@ -1272,6 +1818,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope _environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x32a5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x32b4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x32b7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x32ba
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x32d3
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x32e8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown
 
 
 		// Methods
@@ -1573,6 +2232,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_71696E19_main
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope _environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3446
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main/FunctionObject_FunctionDeclaration_71696E19_main::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_71696E19_main::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3455
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_71696E19_main::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3458
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_71696E19_main::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x345b
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main/FunctionObject_FunctionDeclaration_71696E19_main::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_71696E19_main::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x346d
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main/FunctionObject_FunctionDeclaration_71696E19_main::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_71696E19_main::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x347b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_71696E19_main::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_71696E19_main
 
 
 		// Methods
@@ -2078,15 +2844,15 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope,
-			[1] class FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionDeclaration_71696E19_main,
+			[1] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main/FunctionObject_FunctionDeclaration_71696E19_main,
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
 			[5] object,
 			[6] object,
 			[7] object[],
-			[8] class FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionDeclaration_0544688E_parseArgs,
-			[9] class FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown,
+			[8] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs/FunctionObject_FunctionDeclaration_0544688E_parseArgs,
+			[9] class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown,
 			[10] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
 			[11] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule,
 			[12] object,
@@ -2109,13 +2875,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope
-		IL_001b: newobj instance void FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionDeclaration_0544688E_parseArgs::.ctor(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope)
+		IL_001b: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs/FunctionObject_FunctionDeclaration_0544688E_parseArgs::.ctor(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope)
 		IL_0020: ldc.i4.1
 		IL_0021: conv.r8
 		IL_0022: ldstr "parseArgs"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionDeclaration_0544688E_parseArgs>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs/FunctionObject_FunctionDeclaration_0544688E_parseArgs>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.s 8
 		IL_0030: ldloc.0
 		IL_0031: ldloc.s 8
@@ -2131,13 +2897,13 @@
 		IL_0046: ldc.i4.0
 		IL_0047: ldelem.ref
 		IL_0048: castclass Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope
-		IL_004d: newobj instance void FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::.ctor(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope)
+		IL_004d: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::.ctor(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope)
 		IL_0052: ldc.i4.1
 		IL_0053: conv.r8
 		IL_0054: ldstr "convertHtmlToMarkdown"
 		IL_0059: ldc.i4.0
 		IL_005a: ldc.i4.1
-		IL_005b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown>(!!0, float64, string, bool, bool)
+		IL_005b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown>(!!0, float64, string, bool, bool)
 		IL_0060: stloc.s 9
 		IL_0062: ldloc.0
 		IL_0063: ldloc.s 9
@@ -2153,13 +2919,13 @@
 		IL_0078: ldc.i4.0
 		IL_0079: ldelem.ref
 		IL_007a: castclass Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope
-		IL_007f: newobj instance void FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionDeclaration_71696E19_main::.ctor(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope)
+		IL_007f: newobj instance void Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main/FunctionObject_FunctionDeclaration_71696E19_main::.ctor(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope)
 		IL_0084: ldc.i4.0
 		IL_0085: conv.r8
 		IL_0086: ldstr "main"
 		IL_008b: ldc.i4.0
 		IL_008c: ldc.i4.1
-		IL_008d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionDeclaration_71696E19_main>(!!0, float64, string, bool, bool)
+		IL_008d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main/FunctionObject_FunctionDeclaration_71696E19_main>(!!0, float64, string, bool, bool)
 		IL_0092: stloc.1
 		IL_0093: nop
 		IL_0094: ldarg.1
@@ -2318,6 +3084,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x348a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3492
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3495
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3498
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Packages.turndown.index/TurndownService::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x34a4
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Packages.turndown.index/TurndownService::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x34ac
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2369,6 +3230,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8739CC51_addRule
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x34bb
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_8739CC51_addRule::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x34c3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_8739CC51_addRule::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x34c6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_8739CC51_addRule::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x34c9
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Packages.turndown.index/addRule::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionExpression_8739CC51_addRule::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x34e3
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Packages.turndown.index/addRule::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionExpression_8739CC51_addRule::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x34f9
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_8739CC51_addRule::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_8739CC51_addRule
 
 
 		// Methods
@@ -2431,6 +3399,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C20E11E7_turndown
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3508
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_C20E11E7_turndown::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3510
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C20E11E7_turndown::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3513
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C20E11E7_turndown::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3516
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Packages.turndown.index/turndown::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_C20E11E7_turndown::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3529
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Packages.turndown.index/turndown::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_C20E11E7_turndown::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3538
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_C20E11E7_turndown::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_C20E11E7_turndown
 
 
 		// Methods
@@ -2527,11 +3596,11 @@
 		.maxstack 8
 		.locals init (
 			[0] class Packages.turndown.index/Scope,
-			[1] class FunctionObjects.m_7475726e646f776e2f696e646578_E69F9DEB.FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService,
+			[1] class Packages.turndown.index/TurndownService/FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService,
 			[2] object[],
 			[3] object,
-			[4] class FunctionObjects.m_7475726e646f776e2f696e646578_E69F9DEB.FunctionObject_FunctionExpression_8739CC51_addRule,
-			[5] class FunctionObjects.m_7475726e646f776e2f696e646578_E69F9DEB.FunctionObject_FunctionExpression_C20E11E7_turndown
+			[4] class Packages.turndown.index/addRule/FunctionObject_FunctionExpression_8739CC51_addRule,
+			[5] class Packages.turndown.index/turndown/FunctionObject_FunctionExpression_C20E11E7_turndown
 		)
 
 		IL_0000: newobj instance void Packages.turndown.index/Scope::.ctor()
@@ -2543,13 +3612,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.m_7475726e646f776e2f696e646578_E69F9DEB.FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService::.ctor()
+		IL_0011: newobj instance void Packages.turndown.index/TurndownService/FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "TurndownService"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.m_7475726e646f776e2f696e646578_E69F9DEB.FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Packages.turndown.index/TurndownService/FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -2564,13 +3633,13 @@
 		IL_003b: ldloc.0
 		IL_003c: stelem.ref
 		IL_003d: stloc.2
-		IL_003e: newobj instance void FunctionObjects.m_7475726e646f776e2f696e646578_E69F9DEB.FunctionObject_FunctionExpression_8739CC51_addRule::.ctor()
+		IL_003e: newobj instance void Packages.turndown.index/addRule/FunctionObject_FunctionExpression_8739CC51_addRule::.ctor()
 		IL_0043: ldc.i4.2
 		IL_0044: conv.r8
 		IL_0045: ldstr "addRule"
 		IL_004a: ldc.i4.1
 		IL_004b: ldc.i4.1
-		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.m_7475726e646f776e2f696e646578_E69F9DEB.FunctionObject_FunctionExpression_8739CC51_addRule>(!!0, float64, string, bool, bool)
+		IL_004c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Packages.turndown.index/addRule/FunctionObject_FunctionExpression_8739CC51_addRule>(!!0, float64, string, bool, bool)
 		IL_0051: stloc.s 4
 		IL_0053: ldloc.3
 		IL_0054: ldstr "addRule"
@@ -2589,13 +3658,13 @@
 		IL_0076: ldloc.0
 		IL_0077: stelem.ref
 		IL_0078: stloc.2
-		IL_0079: newobj instance void FunctionObjects.m_7475726e646f776e2f696e646578_E69F9DEB.FunctionObject_FunctionExpression_C20E11E7_turndown::.ctor()
+		IL_0079: newobj instance void Packages.turndown.index/turndown/FunctionObject_FunctionExpression_C20E11E7_turndown::.ctor()
 		IL_007e: ldc.i4.1
 		IL_007f: conv.r8
 		IL_0080: ldstr "turndown"
 		IL_0085: ldc.i4.1
 		IL_0086: ldc.i4.1
-		IL_0087: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.m_7475726e646f776e2f696e646578_E69F9DEB.FunctionObject_FunctionExpression_C20E11E7_turndown>(!!0, float64, string, bool, bool)
+		IL_0087: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Packages.turndown.index/turndown/FunctionObject_FunctionExpression_C20E11E7_turndown>(!!0, float64, string, bool, bool)
 		IL_008c: stloc.s 5
 		IL_008e: ldloc.3
 		IL_008f: ldstr "turndown"
@@ -2613,1075 +3682,6 @@
 	} // end of method index::__js_module_init__
 
 } // end of class Packages.turndown.index
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionDeclaration_0544688E_parseArgs
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope _environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3253
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionDeclaration_0544688E_parseArgs::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0544688E_parseArgs::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3262
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0544688E_parseArgs::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3265
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0544688E_parseArgs::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3268
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionDeclaration_0544688E_parseArgs::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_0544688E_parseArgs::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3281
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionDeclaration_0544688E_parseArgs::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/parseArgs::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_0544688E_parseArgs::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3296
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0544688E_parseArgs::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionDeclaration_0544688E_parseArgs
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope _environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x32a5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x32b4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x32b7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x32ba
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x32d3
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x32e8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionDeclaration_0DF57386_convertHtmlToMarkdown
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionExpression_15C44BEA_L61C16
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x32f7
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_15C44BEA_L61C16::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x32ff
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_15C44BEA_L61C16::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3302
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_15C44BEA_L61C16::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3305
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L61C15::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_15C44BEA_L61C16::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x331f
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L61C15::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_15C44BEA_L61C16::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3335
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_15C44BEA_L61C16::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionExpression_15C44BEA_L61C16
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionExpression_8A5C527C_L74C16
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3344
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_8A5C527C_L74C16::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x334c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_8A5C527C_L74C16::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x334f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_8A5C527C_L74C16::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3352
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L74C15::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_8A5C527C_L74C16::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3365
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L74C15::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_8A5C527C_L74C16::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3374
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_8A5C527C_L74C16::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionExpression_8A5C527C_L74C16
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionExpression_DD415412_L82C11
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3383
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_DD415412_L82C11::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x338b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DD415412_L82C11::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x338e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DD415412_L82C11::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3391
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L82C10::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_DD415412_L82C11::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x33a4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L82C10::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DD415412_L82C11::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x33b3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DD415412_L82C11::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionExpression_DD415412_L82C11
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionExpression_8E7AE75C_L85C16
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope _environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x33c2
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionExpression_8E7AE75C_L85C16::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionExpression_8E7AE75C_L85C16::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_8E7AE75C_L85C16::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x33d8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_8E7AE75C_L85C16::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x33db
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_8E7AE75C_L85C16::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x33de
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionExpression_8E7AE75C_L85C16::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15::__js_call__(object[], object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionExpression_8E7AE75C_L85C16::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x33fe
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionExpression_8E7AE75C_L85C16::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/convertHtmlToMarkdown/FunctionExpression_L85C15::__js_call__(object[], object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionExpression_8E7AE75C_L85C16::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x341a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_8E7AE75C_L85C16::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionExpression_8E7AE75C_L85C16
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionDeclaration_71696E19_main
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope _environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3446
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionDeclaration_71696E19_main::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_71696E19_main::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3455
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_71696E19_main::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3458
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_71696E19_main::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x345b
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionDeclaration_71696E19_main::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_71696E19_main::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x346d
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionDeclaration_71696E19_main::_environment0_Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/main::__js_call__(class Modules.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_71696E19_main::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x347b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_71696E19_main::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_ConvertEcmaExtractHtmlToMarkdown_8FEA63E9.FunctionObject_FunctionDeclaration_71696E19_main
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.m_7475726e646f776e2f696e646578_E69F9DEB.FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x348a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3492
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3495
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3498
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Packages.turndown.index/TurndownService::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x34a4
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Packages.turndown.index/TurndownService::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x34ac
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService::ConstructCore
-
-} // end of class FunctionObjects.m_7475726e646f776e2f696e646578_E69F9DEB.FunctionObject_FunctionDeclaration_C8BD66B4_TurndownService
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.m_7475726e646f776e2f696e646578_E69F9DEB.FunctionObject_FunctionExpression_8739CC51_addRule
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x34bb
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_8739CC51_addRule::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x34c3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_8739CC51_addRule::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x34c6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_8739CC51_addRule::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x34c9
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Packages.turndown.index/addRule::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_8739CC51_addRule::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x34e3
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Packages.turndown.index/addRule::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_8739CC51_addRule::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x34f9
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_8739CC51_addRule::ConstructCore
-
-} // end of class FunctionObjects.m_7475726e646f776e2f696e646578_E69F9DEB.FunctionObject_FunctionExpression_8739CC51_addRule
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.m_7475726e646f776e2f696e646578_E69F9DEB.FunctionObject_FunctionExpression_C20E11E7_turndown
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3508
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_C20E11E7_turndown::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3510
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C20E11E7_turndown::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3513
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C20E11E7_turndown::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3516
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Packages.turndown.index/turndown::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_C20E11E7_turndown::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3529
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Packages.turndown.index/turndown::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C20E11E7_turndown::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3538
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C20E11E7_turndown::ConstructCore
-
-} // end of class FunctionObjects.m_7475726e646f776e2f696e646578_E69F9DEB.FunctionObject_FunctionExpression_C20E11E7_turndown
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_DecompileGeneratorTest.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x35bb
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x35c3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x35c6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x35c9
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Compile_Scripts_DecompileGeneratorTest/getAssemblyFileBaseName::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x35dc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Compile_Scripts_DecompileGeneratorTest/getAssemblyFileBaseName::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x35eb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName
+
 
 		// Methods
 		.method public hidebysig static 
@@ -166,6 +267,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_DecompileGeneratorTest/Scope _environment0_Compile_Scripts_DecompileGeneratorTest
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_DecompileGeneratorTest/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x35fa
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/normalizeCategory/FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3609
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x360c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x360f
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/normalizeCategory/FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Compile_Scripts_DecompileGeneratorTest/normalizeCategory::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3628
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/normalizeCategory/FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Compile_Scripts_DecompileGeneratorTest/normalizeCategory::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x363d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory
 
 
 		// Methods
@@ -547,6 +761,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_DecompileGeneratorTest/Scope _environment0_Compile_Scripts_DecompileGeneratorTest
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_DecompileGeneratorTest/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x364c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots/FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x365b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x365e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3661
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots/FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x367a
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots/FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x368f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots
 
 
 		// Methods
@@ -1067,6 +1394,125 @@
 
 		} // end of class Scope_ForOf_L72C7
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_DecompileGeneratorTest/Scope _environment0_Compile_Scripts_DecompileGeneratorTest
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_DecompileGeneratorTest/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x36d6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x36e5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x36e8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x36eb
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x370b
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3727
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1432,6 +1878,125 @@
 
 		} // end of class Scope_ForOf_L87C7
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_DecompileGeneratorTest/Scope _environment0_Compile_Scripts_DecompileGeneratorTest
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_DecompileGeneratorTest/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x378b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly/FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x379a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x379d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x37a0
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly/FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x37c0
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly/FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x37dc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1638,6 +2203,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_60187D86_findProjectRoot
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_DecompileGeneratorTest/Scope _environment0_Compile_Scripts_DecompileGeneratorTest
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_DecompileGeneratorTest/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x37eb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot/FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x37fa
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x37fd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3800
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot/FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3819
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot/FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x382e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_60187D86_findProjectRoot
 
 
 		// Methods
@@ -1855,6 +2533,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_DecompileGeneratorTest/Scope _environment0_Compile_Scripts_DecompileGeneratorTest
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_DecompileGeneratorTest/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x383d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/getGeneratorTestSnapshotPath/FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x384c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x384f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3852
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/getGeneratorTestSnapshotPath/FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Compile_Scripts_DecompileGeneratorTest/getGeneratorTestSnapshotPath::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3872
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/getGeneratorTestSnapshotPath/FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Compile_Scripts_DecompileGeneratorTest/getGeneratorTestSnapshotPath::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x388e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1953,6 +2750,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_DecompileGeneratorTest/Scope _environment0_Compile_Scripts_DecompileGeneratorTest
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_DecompileGeneratorTest/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x389d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy/FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x38ac
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x38af
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x38b2
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy/FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x38cb
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy/FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x38e0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy
 
 
 		// Methods
@@ -2239,6 +3149,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_62C762B7_main
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_DecompileGeneratorTest/Scope _environment0_Compile_Scripts_DecompileGeneratorTest
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_DecompileGeneratorTest/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x38ef
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/main/FunctionObject_FunctionDeclaration_62C762B7_main::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_62C762B7_main::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x38fe
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_62C762B7_main::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3901
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_62C762B7_main::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3904
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/main/FunctionObject_FunctionDeclaration_62C762B7_main::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Scripts_DecompileGeneratorTest/main::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_62C762B7_main::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3916
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope Modules.Compile_Scripts_DecompileGeneratorTest/main/FunctionObject_FunctionDeclaration_62C762B7_main::_environment0_Compile_Scripts_DecompileGeneratorTest
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Scripts_DecompileGeneratorTest/main::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_62C762B7_main::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3924
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_62C762B7_main::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_62C762B7_main
 
 
 		// Methods
@@ -3036,16 +4053,16 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_DecompileGeneratorTest/Scope,
-			[1] class FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_60187D86_findProjectRoot,
-			[2] class FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_62C762B7_main,
+			[1] class Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot/FunctionObject_FunctionDeclaration_60187D86_findProjectRoot,
+			[2] class Modules.Compile_Scripts_DecompileGeneratorTest/main/FunctionObject_FunctionDeclaration_62C762B7_main,
 			[3] object[],
-			[4] class FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName,
-			[5] class FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory,
-			[6] class FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots,
-			[7] class FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot,
-			[8] class FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly,
-			[9] class FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath,
-			[10] class FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy,
+			[4] class Modules.Compile_Scripts_DecompileGeneratorTest/getAssemblyFileBaseName/FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName,
+			[5] class Modules.Compile_Scripts_DecompileGeneratorTest/normalizeCategory/FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory,
+			[6] class Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots/FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots,
+			[7] class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot,
+			[8] class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly/FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly,
+			[9] class Modules.Compile_Scripts_DecompileGeneratorTest/getGeneratorTestSnapshotPath/FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath,
+			[10] class Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy/FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy,
 			[11] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule,
 			[12] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
 			[13] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule,
@@ -3062,13 +4079,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName::.ctor()
+		IL_0011: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/getAssemblyFileBaseName/FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "getAssemblyFileBaseName"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/getAssemblyFileBaseName/FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.s 4
 		IL_0026: ldloc.0
 		IL_0027: ldloc.s 4
@@ -3084,13 +4101,13 @@
 		IL_003a: ldc.i4.0
 		IL_003b: ldelem.ref
 		IL_003c: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-		IL_0041: newobj instance void FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
+		IL_0041: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/normalizeCategory/FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
 		IL_0046: ldc.i4.1
 		IL_0047: conv.r8
 		IL_0048: ldstr "normalizeCategory"
 		IL_004d: ldc.i4.0
 		IL_004e: ldc.i4.1
-		IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory>(!!0, float64, string, bool, bool)
+		IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/normalizeCategory/FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory>(!!0, float64, string, bool, bool)
 		IL_0054: stloc.s 5
 		IL_0056: ldloc.0
 		IL_0057: ldloc.s 5
@@ -3106,13 +4123,13 @@
 		IL_006a: ldc.i4.0
 		IL_006b: ldelem.ref
 		IL_006c: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-		IL_0071: newobj instance void FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
+		IL_0071: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots/FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
 		IL_0076: ldc.i4.1
 		IL_0077: conv.r8
 		IL_0078: ldstr "getCandidateCategoryRoots"
 		IL_007d: ldc.i4.0
 		IL_007e: ldc.i4.1
-		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots>(!!0, float64, string, bool, bool)
+		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots/FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots>(!!0, float64, string, bool, bool)
 		IL_0084: stloc.s 6
 		IL_0086: ldloc.0
 		IL_0087: ldloc.s 6
@@ -3128,13 +4145,13 @@
 		IL_009a: ldc.i4.0
 		IL_009b: ldelem.ref
 		IL_009c: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-		IL_00a1: newobj instance void FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
+		IL_00a1: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
 		IL_00a6: ldc.i4.2
 		IL_00a7: conv.r8
 		IL_00a8: ldstr "tryFindLatestGeneratedAssemblyInRoot"
 		IL_00ad: ldc.i4.0
 		IL_00ae: ldc.i4.1
-		IL_00af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot>(!!0, float64, string, bool, bool)
+		IL_00af: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot/FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot>(!!0, float64, string, bool, bool)
 		IL_00b4: stloc.s 7
 		IL_00b6: ldloc.0
 		IL_00b7: ldloc.s 7
@@ -3150,13 +4167,13 @@
 		IL_00ca: ldc.i4.0
 		IL_00cb: ldelem.ref
 		IL_00cc: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-		IL_00d1: newobj instance void FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
+		IL_00d1: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly/FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
 		IL_00d6: ldc.i4.2
 		IL_00d7: conv.r8
 		IL_00d8: ldstr "tryFindLatestGeneratedAssembly"
 		IL_00dd: ldc.i4.0
 		IL_00de: ldc.i4.1
-		IL_00df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly>(!!0, float64, string, bool, bool)
+		IL_00df: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly/FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly>(!!0, float64, string, bool, bool)
 		IL_00e4: stloc.s 8
 		IL_00e6: ldloc.0
 		IL_00e7: ldloc.s 8
@@ -3172,13 +4189,13 @@
 		IL_00fa: ldc.i4.0
 		IL_00fb: ldelem.ref
 		IL_00fc: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-		IL_0101: newobj instance void FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
+		IL_0101: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot/FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
 		IL_0106: ldc.i4.1
 		IL_0107: conv.r8
 		IL_0108: ldstr "findProjectRoot"
 		IL_010d: ldc.i4.0
 		IL_010e: ldc.i4.1
-		IL_010f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_60187D86_findProjectRoot>(!!0, float64, string, bool, bool)
+		IL_010f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot/FunctionObject_FunctionDeclaration_60187D86_findProjectRoot>(!!0, float64, string, bool, bool)
 		IL_0114: stloc.1
 		IL_0115: ldc.i4.1
 		IL_0116: newarr [System.Runtime]System.Object
@@ -3191,13 +4208,13 @@
 		IL_0121: ldc.i4.0
 		IL_0122: ldelem.ref
 		IL_0123: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-		IL_0128: newobj instance void FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
+		IL_0128: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/getGeneratorTestSnapshotPath/FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
 		IL_012d: ldc.i4.2
 		IL_012e: conv.r8
 		IL_012f: ldstr "getGeneratorTestSnapshotPath"
 		IL_0134: ldc.i4.0
 		IL_0135: ldc.i4.1
-		IL_0136: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath>(!!0, float64, string, bool, bool)
+		IL_0136: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/getGeneratorTestSnapshotPath/FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath>(!!0, float64, string, bool, bool)
 		IL_013b: stloc.s 9
 		IL_013d: ldloc.0
 		IL_013e: ldloc.s 9
@@ -3213,13 +4230,13 @@
 		IL_0151: ldc.i4.0
 		IL_0152: ldelem.ref
 		IL_0153: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-		IL_0158: newobj instance void FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
+		IL_0158: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy/FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
 		IL_015d: ldc.i4.1
 		IL_015e: conv.r8
 		IL_015f: ldstr "openInIlSpy"
 		IL_0164: ldc.i4.0
 		IL_0165: ldc.i4.1
-		IL_0166: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy>(!!0, float64, string, bool, bool)
+		IL_0166: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy/FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy>(!!0, float64, string, bool, bool)
 		IL_016b: stloc.s 10
 		IL_016d: ldloc.0
 		IL_016e: ldloc.s 10
@@ -3235,13 +4252,13 @@
 		IL_0181: ldc.i4.0
 		IL_0182: ldelem.ref
 		IL_0183: castclass Modules.Compile_Scripts_DecompileGeneratorTest/Scope
-		IL_0188: newobj instance void FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_62C762B7_main::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
+		IL_0188: newobj instance void Modules.Compile_Scripts_DecompileGeneratorTest/main/FunctionObject_FunctionDeclaration_62C762B7_main::.ctor(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope)
 		IL_018d: ldc.i4.0
 		IL_018e: conv.r8
 		IL_018f: ldstr "main"
 		IL_0194: ldc.i4.0
 		IL_0195: ldc.i4.1
-		IL_0196: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_62C762B7_main>(!!0, float64, string, bool, bool)
+		IL_0196: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_DecompileGeneratorTest/main/FunctionObject_FunctionDeclaration_62C762B7_main>(!!0, float64, string, bool, bool)
 		IL_019b: stloc.2
 		IL_019c: nop
 		IL_019d: ldarg.1
@@ -3299,1023 +4316,6 @@
 	} // end of method Compile_Scripts_DecompileGeneratorTest::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_DecompileGeneratorTest
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x35bb
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x35c3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x35c6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x35c9
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Compile_Scripts_DecompileGeneratorTest/getAssemblyFileBaseName::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x35dc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Compile_Scripts_DecompileGeneratorTest/getAssemblyFileBaseName::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x35eb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_4FC85B62_getAssemblyFileBaseName
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_DecompileGeneratorTest/Scope _environment0_Compile_Scripts_DecompileGeneratorTest
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_DecompileGeneratorTest/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x35fa
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::_environment0_Compile_Scripts_DecompileGeneratorTest
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3609
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x360c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x360f
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::_environment0_Compile_Scripts_DecompileGeneratorTest
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Compile_Scripts_DecompileGeneratorTest/normalizeCategory::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3628
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::_environment0_Compile_Scripts_DecompileGeneratorTest
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Compile_Scripts_DecompileGeneratorTest/normalizeCategory::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x363d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_F56F08D1_normalizeCategory
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_DecompileGeneratorTest/Scope _environment0_Compile_Scripts_DecompileGeneratorTest
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_DecompileGeneratorTest/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x364c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::_environment0_Compile_Scripts_DecompileGeneratorTest
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x365b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x365e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3661
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::_environment0_Compile_Scripts_DecompileGeneratorTest
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x367a
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::_environment0_Compile_Scripts_DecompileGeneratorTest
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Compile_Scripts_DecompileGeneratorTest/getCandidateCategoryRoots::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x368f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_2E29E840_getCandidateCategoryRoots
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_DecompileGeneratorTest/Scope _environment0_Compile_Scripts_DecompileGeneratorTest
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_DecompileGeneratorTest/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x36d6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::_environment0_Compile_Scripts_DecompileGeneratorTest
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x36e5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x36e8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x36eb
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::_environment0_Compile_Scripts_DecompileGeneratorTest
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x370b
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::_environment0_Compile_Scripts_DecompileGeneratorTest
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssemblyInRoot::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3727
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_815A60CB_tryFindLatestGeneratedAssemblyInRoot
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_DecompileGeneratorTest/Scope _environment0_Compile_Scripts_DecompileGeneratorTest
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_DecompileGeneratorTest/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x378b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::_environment0_Compile_Scripts_DecompileGeneratorTest
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x379a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x379d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x37a0
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::_environment0_Compile_Scripts_DecompileGeneratorTest
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x37c0
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::_environment0_Compile_Scripts_DecompileGeneratorTest
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Compile_Scripts_DecompileGeneratorTest/tryFindLatestGeneratedAssembly::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x37dc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_8C6B1088_tryFindLatestGeneratedAssembly
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_60187D86_findProjectRoot
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_DecompileGeneratorTest/Scope _environment0_Compile_Scripts_DecompileGeneratorTest
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_DecompileGeneratorTest/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x37eb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::_environment0_Compile_Scripts_DecompileGeneratorTest
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x37fa
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x37fd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3800
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::_environment0_Compile_Scripts_DecompileGeneratorTest
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3819
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::_environment0_Compile_Scripts_DecompileGeneratorTest
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Compile_Scripts_DecompileGeneratorTest/findProjectRoot::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x382e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_60187D86_findProjectRoot::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_60187D86_findProjectRoot
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_DecompileGeneratorTest/Scope _environment0_Compile_Scripts_DecompileGeneratorTest
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_DecompileGeneratorTest/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x383d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::_environment0_Compile_Scripts_DecompileGeneratorTest
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x384c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x384f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3852
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::_environment0_Compile_Scripts_DecompileGeneratorTest
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Compile_Scripts_DecompileGeneratorTest/getGeneratorTestSnapshotPath::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3872
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::_environment0_Compile_Scripts_DecompileGeneratorTest
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Compile_Scripts_DecompileGeneratorTest/getGeneratorTestSnapshotPath::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x388e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_9D4AC1E4_getGeneratorTestSnapshotPath
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_DecompileGeneratorTest/Scope _environment0_Compile_Scripts_DecompileGeneratorTest
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_DecompileGeneratorTest/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x389d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::_environment0_Compile_Scripts_DecompileGeneratorTest
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x38ac
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x38af
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x38b2
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::_environment0_Compile_Scripts_DecompileGeneratorTest
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x38cb
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::_environment0_Compile_Scripts_DecompileGeneratorTest
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Compile_Scripts_DecompileGeneratorTest/openInIlSpy::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x38e0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_C1927AEA_openInIlSpy
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_62C762B7_main
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_DecompileGeneratorTest/Scope _environment0_Compile_Scripts_DecompileGeneratorTest
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_DecompileGeneratorTest/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x38ef
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_62C762B7_main::_environment0_Compile_Scripts_DecompileGeneratorTest
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_62C762B7_main::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x38fe
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_62C762B7_main::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3901
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_62C762B7_main::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3904
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_62C762B7_main::_environment0_Compile_Scripts_DecompileGeneratorTest
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Scripts_DecompileGeneratorTest/main::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_62C762B7_main::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3916
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_DecompileGeneratorTest/Scope FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_62C762B7_main::_environment0_Compile_Scripts_DecompileGeneratorTest
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Scripts_DecompileGeneratorTest/main::__js_call__(class Modules.Compile_Scripts_DecompileGeneratorTest/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_62C762B7_main::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3924
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_62C762B7_main::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_DecompileGeneratorTest_59EC2D5B.FunctionObject_FunctionDeclaration_62C762B7_main
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode.verified.txt
@@ -41,6 +41,99 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5C26764E_run
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope _environment0_Compile_Scripts_ExtractEcma262SectionHtml_AutoMode
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x4734
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/FunctionObject_FunctionDeclaration_5C26764E_run::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_AutoMode
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/FunctionObject_FunctionDeclaration_5C26764E_run::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_5C26764E_run::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x474a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5C26764E_run::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x474d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5C26764E_run::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4750
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/FunctionObject_FunctionDeclaration_5C26764E_run::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_5C26764E_run::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4762
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run/FunctionObject_FunctionDeclaration_5C26764E_run::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_5C26764E_run::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_5C26764E_run
+
 
 		// Methods
 		.method public hidebysig static 
@@ -562,6 +655,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DA704280_normalize
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x478d
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4795
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4798
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x479b
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x47b5
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x47cb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_DA704280_normalize
+
 
 		// Methods
 		.method public hidebysig static 
@@ -870,6 +1070,119 @@
 			} // end of method Scope_For_L30C7::.ctor
 
 		} // end of class Scope_For_L30C7
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0C11330D_parseArgs
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope _environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x47da
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject_FunctionDeclaration_0C11330D_parseArgs::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x47e9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x47ec
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x47ef
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject_FunctionDeclaration_0C11330D_parseArgs::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4808
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject_FunctionDeclaration_0C11330D_parseArgs::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x481d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_0C11330D_parseArgs
 
 
 		// Methods
@@ -2717,6 +3030,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A95D6710_fetchText
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope _environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x482c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject_FunctionDeclaration_A95D6710_fetchText::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x483b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x483e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4841
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject_FunctionDeclaration_A95D6710_fetchText::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4861
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject_FunctionDeclaration_A95D6710_fetchText::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x487d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_A95D6710_fetchText
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2819,6 +3251,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4994
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x499c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x499f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x49a2
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x49b5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x49c4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp
 
 
 		// Methods
@@ -2946,6 +3479,125 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope _environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x49d3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x49e2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x49e5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x49e8
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4a08
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4a24
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt
 
 
 		// Methods
@@ -3414,6 +4066,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DFE1081E_extractElementById
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope _environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4a33
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4a42
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4a45
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4a48
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4a68
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4a84
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_DFE1081E_extractElementById
+
 
 		// Methods
 		.method public hidebysig static 
@@ -3832,6 +4603,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope _environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4a93
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4aa2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4aa5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4aa8
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4ac8
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4ae4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml
+
 
 		// Methods
 		.method public hidebysig static 
@@ -4063,6 +4953,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4af3
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4afb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4afe
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4b01
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.2
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml::__js_call__(object, object, object, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4b22
+				// Header size: 1
+				// Code size: 28 (0x1c)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: ldarg.2
+				IL_0010: ldc.i4.2
+				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0016: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml::__js_call__(object, object, object, object)
+				IL_001b: ret
+			} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4b3f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml
 
 
 		// Methods
@@ -4363,6 +5366,99 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope _environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x4b4e
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4b64
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4b67
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4b6a
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4b7c
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli
 
 
 		// Methods
@@ -5845,14 +6941,14 @@
 			[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
 			[2] object[],
-			[3] class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_DA704280_normalize,
-			[4] class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_0C11330D_parseArgs,
-			[5] class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_A95D6710_fetchText,
-			[6] class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp,
-			[7] class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt,
-			[8] class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_DFE1081E_extractElementById,
-			[9] class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml,
-			[10] class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml,
+			[3] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize/FunctionObject_FunctionDeclaration_DA704280_normalize,
+			[4] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject_FunctionDeclaration_0C11330D_parseArgs,
+			[5] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject_FunctionDeclaration_A95D6710_fetchText,
+			[6] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp/FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp,
+			[7] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt,
+			[8] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject_FunctionDeclaration_DFE1081E_extractElementById,
+			[9] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml,
+			[10] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml/FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml,
 			[11] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
 			[12] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule,
 			[13] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule,
@@ -5870,13 +6966,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_DA704280_normalize::.ctor()
+		IL_0011: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize/FunctionObject_FunctionDeclaration_DA704280_normalize::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "normalize"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_DA704280_normalize>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize/FunctionObject_FunctionDeclaration_DA704280_normalize>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.3
 		IL_0025: ldloc.0
 		IL_0026: ldloc.3
@@ -5892,13 +6988,13 @@
 		IL_0038: ldc.i4.0
 		IL_0039: ldelem.ref
 		IL_003a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-		IL_003f: newobj instance void FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_0C11330D_parseArgs::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
+		IL_003f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject_FunctionDeclaration_0C11330D_parseArgs::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
 		IL_0044: ldc.i4.1
 		IL_0045: conv.r8
 		IL_0046: ldstr "parseArgs"
 		IL_004b: ldc.i4.0
 		IL_004c: ldc.i4.1
-		IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_0C11330D_parseArgs>(!!0, float64, string, bool, bool)
+		IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject_FunctionDeclaration_0C11330D_parseArgs>(!!0, float64, string, bool, bool)
 		IL_0052: stloc.s 4
 		IL_0054: ldloc.0
 		IL_0055: ldloc.s 4
@@ -5914,13 +7010,13 @@
 		IL_0068: ldc.i4.0
 		IL_0069: ldelem.ref
 		IL_006a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-		IL_006f: newobj instance void FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_A95D6710_fetchText::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
+		IL_006f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject_FunctionDeclaration_A95D6710_fetchText::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
 		IL_0074: ldc.i4.1
 		IL_0075: conv.r8
 		IL_0076: ldstr "fetchText"
 		IL_007b: ldc.i4.0
 		IL_007c: ldc.i4.1
-		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_A95D6710_fetchText>(!!0, float64, string, bool, bool)
+		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject_FunctionDeclaration_A95D6710_fetchText>(!!0, float64, string, bool, bool)
 		IL_0082: stloc.s 5
 		IL_0084: ldloc.0
 		IL_0085: ldloc.s 5
@@ -5932,13 +7028,13 @@
 		IL_0094: ldloc.0
 		IL_0095: stelem.ref
 		IL_0096: stloc.2
-		IL_0097: newobj instance void FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::.ctor()
+		IL_0097: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp/FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::.ctor()
 		IL_009c: ldc.i4.1
 		IL_009d: conv.r8
 		IL_009e: ldstr "escapeRegExp"
 		IL_00a3: ldc.i4.0
 		IL_00a4: ldc.i4.1
-		IL_00a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp>(!!0, float64, string, bool, bool)
+		IL_00a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp/FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp>(!!0, float64, string, bool, bool)
 		IL_00aa: stloc.s 6
 		IL_00ac: ldloc.0
 		IL_00ad: ldloc.s 6
@@ -5954,13 +7050,13 @@
 		IL_00c0: ldc.i4.0
 		IL_00c1: ldelem.ref
 		IL_00c2: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-		IL_00c7: newobj instance void FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
+		IL_00c7: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
 		IL_00cc: ldc.i4.2
 		IL_00cd: conv.r8
 		IL_00ce: ldstr "findTagNameAt"
 		IL_00d3: ldc.i4.0
 		IL_00d4: ldc.i4.1
-		IL_00d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt>(!!0, float64, string, bool, bool)
+		IL_00d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt>(!!0, float64, string, bool, bool)
 		IL_00da: stloc.s 7
 		IL_00dc: ldloc.0
 		IL_00dd: ldloc.s 7
@@ -5976,13 +7072,13 @@
 		IL_00f0: ldc.i4.0
 		IL_00f1: ldelem.ref
 		IL_00f2: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-		IL_00f7: newobj instance void FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
+		IL_00f7: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
 		IL_00fc: ldc.i4.2
 		IL_00fd: conv.r8
 		IL_00fe: ldstr "extractElementById"
 		IL_0103: ldc.i4.0
 		IL_0104: ldc.i4.1
-		IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_DFE1081E_extractElementById>(!!0, float64, string, bool, bool)
+		IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject_FunctionDeclaration_DFE1081E_extractElementById>(!!0, float64, string, bool, bool)
 		IL_010a: stloc.s 8
 		IL_010c: ldloc.0
 		IL_010d: ldloc.s 8
@@ -5998,13 +7094,13 @@
 		IL_0120: ldc.i4.0
 		IL_0121: ldelem.ref
 		IL_0122: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-		IL_0127: newobj instance void FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
+		IL_0127: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
 		IL_012c: ldc.i4.2
 		IL_012d: conv.r8
 		IL_012e: ldstr "resolveSectionLinkFromMultipageIndexHtml"
 		IL_0133: ldc.i4.0
 		IL_0134: ldc.i4.1
-		IL_0135: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml>(!!0, float64, string, bool, bool)
+		IL_0135: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml>(!!0, float64, string, bool, bool)
 		IL_013a: stloc.s 9
 		IL_013c: ldloc.0
 		IL_013d: ldloc.s 9
@@ -6016,13 +7112,13 @@
 		IL_014c: ldloc.0
 		IL_014d: stelem.ref
 		IL_014e: stloc.2
-		IL_014f: newobj instance void FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::.ctor()
+		IL_014f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml/FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::.ctor()
 		IL_0154: ldc.i4.3
 		IL_0155: conv.r8
 		IL_0156: ldstr "wrapAsStandaloneHtml"
 		IL_015b: ldc.i4.0
 		IL_015c: ldc.i4.1
-		IL_015d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml>(!!0, float64, string, bool, bool)
+		IL_015d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml/FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml>(!!0, float64, string, bool, bool)
 		IL_0162: stloc.s 10
 		IL_0164: ldloc.0
 		IL_0165: ldloc.s 10
@@ -6116,1102 +7212,6 @@
 	} // end of method Compile_Scripts_ExtractEcma262SectionHtml_TestHarness::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode_B8E9D3F2.FunctionObject_FunctionDeclaration_5C26764E_run
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope _environment0_Compile_Scripts_ExtractEcma262SectionHtml_AutoMode
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x4734
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode_B8E9D3F2.FunctionObject_FunctionDeclaration_5C26764E_run::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_AutoMode
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode_B8E9D3F2.FunctionObject_FunctionDeclaration_5C26764E_run::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_5C26764E_run::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x474a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5C26764E_run::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x474d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5C26764E_run::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4750
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode_B8E9D3F2.FunctionObject_FunctionDeclaration_5C26764E_run::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_5C26764E_run::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4762
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode_B8E9D3F2.FunctionObject_FunctionDeclaration_5C26764E_run::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode/run::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_5C26764E_run::ConstructBodyCore
-
-} // end of class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_AutoMode_B8E9D3F2.FunctionObject_FunctionDeclaration_5C26764E_run
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_DA704280_normalize
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x478d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4795
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4798
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x479b
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x47b5
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x47cb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_DA704280_normalize
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_0C11330D_parseArgs
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope _environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x47da
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_0C11330D_parseArgs::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x47e9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x47ec
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x47ef
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_0C11330D_parseArgs::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4808
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_0C11330D_parseArgs::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x481d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_0C11330D_parseArgs
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_A95D6710_fetchText
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope _environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x482c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_A95D6710_fetchText::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x483b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x483e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4841
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_A95D6710_fetchText::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4861
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_A95D6710_fetchText::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x487d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_A95D6710_fetchText
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x4994
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x499c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x499f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x49a2
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x49b5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x49c4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope _environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x49d3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x49e2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x49e5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x49e8
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4a08
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4a24
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_DFE1081E_extractElementById
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope _environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4a33
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4a42
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4a45
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4a48
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4a68
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4a84
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_DFE1081E_extractElementById
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope _environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4a93
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4aa2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4aa5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4aa8
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4ac8
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4ae4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x4af3
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4afb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4afe
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4b01
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.2
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml::__js_call__(object, object, object, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4b22
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: ldarg.2
-		IL_0010: ldc.i4.2
-		IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0016: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml::__js_call__(object, object, object, object)
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4b3f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope _environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x4b4e
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4b64
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4b67
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4b6a
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4b7c
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::ConstructBodyCore
-
-} // end of class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode.verified.txt
@@ -41,6 +41,99 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_319FFFE4_run
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope _environment0_Compile_Scripts_ExtractEcma262SectionHtml_UrlMode
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x4734
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/FunctionObject_FunctionDeclaration_319FFFE4_run::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_UrlMode
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/FunctionObject_FunctionDeclaration_319FFFE4_run::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_319FFFE4_run::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x474a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_319FFFE4_run::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x474d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_319FFFE4_run::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4750
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/FunctionObject_FunctionDeclaration_319FFFE4_run::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_319FFFE4_run::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4762
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run/FunctionObject_FunctionDeclaration_319FFFE4_run::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_319FFFE4_run::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_319FFFE4_run
+
 
 		// Methods
 		.method public hidebysig static 
@@ -562,6 +655,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DA704280_normalize
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x478d
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4795
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4798
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x479b
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x47b5
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x47cb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_DA704280_normalize
+
 
 		// Methods
 		.method public hidebysig static 
@@ -870,6 +1070,119 @@
 			} // end of method Scope_For_L30C7::.ctor
 
 		} // end of class Scope_For_L30C7
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0C11330D_parseArgs
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope _environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x47da
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject_FunctionDeclaration_0C11330D_parseArgs::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x47e9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x47ec
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x47ef
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject_FunctionDeclaration_0C11330D_parseArgs::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4808
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject_FunctionDeclaration_0C11330D_parseArgs::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x481d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_0C11330D_parseArgs
 
 
 		// Methods
@@ -2717,6 +3030,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A95D6710_fetchText
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope _environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x482c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject_FunctionDeclaration_A95D6710_fetchText::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x483b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x483e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4841
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject_FunctionDeclaration_A95D6710_fetchText::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4861
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject_FunctionDeclaration_A95D6710_fetchText::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x487d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_A95D6710_fetchText
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2819,6 +3251,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4994
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x499c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x499f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x49a2
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x49b5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x49c4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp
 
 
 		// Methods
@@ -2946,6 +3479,125 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope _environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x49d3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x49e2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x49e5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x49e8
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4a08
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4a24
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt
 
 
 		// Methods
@@ -3414,6 +4066,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DFE1081E_extractElementById
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope _environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4a33
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4a42
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4a45
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4a48
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4a68
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4a84
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_DFE1081E_extractElementById
+
 
 		// Methods
 		.method public hidebysig static 
@@ -3832,6 +4603,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope _environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4a93
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4aa2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4aa5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4aa8
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4ac8
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4ae4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml
+
 
 		// Methods
 		.method public hidebysig static 
@@ -4063,6 +4953,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4af3
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4afb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4afe
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4b01
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.2
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml::__js_call__(object, object, object, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4b22
+				// Header size: 1
+				// Code size: 28 (0x1c)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: ldarg.2
+				IL_0010: ldc.i4.2
+				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0016: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml::__js_call__(object, object, object, object)
+				IL_001b: ret
+			} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4b3f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml
 
 
 		// Methods
@@ -4363,6 +5366,99 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope _environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x4b4e
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4b64
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4b67
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4b6a
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4b7c
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli/FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli
 
 
 		// Methods
@@ -5845,14 +6941,14 @@
 			[0] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
 			[2] object[],
-			[3] class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_DA704280_normalize,
-			[4] class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_0C11330D_parseArgs,
-			[5] class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_A95D6710_fetchText,
-			[6] class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp,
-			[7] class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt,
-			[8] class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_DFE1081E_extractElementById,
-			[9] class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml,
-			[10] class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml,
+			[3] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize/FunctionObject_FunctionDeclaration_DA704280_normalize,
+			[4] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject_FunctionDeclaration_0C11330D_parseArgs,
+			[5] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject_FunctionDeclaration_A95D6710_fetchText,
+			[6] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp/FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp,
+			[7] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt,
+			[8] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject_FunctionDeclaration_DFE1081E_extractElementById,
+			[9] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml,
+			[10] class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml/FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml,
 			[11] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
 			[12] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule,
 			[13] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpsModule,
@@ -5870,13 +6966,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_DA704280_normalize::.ctor()
+		IL_0011: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize/FunctionObject_FunctionDeclaration_DA704280_normalize::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "normalize"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_DA704280_normalize>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize/FunctionObject_FunctionDeclaration_DA704280_normalize>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.3
 		IL_0025: ldloc.0
 		IL_0026: ldloc.3
@@ -5892,13 +6988,13 @@
 		IL_0038: ldc.i4.0
 		IL_0039: ldelem.ref
 		IL_003a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-		IL_003f: newobj instance void FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_0C11330D_parseArgs::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
+		IL_003f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject_FunctionDeclaration_0C11330D_parseArgs::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
 		IL_0044: ldc.i4.1
 		IL_0045: conv.r8
 		IL_0046: ldstr "parseArgs"
 		IL_004b: ldc.i4.0
 		IL_004c: ldc.i4.1
-		IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_0C11330D_parseArgs>(!!0, float64, string, bool, bool)
+		IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs/FunctionObject_FunctionDeclaration_0C11330D_parseArgs>(!!0, float64, string, bool, bool)
 		IL_0052: stloc.s 4
 		IL_0054: ldloc.0
 		IL_0055: ldloc.s 4
@@ -5914,13 +7010,13 @@
 		IL_0068: ldc.i4.0
 		IL_0069: ldelem.ref
 		IL_006a: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-		IL_006f: newobj instance void FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_A95D6710_fetchText::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
+		IL_006f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject_FunctionDeclaration_A95D6710_fetchText::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
 		IL_0074: ldc.i4.1
 		IL_0075: conv.r8
 		IL_0076: ldstr "fetchText"
 		IL_007b: ldc.i4.0
 		IL_007c: ldc.i4.1
-		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_A95D6710_fetchText>(!!0, float64, string, bool, bool)
+		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText/FunctionObject_FunctionDeclaration_A95D6710_fetchText>(!!0, float64, string, bool, bool)
 		IL_0082: stloc.s 5
 		IL_0084: ldloc.0
 		IL_0085: ldloc.s 5
@@ -5932,13 +7028,13 @@
 		IL_0094: ldloc.0
 		IL_0095: stelem.ref
 		IL_0096: stloc.2
-		IL_0097: newobj instance void FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::.ctor()
+		IL_0097: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp/FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::.ctor()
 		IL_009c: ldc.i4.1
 		IL_009d: conv.r8
 		IL_009e: ldstr "escapeRegExp"
 		IL_00a3: ldc.i4.0
 		IL_00a4: ldc.i4.1
-		IL_00a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp>(!!0, float64, string, bool, bool)
+		IL_00a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp/FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp>(!!0, float64, string, bool, bool)
 		IL_00aa: stloc.s 6
 		IL_00ac: ldloc.0
 		IL_00ad: ldloc.s 6
@@ -5954,13 +7050,13 @@
 		IL_00c0: ldc.i4.0
 		IL_00c1: ldelem.ref
 		IL_00c2: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-		IL_00c7: newobj instance void FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
+		IL_00c7: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
 		IL_00cc: ldc.i4.2
 		IL_00cd: conv.r8
 		IL_00ce: ldstr "findTagNameAt"
 		IL_00d3: ldc.i4.0
 		IL_00d4: ldc.i4.1
-		IL_00d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt>(!!0, float64, string, bool, bool)
+		IL_00d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt/FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt>(!!0, float64, string, bool, bool)
 		IL_00da: stloc.s 7
 		IL_00dc: ldloc.0
 		IL_00dd: ldloc.s 7
@@ -5976,13 +7072,13 @@
 		IL_00f0: ldc.i4.0
 		IL_00f1: ldelem.ref
 		IL_00f2: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-		IL_00f7: newobj instance void FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
+		IL_00f7: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
 		IL_00fc: ldc.i4.2
 		IL_00fd: conv.r8
 		IL_00fe: ldstr "extractElementById"
 		IL_0103: ldc.i4.0
 		IL_0104: ldc.i4.1
-		IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_DFE1081E_extractElementById>(!!0, float64, string, bool, bool)
+		IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById/FunctionObject_FunctionDeclaration_DFE1081E_extractElementById>(!!0, float64, string, bool, bool)
 		IL_010a: stloc.s 8
 		IL_010c: ldloc.0
 		IL_010d: ldloc.s 8
@@ -5998,13 +7094,13 @@
 		IL_0120: ldc.i4.0
 		IL_0121: ldelem.ref
 		IL_0122: castclass Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope
-		IL_0127: newobj instance void FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
+		IL_0127: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::.ctor(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope)
 		IL_012c: ldc.i4.2
 		IL_012d: conv.r8
 		IL_012e: ldstr "resolveSectionLinkFromMultipageIndexHtml"
 		IL_0133: ldc.i4.0
 		IL_0134: ldc.i4.1
-		IL_0135: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml>(!!0, float64, string, bool, bool)
+		IL_0135: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml/FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml>(!!0, float64, string, bool, bool)
 		IL_013a: stloc.s 9
 		IL_013c: ldloc.0
 		IL_013d: ldloc.s 9
@@ -6016,13 +7112,13 @@
 		IL_014c: ldloc.0
 		IL_014d: stelem.ref
 		IL_014e: stloc.2
-		IL_014f: newobj instance void FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::.ctor()
+		IL_014f: newobj instance void Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml/FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::.ctor()
 		IL_0154: ldc.i4.3
 		IL_0155: conv.r8
 		IL_0156: ldstr "wrapAsStandaloneHtml"
 		IL_015b: ldc.i4.0
 		IL_015c: ldc.i4.1
-		IL_015d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml>(!!0, float64, string, bool, bool)
+		IL_015d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml/FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml>(!!0, float64, string, bool, bool)
 		IL_0162: stloc.s 10
 		IL_0164: ldloc.0
 		IL_0165: ldloc.s 10
@@ -6116,1102 +7212,6 @@
 	} // end of method Compile_Scripts_ExtractEcma262SectionHtml_TestHarness::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode_3D17ED5C.FunctionObject_FunctionDeclaration_319FFFE4_run
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope _environment0_Compile_Scripts_ExtractEcma262SectionHtml_UrlMode
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x4734
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode_3D17ED5C.FunctionObject_FunctionDeclaration_319FFFE4_run::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_UrlMode
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode_3D17ED5C.FunctionObject_FunctionDeclaration_319FFFE4_run::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_319FFFE4_run::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x474a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_319FFFE4_run::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x474d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_319FFFE4_run::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4750
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode_3D17ED5C.FunctionObject_FunctionDeclaration_319FFFE4_run::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_319FFFE4_run::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4762
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode_3D17ED5C.FunctionObject_FunctionDeclaration_319FFFE4_run::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode/run::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_319FFFE4_run::ConstructBodyCore
-
-} // end of class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_UrlMode_3D17ED5C.FunctionObject_FunctionDeclaration_319FFFE4_run
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_DA704280_normalize
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x478d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4795
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4798
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x479b
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x47b5
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/normalize::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x47cb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DA704280_normalize::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_DA704280_normalize
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_0C11330D_parseArgs
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope _environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x47da
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_0C11330D_parseArgs::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x47e9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x47ec
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x47ef
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_0C11330D_parseArgs::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4808
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_0C11330D_parseArgs::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/parseArgs::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x481d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0C11330D_parseArgs::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_0C11330D_parseArgs
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_A95D6710_fetchText
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope _environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x482c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_A95D6710_fetchText::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x483b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x483e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4841
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_A95D6710_fetchText::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4861
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_A95D6710_fetchText::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/fetchText::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x487d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A95D6710_fetchText::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_A95D6710_fetchText
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x4994
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x499c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x499f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x49a2
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x49b5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/escapeRegExp::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x49c4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_A6520F2F_escapeRegExp
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope _environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x49d3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x49e2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x49e5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x49e8
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4a08
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/findTagNameAt::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4a24
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_CFB88B18_findTagNameAt
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_DFE1081E_extractElementById
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope _environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4a33
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4a42
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4a45
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4a48
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4a68
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/extractElementById::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4a84
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DFE1081E_extractElementById::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_DFE1081E_extractElementById
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope _environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4a93
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4aa2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4aa5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4aa8
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4ac8
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/resolveSectionLinkFromMultipageIndexHtml::__js_call__(class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4ae4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_81CF7D8D_resolveSectionLinkFromMultipageIndexHtml
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x4af3
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4afb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4afe
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4b01
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.2
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml::__js_call__(object, object, object, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4b22
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: ldarg.2
-		IL_0010: ldc.i4.2
-		IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0016: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/wrapAsStandaloneHtml::__js_call__(object, object, object, object)
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4b3f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_76C1D0EF_wrapAsStandaloneHtml
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope _environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x4b4e
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/Scope FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::_environment0_Compile_Scripts_ExtractEcma262SectionHtml_TestHarness
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4b64
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4b67
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4b6a
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4b7c
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness/runHarnessCli::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli::ConstructBodyCore
-
-} // end of class FunctionObjects.Compile_Scripts_ExtractEcma262SectionHtml_TestHarness_5CFF973A.FunctionObject_FunctionDeclaration_829B56E8_runHarnessCli
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_GenerateNodeSupportMd.verified.txt
+++ b/tests/Jroc.Tests/Integration/Snapshots/GeneratorTests.Compile_Scripts_GenerateNodeSupportMd.verified.txt
@@ -31,6 +31,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1C7E821E_readJson
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope _environment0_Compile_Scripts_GenerateNodeSupportMd
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x37d8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/readJson/FunctionObject_FunctionDeclaration_1C7E821E_readJson::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_1C7E821E_readJson::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x37e7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1C7E821E_readJson::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x37ea
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1C7E821E_readJson::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x37ed
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/readJson/FunctionObject_FunctionDeclaration_1C7E821E_readJson::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Compile_Scripts_GenerateNodeSupportMd/readJson::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_1C7E821E_readJson::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3806
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/readJson/FunctionObject_FunctionDeclaration_1C7E821E_readJson::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Compile_Scripts_GenerateNodeSupportMd/readJson::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_1C7E821E_readJson::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x381b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_1C7E821E_readJson::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_1C7E821E_readJson
+
 
 		// Methods
 		.method public hidebysig static 
@@ -92,6 +205,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_57160465_asArray
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x382a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_57160465_asArray::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3832
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_57160465_asArray::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3835
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_57160465_asArray::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3838
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Compile_Scripts_GenerateNodeSupportMd/asArray::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_57160465_asArray::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x384b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Compile_Scripts_GenerateNodeSupportMd/asArray::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_57160465_asArray::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x385a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_57160465_asArray::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_57160465_asArray
 
 
 		// Methods
@@ -170,6 +384,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3869
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3871
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3874
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3877
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x388a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3899
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode
+
 
 		// Methods
 		.method public hidebysig static 
@@ -236,6 +551,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C98BDC38_link
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x38a8
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_C98BDC38_link::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x38b0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C98BDC38_link::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x38b3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C98BDC38_link::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x38b6
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Compile_Scripts_GenerateNodeSupportMd/link::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_C98BDC38_link::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x38d0
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Compile_Scripts_GenerateNodeSupportMd/link::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_C98BDC38_link::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x38e6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C98BDC38_link::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C98BDC38_link
 
 
 		// Methods
@@ -334,6 +756,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope _environment0_Compile_Scripts_GenerateNodeSupportMd
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x38f5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader/FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3904
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3907
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x390a
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader/FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3923
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader/FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3938
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader
 
 
 		// Methods
@@ -665,6 +1200,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope _environment0_Compile_Scripts_GenerateNodeSupportMd
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3947
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3956
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3959
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x395c
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3975
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x398a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation
+
 
 		// Methods
 		.method public hidebysig static 
@@ -832,6 +1480,119 @@
 			} // end of method Scope_ForOf_L50C7::.ctor
 
 		} // end of class Scope_ForOf_L50C7
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C787672B_renderApisTable
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope _environment0_Compile_Scripts_GenerateNodeSupportMd
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x39ca
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderApisTable/FunctionObject_FunctionDeclaration_C787672B_renderApisTable::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C787672B_renderApisTable::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x39d9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C787672B_renderApisTable::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x39dc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C787672B_renderApisTable::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x39df
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderApisTable/FunctionObject_FunctionDeclaration_C787672B_renderApisTable::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderApisTable::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_C787672B_renderApisTable::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x39f8
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderApisTable/FunctionObject_FunctionDeclaration_C787672B_renderApisTable::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderApisTable::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_C787672B_renderApisTable::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a0d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C787672B_renderApisTable::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C787672B_renderApisTable
 
 
 		// Methods
@@ -1223,6 +1984,119 @@
 			} // end of method Scope_ForOf_L58C7::.ctor
 
 		} // end of class Scope_ForOf_L58C7
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope _environment0_Compile_Scripts_GenerateNodeSupportMd
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a1c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests/FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3a2b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3a2e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a31
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests/FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a4a
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests/FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a5f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests
 
 
 		// Methods
@@ -1724,6 +2598,119 @@
 			} // end of method Scope_ForOf_L74C7::.ctor
 
 		} // end of class Scope_ForOf_L74C7
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_99982A69_renderModules
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope _environment0_Compile_Scripts_GenerateNodeSupportMd
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a6e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/FunctionObject_FunctionDeclaration_99982A69_renderModules::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_99982A69_renderModules::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3a7d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_99982A69_renderModules::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3a80
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_99982A69_renderModules::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a83
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/FunctionObject_FunctionDeclaration_99982A69_renderModules::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_99982A69_renderModules::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3a9c
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/FunctionObject_FunctionDeclaration_99982A69_renderModules::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_99982A69_renderModules::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ab1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_99982A69_renderModules::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_99982A69_renderModules
 
 
 		// Methods
@@ -2240,6 +3227,119 @@
 
 		} // end of class Scope_ForOf_L101C7
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope _environment0_Compile_Scripts_GenerateNodeSupportMd
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ac0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3acf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3ad2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3ad5
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3aee
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b03
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2739,6 +3839,107 @@
 
 		} // end of class Scope_ForOf_L131C7
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_62338119_renderLimitations
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3b12
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_62338119_renderLimitations::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3b1a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_62338119_renderLimitations::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3b1d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_62338119_renderLimitations::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b20
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderLimitations::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_62338119_renderLimitations::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b33
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderLimitations::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_62338119_renderLimitations::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b42
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_62338119_renderLimitations::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_62338119_renderLimitations
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2920,6 +4121,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_16D03725_main
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope _environment0_Compile_Scripts_GenerateNodeSupportMd
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b51
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/main/FunctionObject_FunctionDeclaration_16D03725_main::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_16D03725_main::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3b60
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_16D03725_main::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3b63
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_16D03725_main::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b66
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/main/FunctionObject_FunctionDeclaration_16D03725_main::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Compile_Scripts_GenerateNodeSupportMd/main::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_16D03725_main::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b78
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope Modules.Compile_Scripts_GenerateNodeSupportMd/main/FunctionObject_FunctionDeclaration_16D03725_main::_environment0_Compile_Scripts_GenerateNodeSupportMd
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Compile_Scripts_GenerateNodeSupportMd/main::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_16D03725_main::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3b86
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_16D03725_main::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_16D03725_main
 
 
 		// Methods
@@ -3230,19 +4538,19 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope,
-			[1] class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_16D03725_main,
+			[1] class Modules.Compile_Scripts_GenerateNodeSupportMd/main/FunctionObject_FunctionDeclaration_16D03725_main,
 			[2] object[],
-			[3] class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_1C7E821E_readJson,
-			[4] class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_57160465_asArray,
-			[5] class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode,
-			[6] class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_C98BDC38_link,
-			[7] class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader,
-			[8] class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation,
-			[9] class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_C787672B_renderApisTable,
-			[10] class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests,
-			[11] class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_99982A69_renderModules,
-			[12] class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals,
-			[13] class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_62338119_renderLimitations,
+			[3] class Modules.Compile_Scripts_GenerateNodeSupportMd/readJson/FunctionObject_FunctionDeclaration_1C7E821E_readJson,
+			[4] class Modules.Compile_Scripts_GenerateNodeSupportMd/asArray/FunctionObject_FunctionDeclaration_57160465_asArray,
+			[5] class Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode/FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode,
+			[6] class Modules.Compile_Scripts_GenerateNodeSupportMd/link/FunctionObject_FunctionDeclaration_C98BDC38_link,
+			[7] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader/FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader,
+			[8] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation,
+			[9] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderApisTable/FunctionObject_FunctionDeclaration_C787672B_renderApisTable,
+			[10] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests/FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests,
+			[11] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/FunctionObject_FunctionDeclaration_99982A69_renderModules,
+			[12] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals,
+			[13] class Modules.Compile_Scripts_GenerateNodeSupportMd/renderLimitations/FunctionObject_FunctionDeclaration_62338119_renderLimitations,
 			[14] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IFsModule,
 			[15] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule
 		)
@@ -3263,13 +4571,13 @@
 		IL_001a: ldc.i4.0
 		IL_001b: ldelem.ref
 		IL_001c: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-		IL_0021: newobj instance void FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_1C7E821E_readJson::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
+		IL_0021: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/readJson/FunctionObject_FunctionDeclaration_1C7E821E_readJson::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
 		IL_0026: ldc.i4.1
 		IL_0027: conv.r8
 		IL_0028: ldstr "readJson"
 		IL_002d: ldc.i4.0
 		IL_002e: ldc.i4.1
-		IL_002f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_1C7E821E_readJson>(!!0, float64, string, bool, bool)
+		IL_002f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/readJson/FunctionObject_FunctionDeclaration_1C7E821E_readJson>(!!0, float64, string, bool, bool)
 		IL_0034: stloc.3
 		IL_0035: ldloc.0
 		IL_0036: ldloc.3
@@ -3281,13 +4589,13 @@
 		IL_0044: ldloc.0
 		IL_0045: stelem.ref
 		IL_0046: stloc.2
-		IL_0047: newobj instance void FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_57160465_asArray::.ctor()
+		IL_0047: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/asArray/FunctionObject_FunctionDeclaration_57160465_asArray::.ctor()
 		IL_004c: ldc.i4.1
 		IL_004d: conv.r8
 		IL_004e: ldstr "asArray"
 		IL_0053: ldc.i4.0
 		IL_0054: ldc.i4.1
-		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_57160465_asArray>(!!0, float64, string, bool, bool)
+		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/asArray/FunctionObject_FunctionDeclaration_57160465_asArray>(!!0, float64, string, bool, bool)
 		IL_005a: stloc.s 4
 		IL_005c: ldloc.0
 		IL_005d: ldloc.s 4
@@ -3299,13 +4607,13 @@
 		IL_006c: ldloc.0
 		IL_006d: stelem.ref
 		IL_006e: stloc.2
-		IL_006f: newobj instance void FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode::.ctor()
+		IL_006f: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode/FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode::.ctor()
 		IL_0074: ldc.i4.1
 		IL_0075: conv.r8
 		IL_0076: ldstr "fmtCode"
 		IL_007b: ldc.i4.0
 		IL_007c: ldc.i4.1
-		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode>(!!0, float64, string, bool, bool)
+		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode/FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode>(!!0, float64, string, bool, bool)
 		IL_0082: stloc.s 5
 		IL_0084: ldloc.0
 		IL_0085: ldloc.s 5
@@ -3317,13 +4625,13 @@
 		IL_0094: ldloc.0
 		IL_0095: stelem.ref
 		IL_0096: stloc.2
-		IL_0097: newobj instance void FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_C98BDC38_link::.ctor()
+		IL_0097: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/link/FunctionObject_FunctionDeclaration_C98BDC38_link::.ctor()
 		IL_009c: ldc.i4.2
 		IL_009d: conv.r8
 		IL_009e: ldstr "link"
 		IL_00a3: ldc.i4.0
 		IL_00a4: ldc.i4.1
-		IL_00a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_C98BDC38_link>(!!0, float64, string, bool, bool)
+		IL_00a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/link/FunctionObject_FunctionDeclaration_C98BDC38_link>(!!0, float64, string, bool, bool)
 		IL_00aa: stloc.s 6
 		IL_00ac: ldloc.0
 		IL_00ad: ldloc.s 6
@@ -3339,13 +4647,13 @@
 		IL_00c0: ldc.i4.0
 		IL_00c1: ldelem.ref
 		IL_00c2: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-		IL_00c7: newobj instance void FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
+		IL_00c7: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader/FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
 		IL_00cc: ldc.i4.1
 		IL_00cd: conv.r8
 		IL_00ce: ldstr "renderHeader"
 		IL_00d3: ldc.i4.0
 		IL_00d4: ldc.i4.1
-		IL_00d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader>(!!0, float64, string, bool, bool)
+		IL_00d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader/FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader>(!!0, float64, string, bool, bool)
 		IL_00da: stloc.s 7
 		IL_00dc: ldloc.0
 		IL_00dd: ldloc.s 7
@@ -3361,13 +4669,13 @@
 		IL_00f0: ldc.i4.0
 		IL_00f1: ldelem.ref
 		IL_00f2: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-		IL_00f7: newobj instance void FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
+		IL_00f7: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
 		IL_00fc: ldc.i4.1
 		IL_00fd: conv.r8
 		IL_00fe: ldstr "renderImplementation"
 		IL_0103: ldc.i4.0
 		IL_0104: ldc.i4.1
-		IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation>(!!0, float64, string, bool, bool)
+		IL_0105: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation/FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation>(!!0, float64, string, bool, bool)
 		IL_010a: stloc.s 8
 		IL_010c: ldloc.0
 		IL_010d: ldloc.s 8
@@ -3383,13 +4691,13 @@
 		IL_0120: ldc.i4.0
 		IL_0121: ldelem.ref
 		IL_0122: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-		IL_0127: newobj instance void FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_C787672B_renderApisTable::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
+		IL_0127: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderApisTable/FunctionObject_FunctionDeclaration_C787672B_renderApisTable::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
 		IL_012c: ldc.i4.1
 		IL_012d: conv.r8
 		IL_012e: ldstr "renderApisTable"
 		IL_0133: ldc.i4.0
 		IL_0134: ldc.i4.1
-		IL_0135: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_C787672B_renderApisTable>(!!0, float64, string, bool, bool)
+		IL_0135: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/renderApisTable/FunctionObject_FunctionDeclaration_C787672B_renderApisTable>(!!0, float64, string, bool, bool)
 		IL_013a: stloc.s 9
 		IL_013c: ldloc.0
 		IL_013d: ldloc.s 9
@@ -3405,13 +4713,13 @@
 		IL_0150: ldc.i4.0
 		IL_0151: ldelem.ref
 		IL_0152: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-		IL_0157: newobj instance void FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
+		IL_0157: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests/FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
 		IL_015c: ldc.i4.1
 		IL_015d: conv.r8
 		IL_015e: ldstr "renderApiTests"
 		IL_0163: ldc.i4.0
 		IL_0164: ldc.i4.1
-		IL_0165: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests>(!!0, float64, string, bool, bool)
+		IL_0165: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests/FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests>(!!0, float64, string, bool, bool)
 		IL_016a: stloc.s 10
 		IL_016c: ldloc.0
 		IL_016d: ldloc.s 10
@@ -3427,13 +4735,13 @@
 		IL_0180: ldc.i4.0
 		IL_0181: ldelem.ref
 		IL_0182: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-		IL_0187: newobj instance void FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_99982A69_renderModules::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
+		IL_0187: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/FunctionObject_FunctionDeclaration_99982A69_renderModules::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
 		IL_018c: ldc.i4.1
 		IL_018d: conv.r8
 		IL_018e: ldstr "renderModules"
 		IL_0193: ldc.i4.0
 		IL_0194: ldc.i4.1
-		IL_0195: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_99982A69_renderModules>(!!0, float64, string, bool, bool)
+		IL_0195: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules/FunctionObject_FunctionDeclaration_99982A69_renderModules>(!!0, float64, string, bool, bool)
 		IL_019a: stloc.s 11
 		IL_019c: ldloc.0
 		IL_019d: ldloc.s 11
@@ -3449,13 +4757,13 @@
 		IL_01b0: ldc.i4.0
 		IL_01b1: ldelem.ref
 		IL_01b2: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-		IL_01b7: newobj instance void FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
+		IL_01b7: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
 		IL_01bc: ldc.i4.1
 		IL_01bd: conv.r8
 		IL_01be: ldstr "renderGlobals"
 		IL_01c3: ldc.i4.0
 		IL_01c4: ldc.i4.1
-		IL_01c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals>(!!0, float64, string, bool, bool)
+		IL_01c5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals/FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals>(!!0, float64, string, bool, bool)
 		IL_01ca: stloc.s 12
 		IL_01cc: ldloc.0
 		IL_01cd: ldloc.s 12
@@ -3467,13 +4775,13 @@
 		IL_01dc: ldloc.0
 		IL_01dd: stelem.ref
 		IL_01de: stloc.2
-		IL_01df: newobj instance void FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_62338119_renderLimitations::.ctor()
+		IL_01df: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/renderLimitations/FunctionObject_FunctionDeclaration_62338119_renderLimitations::.ctor()
 		IL_01e4: ldc.i4.1
 		IL_01e5: conv.r8
 		IL_01e6: ldstr "renderLimitations"
 		IL_01eb: ldc.i4.0
 		IL_01ec: ldc.i4.1
-		IL_01ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_62338119_renderLimitations>(!!0, float64, string, bool, bool)
+		IL_01ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/renderLimitations/FunctionObject_FunctionDeclaration_62338119_renderLimitations>(!!0, float64, string, bool, bool)
 		IL_01f2: stloc.s 13
 		IL_01f4: ldloc.0
 		IL_01f5: ldloc.s 13
@@ -3489,13 +4797,13 @@
 		IL_0208: ldc.i4.0
 		IL_0209: ldelem.ref
 		IL_020a: castclass Modules.Compile_Scripts_GenerateNodeSupportMd/Scope
-		IL_020f: newobj instance void FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_16D03725_main::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
+		IL_020f: newobj instance void Modules.Compile_Scripts_GenerateNodeSupportMd/main/FunctionObject_FunctionDeclaration_16D03725_main::.ctor(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope)
 		IL_0214: ldc.i4.0
 		IL_0215: conv.r8
 		IL_0216: ldstr "main"
 		IL_021b: ldc.i4.0
 		IL_021c: ldc.i4.1
-		IL_021d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_16D03725_main>(!!0, float64, string, bool, bool)
+		IL_021d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Compile_Scripts_GenerateNodeSupportMd/main/FunctionObject_FunctionDeclaration_16D03725_main>(!!0, float64, string, bool, bool)
 		IL_0222: stloc.1
 		IL_0223: nop
 		IL_0224: ldarg.1
@@ -3532,1314 +4840,6 @@
 	} // end of method Compile_Scripts_GenerateNodeSupportMd::__js_module_init__
 
 } // end of class Modules.Compile_Scripts_GenerateNodeSupportMd
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_1C7E821E_readJson
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope _environment0_Compile_Scripts_GenerateNodeSupportMd
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x37d8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_1C7E821E_readJson::_environment0_Compile_Scripts_GenerateNodeSupportMd
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_1C7E821E_readJson::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x37e7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1C7E821E_readJson::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x37ea
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1C7E821E_readJson::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x37ed
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_1C7E821E_readJson::_environment0_Compile_Scripts_GenerateNodeSupportMd
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Compile_Scripts_GenerateNodeSupportMd/readJson::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_1C7E821E_readJson::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3806
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_1C7E821E_readJson::_environment0_Compile_Scripts_GenerateNodeSupportMd
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Compile_Scripts_GenerateNodeSupportMd/readJson::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_1C7E821E_readJson::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x381b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_1C7E821E_readJson::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_1C7E821E_readJson
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_57160465_asArray
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x382a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_57160465_asArray::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3832
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_57160465_asArray::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3835
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_57160465_asArray::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3838
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Compile_Scripts_GenerateNodeSupportMd/asArray::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_57160465_asArray::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x384b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Compile_Scripts_GenerateNodeSupportMd/asArray::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_57160465_asArray::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x385a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_57160465_asArray::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_57160465_asArray
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3869
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3871
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3874
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3877
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x388a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Compile_Scripts_GenerateNodeSupportMd/fmtCode::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3899
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_EBB7B31A_fmtCode
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_C98BDC38_link
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x38a8
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_C98BDC38_link::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x38b0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C98BDC38_link::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x38b3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C98BDC38_link::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x38b6
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Compile_Scripts_GenerateNodeSupportMd/link::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_C98BDC38_link::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x38d0
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Compile_Scripts_GenerateNodeSupportMd/link::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_C98BDC38_link::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x38e6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C98BDC38_link::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_C98BDC38_link
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope _environment0_Compile_Scripts_GenerateNodeSupportMd
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x38f5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::_environment0_Compile_Scripts_GenerateNodeSupportMd
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3904
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3907
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x390a
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::_environment0_Compile_Scripts_GenerateNodeSupportMd
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3923
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::_environment0_Compile_Scripts_GenerateNodeSupportMd
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderHeader::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3938
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_BD8CCD0D_renderHeader
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope _environment0_Compile_Scripts_GenerateNodeSupportMd
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3947
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::_environment0_Compile_Scripts_GenerateNodeSupportMd
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3956
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3959
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x395c
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::_environment0_Compile_Scripts_GenerateNodeSupportMd
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3975
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::_environment0_Compile_Scripts_GenerateNodeSupportMd
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderImplementation::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x398a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_0A69A73A_renderImplementation
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_C787672B_renderApisTable
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope _environment0_Compile_Scripts_GenerateNodeSupportMd
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x39ca
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_C787672B_renderApisTable::_environment0_Compile_Scripts_GenerateNodeSupportMd
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C787672B_renderApisTable::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x39d9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C787672B_renderApisTable::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x39dc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C787672B_renderApisTable::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x39df
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_C787672B_renderApisTable::_environment0_Compile_Scripts_GenerateNodeSupportMd
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderApisTable::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_C787672B_renderApisTable::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x39f8
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_C787672B_renderApisTable::_environment0_Compile_Scripts_GenerateNodeSupportMd
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderApisTable::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_C787672B_renderApisTable::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a0d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C787672B_renderApisTable::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_C787672B_renderApisTable
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope _environment0_Compile_Scripts_GenerateNodeSupportMd
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a1c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::_environment0_Compile_Scripts_GenerateNodeSupportMd
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3a2b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3a2e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a31
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::_environment0_Compile_Scripts_GenerateNodeSupportMd
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a4a
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::_environment0_Compile_Scripts_GenerateNodeSupportMd
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderApiTests::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a5f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_6F3FEEDD_renderApiTests
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_99982A69_renderModules
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope _environment0_Compile_Scripts_GenerateNodeSupportMd
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a6e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_99982A69_renderModules::_environment0_Compile_Scripts_GenerateNodeSupportMd
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_99982A69_renderModules::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3a7d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_99982A69_renderModules::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3a80
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_99982A69_renderModules::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a83
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_99982A69_renderModules::_environment0_Compile_Scripts_GenerateNodeSupportMd
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_99982A69_renderModules::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3a9c
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_99982A69_renderModules::_environment0_Compile_Scripts_GenerateNodeSupportMd
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderModules::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_99982A69_renderModules::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ab1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_99982A69_renderModules::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_99982A69_renderModules
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope _environment0_Compile_Scripts_GenerateNodeSupportMd
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ac0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::_environment0_Compile_Scripts_GenerateNodeSupportMd
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3acf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3ad2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3ad5
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::_environment0_Compile_Scripts_GenerateNodeSupportMd
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3aee
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::_environment0_Compile_Scripts_GenerateNodeSupportMd
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderGlobals::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b03
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_1992B5A4_renderGlobals
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_62338119_renderLimitations
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3b12
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_62338119_renderLimitations::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3b1a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_62338119_renderLimitations::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3b1d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_62338119_renderLimitations::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b20
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderLimitations::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_62338119_renderLimitations::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b33
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Compile_Scripts_GenerateNodeSupportMd/renderLimitations::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_62338119_renderLimitations::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b42
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_62338119_renderLimitations::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_62338119_renderLimitations
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_16D03725_main
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope _environment0_Compile_Scripts_GenerateNodeSupportMd
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b51
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_16D03725_main::_environment0_Compile_Scripts_GenerateNodeSupportMd
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_16D03725_main::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3b60
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_16D03725_main::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3b63
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_16D03725_main::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b66
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_16D03725_main::_environment0_Compile_Scripts_GenerateNodeSupportMd
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Compile_Scripts_GenerateNodeSupportMd/main::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_16D03725_main::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b78
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_16D03725_main::_environment0_Compile_Scripts_GenerateNodeSupportMd
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Compile_Scripts_GenerateNodeSupportMd/main::__js_call__(class Modules.Compile_Scripts_GenerateNodeSupportMd/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_16D03725_main::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3b86
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_16D03725_main::ConstructCore
-
-} // end of class FunctionObjects.Compile_Scripts_GenerateNodeSupportMd_F1F80155.FunctionObject_FunctionDeclaration_16D03725_main
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_ParseInt_Spec.verified.txt
+++ b/tests/Jroc.Tests/IntrinsicCallables/Snapshots/GeneratorTests.IntrinsicCallables_ParseInt_Spec.verified.txt
@@ -31,6 +31,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2983DD78_L142C34
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2f51
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_2983DD78_L142C34::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2f59
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_2983DD78_L142C34::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2f5c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_2983DD78_L142C34::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f5f
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.IntrinsicCallables_ParseInt_Spec/FunctionExpression_L142C33::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_2983DD78_L142C34::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f6b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.IntrinsicCallables_ParseInt_Spec/FunctionExpression_L142C33::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_2983DD78_L142C34::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f73
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_2983DD78_L142C34::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_2983DD78_L142C34
+
 
 		// Methods
 		.method public hidebysig static 
@@ -93,7 +188,7 @@
 			[2] float64,
 			[3] object,
 			[4] object[],
-			[5] class FunctionObjects.IntrinsicCallables_ParseInt_Spec_C508E6DC.FunctionObject_FunctionExpression_2983DD78_L142C34,
+			[5] class Modules.IntrinsicCallables_ParseInt_Spec/FunctionExpression_L142C33/FunctionObject_FunctionExpression_2983DD78_L142C34,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Array
 		)
@@ -1045,13 +1140,13 @@
 		IL_0c38: ldloc.0
 		IL_0c39: stelem.ref
 		IL_0c3a: stloc.s 4
-		IL_0c3c: newobj instance void FunctionObjects.IntrinsicCallables_ParseInt_Spec_C508E6DC.FunctionObject_FunctionExpression_2983DD78_L142C34::.ctor()
+		IL_0c3c: newobj instance void Modules.IntrinsicCallables_ParseInt_Spec/FunctionExpression_L142C33/FunctionObject_FunctionExpression_2983DD78_L142C34::.ctor()
 		IL_0c41: ldc.i4.0
 		IL_0c42: conv.r8
 		IL_0c43: ldstr ""
 		IL_0c48: ldc.i4.0
 		IL_0c49: ldc.i4.1
-		IL_0c4a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.IntrinsicCallables_ParseInt_Spec_C508E6DC.FunctionObject_FunctionExpression_2983DD78_L142C34>(!!0, float64, string, bool, bool)
+		IL_0c4a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.IntrinsicCallables_ParseInt_Spec/FunctionExpression_L142C33/FunctionObject_FunctionExpression_2983DD78_L142C34>(!!0, float64, string, bool, bool)
 		IL_0c4f: stloc.s 5
 		IL_0c51: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0c56: dup
@@ -1260,101 +1355,6 @@
 	} // end of method IntrinsicCallables_ParseInt_Spec::__js_module_init__
 
 } // end of class Modules.IntrinsicCallables_ParseInt_Spec
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.IntrinsicCallables_ParseInt_Spec_C508E6DC.FunctionObject_FunctionExpression_2983DD78_L142C34
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2f51
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_2983DD78_L142C34::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2f59
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2983DD78_L142C34::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2f5c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2983DD78_L142C34::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f5f
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.IntrinsicCallables_ParseInt_Spec/FunctionExpression_L142C33::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_2983DD78_L142C34::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f6b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.IntrinsicCallables_ParseInt_Spec/FunctionExpression_L142C33::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_2983DD78_L142C34::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f73
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2983DD78_L142C34::ConstructCore
-
-} // end of class FunctionObjects.IntrinsicCallables_ParseInt_Spec_C508E6DC.FunctionObject_FunctionExpression_2983DD78_L142C34
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Cleanup.verified.txt
+++ b/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Cleanup.verified.txt
@@ -35,6 +35,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_861DC683_L6C18
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Iterator_Helper_Cleanup/Scope _environment0_Iterator_Helper_Cleanup
+				.field private initonly class Modules.Iterator_Helper_Cleanup/makeIterable/Scope _environment1_makeIterable
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Iterator_Helper_Cleanup/Scope capture0,
+						class Modules.Iterator_Helper_Cleanup/makeIterable/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3299
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17/FunctionObject_FunctionExpression_861DC683_L6C18::_environment0_Iterator_Helper_Cleanup
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Iterator_Helper_Cleanup/makeIterable/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17/FunctionObject_FunctionExpression_861DC683_L6C18::_environment1_makeIterable
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17/FunctionObject_FunctionExpression_861DC683_L6C18::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_861DC683_L6C18::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x32b6
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_861DC683_L6C18::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x32b9
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_861DC683_L6C18::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x32bc
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17/FunctionObject_FunctionExpression_861DC683_L6C18::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_861DC683_L6C18::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x32ce
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17/FunctionObject_FunctionExpression_861DC683_L6C18::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_861DC683_L6C18::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x32dc
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_861DC683_L6C18::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_861DC683_L6C18
+
 
 			// Methods
 			.method public hidebysig static 
@@ -88,6 +205,128 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_72A92B04_L13C25
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Iterator_Helper_Cleanup/Scope _environment0_Iterator_Helper_Cleanup
+					.field private initonly class Modules.Iterator_Helper_Cleanup/makeIterable/Scope _environment1_makeIterable
+					.field private initonly class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope _environment2_FunctionExpression_L10C29
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Iterator_Helper_Cleanup/Scope capture0,
+							class Modules.Iterator_Helper_Cleanup/makeIterable/Scope capture1,
+							class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x333d
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24/FunctionObject_FunctionExpression_72A92B04_L13C25::_environment0_Iterator_Helper_Cleanup
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Iterator_Helper_Cleanup/makeIterable/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24/FunctionObject_FunctionExpression_72A92B04_L13C25::_environment1_makeIterable
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24/FunctionObject_FunctionExpression_72A92B04_L13C25::_environment2_FunctionExpression_L10C29
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24/FunctionObject_FunctionExpression_72A92B04_L13C25::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_72A92B04_L13C25::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x3362
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_72A92B04_L13C25::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x3365
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_72A92B04_L13C25::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x3368
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24/FunctionObject_FunctionExpression_72A92B04_L13C25::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_72A92B04_L13C25::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x337a
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24/FunctionObject_FunctionExpression_72A92B04_L13C25::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_72A92B04_L13C25::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x3388
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_72A92B04_L13C25::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_72A92B04_L13C25
 
 
 				// Methods
@@ -196,6 +435,128 @@
 
 				} // end of class Scope
 
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C0155B76_L17C27
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Iterator_Helper_Cleanup/Scope _environment0_Iterator_Helper_Cleanup
+					.field private initonly class Modules.Iterator_Helper_Cleanup/makeIterable/Scope _environment1_makeIterable
+					.field private initonly class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope _environment2_FunctionExpression_L10C29
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Iterator_Helper_Cleanup/Scope capture0,
+							class Modules.Iterator_Helper_Cleanup/makeIterable/Scope capture1,
+							class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x3397
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject_FunctionExpression_C0155B76_L17C27::_environment0_Iterator_Helper_Cleanup
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Iterator_Helper_Cleanup/makeIterable/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject_FunctionExpression_C0155B76_L17C27::_environment1_makeIterable
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject_FunctionExpression_C0155B76_L17C27::_environment2_FunctionExpression_L10C29
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject_FunctionExpression_C0155B76_L17C27::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_C0155B76_L17C27::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x33bc
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_C0155B76_L17C27::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x33bf
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_C0155B76_L17C27::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x33c2
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject_FunctionExpression_C0155B76_L17C27::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_C0155B76_L17C27::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x33d4
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26/FunctionObject_FunctionExpression_C0155B76_L17C27::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_C0155B76_L17C27::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x33e2
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_C0155B76_L17C27::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_C0155B76_L17C27
+
 
 				// Methods
 				.method public hidebysig static 
@@ -270,6 +631,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_BF3F222A_L10C30
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Iterator_Helper_Cleanup/Scope _environment0_Iterator_Helper_Cleanup
+				.field private initonly class Modules.Iterator_Helper_Cleanup/makeIterable/Scope _environment1_makeIterable
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Iterator_Helper_Cleanup/Scope capture0,
+						class Modules.Iterator_Helper_Cleanup/makeIterable/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x32eb
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject_FunctionExpression_BF3F222A_L10C30::_environment0_Iterator_Helper_Cleanup
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Iterator_Helper_Cleanup/makeIterable/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject_FunctionExpression_BF3F222A_L10C30::_environment1_makeIterable
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject_FunctionExpression_BF3F222A_L10C30::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_BF3F222A_L10C30::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3308
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_BF3F222A_L10C30::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x330b
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_BF3F222A_L10C30::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x330e
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject_FunctionExpression_BF3F222A_L10C30::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_BF3F222A_L10C30::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3320
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionObject_FunctionExpression_BF3F222A_L10C30::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_BF3F222A_L10C30::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x332e
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_BF3F222A_L10C30::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_BF3F222A_L10C30
 
 
 			// Methods
@@ -416,6 +894,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8333AF96_makeIterable
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Iterator_Helper_Cleanup/Scope _environment0_Iterator_Helper_Cleanup
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Iterator_Helper_Cleanup/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3247
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionObject_FunctionDeclaration_8333AF96_makeIterable::_environment0_Iterator_Helper_Cleanup
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8333AF96_makeIterable::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3256
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8333AF96_makeIterable::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3259
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8333AF96_makeIterable::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x325c
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionObject_FunctionDeclaration_8333AF96_makeIterable::_environment0_Iterator_Helper_Cleanup
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Iterator_Helper_Cleanup/makeIterable::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_8333AF96_makeIterable::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3275
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/makeIterable/FunctionObject_FunctionDeclaration_8333AF96_makeIterable::_environment0_Iterator_Helper_Cleanup
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Iterator_Helper_Cleanup/makeIterable::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_8333AF96_makeIterable::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x328a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8333AF96_makeIterable::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_8333AF96_makeIterable
 
 
 		// Methods
@@ -970,6 +1561,128 @@
 
 				} // end of class Scope
 
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_97DA0A87_L64C17
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Iterator_Helper_Cleanup/Scope _environment0_Iterator_Helper_Cleanup
+					.field private initonly class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope _environment1_ArrowFunction_L60C47
+					.field private initonly class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope _environment2_FunctionExpression_flatHelper
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Iterator_Helper_Cleanup/Scope capture0,
+							class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope capture1,
+							class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x34c4
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_97DA0A87_L64C17::_environment0_Iterator_Helper_Cleanup
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_97DA0A87_L64C17::_environment1_ArrowFunction_L60C47
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_97DA0A87_L64C17::_environment2_FunctionExpression_flatHelper
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_97DA0A87_L64C17::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_97DA0A87_L64C17::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x34e9
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_97DA0A87_L64C17::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x34ec
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_97DA0A87_L64C17::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x34ef
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_97DA0A87_L64C17::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_97DA0A87_L64C17::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x3501
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_97DA0A87_L64C17::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_97DA0A87_L64C17::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x350f
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_97DA0A87_L64C17::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_97DA0A87_L64C17
+
 
 				// Methods
 				.method public hidebysig static 
@@ -1063,6 +1776,128 @@
 
 				} // end of class Scope
 
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_BEE289C4_L72C19
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Iterator_Helper_Cleanup/Scope _environment0_Iterator_Helper_Cleanup
+					.field private initonly class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope _environment1_ArrowFunction_L60C47
+					.field private initonly class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope _environment2_FunctionExpression_flatHelper
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Iterator_Helper_Cleanup/Scope capture0,
+							class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope capture1,
+							class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x351e
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject_FunctionExpression_BEE289C4_L72C19::_environment0_Iterator_Helper_Cleanup
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject_FunctionExpression_BEE289C4_L72C19::_environment1_ArrowFunction_L60C47
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject_FunctionExpression_BEE289C4_L72C19::_environment2_FunctionExpression_flatHelper
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject_FunctionExpression_BEE289C4_L72C19::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_BEE289C4_L72C19::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x3543
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_BEE289C4_L72C19::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x3546
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_BEE289C4_L72C19::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x3549
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject_FunctionExpression_BEE289C4_L72C19::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_BEE289C4_L72C19::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x355b
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18/FunctionObject_FunctionExpression_BEE289C4_L72C19::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_BEE289C4_L72C19::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x3569
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_BEE289C4_L72C19::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_BEE289C4_L72C19
+
 
 				// Methods
 				.method public hidebysig static 
@@ -1137,6 +1972,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_EFA19121_L61C22
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Iterator_Helper_Cleanup/Scope _environment0_Iterator_Helper_Cleanup
+				.field private initonly class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope _environment1_ArrowFunction_L60C47
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Iterator_Helper_Cleanup/Scope capture0,
+						class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x3472
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_EFA19121_L61C22::_environment0_Iterator_Helper_Cleanup
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_EFA19121_L61C22::_environment1_ArrowFunction_L60C47
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_EFA19121_L61C22::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_EFA19121_L61C22::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x348f
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_EFA19121_L61C22::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x3492
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_EFA19121_L61C22::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x3495
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_EFA19121_L61C22::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_EFA19121_L61C22::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x34a7
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionObject_FunctionExpression_EFA19121_L61C22::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_EFA19121_L61C22::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x34b5
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_EFA19121_L61C22::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_EFA19121_L61C22
 
 
 			// Methods
@@ -1612,6 +2564,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_649156E0_L99C17
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Iterator_Helper_Cleanup/Scope _environment0_Iterator_Helper_Cleanup
+				.field private initonly class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope _environment1_FunctionExpression_flatThrowHelper
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Iterator_Helper_Cleanup/Scope capture0,
+						class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x35d9
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_649156E0_L99C17::_environment0_Iterator_Helper_Cleanup
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_649156E0_L99C17::_environment1_FunctionExpression_flatThrowHelper
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_649156E0_L99C17::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_649156E0_L99C17::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x35f6
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_649156E0_L99C17::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x35f9
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_649156E0_L99C17::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x35fc
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_649156E0_L99C17::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_649156E0_L99C17::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x360e
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_649156E0_L99C17::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_649156E0_L99C17::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x361c
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_649156E0_L99C17::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_649156E0_L99C17
+
 
 			// Methods
 			.method public hidebysig static 
@@ -1696,6 +2765,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B177656C_L107C19
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Iterator_Helper_Cleanup/Scope _environment0_Iterator_Helper_Cleanup
+				.field private initonly class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope _environment1_FunctionExpression_flatThrowHelper
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Iterator_Helper_Cleanup/Scope capture0,
+						class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x362b
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18/FunctionObject_FunctionExpression_B177656C_L107C19::_environment0_Iterator_Helper_Cleanup
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18/FunctionObject_FunctionExpression_B177656C_L107C19::_environment1_FunctionExpression_flatThrowHelper
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18/FunctionObject_FunctionExpression_B177656C_L107C19::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_B177656C_L107C19::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x3648
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_B177656C_L107C19::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x364b
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_B177656C_L107C19::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x364e
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18/FunctionObject_FunctionExpression_B177656C_L107C19::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_B177656C_L107C19::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x3660
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18/FunctionObject_FunctionExpression_B177656C_L107C19::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_B177656C_L107C19::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x366e
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_B177656C_L107C19::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_B177656C_L107C19
+
 
 			// Methods
 			.method public hidebysig static 
@@ -1770,6 +2956,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_665FA710_L96C22
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Iterator_Helper_Cleanup/Scope _environment0_Iterator_Helper_Cleanup
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Iterator_Helper_Cleanup/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3595
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_665FA710_L96C22::_environment0_Iterator_Helper_Cleanup
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_665FA710_L96C22::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x35a4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_665FA710_L96C22::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x35a7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_665FA710_L96C22::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x35aa
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_665FA710_L96C22::_environment0_Iterator_Helper_Cleanup
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_665FA710_L96C22::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x35bc
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_665FA710_L96C22::_environment0_Iterator_Helper_Cleanup
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_665FA710_L96C22::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x35ca
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_665FA710_L96C22::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_665FA710_L96C22
 
 
 		// Methods
@@ -1906,6 +3199,101 @@
 
 				} // end of class Scope
 
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F596D986_L116C17
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x36f2
+						// Header size: 1
+						// Code size: 7 (0x7)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ret
+					} // end of method FunctionObject_FunctionExpression_F596D986_L116C17::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x36fa
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_F596D986_L116C17::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x36fd
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_F596D986_L116C17::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x3700
+						// Header size: 1
+						// Code size: 11 (0xb)
+						.maxstack 8
+
+						IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_0005: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper::__js_call__(object)
+						IL_000a: ret
+					} // end of method FunctionObject_FunctionExpression_F596D986_L116C17::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x370c
+						// Header size: 1
+						// Code size: 7 (0x7)
+						.maxstack 8
+
+						IL_0000: ldarg.3
+						IL_0001: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper::__js_call__(object)
+						IL_0006: ret
+					} // end of method FunctionObject_FunctionExpression_F596D986_L116C17::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x3714
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_F596D986_L116C17::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_F596D986_L116C17
+
 
 				// Methods
 				.method public hidebysig static 
@@ -1968,6 +3356,118 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C2293FF7_L119C19
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Iterator_Helper_Cleanup/Scope _environment0_Iterator_Helper_Cleanup
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Iterator_Helper_Cleanup/Scope capture0,
+							object[] capture1
+						) cil managed 
+					{
+						// Method begins at RVA 0x3723
+						// Header size: 1
+						// Code size: 21 (0x15)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18/FunctionObject_FunctionExpression_C2293FF7_L119C19::_environment0_Iterator_Helper_Cleanup
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18/FunctionObject_FunctionExpression_C2293FF7_L119C19::_transitionalScopes
+						IL_0014: ret
+					} // end of method FunctionObject_FunctionExpression_C2293FF7_L119C19::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x3739
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_C2293FF7_L119C19::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x373c
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_C2293FF7_L119C19::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x373f
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18/FunctionObject_FunctionExpression_C2293FF7_L119C19::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_C2293FF7_L119C19::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x3751
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18/FunctionObject_FunctionExpression_C2293FF7_L119C19::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_C2293FF7_L119C19::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x375f
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_C2293FF7_L119C19::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_C2293FF7_L119C19
 
 
 				// Methods
@@ -2036,6 +3536,118 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_44F841E1_L114C22
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Iterator_Helper_Cleanup/Scope _environment0_Iterator_Helper_Cleanup
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Iterator_Helper_Cleanup/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x36a7
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_44F841E1_L114C22::_environment0_Iterator_Helper_Cleanup
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_44F841E1_L114C22::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionExpression_44F841E1_L114C22::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x36bd
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_44F841E1_L114C22::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x36c0
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_44F841E1_L114C22::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x36c3
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_44F841E1_L114C22::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_44F841E1_L114C22::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x36d5
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionObject_FunctionExpression_44F841E1_L114C22::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_44F841E1_L114C22::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x36e3
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_44F841E1_L114C22::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_44F841E1_L114C22
 
 
 			// Methods
@@ -2529,7 +4141,7 @@
 		.maxstack 10
 		.locals init (
 			[0] class Modules.Iterator_Helper_Cleanup/Scope,
-			[1] class FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionDeclaration_8333AF96_makeIterable,
+			[1] class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionObject_FunctionDeclaration_8333AF96_makeIterable,
 			[2] object,
 			[3] object,
 			[4] object,
@@ -2582,13 +4194,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Iterator_Helper_Cleanup/Scope
-		IL_001b: newobj instance void FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionDeclaration_8333AF96_makeIterable::.ctor(class Modules.Iterator_Helper_Cleanup/Scope)
+		IL_001b: newobj instance void Modules.Iterator_Helper_Cleanup/makeIterable/FunctionObject_FunctionDeclaration_8333AF96_makeIterable::.ctor(class Modules.Iterator_Helper_Cleanup/Scope)
 		IL_0020: ldc.i4.1
 		IL_0021: conv.r8
 		IL_0022: ldstr "makeIterable"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionDeclaration_8333AF96_makeIterable>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionObject_FunctionDeclaration_8333AF96_makeIterable>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: nop
 		IL_0030: nop
@@ -3265,1618 +4877,6 @@
 	} // end of method Iterator_Helper_Cleanup::__js_module_init__
 
 } // end of class Modules.Iterator_Helper_Cleanup
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionDeclaration_8333AF96_makeIterable
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Iterator_Helper_Cleanup/Scope _environment0_Iterator_Helper_Cleanup
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Iterator_Helper_Cleanup/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3247
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionDeclaration_8333AF96_makeIterable::_environment0_Iterator_Helper_Cleanup
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8333AF96_makeIterable::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3256
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8333AF96_makeIterable::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3259
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8333AF96_makeIterable::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x325c
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Iterator_Helper_Cleanup/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionDeclaration_8333AF96_makeIterable::_environment0_Iterator_Helper_Cleanup
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Iterator_Helper_Cleanup/makeIterable::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_8333AF96_makeIterable::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3275
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Iterator_Helper_Cleanup/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionDeclaration_8333AF96_makeIterable::_environment0_Iterator_Helper_Cleanup
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Iterator_Helper_Cleanup/makeIterable::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_8333AF96_makeIterable::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x328a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8333AF96_makeIterable::ConstructCore
-
-} // end of class FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionDeclaration_8333AF96_makeIterable
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_861DC683_L6C18
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Iterator_Helper_Cleanup/Scope _environment0_Iterator_Helper_Cleanup
-	.field private initonly class Modules.Iterator_Helper_Cleanup/makeIterable/Scope _environment1_makeIterable
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Iterator_Helper_Cleanup/Scope capture0,
-			class Modules.Iterator_Helper_Cleanup/makeIterable/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3299
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_861DC683_L6C18::_environment0_Iterator_Helper_Cleanup
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Iterator_Helper_Cleanup/makeIterable/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_861DC683_L6C18::_environment1_makeIterable
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_861DC683_L6C18::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_861DC683_L6C18::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x32b6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_861DC683_L6C18::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x32b9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_861DC683_L6C18::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x32bc
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_861DC683_L6C18::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_861DC683_L6C18::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x32ce
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_861DC683_L6C18::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L6C17::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_861DC683_L6C18::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x32dc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_861DC683_L6C18::ConstructCore
-
-} // end of class FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_861DC683_L6C18
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_BF3F222A_L10C30
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Iterator_Helper_Cleanup/Scope _environment0_Iterator_Helper_Cleanup
-	.field private initonly class Modules.Iterator_Helper_Cleanup/makeIterable/Scope _environment1_makeIterable
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Iterator_Helper_Cleanup/Scope capture0,
-			class Modules.Iterator_Helper_Cleanup/makeIterable/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x32eb
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_BF3F222A_L10C30::_environment0_Iterator_Helper_Cleanup
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Iterator_Helper_Cleanup/makeIterable/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_BF3F222A_L10C30::_environment1_makeIterable
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_BF3F222A_L10C30::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_BF3F222A_L10C30::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3308
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_BF3F222A_L10C30::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x330b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_BF3F222A_L10C30::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x330e
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_BF3F222A_L10C30::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_BF3F222A_L10C30::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3320
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_BF3F222A_L10C30::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_BF3F222A_L10C30::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x332e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_BF3F222A_L10C30::ConstructCore
-
-} // end of class FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_BF3F222A_L10C30
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_72A92B04_L13C25
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Iterator_Helper_Cleanup/Scope _environment0_Iterator_Helper_Cleanup
-	.field private initonly class Modules.Iterator_Helper_Cleanup/makeIterable/Scope _environment1_makeIterable
-	.field private initonly class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope _environment2_FunctionExpression_L10C29
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Iterator_Helper_Cleanup/Scope capture0,
-			class Modules.Iterator_Helper_Cleanup/makeIterable/Scope capture1,
-			class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x333d
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_72A92B04_L13C25::_environment0_Iterator_Helper_Cleanup
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Iterator_Helper_Cleanup/makeIterable/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_72A92B04_L13C25::_environment1_makeIterable
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_72A92B04_L13C25::_environment2_FunctionExpression_L10C29
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_72A92B04_L13C25::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_72A92B04_L13C25::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3362
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_72A92B04_L13C25::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3365
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_72A92B04_L13C25::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3368
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_72A92B04_L13C25::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_72A92B04_L13C25::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x337a
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_72A92B04_L13C25::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L13C24::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_72A92B04_L13C25::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3388
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_72A92B04_L13C25::ConstructCore
-
-} // end of class FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_72A92B04_L13C25
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_C0155B76_L17C27
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Iterator_Helper_Cleanup/Scope _environment0_Iterator_Helper_Cleanup
-	.field private initonly class Modules.Iterator_Helper_Cleanup/makeIterable/Scope _environment1_makeIterable
-	.field private initonly class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope _environment2_FunctionExpression_L10C29
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Iterator_Helper_Cleanup/Scope capture0,
-			class Modules.Iterator_Helper_Cleanup/makeIterable/Scope capture1,
-			class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x3397
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_C0155B76_L17C27::_environment0_Iterator_Helper_Cleanup
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Iterator_Helper_Cleanup/makeIterable/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_C0155B76_L17C27::_environment1_makeIterable
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_C0155B76_L17C27::_environment2_FunctionExpression_L10C29
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_C0155B76_L17C27::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_C0155B76_L17C27::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x33bc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C0155B76_L17C27::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x33bf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C0155B76_L17C27::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x33c2
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_C0155B76_L17C27::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_C0155B76_L17C27::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x33d4
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_C0155B76_L17C27::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Iterator_Helper_Cleanup/makeIterable/FunctionExpression_L10C29/FunctionExpression_L17C26::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_C0155B76_L17C27::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x33e2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C0155B76_L17C27::ConstructCore
-
-} // end of class FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_C0155B76_L17C27
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_EFA19121_L61C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Iterator_Helper_Cleanup/Scope _environment0_Iterator_Helper_Cleanup
-	.field private initonly class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope _environment1_ArrowFunction_L60C47
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Iterator_Helper_Cleanup/Scope capture0,
-			class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x3472
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_EFA19121_L61C22::_environment0_Iterator_Helper_Cleanup
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_EFA19121_L61C22::_environment1_ArrowFunction_L60C47
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_EFA19121_L61C22::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_EFA19121_L61C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x348f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_EFA19121_L61C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3492
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_EFA19121_L61C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3495
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_EFA19121_L61C22::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_EFA19121_L61C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x34a7
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_EFA19121_L61C22::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_EFA19121_L61C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x34b5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_EFA19121_L61C22::ConstructCore
-
-} // end of class FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_EFA19121_L61C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_97DA0A87_L64C17
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Iterator_Helper_Cleanup/Scope _environment0_Iterator_Helper_Cleanup
-	.field private initonly class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope _environment1_ArrowFunction_L60C47
-	.field private initonly class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope _environment2_FunctionExpression_flatHelper
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Iterator_Helper_Cleanup/Scope capture0,
-			class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope capture1,
-			class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x34c4
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_97DA0A87_L64C17::_environment0_Iterator_Helper_Cleanup
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_97DA0A87_L64C17::_environment1_ArrowFunction_L60C47
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_97DA0A87_L64C17::_environment2_FunctionExpression_flatHelper
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_97DA0A87_L64C17::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_97DA0A87_L64C17::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x34e9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_97DA0A87_L64C17::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x34ec
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_97DA0A87_L64C17::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x34ef
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_97DA0A87_L64C17::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_97DA0A87_L64C17::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3501
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_97DA0A87_L64C17::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_97DA0A87_L64C17::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x350f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_97DA0A87_L64C17::ConstructCore
-
-} // end of class FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_97DA0A87_L64C17
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_BEE289C4_L72C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Iterator_Helper_Cleanup/Scope _environment0_Iterator_Helper_Cleanup
-	.field private initonly class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope _environment1_ArrowFunction_L60C47
-	.field private initonly class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope _environment2_FunctionExpression_flatHelper
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Iterator_Helper_Cleanup/Scope capture0,
-			class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope capture1,
-			class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x351e
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_BEE289C4_L72C19::_environment0_Iterator_Helper_Cleanup
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_BEE289C4_L72C19::_environment1_ArrowFunction_L60C47
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_BEE289C4_L72C19::_environment2_FunctionExpression_flatHelper
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_BEE289C4_L72C19::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_BEE289C4_L72C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3543
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_BEE289C4_L72C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3546
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_BEE289C4_L72C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3549
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_BEE289C4_L72C19::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_BEE289C4_L72C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x355b
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_BEE289C4_L72C19::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L60C47/FunctionExpression_flatHelper/FunctionExpression_flatHelper_L72C18::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_BEE289C4_L72C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3569
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_BEE289C4_L72C19::ConstructCore
-
-} // end of class FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_BEE289C4_L72C19
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_665FA710_L96C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Iterator_Helper_Cleanup/Scope _environment0_Iterator_Helper_Cleanup
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Iterator_Helper_Cleanup/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3595
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_665FA710_L96C22::_environment0_Iterator_Helper_Cleanup
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_665FA710_L96C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x35a4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_665FA710_L96C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x35a7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_665FA710_L96C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x35aa
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Iterator_Helper_Cleanup/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_665FA710_L96C22::_environment0_Iterator_Helper_Cleanup
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_665FA710_L96C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x35bc
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Iterator_Helper_Cleanup/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_665FA710_L96C22::_environment0_Iterator_Helper_Cleanup
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper::__js_call__(class Modules.Iterator_Helper_Cleanup/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_665FA710_L96C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x35ca
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_665FA710_L96C22::ConstructCore
-
-} // end of class FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_665FA710_L96C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_649156E0_L99C17
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Iterator_Helper_Cleanup/Scope _environment0_Iterator_Helper_Cleanup
-	.field private initonly class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope _environment1_FunctionExpression_flatThrowHelper
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Iterator_Helper_Cleanup/Scope capture0,
-			class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x35d9
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_649156E0_L99C17::_environment0_Iterator_Helper_Cleanup
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_649156E0_L99C17::_environment1_FunctionExpression_flatThrowHelper
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_649156E0_L99C17::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_649156E0_L99C17::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x35f6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_649156E0_L99C17::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x35f9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_649156E0_L99C17::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x35fc
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_649156E0_L99C17::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_649156E0_L99C17::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x360e
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_649156E0_L99C17::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_649156E0_L99C17::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x361c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_649156E0_L99C17::ConstructCore
-
-} // end of class FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_649156E0_L99C17
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_B177656C_L107C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Iterator_Helper_Cleanup/Scope _environment0_Iterator_Helper_Cleanup
-	.field private initonly class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope _environment1_FunctionExpression_flatThrowHelper
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Iterator_Helper_Cleanup/Scope capture0,
-			class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x362b
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_B177656C_L107C19::_environment0_Iterator_Helper_Cleanup
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_B177656C_L107C19::_environment1_FunctionExpression_flatThrowHelper
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_B177656C_L107C19::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_B177656C_L107C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3648
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_B177656C_L107C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x364b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_B177656C_L107C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x364e
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_B177656C_L107C19::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_B177656C_L107C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3660
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_B177656C_L107C19::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Iterator_Helper_Cleanup/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L107C18::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_B177656C_L107C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x366e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_B177656C_L107C19::ConstructCore
-
-} // end of class FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_B177656C_L107C19
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_44F841E1_L114C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Iterator_Helper_Cleanup/Scope _environment0_Iterator_Helper_Cleanup
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Iterator_Helper_Cleanup/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x36a7
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_44F841E1_L114C22::_environment0_Iterator_Helper_Cleanup
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_44F841E1_L114C22::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_44F841E1_L114C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x36bd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_44F841E1_L114C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x36c0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_44F841E1_L114C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x36c3
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_44F841E1_L114C22::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_44F841E1_L114C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x36d5
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_44F841E1_L114C22::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_44F841E1_L114C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x36e3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_44F841E1_L114C22::ConstructCore
-
-} // end of class FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_44F841E1_L114C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_F596D986_L116C17
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x36f2
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_F596D986_L116C17::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x36fa
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F596D986_L116C17::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x36fd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F596D986_L116C17::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3700
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_F596D986_L116C17::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x370c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_F596D986_L116C17::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3714
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F596D986_L116C17::ConstructCore
-
-} // end of class FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_F596D986_L116C17
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_C2293FF7_L119C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Iterator_Helper_Cleanup/Scope _environment0_Iterator_Helper_Cleanup
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Iterator_Helper_Cleanup/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x3723
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Iterator_Helper_Cleanup/Scope FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_C2293FF7_L119C19::_environment0_Iterator_Helper_Cleanup
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_C2293FF7_L119C19::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_C2293FF7_L119C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3739
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C2293FF7_L119C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x373c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C2293FF7_L119C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x373f
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_C2293FF7_L119C19::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_C2293FF7_L119C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3751
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_C2293FF7_L119C19::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Iterator_Helper_Cleanup/ArrowFunction_L113C12/FunctionExpression_flatThrowHelper/FunctionExpression_flatThrowHelper_L119C18::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_C2293FF7_L119C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x375f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C2293FF7_L119C19::ConstructCore
-
-} // end of class FunctionObjects.Iterator_Helper_Cleanup_C7DBA78B.FunctionObject_FunctionExpression_C2293FF7_L119C19
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Next_Return.verified.txt
+++ b/tests/Jroc.Tests/Iterator/Snapshots/GeneratorTests.Iterator_Helper_Next_Return.verified.txt
@@ -35,6 +35,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_CB0EEF83_L8C17
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Iterator_Helper_Next_Return/Scope _environment0_Iterator_Helper_Next_Return
+				.field private initonly class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope _environment1_FunctionExpression_iterable
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Iterator_Helper_Next_Return/Scope capture0,
+						class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2789
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Iterator_Helper_Next_Return/Scope Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_CB0EEF83_L8C17::_environment0_Iterator_Helper_Next_Return
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_CB0EEF83_L8C17::_environment1_FunctionExpression_iterable
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_CB0EEF83_L8C17::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_CB0EEF83_L8C17::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x27a6
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_CB0EEF83_L8C17::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x27a9
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_CB0EEF83_L8C17::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x27ac
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_CB0EEF83_L8C17::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_CB0EEF83_L8C17::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x27be
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_CB0EEF83_L8C17::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_CB0EEF83_L8C17::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x27cc
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_CB0EEF83_L8C17::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_CB0EEF83_L8C17
+
 
 			// Methods
 			.method public hidebysig static 
@@ -131,6 +248,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C90FF228_L12C19
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Iterator_Helper_Next_Return/Scope _environment0_Iterator_Helper_Next_Return
+				.field private initonly class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope _environment1_FunctionExpression_iterable
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Iterator_Helper_Next_Return/Scope capture0,
+						class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x27db
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Iterator_Helper_Next_Return/Scope Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18/FunctionObject_FunctionExpression_C90FF228_L12C19::_environment0_Iterator_Helper_Next_Return
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18/FunctionObject_FunctionExpression_C90FF228_L12C19::_environment1_FunctionExpression_iterable
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18/FunctionObject_FunctionExpression_C90FF228_L12C19::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_C90FF228_L12C19::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x27f8
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_C90FF228_L12C19::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x27fb
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_C90FF228_L12C19::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x27fe
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18/FunctionObject_FunctionExpression_C90FF228_L12C19::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_C90FF228_L12C19::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2810
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18/FunctionObject_FunctionExpression_C90FF228_L12C19::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_C90FF228_L12C19::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x281e
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_C90FF228_L12C19::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_C90FF228_L12C19
+
 
 			// Methods
 			.method public hidebysig static 
@@ -209,6 +443,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_86652434_L5C22
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Iterator_Helper_Next_Return/Scope _environment0_Iterator_Helper_Next_Return
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Iterator_Helper_Next_Return/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2745
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Iterator_Helper_Next_Return/Scope Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionObject_FunctionExpression_86652434_L5C22::_environment0_Iterator_Helper_Next_Return
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_86652434_L5C22::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2754
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_86652434_L5C22::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2757
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_86652434_L5C22::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x275a
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Iterator_Helper_Next_Return/Scope Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionObject_FunctionExpression_86652434_L5C22::_environment0_Iterator_Helper_Next_Return
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable::__js_call__(class Modules.Iterator_Helper_Next_Return/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_86652434_L5C22::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x276c
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Iterator_Helper_Next_Return/Scope Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionObject_FunctionExpression_86652434_L5C22::_environment0_Iterator_Helper_Next_Return
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable::__js_call__(class Modules.Iterator_Helper_Next_Return/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_86652434_L5C22::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x277a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_86652434_L5C22::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_86652434_L5C22
 
 
 		// Methods
@@ -869,347 +1210,6 @@
 	} // end of method Iterator_Helper_Next_Return::__js_module_init__
 
 } // end of class Modules.Iterator_Helper_Next_Return
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Iterator_Helper_Next_Return_B29B0767.FunctionObject_FunctionExpression_86652434_L5C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Iterator_Helper_Next_Return/Scope _environment0_Iterator_Helper_Next_Return
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Iterator_Helper_Next_Return/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2745
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Iterator_Helper_Next_Return/Scope FunctionObjects.Iterator_Helper_Next_Return_B29B0767.FunctionObject_FunctionExpression_86652434_L5C22::_environment0_Iterator_Helper_Next_Return
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_86652434_L5C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2754
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_86652434_L5C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2757
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_86652434_L5C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x275a
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Iterator_Helper_Next_Return/Scope FunctionObjects.Iterator_Helper_Next_Return_B29B0767.FunctionObject_FunctionExpression_86652434_L5C22::_environment0_Iterator_Helper_Next_Return
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable::__js_call__(class Modules.Iterator_Helper_Next_Return/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_86652434_L5C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x276c
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Iterator_Helper_Next_Return/Scope FunctionObjects.Iterator_Helper_Next_Return_B29B0767.FunctionObject_FunctionExpression_86652434_L5C22::_environment0_Iterator_Helper_Next_Return
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable::__js_call__(class Modules.Iterator_Helper_Next_Return/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_86652434_L5C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x277a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_86652434_L5C22::ConstructCore
-
-} // end of class FunctionObjects.Iterator_Helper_Next_Return_B29B0767.FunctionObject_FunctionExpression_86652434_L5C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Iterator_Helper_Next_Return_B29B0767.FunctionObject_FunctionExpression_CB0EEF83_L8C17
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Iterator_Helper_Next_Return/Scope _environment0_Iterator_Helper_Next_Return
-	.field private initonly class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope _environment1_FunctionExpression_iterable
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Iterator_Helper_Next_Return/Scope capture0,
-			class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2789
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Iterator_Helper_Next_Return/Scope FunctionObjects.Iterator_Helper_Next_Return_B29B0767.FunctionObject_FunctionExpression_CB0EEF83_L8C17::_environment0_Iterator_Helper_Next_Return
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope FunctionObjects.Iterator_Helper_Next_Return_B29B0767.FunctionObject_FunctionExpression_CB0EEF83_L8C17::_environment1_FunctionExpression_iterable
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Iterator_Helper_Next_Return_B29B0767.FunctionObject_FunctionExpression_CB0EEF83_L8C17::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_CB0EEF83_L8C17::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x27a6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_CB0EEF83_L8C17::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x27a9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_CB0EEF83_L8C17::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x27ac
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Iterator_Helper_Next_Return_B29B0767.FunctionObject_FunctionExpression_CB0EEF83_L8C17::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_CB0EEF83_L8C17::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27be
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Iterator_Helper_Next_Return_B29B0767.FunctionObject_FunctionExpression_CB0EEF83_L8C17::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_CB0EEF83_L8C17::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27cc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_CB0EEF83_L8C17::ConstructCore
-
-} // end of class FunctionObjects.Iterator_Helper_Next_Return_B29B0767.FunctionObject_FunctionExpression_CB0EEF83_L8C17
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Iterator_Helper_Next_Return_B29B0767.FunctionObject_FunctionExpression_C90FF228_L12C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Iterator_Helper_Next_Return/Scope _environment0_Iterator_Helper_Next_Return
-	.field private initonly class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope _environment1_FunctionExpression_iterable
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Iterator_Helper_Next_Return/Scope capture0,
-			class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x27db
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Iterator_Helper_Next_Return/Scope FunctionObjects.Iterator_Helper_Next_Return_B29B0767.FunctionObject_FunctionExpression_C90FF228_L12C19::_environment0_Iterator_Helper_Next_Return
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/Scope FunctionObjects.Iterator_Helper_Next_Return_B29B0767.FunctionObject_FunctionExpression_C90FF228_L12C19::_environment1_FunctionExpression_iterable
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Iterator_Helper_Next_Return_B29B0767.FunctionObject_FunctionExpression_C90FF228_L12C19::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_C90FF228_L12C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x27f8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C90FF228_L12C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x27fb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C90FF228_L12C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x27fe
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Iterator_Helper_Next_Return_B29B0767.FunctionObject_FunctionExpression_C90FF228_L12C19::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_C90FF228_L12C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2810
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Iterator_Helper_Next_Return_B29B0767.FunctionObject_FunctionExpression_C90FF228_L12C19::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Iterator_Helper_Next_Return/FunctionExpression_iterable/FunctionExpression_iterable_L12C18::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_C90FF228_L12C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x281e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C90FF228_L12C19::ConstructCore
-
-} // end of class FunctionObjects.Iterator_Helper_Next_Return_B29B0767.FunctionObject_FunctionExpression_C90FF228_L12C19
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/JSON/Snapshots/GeneratorTests.JSON_Parse_Reviver_Holder.verified.txt
+++ b/tests/Jroc.Tests/JSON/Snapshots/GeneratorTests.JSON_Parse_Reviver_Holder.verified.txt
@@ -113,6 +113,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7D62481C_L5C5
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2342
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_7D62481C_L5C5::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x234a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7D62481C_L5C5::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x234d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7D62481C_L5C5::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2350
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.JSON_Parse_Reviver_Holder/FunctionExpression_result::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionExpression_7D62481C_L5C5::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x236a
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.JSON_Parse_Reviver_Holder/FunctionExpression_result::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionExpression_7D62481C_L5C5::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2380
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_7D62481C_L5C5::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_7D62481C_L5C5
+
 
 		// Methods
 		.method public hidebysig static 
@@ -443,7 +550,7 @@
 			[0] class Modules.JSON_Parse_Reviver_Holder/Scope,
 			[1] object,
 			[2] object[],
-			[3] class FunctionObjects.JSON_Parse_Reviver_Holder_4B7003D4.FunctionObject_FunctionExpression_7D62481C_L5C5,
+			[3] class Modules.JSON_Parse_Reviver_Holder/FunctionExpression_result/FunctionObject_FunctionExpression_7D62481C_L5C5,
 			[4] object,
 			[5] class Modules.JSON_Parse_Reviver_Holder/ArrowFunction_L24C29/FunctionObject,
 			[6] object
@@ -460,13 +567,13 @@
 		IL_0014: ldloc.0
 		IL_0015: stelem.ref
 		IL_0016: stloc.2
-		IL_0017: newobj instance void FunctionObjects.JSON_Parse_Reviver_Holder_4B7003D4.FunctionObject_FunctionExpression_7D62481C_L5C5::.ctor()
+		IL_0017: newobj instance void Modules.JSON_Parse_Reviver_Holder/FunctionExpression_result/FunctionObject_FunctionExpression_7D62481C_L5C5::.ctor()
 		IL_001c: ldc.i4.2
 		IL_001d: conv.r8
 		IL_001e: ldstr ""
 		IL_0023: ldc.i4.1
 		IL_0024: ldc.i4.1
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.JSON_Parse_Reviver_Holder_4B7003D4.FunctionObject_FunctionExpression_7D62481C_L5C5>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.JSON_Parse_Reviver_Holder/FunctionExpression_result/FunctionObject_FunctionExpression_7D62481C_L5C5>(!!0, float64, string, bool, bool)
 		IL_002a: stloc.3
 		IL_002b: ldstr "{\"a\":1,\"nested\":{\"b\":2},\"remove\":3,\"arr\":[4,5]}"
 		IL_0030: ldloc.3
@@ -527,113 +634,6 @@
 	} // end of method JSON_Parse_Reviver_Holder::__js_module_init__
 
 } // end of class Modules.JSON_Parse_Reviver_Holder
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.JSON_Parse_Reviver_Holder_4B7003D4.FunctionObject_FunctionExpression_7D62481C_L5C5
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2342
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_7D62481C_L5C5::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x234a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7D62481C_L5C5::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x234d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7D62481C_L5C5::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2350
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.JSON_Parse_Reviver_Holder/FunctionExpression_result::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_7D62481C_L5C5::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x236a
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.JSON_Parse_Reviver_Holder/FunctionExpression_result::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_7D62481C_L5C5::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2380
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7D62481C_L5C5::ConstructCore
-
-} // end of class FunctionObjects.JSON_Parse_Reviver_Holder_4B7003D4.FunctionObject_FunctionExpression_7D62481C_L5C5
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Constructor_Iterable.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_Constructor_Iterable.verified.txt
@@ -57,6 +57,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E1161D0D_L13C17
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Map_Constructor_Iterable/Scope _environment0_Map_Constructor_Iterable
+				.field private initonly class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope _environment1_FunctionExpression_iterable
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Map_Constructor_Iterable/Scope capture0,
+						class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2a2d
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E1161D0D_L13C17::_environment0_Map_Constructor_Iterable
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E1161D0D_L13C17::_environment1_FunctionExpression_iterable
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E1161D0D_L13C17::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_E1161D0D_L13C17::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2a4a
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_E1161D0D_L13C17::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2a4d
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_E1161D0D_L13C17::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2a50
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E1161D0D_L13C17::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_E1161D0D_L13C17::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2a62
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E1161D0D_L13C17::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_E1161D0D_L13C17::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2a70
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_E1161D0D_L13C17::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_E1161D0D_L13C17
+
 
 			// Methods
 			.method public hidebysig static 
@@ -190,6 +307,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A18A3F87_L4C22
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Map_Constructor_Iterable/Scope _environment0_Map_Constructor_Iterable
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Map_Constructor_Iterable/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x29e9
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_A18A3F87_L4C22::_environment0_Map_Constructor_Iterable
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_A18A3F87_L4C22::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x29f8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A18A3F87_L4C22::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x29fb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A18A3F87_L4C22::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x29fe
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_A18A3F87_L4C22::_environment0_Map_Constructor_Iterable
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Map_Constructor_Iterable/FunctionExpression_iterable::__js_call__(class Modules.Map_Constructor_Iterable/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_A18A3F87_L4C22::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a10
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_A18A3F87_L4C22::_environment0_Map_Constructor_Iterable
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Map_Constructor_Iterable/FunctionExpression_iterable::__js_call__(class Modules.Map_Constructor_Iterable/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_A18A3F87_L4C22::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a1e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_A18A3F87_L4C22::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_A18A3F87_L4C22
 
 
 		// Methods
@@ -348,6 +572,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_99568244_L39C17
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Map_Constructor_Iterable/Scope _environment0_Map_Constructor_Iterable
+				.field private initonly class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope _environment1_FunctionExpression_closableIterable
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Map_Constructor_Iterable/Scope capture0,
+						class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2ac3
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_99568244_L39C17::_environment0_Map_Constructor_Iterable
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_99568244_L39C17::_environment1_FunctionExpression_closableIterable
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_99568244_L39C17::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_99568244_L39C17::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2ae0
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_99568244_L39C17::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2ae3
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_99568244_L39C17::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2ae6
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_99568244_L39C17::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_99568244_L39C17::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2af8
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_99568244_L39C17::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_99568244_L39C17::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2b06
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_99568244_L39C17::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_99568244_L39C17
+
 
 			// Methods
 			.method public hidebysig static 
@@ -477,6 +818,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D3F48DAC_L46C19
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Map_Constructor_Iterable/Scope _environment0_Map_Constructor_Iterable
+				.field private initonly class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope _environment1_FunctionExpression_closableIterable
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Map_Constructor_Iterable/Scope capture0,
+						class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2b15
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18/FunctionObject_FunctionExpression_D3F48DAC_L46C19::_environment0_Map_Constructor_Iterable
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18/FunctionObject_FunctionExpression_D3F48DAC_L46C19::_environment1_FunctionExpression_closableIterable
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18/FunctionObject_FunctionExpression_D3F48DAC_L46C19::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_D3F48DAC_L46C19::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2b32
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_D3F48DAC_L46C19::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2b35
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_D3F48DAC_L46C19::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2b38
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18/FunctionObject_FunctionExpression_D3F48DAC_L46C19::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_D3F48DAC_L46C19::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2b4a
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18/FunctionObject_FunctionExpression_D3F48DAC_L46C19::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_D3F48DAC_L46C19::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2b58
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_D3F48DAC_L46C19::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_D3F48DAC_L46C19
+
 
 			// Methods
 			.method public hidebysig static 
@@ -538,6 +996,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_17108703_L31C22
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Map_Constructor_Iterable/Scope _environment0_Map_Constructor_Iterable
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Map_Constructor_Iterable/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a7f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_17108703_L31C22::_environment0_Map_Constructor_Iterable
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_17108703_L31C22::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2a8e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_17108703_L31C22::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2a91
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_17108703_L31C22::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a94
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_17108703_L31C22::_environment0_Map_Constructor_Iterable
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable::__js_call__(class Modules.Map_Constructor_Iterable/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_17108703_L31C22::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2aa6
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_17108703_L31C22::_environment0_Map_Constructor_Iterable
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable::__js_call__(class Modules.Map_Constructor_Iterable/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_17108703_L31C22::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ab4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_17108703_L31C22::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_17108703_L31C22
 
 
 		// Methods
@@ -719,6 +1284,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A2D37BB5_L70C17
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Map_Constructor_Iterable/Scope _environment0_Map_Constructor_Iterable
+				.field private initonly class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope _environment1_FunctionExpression_invalidIterable
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Map_Constructor_Iterable/Scope capture0,
+						class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2bab
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_A2D37BB5_L70C17::_environment0_Map_Constructor_Iterable
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_A2D37BB5_L70C17::_environment1_FunctionExpression_invalidIterable
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_A2D37BB5_L70C17::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_A2D37BB5_L70C17::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2bc8
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_A2D37BB5_L70C17::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2bcb
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_A2D37BB5_L70C17::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2bce
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_A2D37BB5_L70C17::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_A2D37BB5_L70C17::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2be0
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_A2D37BB5_L70C17::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_A2D37BB5_L70C17::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2bee
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_A2D37BB5_L70C17::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_A2D37BB5_L70C17
+
 
 			// Methods
 			.method public hidebysig static 
@@ -809,6 +1491,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_471A5FC3_L78C19
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Map_Constructor_Iterable/Scope _environment0_Map_Constructor_Iterable
+				.field private initonly class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope _environment1_FunctionExpression_invalidIterable
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Map_Constructor_Iterable/Scope capture0,
+						class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2bfd
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18/FunctionObject_FunctionExpression_471A5FC3_L78C19::_environment0_Map_Constructor_Iterable
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18/FunctionObject_FunctionExpression_471A5FC3_L78C19::_environment1_FunctionExpression_invalidIterable
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18/FunctionObject_FunctionExpression_471A5FC3_L78C19::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_471A5FC3_L78C19::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2c1a
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_471A5FC3_L78C19::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2c1d
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_471A5FC3_L78C19::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2c20
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18/FunctionObject_FunctionExpression_471A5FC3_L78C19::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_471A5FC3_L78C19::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2c32
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18/FunctionObject_FunctionExpression_471A5FC3_L78C19::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_471A5FC3_L78C19::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2c40
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_471A5FC3_L78C19::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_471A5FC3_L78C19
+
 
 			// Methods
 			.method public hidebysig static 
@@ -868,6 +1667,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_EEAD530B_L66C22
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Map_Constructor_Iterable/Scope _environment0_Map_Constructor_Iterable
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Map_Constructor_Iterable/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b67
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_EEAD530B_L66C22::_environment0_Map_Constructor_Iterable
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_EEAD530B_L66C22::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2b76
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_EEAD530B_L66C22::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2b79
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_EEAD530B_L66C22::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b7c
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_EEAD530B_L66C22::_environment0_Map_Constructor_Iterable
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable::__js_call__(class Modules.Map_Constructor_Iterable/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_EEAD530B_L66C22::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b8e
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Map_Constructor_Iterable/Scope Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionObject_FunctionExpression_EEAD530B_L66C22::_environment0_Map_Constructor_Iterable
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable::__js_call__(class Modules.Map_Constructor_Iterable/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_EEAD530B_L66C22::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b9c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_EEAD530B_L66C22::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_EEAD530B_L66C22
 
 
 		// Methods
@@ -1407,912 +2313,6 @@
 	} // end of method Map_Constructor_Iterable::__js_module_init__
 
 } // end of class Modules.Map_Constructor_Iterable
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_A18A3F87_L4C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Map_Constructor_Iterable/Scope _environment0_Map_Constructor_Iterable
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Map_Constructor_Iterable/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x29e9
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_A18A3F87_L4C22::_environment0_Map_Constructor_Iterable
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A18A3F87_L4C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x29f8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A18A3F87_L4C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x29fb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A18A3F87_L4C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x29fe
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Map_Constructor_Iterable/Scope FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_A18A3F87_L4C22::_environment0_Map_Constructor_Iterable
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Map_Constructor_Iterable/FunctionExpression_iterable::__js_call__(class Modules.Map_Constructor_Iterable/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_A18A3F87_L4C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a10
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Map_Constructor_Iterable/Scope FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_A18A3F87_L4C22::_environment0_Map_Constructor_Iterable
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Map_Constructor_Iterable/FunctionExpression_iterable::__js_call__(class Modules.Map_Constructor_Iterable/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_A18A3F87_L4C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a1e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A18A3F87_L4C22::ConstructCore
-
-} // end of class FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_A18A3F87_L4C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_E1161D0D_L13C17
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Map_Constructor_Iterable/Scope _environment0_Map_Constructor_Iterable
-	.field private initonly class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope _environment1_FunctionExpression_iterable
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Map_Constructor_Iterable/Scope capture0,
-			class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a2d
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_E1161D0D_L13C17::_environment0_Map_Constructor_Iterable
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Map_Constructor_Iterable/FunctionExpression_iterable/Scope FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_E1161D0D_L13C17::_environment1_FunctionExpression_iterable
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_E1161D0D_L13C17::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_E1161D0D_L13C17::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a4a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E1161D0D_L13C17::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a4d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E1161D0D_L13C17::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a50
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_E1161D0D_L13C17::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_E1161D0D_L13C17::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a62
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_E1161D0D_L13C17::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Map_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_E1161D0D_L13C17::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a70
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E1161D0D_L13C17::ConstructCore
-
-} // end of class FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_E1161D0D_L13C17
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_17108703_L31C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Map_Constructor_Iterable/Scope _environment0_Map_Constructor_Iterable
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Map_Constructor_Iterable/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a7f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_17108703_L31C22::_environment0_Map_Constructor_Iterable
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_17108703_L31C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a8e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_17108703_L31C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a91
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_17108703_L31C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a94
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Map_Constructor_Iterable/Scope FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_17108703_L31C22::_environment0_Map_Constructor_Iterable
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable::__js_call__(class Modules.Map_Constructor_Iterable/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_17108703_L31C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2aa6
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Map_Constructor_Iterable/Scope FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_17108703_L31C22::_environment0_Map_Constructor_Iterable
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable::__js_call__(class Modules.Map_Constructor_Iterable/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_17108703_L31C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ab4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_17108703_L31C22::ConstructCore
-
-} // end of class FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_17108703_L31C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_99568244_L39C17
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Map_Constructor_Iterable/Scope _environment0_Map_Constructor_Iterable
-	.field private initonly class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope _environment1_FunctionExpression_closableIterable
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Map_Constructor_Iterable/Scope capture0,
-			class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ac3
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_99568244_L39C17::_environment0_Map_Constructor_Iterable
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_99568244_L39C17::_environment1_FunctionExpression_closableIterable
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_99568244_L39C17::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_99568244_L39C17::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2ae0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_99568244_L39C17::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2ae3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_99568244_L39C17::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ae6
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_99568244_L39C17::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_99568244_L39C17::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2af8
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_99568244_L39C17::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_99568244_L39C17::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b06
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_99568244_L39C17::ConstructCore
-
-} // end of class FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_99568244_L39C17
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_D3F48DAC_L46C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Map_Constructor_Iterable/Scope _environment0_Map_Constructor_Iterable
-	.field private initonly class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope _environment1_FunctionExpression_closableIterable
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Map_Constructor_Iterable/Scope capture0,
-			class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b15
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_D3F48DAC_L46C19::_environment0_Map_Constructor_Iterable
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/Scope FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_D3F48DAC_L46C19::_environment1_FunctionExpression_closableIterable
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_D3F48DAC_L46C19::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_D3F48DAC_L46C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2b32
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D3F48DAC_L46C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2b35
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D3F48DAC_L46C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b38
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_D3F48DAC_L46C19::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_D3F48DAC_L46C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b4a
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_D3F48DAC_L46C19::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Map_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L46C18::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_D3F48DAC_L46C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b58
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D3F48DAC_L46C19::ConstructCore
-
-} // end of class FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_D3F48DAC_L46C19
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_EEAD530B_L66C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Map_Constructor_Iterable/Scope _environment0_Map_Constructor_Iterable
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Map_Constructor_Iterable/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b67
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_EEAD530B_L66C22::_environment0_Map_Constructor_Iterable
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_EEAD530B_L66C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2b76
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_EEAD530B_L66C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2b79
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_EEAD530B_L66C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b7c
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Map_Constructor_Iterable/Scope FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_EEAD530B_L66C22::_environment0_Map_Constructor_Iterable
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable::__js_call__(class Modules.Map_Constructor_Iterable/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_EEAD530B_L66C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b8e
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Map_Constructor_Iterable/Scope FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_EEAD530B_L66C22::_environment0_Map_Constructor_Iterable
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable::__js_call__(class Modules.Map_Constructor_Iterable/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_EEAD530B_L66C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b9c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_EEAD530B_L66C22::ConstructCore
-
-} // end of class FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_EEAD530B_L66C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_A2D37BB5_L70C17
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Map_Constructor_Iterable/Scope _environment0_Map_Constructor_Iterable
-	.field private initonly class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope _environment1_FunctionExpression_invalidIterable
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Map_Constructor_Iterable/Scope capture0,
-			class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bab
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_A2D37BB5_L70C17::_environment0_Map_Constructor_Iterable
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_A2D37BB5_L70C17::_environment1_FunctionExpression_invalidIterable
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_A2D37BB5_L70C17::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_A2D37BB5_L70C17::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2bc8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A2D37BB5_L70C17::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2bcb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A2D37BB5_L70C17::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bce
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_A2D37BB5_L70C17::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_A2D37BB5_L70C17::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2be0
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_A2D37BB5_L70C17::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_A2D37BB5_L70C17::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bee
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A2D37BB5_L70C17::ConstructCore
-
-} // end of class FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_A2D37BB5_L70C17
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_471A5FC3_L78C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Map_Constructor_Iterable/Scope _environment0_Map_Constructor_Iterable
-	.field private initonly class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope _environment1_FunctionExpression_invalidIterable
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Map_Constructor_Iterable/Scope capture0,
-			class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bfd
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Map_Constructor_Iterable/Scope FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_471A5FC3_L78C19::_environment0_Map_Constructor_Iterable
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/Scope FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_471A5FC3_L78C19::_environment1_FunctionExpression_invalidIterable
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_471A5FC3_L78C19::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_471A5FC3_L78C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2c1a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_471A5FC3_L78C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2c1d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_471A5FC3_L78C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c20
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_471A5FC3_L78C19::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_471A5FC3_L78C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c32
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_471A5FC3_L78C19::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Map_Constructor_Iterable/FunctionExpression_invalidIterable/FunctionExpression_invalidIterable_L78C18::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_471A5FC3_L78C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c40
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_471A5FC3_L78C19::ConstructCore
-
-} // end of class FunctionObjects.Map_Constructor_Iterable_014AC4BD.FunctionObject_FunctionExpression_471A5FC3_L78C19
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_ForEach_Basic.verified.txt
+++ b/tests/Jroc.Tests/Map/Snapshots/GeneratorTests.Map_ForEach_Basic.verified.txt
@@ -31,6 +31,131 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1DD06151_L11C13
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Map_ForEach_Basic/Scope _environment0_Map_ForEach_Basic
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Map_ForEach_Basic/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2283
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Map_ForEach_Basic/Scope Modules.Map_ForEach_Basic/FunctionExpression_L11C12/FunctionObject_FunctionExpression_1DD06151_L11C13::_environment0_Map_ForEach_Basic
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_1DD06151_L11C13::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2292
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_1DD06151_L11C13::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2295
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_1DD06151_L11C13::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2298
+				// Header size: 1
+				// Code size: 38 (0x26)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Map_ForEach_Basic/Scope Modules.Map_ForEach_Basic/FunctionExpression_L11C12/FunctionObject_FunctionExpression_1DD06151_L11C13::_environment0_Map_ForEach_Basic
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: call object Modules.Map_ForEach_Basic/FunctionExpression_L11C12::__js_call__(class Modules.Map_ForEach_Basic/Scope, object, object, object, object)
+				IL_0025: ret
+			} // end of method FunctionObject_FunctionExpression_1DD06151_L11C13::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22bf
+				// Header size: 1
+				// Code size: 34 (0x22)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Map_ForEach_Basic/Scope Modules.Map_ForEach_Basic/FunctionExpression_L11C12/FunctionObject_FunctionExpression_1DD06151_L11C13::_environment0_Map_ForEach_Basic
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: ldarg.2
+				IL_0016: ldc.i4.2
+				IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001c: call object Modules.Map_ForEach_Basic/FunctionExpression_L11C12::__js_call__(class Modules.Map_ForEach_Basic/Scope, object, object, object, object)
+				IL_0021: ret
+			} // end of method FunctionObject_FunctionExpression_1DD06151_L11C13::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22e2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_1DD06151_L11C13::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_1DD06151_L11C13
+
 
 		// Methods
 		.method public hidebysig static 
@@ -163,7 +288,7 @@
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Map,
 			[4] object,
 			[5] object[],
-			[6] class FunctionObjects.Map_ForEach_Basic_B42A7201.FunctionObject_FunctionExpression_1DD06151_L11C13,
+			[6] class Modules.Map_ForEach_Basic/FunctionExpression_L11C12/FunctionObject_FunctionExpression_1DD06151_L11C13,
 			[7] object,
 			[8] object
 		)
@@ -227,13 +352,13 @@
 		IL_00a7: ldc.i4.0
 		IL_00a8: ldelem.ref
 		IL_00a9: castclass Modules.Map_ForEach_Basic/Scope
-		IL_00ae: newobj instance void FunctionObjects.Map_ForEach_Basic_B42A7201.FunctionObject_FunctionExpression_1DD06151_L11C13::.ctor(class Modules.Map_ForEach_Basic/Scope)
+		IL_00ae: newobj instance void Modules.Map_ForEach_Basic/FunctionExpression_L11C12/FunctionObject_FunctionExpression_1DD06151_L11C13::.ctor(class Modules.Map_ForEach_Basic/Scope)
 		IL_00b3: ldc.i4.3
 		IL_00b4: conv.r8
 		IL_00b5: ldstr ""
 		IL_00ba: ldc.i4.1
 		IL_00bb: ldc.i4.1
-		IL_00bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Map_ForEach_Basic_B42A7201.FunctionObject_FunctionExpression_1DD06151_L11C13>(!!0, float64, string, bool, bool)
+		IL_00bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Map_ForEach_Basic/FunctionExpression_L11C12/FunctionObject_FunctionExpression_1DD06151_L11C13>(!!0, float64, string, bool, bool)
 		IL_00c1: stloc.s 6
 		IL_00c3: ldloc.s 4
 		IL_00c5: ldstr "forEach"
@@ -290,131 +415,6 @@
 	} // end of method Map_ForEach_Basic::__js_module_init__
 
 } // end of class Modules.Map_ForEach_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Map_ForEach_Basic_B42A7201.FunctionObject_FunctionExpression_1DD06151_L11C13
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Map_ForEach_Basic/Scope _environment0_Map_ForEach_Basic
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Map_ForEach_Basic/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2283
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Map_ForEach_Basic/Scope FunctionObjects.Map_ForEach_Basic_B42A7201.FunctionObject_FunctionExpression_1DD06151_L11C13::_environment0_Map_ForEach_Basic
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1DD06151_L11C13::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2292
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1DD06151_L11C13::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2295
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1DD06151_L11C13::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2298
-		// Header size: 1
-		// Code size: 38 (0x26)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Map_ForEach_Basic/Scope FunctionObjects.Map_ForEach_Basic_B42A7201.FunctionObject_FunctionExpression_1DD06151_L11C13::_environment0_Map_ForEach_Basic
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: call object Modules.Map_ForEach_Basic/FunctionExpression_L11C12::__js_call__(class Modules.Map_ForEach_Basic/Scope, object, object, object, object)
-		IL_0025: ret
-	} // end of method FunctionObject_FunctionExpression_1DD06151_L11C13::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22bf
-		// Header size: 1
-		// Code size: 34 (0x22)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Map_ForEach_Basic/Scope FunctionObjects.Map_ForEach_Basic_B42A7201.FunctionObject_FunctionExpression_1DD06151_L11C13::_environment0_Map_ForEach_Basic
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: ldarg.2
-		IL_0016: ldc.i4.2
-		IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001c: call object Modules.Map_ForEach_Basic/FunctionExpression_L11C12::__js_call__(class Modules.Map_ForEach_Basic/Scope, object, object, object, object)
-		IL_0021: ret
-	} // end of method FunctionObject_FunctionExpression_1DD06151_L11C13::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22e2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1DD06151_L11C13::ConstructCore
-
-} // end of class FunctionObjects.Map_ForEach_Basic_B42A7201.FunctionObject_FunctionExpression_1DD06151_L11C13
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_AliasReplacement_Dispatch.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_AliasReplacement_Dispatch.verified.txt
@@ -31,6 +31,118 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_BAC020DF_L2C17
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x210a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_BAC020DF_L2C17::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2112
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_BAC020DF_L2C17::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2115
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_BAC020DF_L2C17::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2118
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_BAC020DF_L2C17::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2120
+				// Header size: 1
+				// Code size: 16 (0x10)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call float64 Modules.Math_AliasReplacement_Dispatch/FunctionExpression_L2C16::__js_call__(object)
+				IL_000a: box [System.Runtime]System.Double
+				IL_000f: ret
+			} // end of method FunctionObject_FunctionExpression_BAC020DF_L2C17::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2131
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call float64 Modules.Math_AliasReplacement_Dispatch/FunctionExpression_L2C16::__js_call__(object)
+				IL_0006: box [System.Runtime]System.Double
+				IL_000b: ret
+			} // end of method FunctionObject_FunctionExpression_BAC020DF_L2C17::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x213e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_BAC020DF_L2C17::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_BAC020DF_L2C17
+
 
 		// Methods
 		.method public hidebysig static 
@@ -91,7 +203,7 @@
 			[0] class Modules.Math_AliasReplacement_Dispatch/Scope,
 			[1] object,
 			[2] object[],
-			[3] class FunctionObjects.Math_AliasReplacement_Dispatch_26CBB2AB.FunctionObject_FunctionExpression_BAC020DF_L2C17,
+			[3] class Modules.Math_AliasReplacement_Dispatch/FunctionExpression_L2C16/FunctionObject_FunctionExpression_BAC020DF_L2C17,
 			[4] object,
 			[5] float64,
 			[6] object,
@@ -110,13 +222,13 @@
 		IL_0019: ldloc.0
 		IL_001a: stelem.ref
 		IL_001b: stloc.2
-		IL_001c: newobj instance void FunctionObjects.Math_AliasReplacement_Dispatch_26CBB2AB.FunctionObject_FunctionExpression_BAC020DF_L2C17::.ctor()
+		IL_001c: newobj instance void Modules.Math_AliasReplacement_Dispatch/FunctionExpression_L2C16/FunctionObject_FunctionExpression_BAC020DF_L2C17::.ctor()
 		IL_0021: ldc.i4.0
 		IL_0022: conv.r8
 		IL_0023: ldstr ""
 		IL_0028: ldc.i4.0
 		IL_0029: ldc.i4.0
-		IL_002a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Math_AliasReplacement_Dispatch_26CBB2AB.FunctionObject_FunctionExpression_BAC020DF_L2C17>(!!0, float64, string, bool, bool)
+		IL_002a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_AliasReplacement_Dispatch/FunctionExpression_L2C16/FunctionObject_FunctionExpression_BAC020DF_L2C17>(!!0, float64, string, bool, bool)
 		IL_002f: stloc.3
 		IL_0030: ldloc.1
 		IL_0031: ldstr "abs"
@@ -150,118 +262,6 @@
 	} // end of method Math_AliasReplacement_Dispatch::__js_module_init__
 
 } // end of class Modules.Math_AliasReplacement_Dispatch
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Math_AliasReplacement_Dispatch_26CBB2AB.FunctionObject_FunctionExpression_BAC020DF_L2C17
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x210a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_BAC020DF_L2C17::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2112
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_BAC020DF_L2C17::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2115
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_BAC020DF_L2C17::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2118
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_BAC020DF_L2C17::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2120
-		// Header size: 1
-		// Code size: 16 (0x10)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call float64 Modules.Math_AliasReplacement_Dispatch/FunctionExpression_L2C16::__js_call__(object)
-		IL_000a: box [System.Runtime]System.Double
-		IL_000f: ret
-	} // end of method FunctionObject_FunctionExpression_BAC020DF_L2C17::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2131
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call float64 Modules.Math_AliasReplacement_Dispatch/FunctionExpression_L2C16::__js_call__(object)
-		IL_0006: box [System.Runtime]System.Double
-		IL_000b: ret
-	} // end of method FunctionObject_FunctionExpression_BAC020DF_L2C17::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x213e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_BAC020DF_L2C17::ConstructCore
-
-} // end of class FunctionObjects.Math_AliasReplacement_Dispatch_26CBB2AB.FunctionObject_FunctionExpression_BAC020DF_L2C17
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_DefinePropertyReplacement_Dispatch.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_DefinePropertyReplacement_Dispatch.verified.txt
@@ -31,6 +31,118 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A40CA478_L2C10
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x212a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_A40CA478_L2C10::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2132
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A40CA478_L2C10::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2135
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A40CA478_L2C10::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2138
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_A40CA478_L2C10::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2140
+				// Header size: 1
+				// Code size: 16 (0x10)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call float64 Modules.Math_DefinePropertyReplacement_Dispatch/FunctionExpression_L2C9::__js_call__(object)
+				IL_000a: box [System.Runtime]System.Double
+				IL_000f: ret
+			} // end of method FunctionObject_FunctionExpression_A40CA478_L2C10::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2151
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call float64 Modules.Math_DefinePropertyReplacement_Dispatch/FunctionExpression_L2C9::__js_call__(object)
+				IL_0006: box [System.Runtime]System.Double
+				IL_000b: ret
+			} // end of method FunctionObject_FunctionExpression_A40CA478_L2C10::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x215e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_A40CA478_L2C10::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_A40CA478_L2C10
+
 
 		// Methods
 		.method public hidebysig static 
@@ -91,7 +203,7 @@
 			[0] class Modules.Math_DefinePropertyReplacement_Dispatch/Scope,
 			[1] object,
 			[2] object[],
-			[3] class FunctionObjects.Math_DefinePropertyReplacement_Dispatch_EA030139.FunctionObject_FunctionExpression_A40CA478_L2C10,
+			[3] class Modules.Math_DefinePropertyReplacement_Dispatch/FunctionExpression_L2C9/FunctionObject_FunctionExpression_A40CA478_L2C10,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[5] object
 		)
@@ -108,13 +220,13 @@
 		IL_0019: ldloc.0
 		IL_001a: stelem.ref
 		IL_001b: stloc.2
-		IL_001c: newobj instance void FunctionObjects.Math_DefinePropertyReplacement_Dispatch_EA030139.FunctionObject_FunctionExpression_A40CA478_L2C10::.ctor()
+		IL_001c: newobj instance void Modules.Math_DefinePropertyReplacement_Dispatch/FunctionExpression_L2C9/FunctionObject_FunctionExpression_A40CA478_L2C10::.ctor()
 		IL_0021: ldc.i4.0
 		IL_0022: conv.r8
 		IL_0023: ldstr ""
 		IL_0028: ldc.i4.0
 		IL_0029: ldc.i4.0
-		IL_002a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Math_DefinePropertyReplacement_Dispatch_EA030139.FunctionObject_FunctionExpression_A40CA478_L2C10>(!!0, float64, string, bool, bool)
+		IL_002a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_DefinePropertyReplacement_Dispatch/FunctionExpression_L2C9/FunctionObject_FunctionExpression_A40CA478_L2C10>(!!0, float64, string, bool, bool)
 		IL_002f: stloc.3
 		IL_0030: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0035: dup
@@ -156,118 +268,6 @@
 	} // end of method Math_DefinePropertyReplacement_Dispatch::__js_module_init__
 
 } // end of class Modules.Math_DefinePropertyReplacement_Dispatch
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Math_DefinePropertyReplacement_Dispatch_EA030139.FunctionObject_FunctionExpression_A40CA478_L2C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x212a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_A40CA478_L2C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2132
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A40CA478_L2C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2135
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A40CA478_L2C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2138
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_A40CA478_L2C10::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2140
-		// Header size: 1
-		// Code size: 16 (0x10)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call float64 Modules.Math_DefinePropertyReplacement_Dispatch/FunctionExpression_L2C9::__js_call__(object)
-		IL_000a: box [System.Runtime]System.Double
-		IL_000f: ret
-	} // end of method FunctionObject_FunctionExpression_A40CA478_L2C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2151
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call float64 Modules.Math_DefinePropertyReplacement_Dispatch/FunctionExpression_L2C9::__js_call__(object)
-		IL_0006: box [System.Runtime]System.Double
-		IL_000b: ret
-	} // end of method FunctionObject_FunctionExpression_A40CA478_L2C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x215e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A40CA478_L2C10::ConstructCore
-
-} // end of class FunctionObjects.Math_DefinePropertyReplacement_Dispatch_EA030139.FunctionObject_FunctionExpression_A40CA478_L2C10
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_Fround_SignedZero.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_Fround_SignedZero.verified.txt
@@ -31,6 +31,109 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F210FF6C_toStr
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21a4
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_F210FF6C_toStr::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21ac
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F210FF6C_toStr::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21af
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F210FF6C_toStr::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21b2
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: call object Modules.Math_Fround_SignedZero/toStr::__js_call__(object, float64)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_F210FF6C_toStr::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21ca
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: call object Modules.Math_Fround_SignedZero/toStr::__js_call__(object, float64)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_F210FF6C_toStr::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21de
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F210FF6C_toStr::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_F210FF6C_toStr
+
 
 		// Methods
 		.method public hidebysig static 
@@ -146,7 +249,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Math_Fround_SignedZero/Scope,
-			[1] class FunctionObjects.Math_Fround_SignedZero_A0F213A5.FunctionObject_FunctionDeclaration_F210FF6C_toStr,
+			[1] class Modules.Math_Fround_SignedZero/toStr/FunctionObject_FunctionDeclaration_F210FF6C_toStr,
 			[2] float64,
 			[3] float64,
 			[4] object[],
@@ -165,13 +268,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 4
-		IL_0012: newobj instance void FunctionObjects.Math_Fround_SignedZero_A0F213A5.FunctionObject_FunctionDeclaration_F210FF6C_toStr::.ctor()
+		IL_0012: newobj instance void Modules.Math_Fround_SignedZero/toStr/FunctionObject_FunctionDeclaration_F210FF6C_toStr::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "toStr"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Math_Fround_SignedZero_A0F213A5.FunctionObject_FunctionDeclaration_F210FF6C_toStr>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_Fround_SignedZero/toStr/FunctionObject_FunctionDeclaration_F210FF6C_toStr>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: ldc.r8 1.337
@@ -220,109 +323,6 @@
 	} // end of method Math_Fround_SignedZero::__js_module_init__
 
 } // end of class Modules.Math_Fround_SignedZero
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Math_Fround_SignedZero_A0F213A5.FunctionObject_FunctionDeclaration_F210FF6C_toStr
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21a4
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_F210FF6C_toStr::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21ac
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F210FF6C_toStr::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21af
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F210FF6C_toStr::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21b2
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: call object Modules.Math_Fround_SignedZero/toStr::__js_call__(object, float64)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_F210FF6C_toStr::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ca
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: call object Modules.Math_Fround_SignedZero/toStr::__js_call__(object, float64)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_F210FF6C_toStr::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21de
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F210FF6C_toStr::ConstructCore
-
-} // end of class FunctionObjects.Math_Fround_SignedZero_A0F213A5.FunctionObject_FunctionDeclaration_F210FF6C_toStr
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_GlobalThisReplacement_Dispatch.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_GlobalThisReplacement_Dispatch.verified.txt
@@ -31,6 +31,118 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_22FAF068_L1C25
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2127
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_22FAF068_L1C25::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x212f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_22FAF068_L1C25::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2132
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_22FAF068_L1C25::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2135
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_22FAF068_L1C25::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x213d
+				// Header size: 1
+				// Code size: 16 (0x10)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call float64 Modules.Math_GlobalThisReplacement_Dispatch/FunctionExpression_L1C24::__js_call__(object)
+				IL_000a: box [System.Runtime]System.Double
+				IL_000f: ret
+			} // end of method FunctionObject_FunctionExpression_22FAF068_L1C25::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x214e
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call float64 Modules.Math_GlobalThisReplacement_Dispatch/FunctionExpression_L1C24::__js_call__(object)
+				IL_0006: box [System.Runtime]System.Double
+				IL_000b: ret
+			} // end of method FunctionObject_FunctionExpression_22FAF068_L1C25::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x215b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_22FAF068_L1C25::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_22FAF068_L1C25
+
 
 		// Methods
 		.method public hidebysig static 
@@ -91,7 +203,7 @@
 			[0] class Modules.Math_GlobalThisReplacement_Dispatch/Scope,
 			[1] object,
 			[2] object[],
-			[3] class FunctionObjects.Math_GlobalThisReplacement_Dispatch_D98F56BC.FunctionObject_FunctionExpression_22FAF068_L1C25,
+			[3] class Modules.Math_GlobalThisReplacement_Dispatch/FunctionExpression_L1C24/FunctionObject_FunctionExpression_22FAF068_L1C25,
 			[4] object
 		)
 
@@ -115,13 +227,13 @@
 		IL_0041: ldloc.0
 		IL_0042: stelem.ref
 		IL_0043: stloc.2
-		IL_0044: newobj instance void FunctionObjects.Math_GlobalThisReplacement_Dispatch_D98F56BC.FunctionObject_FunctionExpression_22FAF068_L1C25::.ctor()
+		IL_0044: newobj instance void Modules.Math_GlobalThisReplacement_Dispatch/FunctionExpression_L1C24/FunctionObject_FunctionExpression_22FAF068_L1C25::.ctor()
 		IL_0049: ldc.i4.0
 		IL_004a: conv.r8
 		IL_004b: ldstr ""
 		IL_0050: ldc.i4.0
 		IL_0051: ldc.i4.0
-		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Math_GlobalThisReplacement_Dispatch_D98F56BC.FunctionObject_FunctionExpression_22FAF068_L1C25>(!!0, float64, string, bool, bool)
+		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_GlobalThisReplacement_Dispatch/FunctionExpression_L1C24/FunctionObject_FunctionExpression_22FAF068_L1C25>(!!0, float64, string, bool, bool)
 		IL_0057: stloc.3
 		IL_0058: ldloc.1
 		IL_0059: ldstr "round"
@@ -150,118 +262,6 @@
 	} // end of method Math_GlobalThisReplacement_Dispatch::__js_module_init__
 
 } // end of class Modules.Math_GlobalThisReplacement_Dispatch
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Math_GlobalThisReplacement_Dispatch_D98F56BC.FunctionObject_FunctionExpression_22FAF068_L1C25
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2127
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_22FAF068_L1C25::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x212f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_22FAF068_L1C25::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2132
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_22FAF068_L1C25::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2135
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_22FAF068_L1C25::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x213d
-		// Header size: 1
-		// Code size: 16 (0x10)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call float64 Modules.Math_GlobalThisReplacement_Dispatch/FunctionExpression_L1C24::__js_call__(object)
-		IL_000a: box [System.Runtime]System.Double
-		IL_000f: ret
-	} // end of method FunctionObject_FunctionExpression_22FAF068_L1C25::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x214e
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call float64 Modules.Math_GlobalThisReplacement_Dispatch/FunctionExpression_L1C24::__js_call__(object)
-		IL_0006: box [System.Runtime]System.Double
-		IL_000b: ret
-	} // end of method FunctionObject_FunctionExpression_22FAF068_L1C25::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x215b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_22FAF068_L1C25::ConstructCore
-
-} // end of class FunctionObjects.Math_GlobalThisReplacement_Dispatch_D98F56BC.FunctionObject_FunctionExpression_22FAF068_L1C25
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_Imul_Clz32_Basics.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_Imul_Clz32_Basics.verified.txt
@@ -31,6 +31,109 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9EEB60C5_toStr
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2274
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_9EEB60C5_toStr::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x227c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9EEB60C5_toStr::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x227f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9EEB60C5_toStr::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2282
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: call object Modules.Math_Imul_Clz32_Basics/toStr::__js_call__(object, float64)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_9EEB60C5_toStr::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x229a
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: call object Modules.Math_Imul_Clz32_Basics/toStr::__js_call__(object, float64)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_9EEB60C5_toStr::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22ae
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9EEB60C5_toStr::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9EEB60C5_toStr
+
 
 		// Methods
 		.method public hidebysig static 
@@ -146,7 +249,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Math_Imul_Clz32_Basics/Scope,
-			[1] class FunctionObjects.Math_Imul_Clz32_Basics_636D37D0.FunctionObject_FunctionDeclaration_9EEB60C5_toStr,
+			[1] class Modules.Math_Imul_Clz32_Basics/toStr/FunctionObject_FunctionDeclaration_9EEB60C5_toStr,
 			[2] float64,
 			[3] float64,
 			[4] float64,
@@ -171,13 +274,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 8
-		IL_0012: newobj instance void FunctionObjects.Math_Imul_Clz32_Basics_636D37D0.FunctionObject_FunctionDeclaration_9EEB60C5_toStr::.ctor()
+		IL_0012: newobj instance void Modules.Math_Imul_Clz32_Basics/toStr/FunctionObject_FunctionDeclaration_9EEB60C5_toStr::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "toStr"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Math_Imul_Clz32_Basics_636D37D0.FunctionObject_FunctionDeclaration_9EEB60C5_toStr>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_Imul_Clz32_Basics/toStr/FunctionObject_FunctionDeclaration_9EEB60C5_toStr>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: ldc.r8 2
@@ -272,109 +375,6 @@
 	} // end of method Math_Imul_Clz32_Basics::__js_module_init__
 
 } // end of class Modules.Math_Imul_Clz32_Basics
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Math_Imul_Clz32_Basics_636D37D0.FunctionObject_FunctionDeclaration_9EEB60C5_toStr
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2274
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_9EEB60C5_toStr::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x227c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9EEB60C5_toStr::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x227f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9EEB60C5_toStr::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2282
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: call object Modules.Math_Imul_Clz32_Basics/toStr::__js_call__(object, float64)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_9EEB60C5_toStr::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x229a
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: call object Modules.Math_Imul_Clz32_Basics/toStr::__js_call__(object, float64)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_9EEB60C5_toStr::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22ae
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9EEB60C5_toStr::ConstructCore
-
-} // end of class FunctionObjects.Math_Imul_Clz32_Basics_636D37D0.FunctionObject_FunctionDeclaration_9EEB60C5_toStr
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes.verified.txt
@@ -905,6 +905,355 @@
 
 		} // end of class Scope_searchBitFalse
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_25D92CDA_BitArray
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x3281
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray/FunctionObject_ClassConstructor_25D92CDA_BitArray::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_25D92CDA_BitArray::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3290
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_25D92CDA_BitArray::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3293
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_25D92CDA_BitArray::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3296
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_25D92CDA_BitArray::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x32a2
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_25D92CDA_BitArray::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_25D92CDA_BitArray
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x32ae
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x32b6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x32b9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x32bc
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0012: call instance object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::setBitTrue(float64)
+				IL_0017: ret
+			} // end of method FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue::CallCore
+
+		} // end of class FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x32d5
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x32dd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x32e0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x32e3
+				// Header size: 1
+				// Code size: 48 (0x30)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_001e: ldarg.2
+				IL_001f: ldc.i4.2
+				IL_0020: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0025: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_002a: call instance object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::setBitsTrue(float64, float64, float64)
+				IL_002f: ret
+			} // end of method FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue::CallCore
+
+		} // end of class FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3314
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x331c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x331f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3322
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0012: call instance float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::testBitTrue(float64)
+				IL_0017: box [System.Runtime]System.Double
+				IL_001c: ret
+			} // end of method FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue::CallCore
+
+		} // end of class FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x3340
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3348
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x334b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x334e
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0012: call instance float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::searchBitFalse(float64)
+				IL_0017: box [System.Runtime]System.Double
+				IL_001c: ret
+			} // end of method FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse::CallCore
+
+		} // end of class FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse
+
 
 		// Fields
 		.field private object[] _scopes
@@ -1685,6 +2034,342 @@
 			} // end of method Scope_validatePrimeCount::.ctor
 
 		} // end of class Scope_validatePrimeCount
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_89EFC421_PrimeSieve
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope _environment0_Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x336c
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassConstructor_89EFC421_PrimeSieve::_environment0_Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve/FunctionObject_ClassConstructor_89EFC421_PrimeSieve::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_ClassConstructor_89EFC421_PrimeSieve::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3382
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_89EFC421_PrimeSieve::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3385
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_89EFC421_PrimeSieve::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3388
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_89EFC421_PrimeSieve::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3394
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_89EFC421_PrimeSieve::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_89EFC421_PrimeSieve
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x33a0
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x33a8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x33ab
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x33ae
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+				IL_0006: call instance class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::runSieve()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve::CallCore
+
+		} // end of class FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x33bb
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x33c3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x33c6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x33c9
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+				IL_0006: call instance float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::countPrimes()
+				IL_000b: box [System.Runtime]System.Double
+				IL_0010: ret
+			} // end of method FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes::CallCore
+
+		} // end of class FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x33db
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x33e3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x33e6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x33e9
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::getPrimes(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes::CallCore
+
+		} // end of class FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x33fd
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3405
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x3408
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x340b
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance bool Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::validatePrimeCount(object)
+				IL_0012: box [System.Runtime]System.Boolean
+				IL_0017: ret
+			} // end of method FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount::CallCore
+
+		} // end of class FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount
 
 
 		// Fields
@@ -3060,691 +3745,6 @@
 	} // end of method Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes::__js_module_init__
 
 } // end of class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes_678C0613.FunctionObject_ClassConstructor_25D92CDA_BitArray
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x3281
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes_678C0613.FunctionObject_ClassConstructor_25D92CDA_BitArray::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_25D92CDA_BitArray::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3290
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_25D92CDA_BitArray::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3293
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_25D92CDA_BitArray::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3296
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_25D92CDA_BitArray::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x32a2
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_25D92CDA_BitArray::ConstructCore
-
-} // end of class FunctionObjects.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes_678C0613.FunctionObject_ClassConstructor_25D92CDA_BitArray
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes_678C0613.FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x32ae
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x32b6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x32b9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x32bc
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0012: call instance object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::setBitTrue(float64)
-		IL_0017: ret
-	} // end of method FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue::CallCore
-
-} // end of class FunctionObjects.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes_678C0613.FunctionObject_ClassMethod_12A6AC5E_BitArray_setBitTrue
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes_678C0613.FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x32d5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x32dd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x32e0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x32e3
-		// Header size: 1
-		// Code size: 48 (0x30)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_001e: ldarg.2
-		IL_001f: ldc.i4.2
-		IL_0020: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0025: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_002a: call instance object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::setBitsTrue(float64, float64, float64)
-		IL_002f: ret
-	} // end of method FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue::CallCore
-
-} // end of class FunctionObjects.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes_678C0613.FunctionObject_ClassMethod_37A6661F_BitArray_setBitsTrue
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes_678C0613.FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3314
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x331c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x331f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3322
-		// Header size: 1
-		// Code size: 29 (0x1d)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0012: call instance float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::testBitTrue(float64)
-		IL_0017: box [System.Runtime]System.Double
-		IL_001c: ret
-	} // end of method FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue::CallCore
-
-} // end of class FunctionObjects.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes_678C0613.FunctionObject_ClassMethod_53D6CD14_BitArray_testBitTrue
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes_678C0613.FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x3340
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3348
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x334b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x334e
-		// Header size: 1
-		// Code size: 29 (0x1d)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0012: call instance float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/BitArray::searchBitFalse(float64)
-		IL_0017: box [System.Runtime]System.Double
-		IL_001c: ret
-	} // end of method FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse::CallCore
-
-} // end of class FunctionObjects.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes_678C0613.FunctionObject_ClassMethod_5710166B_BitArray_searchBitFalse
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes_678C0613.FunctionObject_ClassConstructor_89EFC421_PrimeSieve
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope _environment0_Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x336c
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/Scope FunctionObjects.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes_678C0613.FunctionObject_ClassConstructor_89EFC421_PrimeSieve::_environment0_Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes_678C0613.FunctionObject_ClassConstructor_89EFC421_PrimeSieve::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_ClassConstructor_89EFC421_PrimeSieve::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3382
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_89EFC421_PrimeSieve::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3385
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_89EFC421_PrimeSieve::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3388
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_89EFC421_PrimeSieve::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3394
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_89EFC421_PrimeSieve::ConstructCore
-
-} // end of class FunctionObjects.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes_678C0613.FunctionObject_ClassConstructor_89EFC421_PrimeSieve
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes_678C0613.FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x33a0
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x33a8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x33ab
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x33ae
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-		IL_0006: call instance class Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::runSieve()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve::CallCore
-
-} // end of class FunctionObjects.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes_678C0613.FunctionObject_ClassMethod_65DB1A4D_PrimeSieve_runSieve
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes_678C0613.FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x33bb
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x33c3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x33c6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x33c9
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-		IL_0006: call instance float64 Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::countPrimes()
-		IL_000b: box [System.Runtime]System.Double
-		IL_0010: ret
-	} // end of method FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes::CallCore
-
-} // end of class FunctionObjects.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes_678C0613.FunctionObject_ClassMethod_87AD4A3F_PrimeSieve_countPrimes
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes_678C0613.FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x33db
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x33e3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x33e6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x33e9
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::getPrimes(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes::CallCore
-
-} // end of class FunctionObjects.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes_678C0613.FunctionObject_ClassMethod_9CD7A204_PrimeSieve_getPrimes
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes_678C0613.FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x33fd
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3405
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x3408
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x340b
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance bool Modules.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes/PrimeSieve::validatePrimeCount(object)
-		IL_0012: box [System.Runtime]System.Boolean
-		IL_0017: ret
-	} // end of method FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount::CallCore
-
-} // end of class FunctionObjects.Math_PrimeJavaScript_SieveSize1000_OnePass_LogsPrimes_678C0613.FunctionObject_ClassMethod_7586A8E0_PrimeSieve_validatePrimeCount
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_Round_Trunc_NegativeHalves.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_Round_Trunc_NegativeHalves.verified.txt
@@ -263,6 +263,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_48B435D9_toStr
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x233b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_48B435D9_toStr::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2343
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_48B435D9_toStr::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2346
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_48B435D9_toStr::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2349
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Math_Round_Trunc_NegativeHalves/toStr::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_48B435D9_toStr::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x235c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Math_Round_Trunc_NegativeHalves/toStr::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_48B435D9_toStr::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x236b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_48B435D9_toStr::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_48B435D9_toStr
+
 
 		// Methods
 		.method public hidebysig static 
@@ -383,7 +484,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Math_Round_Trunc_NegativeHalves/Scope,
-			[1] class FunctionObjects.Math_Round_Trunc_NegativeHalves_E758A984.FunctionObject_FunctionDeclaration_48B435D9_toStr,
+			[1] class Modules.Math_Round_Trunc_NegativeHalves/toStr/FunctionObject_FunctionDeclaration_48B435D9_toStr,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
@@ -404,13 +505,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 5
-		IL_0012: newobj instance void FunctionObjects.Math_Round_Trunc_NegativeHalves_E758A984.FunctionObject_FunctionDeclaration_48B435D9_toStr::.ctor()
+		IL_0012: newobj instance void Modules.Math_Round_Trunc_NegativeHalves/toStr/FunctionObject_FunctionDeclaration_48B435D9_toStr::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "toStr"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Math_Round_Trunc_NegativeHalves_E758A984.FunctionObject_FunctionDeclaration_48B435D9_toStr>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_Round_Trunc_NegativeHalves/toStr/FunctionObject_FunctionDeclaration_48B435D9_toStr>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: ldc.i4.8
@@ -559,107 +660,6 @@
 	} // end of method Math_Round_Trunc_NegativeHalves::__js_module_init__
 
 } // end of class Modules.Math_Round_Trunc_NegativeHalves
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Math_Round_Trunc_NegativeHalves_E758A984.FunctionObject_FunctionDeclaration_48B435D9_toStr
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x233b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_48B435D9_toStr::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2343
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_48B435D9_toStr::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2346
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_48B435D9_toStr::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2349
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Math_Round_Trunc_NegativeHalves/toStr::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_48B435D9_toStr::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x235c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Math_Round_Trunc_NegativeHalves/toStr::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_48B435D9_toStr::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x236b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_48B435D9_toStr::ConstructCore
-
-} // end of class FunctionObjects.Math_Round_Trunc_NegativeHalves_E758A984.FunctionObject_FunctionDeclaration_48B435D9_toStr
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_ShadowedAndReplaced_Dispatch.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_ShadowedAndReplaced_Dispatch.verified.txt
@@ -35,6 +35,118 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_33643B44_L3C10
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2311
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_33643B44_L3C10::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2319
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_33643B44_L3C10::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x231c
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_33643B44_L3C10::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object ResolveThisArgumentCore (
+						object thisArgument
+					) cil managed 
+				{
+					// Method begins at RVA 0x231f
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_33643B44_L3C10::ResolveThisArgumentCore
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2327
+					// Header size: 1
+					// Code size: 16 (0x10)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: call float64 Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math::__js_call__(object)
+					IL_000a: box [System.Runtime]System.Double
+					IL_000f: ret
+				} // end of method FunctionObject_FunctionExpression_33643B44_L3C10::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2338
+					// Header size: 1
+					// Code size: 12 (0xc)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: call float64 Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math::__js_call__(object)
+					IL_0006: box [System.Runtime]System.Double
+					IL_000b: ret
+				} // end of method FunctionObject_FunctionExpression_33643B44_L3C10::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2345
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_33643B44_L3C10::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_33643B44_L3C10
+
 
 			// Methods
 			.method public hidebysig static 
@@ -80,6 +192,118 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1F283315_L4C12
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2354
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_1F283315_L4C12::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x235c
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_1F283315_L4C12::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x235f
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_1F283315_L4C12::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object ResolveThisArgumentCore (
+						object thisArgument
+					) cil managed 
+				{
+					// Method begins at RVA 0x2362
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_1F283315_L4C12::ResolveThisArgumentCore
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x236a
+					// Header size: 1
+					// Code size: 16 (0x10)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: call float64 Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math_L4C11::__js_call__(object)
+					IL_000a: box [System.Runtime]System.Double
+					IL_000f: ret
+				} // end of method FunctionObject_FunctionExpression_1F283315_L4C12::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x237b
+					// Header size: 1
+					// Code size: 12 (0xc)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: call float64 Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math_L4C11::__js_call__(object)
+					IL_0006: box [System.Runtime]System.Double
+					IL_000b: ret
+				} // end of method FunctionObject_FunctionExpression_1F283315_L4C12::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2388
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_1F283315_L4C12::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_1F283315_L4C12
+
 
 			// Methods
 			.method public hidebysig static 
@@ -121,6 +345,128 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8AAEF358_L1C2
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Math_ShadowedAndReplaced_Dispatch/Scope _environment0_Math_ShadowedAndReplaced_Dispatch
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Math_ShadowedAndReplaced_Dispatch/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x22c5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Math_ShadowedAndReplaced_Dispatch/Scope Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionObject_FunctionExpression_8AAEF358_L1C2::_environment0_Math_ShadowedAndReplaced_Dispatch
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_8AAEF358_L1C2::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22d4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_8AAEF358_L1C2::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22d7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_8AAEF358_L1C2::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x22da
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_8AAEF358_L1C2::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22e2
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Math_ShadowedAndReplaced_Dispatch/Scope Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionObject_FunctionExpression_8AAEF358_L1C2::_environment0_Math_ShadowedAndReplaced_Dispatch
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1::__js_call__(class Modules.Math_ShadowedAndReplaced_Dispatch/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_8AAEF358_L1C2::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22f4
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Math_ShadowedAndReplaced_Dispatch/Scope Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionObject_FunctionExpression_8AAEF358_L1C2::_environment0_Math_ShadowedAndReplaced_Dispatch
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1::__js_call__(class Modules.Math_ShadowedAndReplaced_Dispatch/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_8AAEF358_L1C2::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2302
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_8AAEF358_L1C2::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_8AAEF358_L1C2
+
 
 		// Methods
 		.method public hidebysig static 
@@ -142,8 +488,8 @@
 				[0] class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/Scope,
 				[1] class Modules.Math_ShadowedAndReplaced_Dispatch/ObjectLiterals/L2C16_Math,
 				[2] object[],
-				[3] class FunctionObjects.Math_ShadowedAndReplaced_Dispatch_56AE9C5D.FunctionObject_FunctionExpression_33643B44_L3C10,
-				[4] class FunctionObjects.Math_ShadowedAndReplaced_Dispatch_56AE9C5D.FunctionObject_FunctionExpression_1F283315_L4C12,
+				[3] class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math/FunctionObject_FunctionExpression_33643B44_L3C10,
+				[4] class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math_L4C11/FunctionObject_FunctionExpression_1F283315_L4C12,
 				[5] object,
 				[6] float64,
 				[7] object,
@@ -160,13 +506,13 @@
 			IL_000e: ldarg.0
 			IL_000f: stelem.ref
 			IL_0010: stloc.2
-			IL_0011: newobj instance void FunctionObjects.Math_ShadowedAndReplaced_Dispatch_56AE9C5D.FunctionObject_FunctionExpression_33643B44_L3C10::.ctor()
+			IL_0011: newobj instance void Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math/FunctionObject_FunctionExpression_33643B44_L3C10::.ctor()
 			IL_0016: ldc.i4.0
 			IL_0017: conv.r8
 			IL_0018: ldstr ""
 			IL_001d: ldc.i4.0
 			IL_001e: ldc.i4.0
-			IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Math_ShadowedAndReplaced_Dispatch_56AE9C5D.FunctionObject_FunctionExpression_33643B44_L3C10>(!!0, float64, string, bool, bool)
+			IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math/FunctionObject_FunctionExpression_33643B44_L3C10>(!!0, float64, string, bool, bool)
 			IL_0024: stloc.3
 			IL_0025: ldc.i4.1
 			IL_0026: newarr [System.Runtime]System.Object
@@ -175,13 +521,13 @@
 			IL_002d: ldarg.0
 			IL_002e: stelem.ref
 			IL_002f: stloc.2
-			IL_0030: newobj instance void FunctionObjects.Math_ShadowedAndReplaced_Dispatch_56AE9C5D.FunctionObject_FunctionExpression_1F283315_L4C12::.ctor()
+			IL_0030: newobj instance void Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math_L4C11/FunctionObject_FunctionExpression_1F283315_L4C12::.ctor()
 			IL_0035: ldc.i4.0
 			IL_0036: conv.r8
 			IL_0037: ldstr ""
 			IL_003c: ldc.i4.0
 			IL_003d: ldc.i4.0
-			IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Math_ShadowedAndReplaced_Dispatch_56AE9C5D.FunctionObject_FunctionExpression_1F283315_L4C12>(!!0, float64, string, bool, bool)
+			IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math_L4C11/FunctionObject_FunctionExpression_1F283315_L4C12>(!!0, float64, string, bool, bool)
 			IL_0043: stloc.s 4
 			IL_0045: newobj instance void Modules.Math_ShadowedAndReplaced_Dispatch/ObjectLiterals/L2C16_Math::.ctor()
 			IL_004a: stloc.1
@@ -258,6 +604,118 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E8504F2A_L11C12
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2397
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_E8504F2A_L11C12::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x239f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E8504F2A_L11C12::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x23a2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E8504F2A_L11C12::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x23a5
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_E8504F2A_L11C12::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x23ad
+				// Header size: 1
+				// Code size: 16 (0x10)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call float64 Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L11C11::__js_call__(object)
+				IL_000a: box [System.Runtime]System.Double
+				IL_000f: ret
+			} // end of method FunctionObject_FunctionExpression_E8504F2A_L11C12::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23be
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call float64 Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L11C11::__js_call__(object)
+				IL_0006: box [System.Runtime]System.Double
+				IL_000b: ret
+			} // end of method FunctionObject_FunctionExpression_E8504F2A_L11C12::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23cb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E8504F2A_L11C12::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_E8504F2A_L11C12
 
 
 		// Methods
@@ -448,9 +906,9 @@
 		.locals init (
 			[0] class Modules.Math_ShadowedAndReplaced_Dispatch/Scope,
 			[1] object[],
-			[2] class FunctionObjects.Math_ShadowedAndReplaced_Dispatch_56AE9C5D.FunctionObject_FunctionExpression_8AAEF358_L1C2,
+			[2] class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionObject_FunctionExpression_8AAEF358_L1C2,
 			[3] object,
-			[4] class FunctionObjects.Math_ShadowedAndReplaced_Dispatch_56AE9C5D.FunctionObject_FunctionExpression_E8504F2A_L11C12,
+			[4] class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L11C11/FunctionObject_FunctionExpression_E8504F2A_L11C12,
 			[5] float64,
 			[6] object,
 			[7] object
@@ -469,13 +927,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Math_ShadowedAndReplaced_Dispatch/Scope
-		IL_0019: newobj instance void FunctionObjects.Math_ShadowedAndReplaced_Dispatch_56AE9C5D.FunctionObject_FunctionExpression_8AAEF358_L1C2::.ctor(class Modules.Math_ShadowedAndReplaced_Dispatch/Scope)
+		IL_0019: newobj instance void Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionObject_FunctionExpression_8AAEF358_L1C2::.ctor(class Modules.Math_ShadowedAndReplaced_Dispatch/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr ""
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.0
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Math_ShadowedAndReplaced_Dispatch_56AE9C5D.FunctionObject_FunctionExpression_8AAEF358_L1C2>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionObject_FunctionExpression_8AAEF358_L1C2>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.2
 		IL_002d: ldc.i4.0
 		IL_002e: newarr [System.Runtime]System.Object
@@ -495,13 +953,13 @@
 		IL_0054: ldloc.0
 		IL_0055: stelem.ref
 		IL_0056: stloc.1
-		IL_0057: newobj instance void FunctionObjects.Math_ShadowedAndReplaced_Dispatch_56AE9C5D.FunctionObject_FunctionExpression_E8504F2A_L11C12::.ctor()
+		IL_0057: newobj instance void Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L11C11/FunctionObject_FunctionExpression_E8504F2A_L11C12::.ctor()
 		IL_005c: ldc.i4.0
 		IL_005d: conv.r8
 		IL_005e: ldstr ""
 		IL_0063: ldc.i4.0
 		IL_0064: ldc.i4.0
-		IL_0065: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Math_ShadowedAndReplaced_Dispatch_56AE9C5D.FunctionObject_FunctionExpression_E8504F2A_L11C12>(!!0, float64, string, bool, bool)
+		IL_0065: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L11C11/FunctionObject_FunctionExpression_E8504F2A_L11C12>(!!0, float64, string, bool, bool)
 		IL_006a: stloc.s 4
 		IL_006c: ldloc.3
 		IL_006d: ldstr "abs"
@@ -535,464 +993,6 @@
 	} // end of method Math_ShadowedAndReplaced_Dispatch::__js_module_init__
 
 } // end of class Modules.Math_ShadowedAndReplaced_Dispatch
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Math_ShadowedAndReplaced_Dispatch_56AE9C5D.FunctionObject_FunctionExpression_8AAEF358_L1C2
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Math_ShadowedAndReplaced_Dispatch/Scope _environment0_Math_ShadowedAndReplaced_Dispatch
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Math_ShadowedAndReplaced_Dispatch/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x22c5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Math_ShadowedAndReplaced_Dispatch/Scope FunctionObjects.Math_ShadowedAndReplaced_Dispatch_56AE9C5D.FunctionObject_FunctionExpression_8AAEF358_L1C2::_environment0_Math_ShadowedAndReplaced_Dispatch
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_8AAEF358_L1C2::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22d4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_8AAEF358_L1C2::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22d7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_8AAEF358_L1C2::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x22da
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_8AAEF358_L1C2::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22e2
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Math_ShadowedAndReplaced_Dispatch/Scope FunctionObjects.Math_ShadowedAndReplaced_Dispatch_56AE9C5D.FunctionObject_FunctionExpression_8AAEF358_L1C2::_environment0_Math_ShadowedAndReplaced_Dispatch
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1::__js_call__(class Modules.Math_ShadowedAndReplaced_Dispatch/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_8AAEF358_L1C2::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22f4
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Math_ShadowedAndReplaced_Dispatch/Scope FunctionObjects.Math_ShadowedAndReplaced_Dispatch_56AE9C5D.FunctionObject_FunctionExpression_8AAEF358_L1C2::_environment0_Math_ShadowedAndReplaced_Dispatch
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1::__js_call__(class Modules.Math_ShadowedAndReplaced_Dispatch/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_8AAEF358_L1C2::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2302
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_8AAEF358_L1C2::ConstructCore
-
-} // end of class FunctionObjects.Math_ShadowedAndReplaced_Dispatch_56AE9C5D.FunctionObject_FunctionExpression_8AAEF358_L1C2
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Math_ShadowedAndReplaced_Dispatch_56AE9C5D.FunctionObject_FunctionExpression_33643B44_L3C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2311
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_33643B44_L3C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2319
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_33643B44_L3C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x231c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_33643B44_L3C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x231f
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_33643B44_L3C10::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2327
-		// Header size: 1
-		// Code size: 16 (0x10)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call float64 Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math::__js_call__(object)
-		IL_000a: box [System.Runtime]System.Double
-		IL_000f: ret
-	} // end of method FunctionObject_FunctionExpression_33643B44_L3C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2338
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call float64 Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math::__js_call__(object)
-		IL_0006: box [System.Runtime]System.Double
-		IL_000b: ret
-	} // end of method FunctionObject_FunctionExpression_33643B44_L3C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2345
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_33643B44_L3C10::ConstructCore
-
-} // end of class FunctionObjects.Math_ShadowedAndReplaced_Dispatch_56AE9C5D.FunctionObject_FunctionExpression_33643B44_L3C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Math_ShadowedAndReplaced_Dispatch_56AE9C5D.FunctionObject_FunctionExpression_1F283315_L4C12
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2354
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_1F283315_L4C12::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x235c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1F283315_L4C12::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x235f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1F283315_L4C12::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2362
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_1F283315_L4C12::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x236a
-		// Header size: 1
-		// Code size: 16 (0x10)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call float64 Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math_L4C11::__js_call__(object)
-		IL_000a: box [System.Runtime]System.Double
-		IL_000f: ret
-	} // end of method FunctionObject_FunctionExpression_1F283315_L4C12::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x237b
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call float64 Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L1C1/FunctionExpression_Math_L4C11::__js_call__(object)
-		IL_0006: box [System.Runtime]System.Double
-		IL_000b: ret
-	} // end of method FunctionObject_FunctionExpression_1F283315_L4C12::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2388
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1F283315_L4C12::ConstructCore
-
-} // end of class FunctionObjects.Math_ShadowedAndReplaced_Dispatch_56AE9C5D.FunctionObject_FunctionExpression_1F283315_L4C12
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Math_ShadowedAndReplaced_Dispatch_56AE9C5D.FunctionObject_FunctionExpression_E8504F2A_L11C12
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2397
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_E8504F2A_L11C12::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x239f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E8504F2A_L11C12::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23a2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E8504F2A_L11C12::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x23a5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_E8504F2A_L11C12::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23ad
-		// Header size: 1
-		// Code size: 16 (0x10)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call float64 Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L11C11::__js_call__(object)
-		IL_000a: box [System.Runtime]System.Double
-		IL_000f: ret
-	} // end of method FunctionObject_FunctionExpression_E8504F2A_L11C12::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23be
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call float64 Modules.Math_ShadowedAndReplaced_Dispatch/FunctionExpression_L11C11::__js_call__(object)
-		IL_0006: box [System.Runtime]System.Double
-		IL_000b: ret
-	} // end of method FunctionObject_FunctionExpression_E8504F2A_L11C12::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23cb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E8504F2A_L11C12::ConstructCore
-
-} // end of class FunctionObjects.Math_ShadowedAndReplaced_Dispatch_56AE9C5D.FunctionObject_FunctionExpression_E8504F2A_L11C12
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_Sign_ZeroVariants.verified.txt
+++ b/tests/Jroc.Tests/Math/Snapshots/GeneratorTests.Math_Sign_ZeroVariants.verified.txt
@@ -147,6 +147,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5635EB9B_toStr
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2279
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_5635EB9B_toStr::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2281
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5635EB9B_toStr::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2284
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5635EB9B_toStr::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2287
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Math_Sign_ZeroVariants/toStr::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_5635EB9B_toStr::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x229a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Math_Sign_ZeroVariants/toStr::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5635EB9B_toStr::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22a9
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5635EB9B_toStr::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_5635EB9B_toStr
+
 
 		// Methods
 		.method public hidebysig static 
@@ -267,7 +368,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Math_Sign_ZeroVariants/Scope,
-			[1] class FunctionObjects.Math_Sign_ZeroVariants_B7DB942E.FunctionObject_FunctionDeclaration_5635EB9B_toStr,
+			[1] class Modules.Math_Sign_ZeroVariants/toStr/FunctionObject_FunctionDeclaration_5635EB9B_toStr,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[4] object[],
@@ -286,13 +387,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 4
-		IL_0012: newobj instance void FunctionObjects.Math_Sign_ZeroVariants_B7DB942E.FunctionObject_FunctionDeclaration_5635EB9B_toStr::.ctor()
+		IL_0012: newobj instance void Modules.Math_Sign_ZeroVariants/toStr/FunctionObject_FunctionDeclaration_5635EB9B_toStr::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "toStr"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Math_Sign_ZeroVariants_B7DB942E.FunctionObject_FunctionDeclaration_5635EB9B_toStr>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Math_Sign_ZeroVariants/toStr/FunctionObject_FunctionDeclaration_5635EB9B_toStr>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: ldc.i4.7
@@ -386,107 +487,6 @@
 	} // end of method Math_Sign_ZeroVariants::__js_module_init__
 
 } // end of class Modules.Math_Sign_ZeroVariants
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Math_Sign_ZeroVariants_B7DB942E.FunctionObject_FunctionDeclaration_5635EB9B_toStr
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2279
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_5635EB9B_toStr::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2281
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5635EB9B_toStr::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2284
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5635EB9B_toStr::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2287
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Math_Sign_ZeroVariants/toStr::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_5635EB9B_toStr::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x229a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Math_Sign_ZeroVariants/toStr::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5635EB9B_toStr::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22a9
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5635EB9B_toStr::ConstructCore
-
-} // end of class FunctionObjects.Math_Sign_ZeroVariants_B7DB942E.FunctionObject_FunctionDeclaration_5635EB9B_toStr
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Silent.verified.txt
+++ b/tests/Jroc.Tests/Node/ChildProcess/Snapshots/GeneratorTests.Require_ChildProcess_Fork_Silent.verified.txt
@@ -761,6 +761,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Require_ChildProcess_Fork_Silent/Scope _environment0_Require_ChildProcess_Fork_Silent
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Require_ChildProcess_Fork_Silent/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a98
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Require_ChildProcess_Fork_Silent/Scope Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::_environment0_Require_ChildProcess_Fork_Silent
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2aa7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2aaa
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2aad
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Require_ChildProcess_Fork_Silent/Scope Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::_environment0_Require_ChildProcess_Fork_Silent
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue::__js_call__(class Modules.Require_ChildProcess_Fork_Silent/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2abf
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Require_ChildProcess_Fork_Silent/Scope Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::_environment0_Require_ChildProcess_Fork_Silent
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue::__js_call__(class Modules.Require_ChildProcess_Fork_Silent/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2acd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1407,6 +1514,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Require_ChildProcess_Fork_Silent/Scope _environment0_Require_ChildProcess_Fork_Silent
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Require_ChildProcess_Fork_Silent/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bbc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Require_ChildProcess_Fork_Silent/Scope Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::_environment0_Require_ChildProcess_Fork_Silent
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2bcb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2bce
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bd1
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Require_ChildProcess_Fork_Silent/Scope Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::_environment0_Require_ChildProcess_Fork_Silent
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse::__js_call__(class Modules.Require_ChildProcess_Fork_Silent/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2be3
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Require_ChildProcess_Fork_Silent/Scope Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::_environment0_Require_ChildProcess_Fork_Silent
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse::__js_call__(class Modules.Require_ChildProcess_Fork_Silent/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bf1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1669,9 +1883,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_ChildProcess_Fork_Silent/Scope,
-			[1] class FunctionObjects.Require_ChildProcess_Fork_Silent_2E97DFA1.FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue,
+			[1] class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue,
 			[2] object[],
-			[3] class FunctionObjects.Require_ChildProcess_Fork_Silent_2E97DFA1.FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse,
+			[3] class Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse,
 			[4] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IChildProcessModule
 		)
 
@@ -1688,13 +1902,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Require_ChildProcess_Fork_Silent/Scope
-		IL_0019: newobj instance void FunctionObjects.Require_ChildProcess_Fork_Silent_2E97DFA1.FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::.ctor(class Modules.Require_ChildProcess_Fork_Silent/Scope)
+		IL_0019: newobj instance void Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::.ctor(class Modules.Require_ChildProcess_Fork_Silent/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "runSilentTrue"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Require_ChildProcess_Fork_Silent_2E97DFA1.FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_Silent/runSilentTrue/FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: ldc.i4.1
 		IL_002e: newarr [System.Runtime]System.Object
@@ -1707,13 +1921,13 @@
 		IL_0039: ldc.i4.0
 		IL_003a: ldelem.ref
 		IL_003b: castclass Modules.Require_ChildProcess_Fork_Silent/Scope
-		IL_0040: newobj instance void FunctionObjects.Require_ChildProcess_Fork_Silent_2E97DFA1.FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::.ctor(class Modules.Require_ChildProcess_Fork_Silent/Scope)
+		IL_0040: newobj instance void Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::.ctor(class Modules.Require_ChildProcess_Fork_Silent/Scope)
 		IL_0045: ldc.i4.0
 		IL_0046: conv.r8
 		IL_0047: ldstr "runSilentFalse"
 		IL_004c: ldc.i4.0
 		IL_004d: ldc.i4.1
-		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Require_ChildProcess_Fork_Silent_2E97DFA1.FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse>(!!0, float64, string, bool, bool)
+		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_ChildProcess_Fork_Silent/runSilentFalse/FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse>(!!0, float64, string, bool, bool)
 		IL_0053: stloc.3
 		IL_0054: ldloc.0
 		IL_0055: ldloc.3
@@ -2073,220 +2287,6 @@
 	} // end of method Require_ChildProcess_Fork_Silent_Child::__js_module_init__
 
 } // end of class Modules.Require_ChildProcess_Fork_Silent_Child
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Require_ChildProcess_Fork_Silent_2E97DFA1.FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Require_ChildProcess_Fork_Silent/Scope _environment0_Require_ChildProcess_Fork_Silent
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Require_ChildProcess_Fork_Silent/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a98
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Require_ChildProcess_Fork_Silent/Scope FunctionObjects.Require_ChildProcess_Fork_Silent_2E97DFA1.FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::_environment0_Require_ChildProcess_Fork_Silent
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2aa7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2aaa
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2aad
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Require_ChildProcess_Fork_Silent/Scope FunctionObjects.Require_ChildProcess_Fork_Silent_2E97DFA1.FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::_environment0_Require_ChildProcess_Fork_Silent
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue::__js_call__(class Modules.Require_ChildProcess_Fork_Silent/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2abf
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Require_ChildProcess_Fork_Silent/Scope FunctionObjects.Require_ChildProcess_Fork_Silent_2E97DFA1.FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::_environment0_Require_ChildProcess_Fork_Silent
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Require_ChildProcess_Fork_Silent/runSilentTrue::__js_call__(class Modules.Require_ChildProcess_Fork_Silent/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2acd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue::ConstructCore
-
-} // end of class FunctionObjects.Require_ChildProcess_Fork_Silent_2E97DFA1.FunctionObject_FunctionDeclaration_07ACA598_runSilentTrue
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Require_ChildProcess_Fork_Silent_2E97DFA1.FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Require_ChildProcess_Fork_Silent/Scope _environment0_Require_ChildProcess_Fork_Silent
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Require_ChildProcess_Fork_Silent/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bbc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Require_ChildProcess_Fork_Silent/Scope FunctionObjects.Require_ChildProcess_Fork_Silent_2E97DFA1.FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::_environment0_Require_ChildProcess_Fork_Silent
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2bcb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2bce
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bd1
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Require_ChildProcess_Fork_Silent/Scope FunctionObjects.Require_ChildProcess_Fork_Silent_2E97DFA1.FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::_environment0_Require_ChildProcess_Fork_Silent
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse::__js_call__(class Modules.Require_ChildProcess_Fork_Silent/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2be3
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Require_ChildProcess_Fork_Silent/Scope FunctionObjects.Require_ChildProcess_Fork_Silent_2E97DFA1.FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::_environment0_Require_ChildProcess_Fork_Silent
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Require_ChildProcess_Fork_Silent/runSilentFalse::__js_call__(class Modules.Require_ChildProcess_Fork_Silent/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bf1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse::ConstructCore
-
-} // end of class FunctionObjects.Require_ChildProcess_Fork_Silent_2E97DFA1.FunctionObject_FunctionDeclaration_7A282A73_runSilentFalse
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_Undici_Transform_Table.verified.txt
+++ b/tests/Jroc.Tests/Node/Console/Snapshots/GeneratorTests.Console_Undici_Transform_Table.verified.txt
@@ -31,6 +31,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B23CAF09_L7C12
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2279
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_B23CAF09_L7C12::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2281
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_B23CAF09_L7C12::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2284
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_B23CAF09_L7C12::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2287
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.2
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.Console_Undici_Transform_Table/FunctionExpression_output::__js_call__(object, object, object, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionExpression_B23CAF09_L7C12::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22a8
+				// Header size: 1
+				// Code size: 28 (0x1c)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: ldarg.2
+				IL_0010: ldc.i4.2
+				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0016: call object Modules.Console_Undici_Transform_Table/FunctionExpression_output::__js_call__(object, object, object, object)
+				IL_001b: ret
+			} // end of method FunctionObject_FunctionExpression_B23CAF09_L7C12::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22c5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_B23CAF09_L7C12::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_B23CAF09_L7C12
+
 
 		// Methods
 		.method public hidebysig static 
@@ -275,119 +388,6 @@
 	} // end of method Console_Undici_Transform_Table::__js_module_init__
 
 } // end of class Modules.Console_Undici_Transform_Table
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Console_Undici_Transform_Table_41470C6B.FunctionObject_FunctionExpression_B23CAF09_L7C12
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2279
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_B23CAF09_L7C12::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2281
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_B23CAF09_L7C12::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2284
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_B23CAF09_L7C12::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2287
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.2
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.Console_Undici_Transform_Table/FunctionExpression_output::__js_call__(object, object, object, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionExpression_B23CAF09_L7C12::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22a8
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: ldarg.2
-		IL_0010: ldc.i4.2
-		IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0016: call object Modules.Console_Undici_Transform_Table/FunctionExpression_output::__js_call__(object, object, object, object)
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_B23CAF09_L7C12::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22c5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_B23CAF09_L7C12::ConstructCore
-
-} // end of class FunctionObjects.Console_Undici_Transform_Table_41470C6B.FunctionObject_FunctionExpression_B23CAF09_L7C12
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_ErrorPaths.verified.txt
+++ b/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_ErrorPaths.verified.txt
@@ -73,6 +73,115 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B38D6CE6_logError
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x4127
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_B38D6CE6_logError::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x412f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B38D6CE6_logError::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4132
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B38D6CE6_logError::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4135
+				// Header size: 1
+				// Code size: 30 (0x1e)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, string, object)
+				IL_001d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B38D6CE6_logError::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4154
+				// Header size: 1
+				// Code size: 26 (0x1a)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, string, object)
+				IL_0019: ret
+			} // end of method FunctionObject_FunctionDeclaration_B38D6CE6_logError::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x416f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B38D6CE6_logError::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_B38D6CE6_logError
+
 
 		// Methods
 		.method public hidebysig static 
@@ -2809,6 +2918,106 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x4417
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Require_Crypto_ErrorPaths/logPromiseError/FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x4426
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4429
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x442c
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Require_Crypto_ErrorPaths/logPromiseError/FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x444c
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Require_Crypto_ErrorPaths/logPromiseError/FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError
+
 
 		// Methods
 		.method public hidebysig static 
@@ -4796,6 +5005,99 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Require_Crypto_ErrorPaths/Scope _environment0_Require_Crypto_ErrorPaths
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Require_Crypto_ErrorPaths/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x4468
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Require_Crypto_ErrorPaths/Scope Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors::_environment0_Require_Crypto_ErrorPaths
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x447e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x4481
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x4484
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x4496
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors/FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors
+
 
 		// Methods
 		.method public hidebysig static 
@@ -6700,7 +7002,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Crypto_ErrorPaths/Scope,
-			[1] class FunctionObjects.Require_Crypto_ErrorPaths_B4903C87.FunctionObject_FunctionDeclaration_B38D6CE6_logError,
+			[1] class Modules.Require_Crypto_ErrorPaths/logError/FunctionObject_FunctionDeclaration_B38D6CE6_logError,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
 			[3] object[],
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes2,
@@ -6739,13 +7041,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.Require_Crypto_ErrorPaths_B4903C87.FunctionObject_FunctionDeclaration_B38D6CE6_logError::.ctor()
+		IL_0011: newobj instance void Modules.Require_Crypto_ErrorPaths/logError/FunctionObject_FunctionDeclaration_B38D6CE6_logError::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "logError"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Require_Crypto_ErrorPaths_B4903C87.FunctionObject_FunctionDeclaration_B38D6CE6_logError>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Crypto_ErrorPaths/logError/FunctionObject_FunctionDeclaration_B38D6CE6_logError>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: ldc.i4.1
 		IL_0026: newarr [System.Runtime]System.Object
@@ -7406,308 +7708,6 @@
 	} // end of method Require_Crypto_ErrorPaths::__js_module_init__
 
 } // end of class Modules.Require_Crypto_ErrorPaths
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Require_Crypto_ErrorPaths_B4903C87.FunctionObject_FunctionDeclaration_B38D6CE6_logError
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x4127
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_B38D6CE6_logError::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x412f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B38D6CE6_logError::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4132
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B38D6CE6_logError::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4135
-		// Header size: 1
-		// Code size: 30 (0x1e)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, string, object)
-		IL_001d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B38D6CE6_logError::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4154
-		// Header size: 1
-		// Code size: 26 (0x1a)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call object Modules.Require_Crypto_ErrorPaths/logError::__js_call__(object, string, object)
-		IL_0019: ret
-	} // end of method FunctionObject_FunctionDeclaration_B38D6CE6_logError::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x416f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B38D6CE6_logError::ConstructCore
-
-} // end of class FunctionObjects.Require_Crypto_ErrorPaths_B4903C87.FunctionObject_FunctionDeclaration_B38D6CE6_logError
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Require_Crypto_ErrorPaths_B4903C87.FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x4417
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Require_Crypto_ErrorPaths_B4903C87.FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x4426
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4429
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x442c
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Require_Crypto_ErrorPaths_B4903C87.FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x444c
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Require_Crypto_ErrorPaths_B4903C87.FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Require_Crypto_ErrorPaths/logPromiseError::__js_call__(object[], object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError::ConstructBodyCore
-
-} // end of class FunctionObjects.Require_Crypto_ErrorPaths_B4903C87.FunctionObject_FunctionDeclaration_8C7B1B0D_logPromiseError
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Require_Crypto_ErrorPaths_B4903C87.FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Require_Crypto_ErrorPaths/Scope _environment0_Require_Crypto_ErrorPaths
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Require_Crypto_ErrorPaths/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x4468
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Require_Crypto_ErrorPaths/Scope FunctionObjects.Require_Crypto_ErrorPaths_B4903C87.FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors::_environment0_Require_Crypto_ErrorPaths
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Require_Crypto_ErrorPaths_B4903C87.FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x447e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x4481
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x4484
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Require_Crypto_ErrorPaths_B4903C87.FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x4496
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Require_Crypto_ErrorPaths_B4903C87.FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Require_Crypto_ErrorPaths/runWebCryptoErrors::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors::ConstructBodyCore
-
-} // end of class FunctionObjects.Require_Crypto_ErrorPaths_B4903C87.FunctionObject_FunctionDeclaration_F31DA885_runWebCryptoErrors
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_WebCrypto_Subtle.verified.txt
+++ b/tests/Jroc.Tests/Node/Crypto/Snapshots/GeneratorTests.Require_Crypto_WebCrypto_Subtle.verified.txt
@@ -82,6 +82,99 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_02C500D8_run
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Require_Crypto_WebCrypto_Subtle/Scope _environment0_Require_Crypto_WebCrypto_Subtle
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Require_Crypto_WebCrypto_Subtle/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d2a
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Require_Crypto_WebCrypto_Subtle/Scope Modules.Require_Crypto_WebCrypto_Subtle/run/FunctionObject_FunctionDeclaration_02C500D8_run::_environment0_Require_Crypto_WebCrypto_Subtle
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.Require_Crypto_WebCrypto_Subtle/run/FunctionObject_FunctionDeclaration_02C500D8_run::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_02C500D8_run::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2d40
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_02C500D8_run::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2d43
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_02C500D8_run::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d46
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Require_Crypto_WebCrypto_Subtle/run/FunctionObject_FunctionDeclaration_02C500D8_run::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Require_Crypto_WebCrypto_Subtle/run::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_02C500D8_run::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d58
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Require_Crypto_WebCrypto_Subtle/run/FunctionObject_FunctionDeclaration_02C500D8_run::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Require_Crypto_WebCrypto_Subtle/run::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_02C500D8_run::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_02C500D8_run
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1685,99 +1778,6 @@
 	} // end of method Require_Crypto_WebCrypto_Subtle::__js_module_init__
 
 } // end of class Modules.Require_Crypto_WebCrypto_Subtle
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Require_Crypto_WebCrypto_Subtle_90E2FB88.FunctionObject_FunctionDeclaration_02C500D8_run
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Require_Crypto_WebCrypto_Subtle/Scope _environment0_Require_Crypto_WebCrypto_Subtle
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Require_Crypto_WebCrypto_Subtle/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d2a
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Require_Crypto_WebCrypto_Subtle/Scope FunctionObjects.Require_Crypto_WebCrypto_Subtle_90E2FB88.FunctionObject_FunctionDeclaration_02C500D8_run::_environment0_Require_Crypto_WebCrypto_Subtle
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Require_Crypto_WebCrypto_Subtle_90E2FB88.FunctionObject_FunctionDeclaration_02C500D8_run::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_02C500D8_run::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2d40
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_02C500D8_run::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2d43
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_02C500D8_run::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d46
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Require_Crypto_WebCrypto_Subtle_90E2FB88.FunctionObject_FunctionDeclaration_02C500D8_run::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Require_Crypto_WebCrypto_Subtle/run::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_02C500D8_run::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d58
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Require_Crypto_WebCrypto_Subtle_90E2FB88.FunctionObject_FunctionDeclaration_02C500D8_run::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Require_Crypto_WebCrypto_Subtle/run::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_02C500D8_run::ConstructBodyCore
-
-} // end of class FunctionObjects.Require_Crypto_WebCrypto_Subtle_90E2FB88.FunctionObject_FunctionDeclaration_02C500D8_run
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_AsyncHelpers_On_Once.verified.txt
+++ b/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_AsyncHelpers_On_Once.verified.txt
@@ -105,6 +105,99 @@
 
 		} // end of class Scope_ForOf_L14C13
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Events_AsyncHelpers_On_Once/Scope _environment0_Events_AsyncHelpers_On_Once
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Events_AsyncHelpers_On_Once/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x31e5
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Events_AsyncHelpers_On_Once/Scope Modules.Events_AsyncHelpers_On_Once/runOnBreak/FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak::_environment0_Events_AsyncHelpers_On_Once
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.Events_AsyncHelpers_On_Once/runOnBreak/FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x31fb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x31fe
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x3201
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Events_AsyncHelpers_On_Once/runOnBreak/FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Events_AsyncHelpers_On_Once/runOnBreak::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x3213
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Events_AsyncHelpers_On_Once/runOnBreak/FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Events_AsyncHelpers_On_Once/runOnBreak::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1388,6 +1481,99 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Events_AsyncHelpers_On_Once/Scope _environment0_Events_AsyncHelpers_On_Once
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Events_AsyncHelpers_On_Once/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x3221
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Events_AsyncHelpers_On_Once/Scope Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject::_environment0_Events_AsyncHelpers_On_Once
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x3237
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x323a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x323d
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x324f
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Events_AsyncHelpers_On_Once/runOnErrorReject/FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1678,6 +1864,99 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Events_AsyncHelpers_On_Once/Scope _environment0_Events_AsyncHelpers_On_Once
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Events_AsyncHelpers_On_Once/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x328e
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Events_AsyncHelpers_On_Once/Scope Modules.Events_AsyncHelpers_On_Once/runOnceResolve/FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve::_environment0_Events_AsyncHelpers_On_Once
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.Events_AsyncHelpers_On_Once/runOnceResolve/FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x32a4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x32a7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x32aa
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Events_AsyncHelpers_On_Once/runOnceResolve/FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Events_AsyncHelpers_On_Once/runOnceResolve::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x32bc
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Events_AsyncHelpers_On_Once/runOnceResolve/FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Events_AsyncHelpers_On_Once/runOnceResolve::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve
 
 
 		// Methods
@@ -2010,6 +2289,99 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D30260CA_runOnceReject
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Events_AsyncHelpers_On_Once/Scope _environment0_Events_AsyncHelpers_On_Once
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Events_AsyncHelpers_On_Once/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x32ca
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Events_AsyncHelpers_On_Once/Scope Modules.Events_AsyncHelpers_On_Once/runOnceReject/FunctionObject_FunctionDeclaration_D30260CA_runOnceReject::_environment0_Events_AsyncHelpers_On_Once
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.Events_AsyncHelpers_On_Once/runOnceReject/FunctionObject_FunctionDeclaration_D30260CA_runOnceReject::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_D30260CA_runOnceReject::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x32e0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D30260CA_runOnceReject::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x32e3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D30260CA_runOnceReject::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x32e6
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Events_AsyncHelpers_On_Once/runOnceReject/FunctionObject_FunctionDeclaration_D30260CA_runOnceReject::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Events_AsyncHelpers_On_Once/runOnceReject::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_D30260CA_runOnceReject::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x32f8
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Events_AsyncHelpers_On_Once/runOnceReject/FunctionObject_FunctionDeclaration_D30260CA_runOnceReject::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Events_AsyncHelpers_On_Once/runOnceReject::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_D30260CA_runOnceReject::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_D30260CA_runOnceReject
 
 
 		// Methods
@@ -2572,378 +2944,6 @@
 	} // end of method Events_AsyncHelpers_On_Once::__js_module_init__
 
 } // end of class Modules.Events_AsyncHelpers_On_Once
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Events_AsyncHelpers_On_Once_26605980.FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Events_AsyncHelpers_On_Once/Scope _environment0_Events_AsyncHelpers_On_Once
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Events_AsyncHelpers_On_Once/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x31e5
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Events_AsyncHelpers_On_Once/Scope FunctionObjects.Events_AsyncHelpers_On_Once_26605980.FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak::_environment0_Events_AsyncHelpers_On_Once
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Events_AsyncHelpers_On_Once_26605980.FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x31fb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x31fe
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x3201
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Events_AsyncHelpers_On_Once_26605980.FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Events_AsyncHelpers_On_Once/runOnBreak::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x3213
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Events_AsyncHelpers_On_Once_26605980.FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Events_AsyncHelpers_On_Once/runOnBreak::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak::ConstructBodyCore
-
-} // end of class FunctionObjects.Events_AsyncHelpers_On_Once_26605980.FunctionObject_FunctionDeclaration_9A04C0CC_runOnBreak
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Events_AsyncHelpers_On_Once_26605980.FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Events_AsyncHelpers_On_Once/Scope _environment0_Events_AsyncHelpers_On_Once
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Events_AsyncHelpers_On_Once/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x3221
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Events_AsyncHelpers_On_Once/Scope FunctionObjects.Events_AsyncHelpers_On_Once_26605980.FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject::_environment0_Events_AsyncHelpers_On_Once
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Events_AsyncHelpers_On_Once_26605980.FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x3237
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x323a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x323d
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Events_AsyncHelpers_On_Once_26605980.FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x324f
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Events_AsyncHelpers_On_Once_26605980.FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Events_AsyncHelpers_On_Once/runOnErrorReject::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject::ConstructBodyCore
-
-} // end of class FunctionObjects.Events_AsyncHelpers_On_Once_26605980.FunctionObject_FunctionDeclaration_045E715E_runOnErrorReject
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Events_AsyncHelpers_On_Once_26605980.FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Events_AsyncHelpers_On_Once/Scope _environment0_Events_AsyncHelpers_On_Once
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Events_AsyncHelpers_On_Once/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x328e
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Events_AsyncHelpers_On_Once/Scope FunctionObjects.Events_AsyncHelpers_On_Once_26605980.FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve::_environment0_Events_AsyncHelpers_On_Once
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Events_AsyncHelpers_On_Once_26605980.FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x32a4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x32a7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x32aa
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Events_AsyncHelpers_On_Once_26605980.FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Events_AsyncHelpers_On_Once/runOnceResolve::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x32bc
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Events_AsyncHelpers_On_Once_26605980.FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Events_AsyncHelpers_On_Once/runOnceResolve::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve::ConstructBodyCore
-
-} // end of class FunctionObjects.Events_AsyncHelpers_On_Once_26605980.FunctionObject_FunctionDeclaration_1F0EFA8F_runOnceResolve
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Events_AsyncHelpers_On_Once_26605980.FunctionObject_FunctionDeclaration_D30260CA_runOnceReject
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Events_AsyncHelpers_On_Once/Scope _environment0_Events_AsyncHelpers_On_Once
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Events_AsyncHelpers_On_Once/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x32ca
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Events_AsyncHelpers_On_Once/Scope FunctionObjects.Events_AsyncHelpers_On_Once_26605980.FunctionObject_FunctionDeclaration_D30260CA_runOnceReject::_environment0_Events_AsyncHelpers_On_Once
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Events_AsyncHelpers_On_Once_26605980.FunctionObject_FunctionDeclaration_D30260CA_runOnceReject::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_D30260CA_runOnceReject::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x32e0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D30260CA_runOnceReject::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x32e3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D30260CA_runOnceReject::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x32e6
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Events_AsyncHelpers_On_Once_26605980.FunctionObject_FunctionDeclaration_D30260CA_runOnceReject::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Events_AsyncHelpers_On_Once/runOnceReject::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_D30260CA_runOnceReject::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x32f8
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Events_AsyncHelpers_On_Once_26605980.FunctionObject_FunctionDeclaration_D30260CA_runOnceReject::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Events_AsyncHelpers_On_Once/runOnceReject::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_D30260CA_runOnceReject::ConstructBodyCore
-
-} // end of class FunctionObjects.Events_AsyncHelpers_On_Once_26605980.FunctionObject_FunctionDeclaration_D30260CA_runOnceReject
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_Complete.verified.txt
+++ b/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_Complete.verified.txt
@@ -31,6 +31,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_AAE3580A_L9C20
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2a09
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_AAE3580A_L9C20::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2a11
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_AAE3580A_L9C20::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2a14
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_AAE3580A_L9C20::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a17
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L9C19::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_AAE3580A_L9C20::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a23
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L9C19::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_AAE3580A_L9C20::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a2b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_AAE3580A_L9C20::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_AAE3580A_L9C20
+
 
 		// Methods
 		.method public hidebysig static 
@@ -75,6 +170,101 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8B3472AC_L10C20
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2a3a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_8B3472AC_L10C20::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2a42
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_8B3472AC_L10C20::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2a45
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_8B3472AC_L10C20::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a48
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L10C19::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_8B3472AC_L10C20::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a54
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L10C19::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_8B3472AC_L10C20::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a5c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_8B3472AC_L10C20::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_8B3472AC_L10C20
 
 
 		// Methods
@@ -121,6 +311,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B4812E11_listener1
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2a6b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_B4812E11_listener1::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2a73
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B4812E11_listener1::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2a76
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B4812E11_listener1::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a79
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Events_EventEmitter_Complete/listener1::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_B4812E11_listener1::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a85
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Events_EventEmitter_Complete/listener1::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_B4812E11_listener1::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a8d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B4812E11_listener1::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_B4812E11_listener1
+
 
 		// Methods
 		.method public hidebysig static 
@@ -166,6 +451,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B1812958_listener2
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2a9c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_B1812958_listener2::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2aa4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B1812958_listener2::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2aa7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B1812958_listener2::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2aaa
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Events_EventEmitter_Complete/listener2::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_B1812958_listener2::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ab6
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Events_EventEmitter_Complete/listener2::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_B1812958_listener2::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2abe
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B1812958_listener2::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_B1812958_listener2
+
 
 		// Methods
 		.method public hidebysig static 
@@ -210,6 +590,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A32A464C_L27C22
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Events_EventEmitter_Complete/Scope _environment0_Events_EventEmitter_Complete
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Events_EventEmitter_Complete/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2acd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21/FunctionObject_FunctionExpression_A32A464C_L27C22::_environment0_Events_EventEmitter_Complete
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_A32A464C_L27C22::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2adc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A32A464C_L27C22::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2adf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A32A464C_L27C22::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ae2
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21/FunctionObject_FunctionExpression_A32A464C_L27C22::_environment0_Events_EventEmitter_Complete
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21::__js_call__(class Modules.Events_EventEmitter_Complete/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_A32A464C_L27C22::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2af4
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21/FunctionObject_FunctionExpression_A32A464C_L27C22::_environment0_Events_EventEmitter_Complete
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21::__js_call__(class Modules.Events_EventEmitter_Complete/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_A32A464C_L27C22::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b02
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_A32A464C_L27C22::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_A32A464C_L27C22
 
 
 		// Methods
@@ -273,6 +760,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_12958C6C_L30C35
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Events_EventEmitter_Complete/Scope _environment0_Events_EventEmitter_Complete
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Events_EventEmitter_Complete/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b11
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34/FunctionObject_FunctionExpression_12958C6C_L30C35::_environment0_Events_EventEmitter_Complete
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_12958C6C_L30C35::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2b20
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_12958C6C_L30C35::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2b23
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_12958C6C_L30C35::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b26
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34/FunctionObject_FunctionExpression_12958C6C_L30C35::_environment0_Events_EventEmitter_Complete
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34::__js_call__(class Modules.Events_EventEmitter_Complete/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_12958C6C_L30C35::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b38
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34/FunctionObject_FunctionExpression_12958C6C_L30C35::_environment0_Events_EventEmitter_Complete
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34::__js_call__(class Modules.Events_EventEmitter_Complete/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_12958C6C_L30C35::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b46
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_12958C6C_L30C35::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_12958C6C_L30C35
+
 
 		// Methods
 		.method public hidebysig static 
@@ -334,6 +928,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_906D07E0_L39C21
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Events_EventEmitter_Complete/Scope _environment0_Events_EventEmitter_Complete
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Events_EventEmitter_Complete/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b55
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20/FunctionObject_FunctionExpression_906D07E0_L39C21::_environment0_Events_EventEmitter_Complete
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_906D07E0_L39C21::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2b64
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_906D07E0_L39C21::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2b67
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_906D07E0_L39C21::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b6a
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20/FunctionObject_FunctionExpression_906D07E0_L39C21::_environment0_Events_EventEmitter_Complete
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20::__js_call__(class Modules.Events_EventEmitter_Complete/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_906D07E0_L39C21::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b7c
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20/FunctionObject_FunctionExpression_906D07E0_L39C21::_environment0_Events_EventEmitter_Complete
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20::__js_call__(class Modules.Events_EventEmitter_Complete/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_906D07E0_L39C21::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b8a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_906D07E0_L39C21::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_906D07E0_L39C21
 
 
 		// Methods
@@ -397,6 +1098,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_662FFF80_L42C38
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Events_EventEmitter_Complete/Scope _environment0_Events_EventEmitter_Complete
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Events_EventEmitter_Complete/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b99
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37/FunctionObject_FunctionExpression_662FFF80_L42C38::_environment0_Events_EventEmitter_Complete
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_662FFF80_L42C38::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2ba8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_662FFF80_L42C38::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2bab
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_662FFF80_L42C38::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bae
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37/FunctionObject_FunctionExpression_662FFF80_L42C38::_environment0_Events_EventEmitter_Complete
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37::__js_call__(class Modules.Events_EventEmitter_Complete/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_662FFF80_L42C38::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bc0
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37/FunctionObject_FunctionExpression_662FFF80_L42C38::_environment0_Events_EventEmitter_Complete
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37::__js_call__(class Modules.Events_EventEmitter_Complete/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_662FFF80_L42C38::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bce
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_662FFF80_L42C38::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_662FFF80_L42C38
+
 
 		// Methods
 		.method public hidebysig static 
@@ -459,6 +1267,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_EFF25745_L60C20
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2bdd
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_EFF25745_L60C20::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2be5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_EFF25745_L60C20::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2be8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_EFF25745_L60C20::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2beb
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L60C19::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_EFF25745_L60C20::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bf7
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L60C19::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_EFF25745_L60C20::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bff
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_EFF25745_L60C20::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_EFF25745_L60C20
+
 
 		// Methods
 		.method public hidebysig static 
@@ -503,6 +1406,101 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_00D9E772_L61C22
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2c0e
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_00D9E772_L61C22::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2c16
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_00D9E772_L61C22::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2c19
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_00D9E772_L61C22::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c1c
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L61C21::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_00D9E772_L61C22::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c28
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L61C21::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_00D9E772_L61C22::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c30
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_00D9E772_L61C22::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_00D9E772_L61C22
 
 
 		// Methods
@@ -549,6 +1547,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_36454590_L68C12
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2c3f
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_36454590_L68C12::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2c47
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_36454590_L68C12::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2c4a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_36454590_L68C12::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c4d
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Events_EventEmitter_Complete/FunctionExpression_result::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_36454590_L68C12::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c59
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Events_EventEmitter_Complete/FunctionExpression_result::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_36454590_L68C12::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c61
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_36454590_L68C12::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_36454590_L68C12
+
 
 		// Methods
 		.method public hidebysig static 
@@ -594,6 +1687,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_504662DB_L69C25
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2c70
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_504662DB_L69C25::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2c78
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_504662DB_L69C25::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2c7b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_504662DB_L69C25::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c7e
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Events_EventEmitter_Complete/FunctionExpression_result_L69C24::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_504662DB_L69C25::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c8a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Events_EventEmitter_Complete/FunctionExpression_result_L69C24::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_504662DB_L69C25::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c92
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_504662DB_L69C25::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_504662DB_L69C25
+
 
 		// Methods
 		.method public hidebysig static 
@@ -638,6 +1826,101 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D817B431_L78C21
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2ca1
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_D817B431_L78C21::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2ca9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D817B431_L78C21::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2cac
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D817B431_L78C21::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2caf
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L78C20::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_D817B431_L78C21::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2cbb
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L78C20::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_D817B431_L78C21::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2cc3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_D817B431_L78C21::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_D817B431_L78C21
 
 
 		// Methods
@@ -712,8 +1995,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Events_EventEmitter_Complete/Scope,
-			[1] class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionDeclaration_B4812E11_listener1,
-			[2] class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionDeclaration_B1812958_listener2,
+			[1] class Modules.Events_EventEmitter_Complete/listener1/FunctionObject_FunctionDeclaration_B4812E11_listener1,
+			[2] class Modules.Events_EventEmitter_Complete/listener2/FunctionObject_FunctionDeclaration_B1812958_listener2,
 			[3] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule,
 			[4] object,
 			[5] object,
@@ -733,19 +2016,19 @@
 			[19] object[],
 			[20] object,
 			[21] object,
-			[22] class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_AAE3580A_L9C20,
-			[23] class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_8B3472AC_L10C20,
-			[24] class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_A32A464C_L27C22,
-			[25] class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_12958C6C_L30C35,
-			[26] class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_906D07E0_L39C21,
-			[27] class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_662FFF80_L42C38,
-			[28] class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_EFF25745_L60C20,
-			[29] class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_00D9E772_L61C22,
-			[30] class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_36454590_L68C12,
-			[31] class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_504662DB_L69C25,
+			[22] class Modules.Events_EventEmitter_Complete/FunctionExpression_L9C19/FunctionObject_FunctionExpression_AAE3580A_L9C20,
+			[23] class Modules.Events_EventEmitter_Complete/FunctionExpression_L10C19/FunctionObject_FunctionExpression_8B3472AC_L10C20,
+			[24] class Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21/FunctionObject_FunctionExpression_A32A464C_L27C22,
+			[25] class Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34/FunctionObject_FunctionExpression_12958C6C_L30C35,
+			[26] class Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20/FunctionObject_FunctionExpression_906D07E0_L39C21,
+			[27] class Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37/FunctionObject_FunctionExpression_662FFF80_L42C38,
+			[28] class Modules.Events_EventEmitter_Complete/FunctionExpression_L60C19/FunctionObject_FunctionExpression_EFF25745_L60C20,
+			[29] class Modules.Events_EventEmitter_Complete/FunctionExpression_L61C21/FunctionObject_FunctionExpression_00D9E772_L61C22,
+			[30] class Modules.Events_EventEmitter_Complete/FunctionExpression_result/FunctionObject_FunctionExpression_36454590_L68C12,
+			[31] class Modules.Events_EventEmitter_Complete/FunctionExpression_result_L69C24/FunctionObject_FunctionExpression_504662DB_L69C25,
 			[32] bool,
 			[33] object,
-			[34] class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_D817B431_L78C21
+			[34] class Modules.Events_EventEmitter_Complete/FunctionExpression_L78C20/FunctionObject_FunctionExpression_D817B431_L78C21
 		)
 
 		IL_0000: newobj instance void Modules.Events_EventEmitter_Complete/Scope::.ctor()
@@ -757,13 +2040,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 19
-		IL_0012: newobj instance void FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionDeclaration_B4812E11_listener1::.ctor()
+		IL_0012: newobj instance void Modules.Events_EventEmitter_Complete/listener1/FunctionObject_FunctionDeclaration_B4812E11_listener1::.ctor()
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "listener1"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionDeclaration_B4812E11_listener1>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/listener1/FunctionObject_FunctionDeclaration_B4812E11_listener1>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -772,13 +2055,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 19
-		IL_0032: newobj instance void FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionDeclaration_B1812958_listener2::.ctor()
+		IL_0032: newobj instance void Modules.Events_EventEmitter_Complete/listener2/FunctionObject_FunctionDeclaration_B1812958_listener2::.ctor()
 		IL_0037: ldc.i4.0
 		IL_0038: conv.r8
 		IL_0039: ldstr "listener2"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionDeclaration_B1812958_listener2>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/listener2/FunctionObject_FunctionDeclaration_B1812958_listener2>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: nop
 		IL_0047: ldarg.1
@@ -821,13 +2104,13 @@
 		IL_00bc: ldloc.0
 		IL_00bd: stelem.ref
 		IL_00be: stloc.s 19
-		IL_00c0: newobj instance void FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_AAE3580A_L9C20::.ctor()
+		IL_00c0: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L9C19/FunctionObject_FunctionExpression_AAE3580A_L9C20::.ctor()
 		IL_00c5: ldc.i4.0
 		IL_00c6: conv.r8
 		IL_00c7: ldstr ""
 		IL_00cc: ldc.i4.0
 		IL_00cd: ldc.i4.1
-		IL_00ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_AAE3580A_L9C20>(!!0, float64, string, bool, bool)
+		IL_00ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L9C19/FunctionObject_FunctionExpression_AAE3580A_L9C20>(!!0, float64, string, bool, bool)
 		IL_00d3: stloc.s 22
 		IL_00d5: ldloc.s 21
 		IL_00d7: ldstr "on"
@@ -845,13 +2128,13 @@
 		IL_00fa: ldloc.0
 		IL_00fb: stelem.ref
 		IL_00fc: stloc.s 19
-		IL_00fe: newobj instance void FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_8B3472AC_L10C20::.ctor()
+		IL_00fe: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L10C19/FunctionObject_FunctionExpression_8B3472AC_L10C20::.ctor()
 		IL_0103: ldc.i4.0
 		IL_0104: conv.r8
 		IL_0105: ldstr ""
 		IL_010a: ldc.i4.0
 		IL_010b: ldc.i4.1
-		IL_010c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_8B3472AC_L10C20>(!!0, float64, string, bool, bool)
+		IL_010c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L10C19/FunctionObject_FunctionExpression_8B3472AC_L10C20>(!!0, float64, string, bool, bool)
 		IL_0111: stloc.s 23
 		IL_0113: ldloc.s 21
 		IL_0115: ldstr "on"
@@ -958,13 +2241,13 @@
 		IL_0266: ldc.i4.0
 		IL_0267: ldelem.ref
 		IL_0268: castclass Modules.Events_EventEmitter_Complete/Scope
-		IL_026d: newobj instance void FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_A32A464C_L27C22::.ctor(class Modules.Events_EventEmitter_Complete/Scope)
+		IL_026d: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21/FunctionObject_FunctionExpression_A32A464C_L27C22::.ctor(class Modules.Events_EventEmitter_Complete/Scope)
 		IL_0272: ldc.i4.0
 		IL_0273: conv.r8
 		IL_0274: ldstr ""
 		IL_0279: ldc.i4.0
 		IL_027a: ldc.i4.1
-		IL_027b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_A32A464C_L27C22>(!!0, float64, string, bool, bool)
+		IL_027b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21/FunctionObject_FunctionExpression_A32A464C_L27C22>(!!0, float64, string, bool, bool)
 		IL_0280: stloc.s 24
 		IL_0282: ldloc.s 20
 		IL_0284: ldstr "on"
@@ -986,13 +2269,13 @@
 		IL_02ad: ldc.i4.0
 		IL_02ae: ldelem.ref
 		IL_02af: castclass Modules.Events_EventEmitter_Complete/Scope
-		IL_02b4: newobj instance void FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_12958C6C_L30C35::.ctor(class Modules.Events_EventEmitter_Complete/Scope)
+		IL_02b4: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34/FunctionObject_FunctionExpression_12958C6C_L30C35::.ctor(class Modules.Events_EventEmitter_Complete/Scope)
 		IL_02b9: ldc.i4.0
 		IL_02ba: conv.r8
 		IL_02bb: ldstr ""
 		IL_02c0: ldc.i4.0
 		IL_02c1: ldc.i4.1
-		IL_02c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_12958C6C_L30C35>(!!0, float64, string, bool, bool)
+		IL_02c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34/FunctionObject_FunctionExpression_12958C6C_L30C35>(!!0, float64, string, bool, bool)
 		IL_02c7: stloc.s 25
 		IL_02c9: ldloc.s 20
 		IL_02cb: ldstr "prependListener"
@@ -1040,13 +2323,13 @@
 		IL_034d: ldc.i4.0
 		IL_034e: ldelem.ref
 		IL_034f: castclass Modules.Events_EventEmitter_Complete/Scope
-		IL_0354: newobj instance void FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_906D07E0_L39C21::.ctor(class Modules.Events_EventEmitter_Complete/Scope)
+		IL_0354: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20/FunctionObject_FunctionExpression_906D07E0_L39C21::.ctor(class Modules.Events_EventEmitter_Complete/Scope)
 		IL_0359: ldc.i4.0
 		IL_035a: conv.r8
 		IL_035b: ldstr ""
 		IL_0360: ldc.i4.0
 		IL_0361: ldc.i4.1
-		IL_0362: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_906D07E0_L39C21>(!!0, float64, string, bool, bool)
+		IL_0362: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20/FunctionObject_FunctionExpression_906D07E0_L39C21>(!!0, float64, string, bool, bool)
 		IL_0367: stloc.s 26
 		IL_0369: ldloc.s 21
 		IL_036b: ldstr "on"
@@ -1068,13 +2351,13 @@
 		IL_0394: ldc.i4.0
 		IL_0395: ldelem.ref
 		IL_0396: castclass Modules.Events_EventEmitter_Complete/Scope
-		IL_039b: newobj instance void FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_662FFF80_L42C38::.ctor(class Modules.Events_EventEmitter_Complete/Scope)
+		IL_039b: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37/FunctionObject_FunctionExpression_662FFF80_L42C38::.ctor(class Modules.Events_EventEmitter_Complete/Scope)
 		IL_03a0: ldc.i4.0
 		IL_03a1: conv.r8
 		IL_03a2: ldstr ""
 		IL_03a7: ldc.i4.0
 		IL_03a8: ldc.i4.1
-		IL_03a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_662FFF80_L42C38>(!!0, float64, string, bool, bool)
+		IL_03a9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37/FunctionObject_FunctionExpression_662FFF80_L42C38>(!!0, float64, string, bool, bool)
 		IL_03ae: stloc.s 27
 		IL_03b0: ldloc.s 21
 		IL_03b2: ldstr "prependOnceListener"
@@ -1194,13 +2477,13 @@
 		IL_054a: ldloc.0
 		IL_054b: stelem.ref
 		IL_054c: stloc.s 19
-		IL_054e: newobj instance void FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_EFF25745_L60C20::.ctor()
+		IL_054e: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L60C19/FunctionObject_FunctionExpression_EFF25745_L60C20::.ctor()
 		IL_0553: ldc.i4.0
 		IL_0554: conv.r8
 		IL_0555: ldstr ""
 		IL_055a: ldc.i4.0
 		IL_055b: ldc.i4.1
-		IL_055c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_EFF25745_L60C20>(!!0, float64, string, bool, bool)
+		IL_055c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L60C19/FunctionObject_FunctionExpression_EFF25745_L60C20>(!!0, float64, string, bool, bool)
 		IL_0561: stloc.s 28
 		IL_0563: ldloc.s 20
 		IL_0565: ldstr "on"
@@ -1218,13 +2501,13 @@
 		IL_0588: ldloc.0
 		IL_0589: stelem.ref
 		IL_058a: stloc.s 19
-		IL_058c: newobj instance void FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_00D9E772_L61C22::.ctor()
+		IL_058c: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L61C21/FunctionObject_FunctionExpression_00D9E772_L61C22::.ctor()
 		IL_0591: ldc.i4.0
 		IL_0592: conv.r8
 		IL_0593: ldstr ""
 		IL_0598: ldc.i4.0
 		IL_0599: ldc.i4.1
-		IL_059a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_00D9E772_L61C22>(!!0, float64, string, bool, bool)
+		IL_059a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L61C21/FunctionObject_FunctionExpression_00D9E772_L61C22>(!!0, float64, string, bool, bool)
 		IL_059f: stloc.s 29
 		IL_05a1: ldloc.s 20
 		IL_05a3: ldstr "once"
@@ -1266,13 +2549,13 @@
 		IL_061b: ldloc.0
 		IL_061c: stelem.ref
 		IL_061d: stloc.s 19
-		IL_061f: newobj instance void FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_36454590_L68C12::.ctor()
+		IL_061f: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_result/FunctionObject_FunctionExpression_36454590_L68C12::.ctor()
 		IL_0624: ldc.i4.0
 		IL_0625: conv.r8
 		IL_0626: ldstr ""
 		IL_062b: ldc.i4.0
 		IL_062c: ldc.i4.1
-		IL_062d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_36454590_L68C12>(!!0, float64, string, bool, bool)
+		IL_062d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_result/FunctionObject_FunctionExpression_36454590_L68C12>(!!0, float64, string, bool, bool)
 		IL_0632: stloc.s 30
 		IL_0634: ldloc.s 21
 		IL_0636: ldstr "on"
@@ -1290,13 +2573,13 @@
 		IL_065a: ldloc.0
 		IL_065b: stelem.ref
 		IL_065c: stloc.s 19
-		IL_065e: newobj instance void FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_504662DB_L69C25::.ctor()
+		IL_065e: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_result_L69C24/FunctionObject_FunctionExpression_504662DB_L69C25::.ctor()
 		IL_0663: ldc.i4.0
 		IL_0664: conv.r8
 		IL_0665: ldstr ""
 		IL_066a: ldc.i4.0
 		IL_066b: ldc.i4.1
-		IL_066c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_504662DB_L69C25>(!!0, float64, string, bool, bool)
+		IL_066c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_result_L69C24/FunctionObject_FunctionExpression_504662DB_L69C25>(!!0, float64, string, bool, bool)
 		IL_0671: stloc.s 31
 		IL_0673: ldloc.s 21
 		IL_0675: ldstr "prependListener"
@@ -1379,13 +2662,13 @@
 		IL_0784: ldloc.0
 		IL_0785: stelem.ref
 		IL_0786: stloc.s 19
-		IL_0788: newobj instance void FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_D817B431_L78C21::.ctor()
+		IL_0788: newobj instance void Modules.Events_EventEmitter_Complete/FunctionExpression_L78C20/FunctionObject_FunctionExpression_D817B431_L78C21::.ctor()
 		IL_078d: ldc.i4.0
 		IL_078e: conv.r8
 		IL_078f: ldstr ""
 		IL_0794: ldc.i4.0
 		IL_0795: ldc.i4.1
-		IL_0796: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_D817B431_L78C21>(!!0, float64, string, bool, bool)
+		IL_0796: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Complete/FunctionExpression_L78C20/FunctionObject_FunctionExpression_D817B431_L78C21>(!!0, float64, string, bool, bool)
 		IL_079b: stloc.s 34
 		IL_079d: ldloc.s 21
 		IL_079f: ldstr "on"
@@ -1451,1289 +2734,6 @@
 	} // end of method Events_EventEmitter_Complete::__js_module_init__
 
 } // end of class Modules.Events_EventEmitter_Complete
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_AAE3580A_L9C20
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2a09
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_AAE3580A_L9C20::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a11
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_AAE3580A_L9C20::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a14
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_AAE3580A_L9C20::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a17
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L9C19::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_AAE3580A_L9C20::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a23
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L9C19::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_AAE3580A_L9C20::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a2b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_AAE3580A_L9C20::ConstructCore
-
-} // end of class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_AAE3580A_L9C20
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_8B3472AC_L10C20
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2a3a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_8B3472AC_L10C20::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a42
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_8B3472AC_L10C20::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a45
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_8B3472AC_L10C20::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a48
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L10C19::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_8B3472AC_L10C20::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a54
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L10C19::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_8B3472AC_L10C20::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a5c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_8B3472AC_L10C20::ConstructCore
-
-} // end of class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_8B3472AC_L10C20
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionDeclaration_B4812E11_listener1
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2a6b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_B4812E11_listener1::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a73
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B4812E11_listener1::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a76
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B4812E11_listener1::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a79
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Events_EventEmitter_Complete/listener1::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_B4812E11_listener1::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a85
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Events_EventEmitter_Complete/listener1::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_B4812E11_listener1::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a8d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B4812E11_listener1::ConstructCore
-
-} // end of class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionDeclaration_B4812E11_listener1
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionDeclaration_B1812958_listener2
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2a9c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_B1812958_listener2::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2aa4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B1812958_listener2::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2aa7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B1812958_listener2::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2aaa
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Events_EventEmitter_Complete/listener2::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_B1812958_listener2::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ab6
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Events_EventEmitter_Complete/listener2::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_B1812958_listener2::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2abe
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B1812958_listener2::ConstructCore
-
-} // end of class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionDeclaration_B1812958_listener2
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_A32A464C_L27C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Events_EventEmitter_Complete/Scope _environment0_Events_EventEmitter_Complete
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Events_EventEmitter_Complete/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2acd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Events_EventEmitter_Complete/Scope FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_A32A464C_L27C22::_environment0_Events_EventEmitter_Complete
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A32A464C_L27C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2adc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A32A464C_L27C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2adf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A32A464C_L27C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ae2
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_A32A464C_L27C22::_environment0_Events_EventEmitter_Complete
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21::__js_call__(class Modules.Events_EventEmitter_Complete/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_A32A464C_L27C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2af4
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_A32A464C_L27C22::_environment0_Events_EventEmitter_Complete
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L27C21::__js_call__(class Modules.Events_EventEmitter_Complete/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_A32A464C_L27C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b02
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A32A464C_L27C22::ConstructCore
-
-} // end of class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_A32A464C_L27C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_12958C6C_L30C35
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Events_EventEmitter_Complete/Scope _environment0_Events_EventEmitter_Complete
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Events_EventEmitter_Complete/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b11
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Events_EventEmitter_Complete/Scope FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_12958C6C_L30C35::_environment0_Events_EventEmitter_Complete
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_12958C6C_L30C35::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2b20
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_12958C6C_L30C35::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2b23
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_12958C6C_L30C35::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b26
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_12958C6C_L30C35::_environment0_Events_EventEmitter_Complete
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34::__js_call__(class Modules.Events_EventEmitter_Complete/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_12958C6C_L30C35::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b38
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_12958C6C_L30C35::_environment0_Events_EventEmitter_Complete
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L30C34::__js_call__(class Modules.Events_EventEmitter_Complete/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_12958C6C_L30C35::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b46
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_12958C6C_L30C35::ConstructCore
-
-} // end of class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_12958C6C_L30C35
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_906D07E0_L39C21
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Events_EventEmitter_Complete/Scope _environment0_Events_EventEmitter_Complete
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Events_EventEmitter_Complete/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b55
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Events_EventEmitter_Complete/Scope FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_906D07E0_L39C21::_environment0_Events_EventEmitter_Complete
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_906D07E0_L39C21::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2b64
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_906D07E0_L39C21::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2b67
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_906D07E0_L39C21::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b6a
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_906D07E0_L39C21::_environment0_Events_EventEmitter_Complete
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20::__js_call__(class Modules.Events_EventEmitter_Complete/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_906D07E0_L39C21::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b7c
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_906D07E0_L39C21::_environment0_Events_EventEmitter_Complete
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L39C20::__js_call__(class Modules.Events_EventEmitter_Complete/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_906D07E0_L39C21::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b8a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_906D07E0_L39C21::ConstructCore
-
-} // end of class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_906D07E0_L39C21
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_662FFF80_L42C38
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Events_EventEmitter_Complete/Scope _environment0_Events_EventEmitter_Complete
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Events_EventEmitter_Complete/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b99
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Events_EventEmitter_Complete/Scope FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_662FFF80_L42C38::_environment0_Events_EventEmitter_Complete
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_662FFF80_L42C38::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2ba8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_662FFF80_L42C38::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2bab
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_662FFF80_L42C38::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bae
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_662FFF80_L42C38::_environment0_Events_EventEmitter_Complete
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37::__js_call__(class Modules.Events_EventEmitter_Complete/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_662FFF80_L42C38::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bc0
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Events_EventEmitter_Complete/Scope FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_662FFF80_L42C38::_environment0_Events_EventEmitter_Complete
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L42C37::__js_call__(class Modules.Events_EventEmitter_Complete/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_662FFF80_L42C38::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bce
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_662FFF80_L42C38::ConstructCore
-
-} // end of class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_662FFF80_L42C38
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_EFF25745_L60C20
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2bdd
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_EFF25745_L60C20::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2be5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_EFF25745_L60C20::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2be8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_EFF25745_L60C20::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2beb
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L60C19::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_EFF25745_L60C20::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bf7
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L60C19::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_EFF25745_L60C20::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bff
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_EFF25745_L60C20::ConstructCore
-
-} // end of class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_EFF25745_L60C20
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_00D9E772_L61C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2c0e
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_00D9E772_L61C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2c16
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_00D9E772_L61C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2c19
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_00D9E772_L61C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c1c
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L61C21::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_00D9E772_L61C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c28
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L61C21::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_00D9E772_L61C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c30
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_00D9E772_L61C22::ConstructCore
-
-} // end of class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_00D9E772_L61C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_36454590_L68C12
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2c3f
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_36454590_L68C12::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2c47
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_36454590_L68C12::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2c4a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_36454590_L68C12::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c4d
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Events_EventEmitter_Complete/FunctionExpression_result::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_36454590_L68C12::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c59
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Events_EventEmitter_Complete/FunctionExpression_result::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_36454590_L68C12::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c61
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_36454590_L68C12::ConstructCore
-
-} // end of class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_36454590_L68C12
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_504662DB_L69C25
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2c70
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_504662DB_L69C25::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2c78
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_504662DB_L69C25::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2c7b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_504662DB_L69C25::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c7e
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Events_EventEmitter_Complete/FunctionExpression_result_L69C24::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_504662DB_L69C25::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c8a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Events_EventEmitter_Complete/FunctionExpression_result_L69C24::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_504662DB_L69C25::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c92
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_504662DB_L69C25::ConstructCore
-
-} // end of class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_504662DB_L69C25
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_D817B431_L78C21
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2ca1
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_D817B431_L78C21::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2ca9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D817B431_L78C21::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2cac
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D817B431_L78C21::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2caf
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L78C20::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_D817B431_L78C21::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cbb
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Events_EventEmitter_Complete/FunctionExpression_L78C20::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_D817B431_L78C21::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cc3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D817B431_L78C21::ConstructCore
-
-} // end of class FunctionObjects.Events_EventEmitter_Complete_109889D3.FunctionObject_FunctionExpression_D817B431_L78C21
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_Emit_Args.verified.txt
+++ b/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_Emit_Args.verified.txt
@@ -31,6 +31,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0BA33AEA_L10C19
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Events_EventEmitter_Emit_Args/Scope _environment0_Events_EventEmitter_Emit_Args
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Events_EventEmitter_Emit_Args/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2311
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Events_EventEmitter_Emit_Args/Scope Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L10C18/FunctionObject_FunctionExpression_0BA33AEA_L10C19::_environment0_Events_EventEmitter_Emit_Args
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_0BA33AEA_L10C19::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2320
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_0BA33AEA_L10C19::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2323
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_0BA33AEA_L10C19::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2326
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Events_EventEmitter_Emit_Args/Scope Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L10C18/FunctionObject_FunctionExpression_0BA33AEA_L10C19::_environment0_Events_EventEmitter_Emit_Args
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L10C18::__js_call__(class Modules.Events_EventEmitter_Emit_Args/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionExpression_0BA33AEA_L10C19::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2346
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Events_EventEmitter_Emit_Args/Scope Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L10C18/FunctionObject_FunctionExpression_0BA33AEA_L10C19::_environment0_Events_EventEmitter_Emit_Args
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L10C18::__js_call__(class Modules.Events_EventEmitter_Emit_Args/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionExpression_0BA33AEA_L10C19::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2362
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_0BA33AEA_L10C19::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_0BA33AEA_L10C19
+
 
 		// Methods
 		.method public hidebysig static 
@@ -90,6 +209,131 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9BAF52F7_L14C23
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Events_EventEmitter_Emit_Args/Scope _environment0_Events_EventEmitter_Emit_Args
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Events_EventEmitter_Emit_Args/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2371
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Events_EventEmitter_Emit_Args/Scope Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L14C22/FunctionObject_FunctionExpression_9BAF52F7_L14C23::_environment0_Events_EventEmitter_Emit_Args
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_9BAF52F7_L14C23::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2380
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_9BAF52F7_L14C23::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2383
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_9BAF52F7_L14C23::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2386
+				// Header size: 1
+				// Code size: 38 (0x26)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Events_EventEmitter_Emit_Args/Scope Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L14C22/FunctionObject_FunctionExpression_9BAF52F7_L14C23::_environment0_Events_EventEmitter_Emit_Args
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: call object Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L14C22::__js_call__(class Modules.Events_EventEmitter_Emit_Args/Scope, object, object, object, object)
+				IL_0025: ret
+			} // end of method FunctionObject_FunctionExpression_9BAF52F7_L14C23::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23ad
+				// Header size: 1
+				// Code size: 34 (0x22)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Events_EventEmitter_Emit_Args/Scope Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L14C22/FunctionObject_FunctionExpression_9BAF52F7_L14C23::_environment0_Events_EventEmitter_Emit_Args
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: ldarg.2
+				IL_0016: ldc.i4.2
+				IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001c: call object Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L14C22::__js_call__(class Modules.Events_EventEmitter_Emit_Args/Scope, object, object, object, object)
+				IL_0021: ret
+			} // end of method FunctionObject_FunctionExpression_9BAF52F7_L14C23::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23d0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_9BAF52F7_L14C23::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_9BAF52F7_L14C23
 
 
 		// Methods
@@ -188,8 +432,8 @@
 			[3] object,
 			[4] object,
 			[5] object[],
-			[6] class FunctionObjects.Events_EventEmitter_Emit_Args_05D7463D.FunctionObject_FunctionExpression_0BA33AEA_L10C19,
-			[7] class FunctionObjects.Events_EventEmitter_Emit_Args_05D7463D.FunctionObject_FunctionExpression_9BAF52F7_L14C23,
+			[6] class Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L10C18/FunctionObject_FunctionExpression_0BA33AEA_L10C19,
+			[7] class Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L14C22/FunctionObject_FunctionExpression_9BAF52F7_L14C23,
 			[8] object
 		)
 
@@ -230,13 +474,13 @@
 		IL_0065: ldc.i4.0
 		IL_0066: ldelem.ref
 		IL_0067: castclass Modules.Events_EventEmitter_Emit_Args/Scope
-		IL_006c: newobj instance void FunctionObjects.Events_EventEmitter_Emit_Args_05D7463D.FunctionObject_FunctionExpression_0BA33AEA_L10C19::.ctor(class Modules.Events_EventEmitter_Emit_Args/Scope)
+		IL_006c: newobj instance void Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L10C18/FunctionObject_FunctionExpression_0BA33AEA_L10C19::.ctor(class Modules.Events_EventEmitter_Emit_Args/Scope)
 		IL_0071: ldc.i4.2
 		IL_0072: conv.r8
 		IL_0073: ldstr ""
 		IL_0078: ldc.i4.0
 		IL_0079: ldc.i4.1
-		IL_007a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Events_EventEmitter_Emit_Args_05D7463D.FunctionObject_FunctionExpression_0BA33AEA_L10C19>(!!0, float64, string, bool, bool)
+		IL_007a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L10C18/FunctionObject_FunctionExpression_0BA33AEA_L10C19>(!!0, float64, string, bool, bool)
 		IL_007f: stloc.s 6
 		IL_0081: ldloc.s 4
 		IL_0083: ldstr "on"
@@ -258,13 +502,13 @@
 		IL_00ab: ldc.i4.0
 		IL_00ac: ldelem.ref
 		IL_00ad: castclass Modules.Events_EventEmitter_Emit_Args/Scope
-		IL_00b2: newobj instance void FunctionObjects.Events_EventEmitter_Emit_Args_05D7463D.FunctionObject_FunctionExpression_9BAF52F7_L14C23::.ctor(class Modules.Events_EventEmitter_Emit_Args/Scope)
+		IL_00b2: newobj instance void Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L14C22/FunctionObject_FunctionExpression_9BAF52F7_L14C23::.ctor(class Modules.Events_EventEmitter_Emit_Args/Scope)
 		IL_00b7: ldc.i4.3
 		IL_00b8: conv.r8
 		IL_00b9: ldstr ""
 		IL_00be: ldc.i4.0
 		IL_00bf: ldc.i4.1
-		IL_00c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Events_EventEmitter_Emit_Args_05D7463D.FunctionObject_FunctionExpression_9BAF52F7_L14C23>(!!0, float64, string, bool, bool)
+		IL_00c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L14C22/FunctionObject_FunctionExpression_9BAF52F7_L14C23>(!!0, float64, string, bool, bool)
 		IL_00c5: stloc.s 7
 		IL_00c7: ldloc.s 4
 		IL_00c9: ldstr "on"
@@ -373,250 +617,6 @@
 	} // end of method Events_EventEmitter_Emit_Args::__js_module_init__
 
 } // end of class Modules.Events_EventEmitter_Emit_Args
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Events_EventEmitter_Emit_Args_05D7463D.FunctionObject_FunctionExpression_0BA33AEA_L10C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Events_EventEmitter_Emit_Args/Scope _environment0_Events_EventEmitter_Emit_Args
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Events_EventEmitter_Emit_Args/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2311
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Events_EventEmitter_Emit_Args/Scope FunctionObjects.Events_EventEmitter_Emit_Args_05D7463D.FunctionObject_FunctionExpression_0BA33AEA_L10C19::_environment0_Events_EventEmitter_Emit_Args
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_0BA33AEA_L10C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2320
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_0BA33AEA_L10C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2323
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_0BA33AEA_L10C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2326
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Events_EventEmitter_Emit_Args/Scope FunctionObjects.Events_EventEmitter_Emit_Args_05D7463D.FunctionObject_FunctionExpression_0BA33AEA_L10C19::_environment0_Events_EventEmitter_Emit_Args
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L10C18::__js_call__(class Modules.Events_EventEmitter_Emit_Args/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionExpression_0BA33AEA_L10C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2346
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Events_EventEmitter_Emit_Args/Scope FunctionObjects.Events_EventEmitter_Emit_Args_05D7463D.FunctionObject_FunctionExpression_0BA33AEA_L10C19::_environment0_Events_EventEmitter_Emit_Args
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L10C18::__js_call__(class Modules.Events_EventEmitter_Emit_Args/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionExpression_0BA33AEA_L10C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2362
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_0BA33AEA_L10C19::ConstructCore
-
-} // end of class FunctionObjects.Events_EventEmitter_Emit_Args_05D7463D.FunctionObject_FunctionExpression_0BA33AEA_L10C19
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Events_EventEmitter_Emit_Args_05D7463D.FunctionObject_FunctionExpression_9BAF52F7_L14C23
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Events_EventEmitter_Emit_Args/Scope _environment0_Events_EventEmitter_Emit_Args
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Events_EventEmitter_Emit_Args/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2371
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Events_EventEmitter_Emit_Args/Scope FunctionObjects.Events_EventEmitter_Emit_Args_05D7463D.FunctionObject_FunctionExpression_9BAF52F7_L14C23::_environment0_Events_EventEmitter_Emit_Args
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_9BAF52F7_L14C23::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2380
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9BAF52F7_L14C23::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2383
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9BAF52F7_L14C23::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2386
-		// Header size: 1
-		// Code size: 38 (0x26)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Events_EventEmitter_Emit_Args/Scope FunctionObjects.Events_EventEmitter_Emit_Args_05D7463D.FunctionObject_FunctionExpression_9BAF52F7_L14C23::_environment0_Events_EventEmitter_Emit_Args
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: call object Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L14C22::__js_call__(class Modules.Events_EventEmitter_Emit_Args/Scope, object, object, object, object)
-		IL_0025: ret
-	} // end of method FunctionObject_FunctionExpression_9BAF52F7_L14C23::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23ad
-		// Header size: 1
-		// Code size: 34 (0x22)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Events_EventEmitter_Emit_Args/Scope FunctionObjects.Events_EventEmitter_Emit_Args_05D7463D.FunctionObject_FunctionExpression_9BAF52F7_L14C23::_environment0_Events_EventEmitter_Emit_Args
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: ldarg.2
-		IL_0016: ldc.i4.2
-		IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001c: call object Modules.Events_EventEmitter_Emit_Args/FunctionExpression_L14C22::__js_call__(class Modules.Events_EventEmitter_Emit_Args/Scope, object, object, object, object)
-		IL_0021: ret
-	} // end of method FunctionObject_FunctionExpression_9BAF52F7_L14C23::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23d0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_9BAF52F7_L14C23::ConstructCore
-
-} // end of class FunctionObjects.Events_EventEmitter_Emit_Args_05D7463D.FunctionObject_FunctionExpression_9BAF52F7_L14C23
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_ErrorMonitor.verified.txt
+++ b/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_ErrorMonitor.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DA01CEF5_L7C33
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x231d
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_DA01CEF5_L7C33::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2325
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_DA01CEF5_L7C33::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2328
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_DA01CEF5_L7C33::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x232b
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L7C32::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_DA01CEF5_L7C33::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x233e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L7C32::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_DA01CEF5_L7C33::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x234d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_DA01CEF5_L7C33::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_DA01CEF5_L7C33
+
 
 		// Methods
 		.method public hidebysig static 
@@ -99,6 +200,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2AF8E8BC_L10C21
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x235c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_2AF8E8BC_L10C21::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2364
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_2AF8E8BC_L10C21::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2367
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_2AF8E8BC_L10C21::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x236a
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L10C20::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_2AF8E8BC_L10C21::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x237d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L10C20::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_2AF8E8BC_L10C21::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x238c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_2AF8E8BC_L10C21::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_2AF8E8BC_L10C21
+
 
 		// Methods
 		.method public hidebysig static 
@@ -166,6 +368,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A8471C41_L17C34
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x239b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_A8471C41_L17C34::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x23a3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A8471C41_L17C34::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x23a6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A8471C41_L17C34::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x23a9
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L17C33::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_A8471C41_L17C34::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23bc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L17C33::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_A8471C41_L17C34::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23cb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_A8471C41_L17C34::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_A8471C41_L17C34
 
 
 		// Methods
@@ -296,10 +599,10 @@
 			[9] object,
 			[10] object,
 			[11] object[],
-			[12] class FunctionObjects.Events_EventEmitter_ErrorMonitor_4ED5806C.FunctionObject_FunctionExpression_DA01CEF5_L7C33,
-			[13] class FunctionObjects.Events_EventEmitter_ErrorMonitor_4ED5806C.FunctionObject_FunctionExpression_2AF8E8BC_L10C21,
+			[12] class Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L7C32/FunctionObject_FunctionExpression_DA01CEF5_L7C33,
+			[13] class Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L10C20/FunctionObject_FunctionExpression_2AF8E8BC_L10C21,
 			[14] class [JavaScriptRuntime]JavaScriptRuntime.Error,
-			[15] class FunctionObjects.Events_EventEmitter_ErrorMonitor_4ED5806C.FunctionObject_FunctionExpression_A8471C41_L17C34
+			[15] class Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L17C33/FunctionObject_FunctionExpression_A8471C41_L17C34
 		)
 
 		IL_0000: newobj instance void Modules.Events_EventEmitter_ErrorMonitor/Scope::.ctor()
@@ -330,13 +633,13 @@
 		IL_003f: ldloc.0
 		IL_0040: stelem.ref
 		IL_0041: stloc.s 11
-		IL_0043: newobj instance void FunctionObjects.Events_EventEmitter_ErrorMonitor_4ED5806C.FunctionObject_FunctionExpression_DA01CEF5_L7C33::.ctor()
+		IL_0043: newobj instance void Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L7C32/FunctionObject_FunctionExpression_DA01CEF5_L7C33::.ctor()
 		IL_0048: ldc.i4.1
 		IL_0049: conv.r8
 		IL_004a: ldstr ""
 		IL_004f: ldc.i4.0
 		IL_0050: ldc.i4.1
-		IL_0051: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Events_EventEmitter_ErrorMonitor_4ED5806C.FunctionObject_FunctionExpression_DA01CEF5_L7C33>(!!0, float64, string, bool, bool)
+		IL_0051: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L7C32/FunctionObject_FunctionExpression_DA01CEF5_L7C33>(!!0, float64, string, bool, bool)
 		IL_0056: stloc.s 12
 		IL_0058: ldloc.s 9
 		IL_005a: ldstr "on"
@@ -354,13 +657,13 @@
 		IL_0079: ldloc.0
 		IL_007a: stelem.ref
 		IL_007b: stloc.s 11
-		IL_007d: newobj instance void FunctionObjects.Events_EventEmitter_ErrorMonitor_4ED5806C.FunctionObject_FunctionExpression_2AF8E8BC_L10C21::.ctor()
+		IL_007d: newobj instance void Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L10C20/FunctionObject_FunctionExpression_2AF8E8BC_L10C21::.ctor()
 		IL_0082: ldc.i4.1
 		IL_0083: conv.r8
 		IL_0084: ldstr ""
 		IL_0089: ldc.i4.0
 		IL_008a: ldc.i4.1
-		IL_008b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Events_EventEmitter_ErrorMonitor_4ED5806C.FunctionObject_FunctionExpression_2AF8E8BC_L10C21>(!!0, float64, string, bool, bool)
+		IL_008b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L10C20/FunctionObject_FunctionExpression_2AF8E8BC_L10C21>(!!0, float64, string, bool, bool)
 		IL_0090: stloc.s 13
 		IL_0092: ldloc.s 10
 		IL_0094: ldstr "on"
@@ -398,13 +701,13 @@
 		IL_00f5: ldloc.0
 		IL_00f6: stelem.ref
 		IL_00f7: stloc.s 11
-		IL_00f9: newobj instance void FunctionObjects.Events_EventEmitter_ErrorMonitor_4ED5806C.FunctionObject_FunctionExpression_A8471C41_L17C34::.ctor()
+		IL_00f9: newobj instance void Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L17C33/FunctionObject_FunctionExpression_A8471C41_L17C34::.ctor()
 		IL_00fe: ldc.i4.1
 		IL_00ff: conv.r8
 		IL_0100: ldstr ""
 		IL_0105: ldc.i4.0
 		IL_0106: ldc.i4.1
-		IL_0107: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Events_EventEmitter_ErrorMonitor_4ED5806C.FunctionObject_FunctionExpression_A8471C41_L17C34>(!!0, float64, string, bool, bool)
+		IL_0107: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L17C33/FunctionObject_FunctionExpression_A8471C41_L17C34>(!!0, float64, string, bool, bool)
 		IL_010c: stloc.s 15
 		IL_010e: ldloc.s 10
 		IL_0110: ldstr "on"
@@ -472,309 +775,6 @@
 	} // end of method Events_EventEmitter_ErrorMonitor::__js_module_init__
 
 } // end of class Modules.Events_EventEmitter_ErrorMonitor
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Events_EventEmitter_ErrorMonitor_4ED5806C.FunctionObject_FunctionExpression_DA01CEF5_L7C33
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x231d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_DA01CEF5_L7C33::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2325
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DA01CEF5_L7C33::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2328
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DA01CEF5_L7C33::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x232b
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L7C32::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_DA01CEF5_L7C33::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x233e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L7C32::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DA01CEF5_L7C33::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x234d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DA01CEF5_L7C33::ConstructCore
-
-} // end of class FunctionObjects.Events_EventEmitter_ErrorMonitor_4ED5806C.FunctionObject_FunctionExpression_DA01CEF5_L7C33
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Events_EventEmitter_ErrorMonitor_4ED5806C.FunctionObject_FunctionExpression_2AF8E8BC_L10C21
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x235c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_2AF8E8BC_L10C21::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2364
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2AF8E8BC_L10C21::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2367
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2AF8E8BC_L10C21::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x236a
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L10C20::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_2AF8E8BC_L10C21::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x237d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L10C20::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2AF8E8BC_L10C21::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x238c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2AF8E8BC_L10C21::ConstructCore
-
-} // end of class FunctionObjects.Events_EventEmitter_ErrorMonitor_4ED5806C.FunctionObject_FunctionExpression_2AF8E8BC_L10C21
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Events_EventEmitter_ErrorMonitor_4ED5806C.FunctionObject_FunctionExpression_A8471C41_L17C34
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x239b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_A8471C41_L17C34::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23a3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A8471C41_L17C34::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23a6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A8471C41_L17C34::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23a9
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L17C33::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_A8471C41_L17C34::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23bc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Events_EventEmitter_ErrorMonitor/FunctionExpression_L17C33::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A8471C41_L17C34::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23cb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A8471C41_L17C34::ConstructCore
-
-} // end of class FunctionObjects.Events_EventEmitter_ErrorMonitor_4ED5806C.FunctionObject_FunctionExpression_A8471C41_L17C34
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_On_Off_Once.verified.txt
+++ b/tests/Jroc.Tests/Node/Events/Snapshots/GeneratorTests.Events_EventEmitter_On_Off_Once.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E40C4F21_onData
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Events_EventEmitter_On_Off_Once/Scope _environment0_Events_EventEmitter_On_Off_Once
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Events_EventEmitter_On_Off_Once/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x24ef
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Events_EventEmitter_On_Off_Once/Scope Modules.Events_EventEmitter_On_Off_Once/onData/FunctionObject_FunctionDeclaration_E40C4F21_onData::_environment0_Events_EventEmitter_On_Off_Once
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E40C4F21_onData::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24fe
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E40C4F21_onData::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2501
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E40C4F21_onData::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2504
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Events_EventEmitter_On_Off_Once/Scope Modules.Events_EventEmitter_On_Off_Once/onData/FunctionObject_FunctionDeclaration_E40C4F21_onData::_environment0_Events_EventEmitter_On_Off_Once
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Events_EventEmitter_On_Off_Once/onData::__js_call__(class Modules.Events_EventEmitter_On_Off_Once/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_E40C4F21_onData::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2516
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Events_EventEmitter_On_Off_Once/Scope Modules.Events_EventEmitter_On_Off_Once/onData/FunctionObject_FunctionDeclaration_E40C4F21_onData::_environment0_Events_EventEmitter_On_Off_Once
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Events_EventEmitter_On_Off_Once/onData::__js_call__(class Modules.Events_EventEmitter_On_Off_Once/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_E40C4F21_onData::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2524
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E40C4F21_onData::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E40C4F21_onData
+
 
 		// Methods
 		.method public hidebysig static 
@@ -92,6 +199,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_BB5FB80E_L23C22
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Events_EventEmitter_On_Off_Once/Scope _environment0_Events_EventEmitter_On_Off_Once
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Events_EventEmitter_On_Off_Once/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2533
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Events_EventEmitter_On_Off_Once/Scope Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21/FunctionObject_FunctionExpression_BB5FB80E_L23C22::_environment0_Events_EventEmitter_On_Off_Once
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_BB5FB80E_L23C22::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2542
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_BB5FB80E_L23C22::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2545
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_BB5FB80E_L23C22::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2548
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Events_EventEmitter_On_Off_Once/Scope Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21/FunctionObject_FunctionExpression_BB5FB80E_L23C22::_environment0_Events_EventEmitter_On_Off_Once
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21::__js_call__(class Modules.Events_EventEmitter_On_Off_Once/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_BB5FB80E_L23C22::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x255a
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Events_EventEmitter_On_Off_Once/Scope Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21/FunctionObject_FunctionExpression_BB5FB80E_L23C22::_environment0_Events_EventEmitter_On_Off_Once
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21::__js_call__(class Modules.Events_EventEmitter_On_Off_Once/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_BB5FB80E_L23C22::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2568
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_BB5FB80E_L23C22::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_BB5FB80E_L23C22
 
 
 		// Methods
@@ -155,6 +369,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E84513BE_L31C21
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2577
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_E84513BE_L31C21::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x257f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E84513BE_L31C21::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2582
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E84513BE_L31C21::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2585
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L31C20::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_E84513BE_L31C21::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2591
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L31C20::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_E84513BE_L31C21::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2599
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E84513BE_L31C21::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_E84513BE_L31C21
+
 
 		// Methods
 		.method public hidebysig static 
@@ -199,6 +508,101 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D268090E_L32C20
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x25a8
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_D268090E_L32C20::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x25b0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D268090E_L32C20::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x25b3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D268090E_L32C20::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x25b6
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L32C19::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_D268090E_L32C20::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25c2
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L32C19::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_D268090E_L32C20::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25ca
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_D268090E_L32C20::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_D268090E_L32C20
 
 
 		// Methods
@@ -269,16 +673,16 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Events_EventEmitter_On_Off_Once/Scope,
-			[1] class FunctionObjects.Events_EventEmitter_On_Off_Once_DFE60B95.FunctionObject_FunctionDeclaration_E40C4F21_onData,
+			[1] class Modules.Events_EventEmitter_On_Off_Once/onData/FunctionObject_FunctionDeclaration_E40C4F21_onData,
 			[2] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IEventsModule,
 			[3] object,
 			[4] object,
 			[5] object[],
 			[6] object,
 			[7] object,
-			[8] class FunctionObjects.Events_EventEmitter_On_Off_Once_DFE60B95.FunctionObject_FunctionExpression_BB5FB80E_L23C22,
-			[9] class FunctionObjects.Events_EventEmitter_On_Off_Once_DFE60B95.FunctionObject_FunctionExpression_E84513BE_L31C21,
-			[10] class FunctionObjects.Events_EventEmitter_On_Off_Once_DFE60B95.FunctionObject_FunctionExpression_D268090E_L32C20
+			[8] class Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21/FunctionObject_FunctionExpression_BB5FB80E_L23C22,
+			[9] class Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L31C20/FunctionObject_FunctionExpression_E84513BE_L31C21,
+			[10] class Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L32C19/FunctionObject_FunctionExpression_D268090E_L32C20
 		)
 
 		IL_0000: newobj instance void Modules.Events_EventEmitter_On_Off_Once/Scope::.ctor()
@@ -294,13 +698,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Events_EventEmitter_On_Off_Once/Scope
-		IL_001b: newobj instance void FunctionObjects.Events_EventEmitter_On_Off_Once_DFE60B95.FunctionObject_FunctionDeclaration_E40C4F21_onData::.ctor(class Modules.Events_EventEmitter_On_Off_Once/Scope)
+		IL_001b: newobj instance void Modules.Events_EventEmitter_On_Off_Once/onData/FunctionObject_FunctionDeclaration_E40C4F21_onData::.ctor(class Modules.Events_EventEmitter_On_Off_Once/Scope)
 		IL_0020: ldc.i4.0
 		IL_0021: conv.r8
 		IL_0022: ldstr "onData"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Events_EventEmitter_On_Off_Once_DFE60B95.FunctionObject_FunctionDeclaration_E40C4F21_onData>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_On_Off_Once/onData/FunctionObject_FunctionDeclaration_E40C4F21_onData>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: nop
 		IL_0030: ldarg.1
@@ -436,13 +840,13 @@
 		IL_01f1: ldc.i4.0
 		IL_01f2: ldelem.ref
 		IL_01f3: castclass Modules.Events_EventEmitter_On_Off_Once/Scope
-		IL_01f8: newobj instance void FunctionObjects.Events_EventEmitter_On_Off_Once_DFE60B95.FunctionObject_FunctionExpression_BB5FB80E_L23C22::.ctor(class Modules.Events_EventEmitter_On_Off_Once/Scope)
+		IL_01f8: newobj instance void Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21/FunctionObject_FunctionExpression_BB5FB80E_L23C22::.ctor(class Modules.Events_EventEmitter_On_Off_Once/Scope)
 		IL_01fd: ldc.i4.0
 		IL_01fe: conv.r8
 		IL_01ff: ldstr ""
 		IL_0204: ldc.i4.0
 		IL_0205: ldc.i4.1
-		IL_0206: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Events_EventEmitter_On_Off_Once_DFE60B95.FunctionObject_FunctionExpression_BB5FB80E_L23C22>(!!0, float64, string, bool, bool)
+		IL_0206: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21/FunctionObject_FunctionExpression_BB5FB80E_L23C22>(!!0, float64, string, bool, bool)
 		IL_020b: stloc.s 8
 		IL_020d: ldloc.s 6
 		IL_020f: ldstr "once"
@@ -517,13 +921,13 @@
 		IL_0302: ldloc.0
 		IL_0303: stelem.ref
 		IL_0304: stloc.s 5
-		IL_0306: newobj instance void FunctionObjects.Events_EventEmitter_On_Off_Once_DFE60B95.FunctionObject_FunctionExpression_E84513BE_L31C21::.ctor()
+		IL_0306: newobj instance void Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L31C20/FunctionObject_FunctionExpression_E84513BE_L31C21::.ctor()
 		IL_030b: ldc.i4.0
 		IL_030c: conv.r8
 		IL_030d: ldstr ""
 		IL_0312: ldc.i4.0
 		IL_0313: ldc.i4.1
-		IL_0314: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Events_EventEmitter_On_Off_Once_DFE60B95.FunctionObject_FunctionExpression_E84513BE_L31C21>(!!0, float64, string, bool, bool)
+		IL_0314: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L31C20/FunctionObject_FunctionExpression_E84513BE_L31C21>(!!0, float64, string, bool, bool)
 		IL_0319: stloc.s 9
 		IL_031b: ldloc.s 6
 		IL_031d: ldstr "on"
@@ -541,13 +945,13 @@
 		IL_0340: ldloc.0
 		IL_0341: stelem.ref
 		IL_0342: stloc.s 5
-		IL_0344: newobj instance void FunctionObjects.Events_EventEmitter_On_Off_Once_DFE60B95.FunctionObject_FunctionExpression_D268090E_L32C20::.ctor()
+		IL_0344: newobj instance void Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L32C19/FunctionObject_FunctionExpression_D268090E_L32C20::.ctor()
 		IL_0349: ldc.i4.0
 		IL_034a: conv.r8
 		IL_034b: ldstr ""
 		IL_0350: ldc.i4.0
 		IL_0351: ldc.i4.1
-		IL_0352: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Events_EventEmitter_On_Off_Once_DFE60B95.FunctionObject_FunctionExpression_D268090E_L32C20>(!!0, float64, string, bool, bool)
+		IL_0352: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L32C19/FunctionObject_FunctionExpression_D268090E_L32C20>(!!0, float64, string, bool, bool)
 		IL_0357: stloc.s 10
 		IL_0359: ldloc.s 6
 		IL_035b: ldstr "on"
@@ -600,410 +1004,6 @@
 	} // end of method Events_EventEmitter_On_Off_Once::__js_module_init__
 
 } // end of class Modules.Events_EventEmitter_On_Off_Once
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Events_EventEmitter_On_Off_Once_DFE60B95.FunctionObject_FunctionDeclaration_E40C4F21_onData
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Events_EventEmitter_On_Off_Once/Scope _environment0_Events_EventEmitter_On_Off_Once
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Events_EventEmitter_On_Off_Once/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x24ef
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Events_EventEmitter_On_Off_Once/Scope FunctionObjects.Events_EventEmitter_On_Off_Once_DFE60B95.FunctionObject_FunctionDeclaration_E40C4F21_onData::_environment0_Events_EventEmitter_On_Off_Once
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E40C4F21_onData::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24fe
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E40C4F21_onData::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2501
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E40C4F21_onData::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2504
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Events_EventEmitter_On_Off_Once/Scope FunctionObjects.Events_EventEmitter_On_Off_Once_DFE60B95.FunctionObject_FunctionDeclaration_E40C4F21_onData::_environment0_Events_EventEmitter_On_Off_Once
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Events_EventEmitter_On_Off_Once/onData::__js_call__(class Modules.Events_EventEmitter_On_Off_Once/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_E40C4F21_onData::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2516
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Events_EventEmitter_On_Off_Once/Scope FunctionObjects.Events_EventEmitter_On_Off_Once_DFE60B95.FunctionObject_FunctionDeclaration_E40C4F21_onData::_environment0_Events_EventEmitter_On_Off_Once
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Events_EventEmitter_On_Off_Once/onData::__js_call__(class Modules.Events_EventEmitter_On_Off_Once/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_E40C4F21_onData::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2524
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E40C4F21_onData::ConstructCore
-
-} // end of class FunctionObjects.Events_EventEmitter_On_Off_Once_DFE60B95.FunctionObject_FunctionDeclaration_E40C4F21_onData
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Events_EventEmitter_On_Off_Once_DFE60B95.FunctionObject_FunctionExpression_BB5FB80E_L23C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Events_EventEmitter_On_Off_Once/Scope _environment0_Events_EventEmitter_On_Off_Once
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Events_EventEmitter_On_Off_Once/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2533
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Events_EventEmitter_On_Off_Once/Scope FunctionObjects.Events_EventEmitter_On_Off_Once_DFE60B95.FunctionObject_FunctionExpression_BB5FB80E_L23C22::_environment0_Events_EventEmitter_On_Off_Once
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_BB5FB80E_L23C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2542
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_BB5FB80E_L23C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2545
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_BB5FB80E_L23C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2548
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Events_EventEmitter_On_Off_Once/Scope FunctionObjects.Events_EventEmitter_On_Off_Once_DFE60B95.FunctionObject_FunctionExpression_BB5FB80E_L23C22::_environment0_Events_EventEmitter_On_Off_Once
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21::__js_call__(class Modules.Events_EventEmitter_On_Off_Once/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_BB5FB80E_L23C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x255a
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Events_EventEmitter_On_Off_Once/Scope FunctionObjects.Events_EventEmitter_On_Off_Once_DFE60B95.FunctionObject_FunctionExpression_BB5FB80E_L23C22::_environment0_Events_EventEmitter_On_Off_Once
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L23C21::__js_call__(class Modules.Events_EventEmitter_On_Off_Once/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_BB5FB80E_L23C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2568
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_BB5FB80E_L23C22::ConstructCore
-
-} // end of class FunctionObjects.Events_EventEmitter_On_Off_Once_DFE60B95.FunctionObject_FunctionExpression_BB5FB80E_L23C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Events_EventEmitter_On_Off_Once_DFE60B95.FunctionObject_FunctionExpression_E84513BE_L31C21
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2577
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_E84513BE_L31C21::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x257f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E84513BE_L31C21::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2582
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E84513BE_L31C21::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2585
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L31C20::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_E84513BE_L31C21::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2591
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L31C20::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_E84513BE_L31C21::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2599
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E84513BE_L31C21::ConstructCore
-
-} // end of class FunctionObjects.Events_EventEmitter_On_Off_Once_DFE60B95.FunctionObject_FunctionExpression_E84513BE_L31C21
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Events_EventEmitter_On_Off_Once_DFE60B95.FunctionObject_FunctionExpression_D268090E_L32C20
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x25a8
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_D268090E_L32C20::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x25b0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D268090E_L32C20::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x25b3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D268090E_L32C20::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x25b6
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L32C19::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_D268090E_L32C20::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25c2
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Events_EventEmitter_On_Off_Once/FunctionExpression_L32C19::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_D268090E_L32C20::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25ca
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D268090E_L32C20::ConstructCore
-
-} // end of class FunctionObjects.Events_EventEmitter_On_Off_Once_DFE60B95.FunctionObject_FunctionExpression_D268090E_L32C20
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Agent_KeepAlive_Reuses_Connection.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Agent_KeepAlive_Reuses_Connection.verified.txt
@@ -31,6 +31,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_AD8A01FB_L9C34
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope _environment0_Http_Agent_KeepAlive_Reuses_Connection
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x28e4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_server/FunctionObject_FunctionExpression_AD8A01FB_L9C34::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_AD8A01FB_L9C34::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x28f3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_AD8A01FB_L9C34::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x28f6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_AD8A01FB_L9C34::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x28f9
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_server/FunctionObject_FunctionExpression_AD8A01FB_L9C34::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_server::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionExpression_AD8A01FB_L9C34::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2919
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_server/FunctionObject_FunctionExpression_AD8A01FB_L9C34::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_server::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionExpression_AD8A01FB_L9C34::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2935
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_AD8A01FB_L9C34::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_AD8A01FB_L9C34
+
 
 		// Methods
 		.method public hidebysig static 
@@ -118,6 +237,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2B9E525E_L15C25
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope _environment0_Http_Agent_KeepAlive_Reuses_Connection
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2944
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L15C24/FunctionObject_FunctionExpression_2B9E525E_L15C25::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_2B9E525E_L15C25::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2953
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_2B9E525E_L15C25::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2956
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_2B9E525E_L15C25::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2959
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L15C24/FunctionObject_FunctionExpression_2B9E525E_L15C25::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L15C24::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_2B9E525E_L15C25::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x296b
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L15C24/FunctionObject_FunctionExpression_2B9E525E_L15C25::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L15C24::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_2B9E525E_L15C25::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2979
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_2B9E525E_L15C25::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_2B9E525E_L15C25
+
 
 		// Methods
 		.method public hidebysig static 
@@ -187,6 +413,134 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_83707BD8_L34C22
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope _environment0_Http_Agent_KeepAlive_Reuses_Connection
+					.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope _environment1_FunctionExpression_L19C30
+					.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope _environment2_FunctionExpression_L29C4
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope capture0,
+							class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope capture1,
+							class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x2a2c
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject_FunctionExpression_83707BD8_L34C22::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject_FunctionExpression_83707BD8_L34C22::_environment1_FunctionExpression_L19C30
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject_FunctionExpression_83707BD8_L34C22::_environment2_FunctionExpression_L29C4
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject_FunctionExpression_83707BD8_L34C22::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_83707BD8_L34C22::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x2a51
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_83707BD8_L34C22::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x2a54
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_83707BD8_L34C22::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x2a57
+						// Header size: 1
+						// Code size: 24 (0x18)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject_FunctionExpression_83707BD8_L34C22::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: ldarg.2
+						IL_000c: ldc.i4.0
+						IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+						IL_0012: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21::__js_call__(object[], object, object)
+						IL_0017: ret
+					} // end of method FunctionObject_FunctionExpression_83707BD8_L34C22::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x2a70
+						// Header size: 1
+						// Code size: 20 (0x14)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject_FunctionExpression_83707BD8_L34C22::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: ldarg.2
+						IL_0008: ldc.i4.0
+						IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+						IL_000e: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21::__js_call__(object[], object, object)
+						IL_0013: ret
+					} // end of method FunctionObject_FunctionExpression_83707BD8_L34C22::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x2a85
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_83707BD8_L34C22::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_83707BD8_L34C22
 
 
 				// Methods
@@ -263,6 +617,139 @@
 
 						} // end of class Scope
 
+						.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_609C8B8A_L53C32
+							extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+						{
+							// Fields
+							.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope _environment0_Http_Agent_KeepAlive_Reuses_Connection
+							.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope _environment1_FunctionExpression_L19C30
+							.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope _environment2_FunctionExpression_L29C4
+							.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope _environment4_FunctionExpression_L48C10
+							.field private initonly object[] _transitionalScopes
+
+							// Methods
+							.method public hidebysig specialname rtspecialname 
+								instance void .ctor (
+									class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope capture0,
+									class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope capture1,
+									class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope capture2,
+									class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope capture3,
+									object[] capture4
+								) cil managed 
+							{
+								// Method begins at RVA 0x2b56
+								// Header size: 1
+								// Code size: 44 (0x2c)
+								.maxstack 8
+
+								IL_0000: ldarg.0
+								IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+								IL_0006: ldarg.0
+								IL_0007: ldarg.1
+								IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject_FunctionExpression_609C8B8A_L53C32::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+								IL_000d: ldarg.0
+								IL_000e: ldarg.2
+								IL_000f: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject_FunctionExpression_609C8B8A_L53C32::_environment1_FunctionExpression_L19C30
+								IL_0014: ldarg.0
+								IL_0015: ldarg.3
+								IL_0016: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject_FunctionExpression_609C8B8A_L53C32::_environment2_FunctionExpression_L29C4
+								IL_001b: ldarg.0
+								IL_001c: ldarg.s capture3
+								IL_001e: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject_FunctionExpression_609C8B8A_L53C32::_environment4_FunctionExpression_L48C10
+								IL_0023: ldarg.0
+								IL_0024: ldarg.s capture4
+								IL_0026: stfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject_FunctionExpression_609C8B8A_L53C32::_transitionalScopes
+								IL_002b: ret
+							} // end of method FunctionObject_FunctionExpression_609C8B8A_L53C32::.ctor
+
+							.method public hidebysig specialname virtual 
+								instance bool get_IsConstructor () cil managed 
+							{
+								// Method begins at RVA 0x2b83
+								// Header size: 1
+								// Code size: 2 (0x2)
+								.maxstack 8
+
+								IL_0000: ldc.i4.1
+								IL_0001: ret
+							} // end of method FunctionObject_FunctionExpression_609C8B8A_L53C32::get_IsConstructor
+
+							.method public hidebysig specialname virtual 
+								instance bool get_RequiresInvocationContext () cil managed 
+							{
+								// Method begins at RVA 0x2b86
+								// Header size: 1
+								// Code size: 2 (0x2)
+								.maxstack 8
+
+								IL_0000: ldc.i4.0
+								IL_0001: ret
+							} // end of method FunctionObject_FunctionExpression_609C8B8A_L53C32::get_RequiresInvocationContext
+
+							.method family hidebysig virtual 
+								instance object CallCore (
+									object thisArgument,
+									[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+								) cil managed 
+							{
+								// Method begins at RVA 0x2b89
+								// Header size: 1
+								// Code size: 24 (0x18)
+								.maxstack 8
+
+								IL_0000: ldarg.0
+								IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject_FunctionExpression_609C8B8A_L53C32::_transitionalScopes
+								IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+								IL_000b: ldarg.2
+								IL_000c: ldc.i4.0
+								IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+								IL_0012: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31::__js_call__(object[], object, object)
+								IL_0017: ret
+							} // end of method FunctionObject_FunctionExpression_609C8B8A_L53C32::CallCore
+
+							.method family hidebysig virtual 
+								instance object ConstructBodyCore (
+									object receiver,
+									[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+									object newTarget
+								) cil managed 
+							{
+								// Method begins at RVA 0x2ba2
+								// Header size: 1
+								// Code size: 20 (0x14)
+								.maxstack 8
+
+								IL_0000: ldarg.0
+								IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject_FunctionExpression_609C8B8A_L53C32::_transitionalScopes
+								IL_0006: ldarg.3
+								IL_0007: ldarg.2
+								IL_0008: ldc.i4.0
+								IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+								IL_000e: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31::__js_call__(object[], object, object)
+								IL_0013: ret
+							} // end of method FunctionObject_FunctionExpression_609C8B8A_L53C32::ConstructBodyCore
+
+							.method family hidebysig virtual 
+								instance object ConstructCore (
+									[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+									object newTarget
+								) cil managed 
+							{
+								// Method begins at RVA 0x2bb7
+								// Header size: 1
+								// Code size: 14 (0xe)
+								.maxstack 8
+
+								IL_0000: ldarg.0
+								IL_0001: ldarg.1
+								IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+								IL_0007: ldarg.2
+								IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+								IL_000d: ret
+							} // end of method FunctionObject_FunctionExpression_609C8B8A_L53C32::ConstructCore
+
+						} // end of class FunctionObject_FunctionExpression_609C8B8A_L53C32
+
 
 						// Methods
 						.method public hidebysig static 
@@ -334,6 +821,101 @@
 
 							} // end of class Scope
 
+							.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_71E42388_L61C28
+								extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+							{
+								// Methods
+								.method public hidebysig specialname rtspecialname 
+									instance void .ctor () cil managed 
+								{
+									// Method begins at RVA 0x2c28
+									// Header size: 1
+									// Code size: 7 (0x7)
+									.maxstack 8
+
+									IL_0000: ldarg.0
+									IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+									IL_0006: ret
+								} // end of method FunctionObject_FunctionExpression_71E42388_L61C28::.ctor
+
+								.method public hidebysig specialname virtual 
+									instance bool get_IsConstructor () cil managed 
+								{
+									// Method begins at RVA 0x2c30
+									// Header size: 1
+									// Code size: 2 (0x2)
+									.maxstack 8
+
+									IL_0000: ldc.i4.1
+									IL_0001: ret
+								} // end of method FunctionObject_FunctionExpression_71E42388_L61C28::get_IsConstructor
+
+								.method public hidebysig specialname virtual 
+									instance bool get_RequiresInvocationContext () cil managed 
+								{
+									// Method begins at RVA 0x2c33
+									// Header size: 1
+									// Code size: 2 (0x2)
+									.maxstack 8
+
+									IL_0000: ldc.i4.0
+									IL_0001: ret
+								} // end of method FunctionObject_FunctionExpression_71E42388_L61C28::get_RequiresInvocationContext
+
+								.method family hidebysig virtual 
+									instance object CallCore (
+										object thisArgument,
+										[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+									) cil managed 
+								{
+									// Method begins at RVA 0x2c36
+									// Header size: 1
+									// Code size: 11 (0xb)
+									.maxstack 8
+
+									IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+									IL_0005: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionExpression_L61C27::__js_call__(object)
+									IL_000a: ret
+								} // end of method FunctionObject_FunctionExpression_71E42388_L61C28::CallCore
+
+								.method family hidebysig virtual 
+									instance object ConstructBodyCore (
+										object receiver,
+										[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+										object newTarget
+									) cil managed 
+								{
+									// Method begins at RVA 0x2c42
+									// Header size: 1
+									// Code size: 7 (0x7)
+									.maxstack 8
+
+									IL_0000: ldarg.3
+									IL_0001: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionExpression_L61C27::__js_call__(object)
+									IL_0006: ret
+								} // end of method FunctionObject_FunctionExpression_71E42388_L61C28::ConstructBodyCore
+
+								.method family hidebysig virtual 
+									instance object ConstructCore (
+										[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+										object newTarget
+									) cil managed 
+								{
+									// Method begins at RVA 0x2c4a
+									// Header size: 1
+									// Code size: 14 (0xe)
+									.maxstack 8
+
+									IL_0000: ldarg.0
+									IL_0001: ldarg.1
+									IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+									IL_0007: ldarg.2
+									IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+									IL_000d: ret
+								} // end of method FunctionObject_FunctionExpression_71E42388_L61C28::ConstructCore
+
+							} // end of class FunctionObject_FunctionExpression_71E42388_L61C28
+
 
 							// Methods
 							.method public hidebysig static 
@@ -382,6 +964,133 @@
 
 						} // end of class Scope
 
+						.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_CD92AD5B_L57C31
+							extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+						{
+							// Fields
+							.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope _environment0_Http_Agent_KeepAlive_Reuses_Connection
+							.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope _environment1_FunctionExpression_L19C30
+							.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope _environment2_FunctionExpression_L29C4
+							.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope _environment4_FunctionExpression_L48C10
+							.field private initonly object[] _transitionalScopes
+
+							// Methods
+							.method public hidebysig specialname rtspecialname 
+								instance void .ctor (
+									class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope capture0,
+									class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope capture1,
+									class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope capture2,
+									class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope capture3,
+									object[] capture4
+								) cil managed 
+							{
+								// Method begins at RVA 0x2bc6
+								// Header size: 1
+								// Code size: 44 (0x2c)
+								.maxstack 8
+
+								IL_0000: ldarg.0
+								IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+								IL_0006: ldarg.0
+								IL_0007: ldarg.1
+								IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject_FunctionExpression_CD92AD5B_L57C31::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+								IL_000d: ldarg.0
+								IL_000e: ldarg.2
+								IL_000f: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject_FunctionExpression_CD92AD5B_L57C31::_environment1_FunctionExpression_L19C30
+								IL_0014: ldarg.0
+								IL_0015: ldarg.3
+								IL_0016: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject_FunctionExpression_CD92AD5B_L57C31::_environment2_FunctionExpression_L29C4
+								IL_001b: ldarg.0
+								IL_001c: ldarg.s capture3
+								IL_001e: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject_FunctionExpression_CD92AD5B_L57C31::_environment4_FunctionExpression_L48C10
+								IL_0023: ldarg.0
+								IL_0024: ldarg.s capture4
+								IL_0026: stfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject_FunctionExpression_CD92AD5B_L57C31::_transitionalScopes
+								IL_002b: ret
+							} // end of method FunctionObject_FunctionExpression_CD92AD5B_L57C31::.ctor
+
+							.method public hidebysig specialname virtual 
+								instance bool get_IsConstructor () cil managed 
+							{
+								// Method begins at RVA 0x2bf3
+								// Header size: 1
+								// Code size: 2 (0x2)
+								.maxstack 8
+
+								IL_0000: ldc.i4.1
+								IL_0001: ret
+							} // end of method FunctionObject_FunctionExpression_CD92AD5B_L57C31::get_IsConstructor
+
+							.method public hidebysig specialname virtual 
+								instance bool get_RequiresInvocationContext () cil managed 
+							{
+								// Method begins at RVA 0x2bf6
+								// Header size: 1
+								// Code size: 2 (0x2)
+								.maxstack 8
+
+								IL_0000: ldc.i4.0
+								IL_0001: ret
+							} // end of method FunctionObject_FunctionExpression_CD92AD5B_L57C31::get_RequiresInvocationContext
+
+							.method family hidebysig virtual 
+								instance object CallCore (
+									object thisArgument,
+									[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+								) cil managed 
+							{
+								// Method begins at RVA 0x2bf9
+								// Header size: 1
+								// Code size: 17 (0x11)
+								.maxstack 8
+
+								IL_0000: ldarg.0
+								IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject_FunctionExpression_CD92AD5B_L57C31::_transitionalScopes
+								IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+								IL_000b: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30::__js_call__(object[], object)
+								IL_0010: ret
+							} // end of method FunctionObject_FunctionExpression_CD92AD5B_L57C31::CallCore
+
+							.method family hidebysig virtual 
+								instance object ConstructBodyCore (
+									object receiver,
+									[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+									object newTarget
+								) cil managed 
+							{
+								// Method begins at RVA 0x2c0b
+								// Header size: 1
+								// Code size: 13 (0xd)
+								.maxstack 8
+
+								IL_0000: ldarg.0
+								IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject_FunctionExpression_CD92AD5B_L57C31::_transitionalScopes
+								IL_0006: ldarg.3
+								IL_0007: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30::__js_call__(object[], object)
+								IL_000c: ret
+							} // end of method FunctionObject_FunctionExpression_CD92AD5B_L57C31::ConstructBodyCore
+
+							.method family hidebysig virtual 
+								instance object ConstructCore (
+									[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+									object newTarget
+								) cil managed 
+							{
+								// Method begins at RVA 0x2c19
+								// Header size: 1
+								// Code size: 14 (0xe)
+								.maxstack 8
+
+								IL_0000: ldarg.0
+								IL_0001: ldarg.1
+								IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+								IL_0007: ldarg.2
+								IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+								IL_000d: ret
+							} // end of method FunctionObject_FunctionExpression_CD92AD5B_L57C31::ConstructCore
+
+						} // end of class FunctionObject_FunctionExpression_CD92AD5B_L57C31
+
 
 						// Methods
 						.method public hidebysig static 
@@ -403,7 +1112,7 @@
 								[2] object,
 								[3] object,
 								[4] object[],
-								[5] class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_71E42388_L61C28
+								[5] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionExpression_L61C27/FunctionObject_FunctionExpression_71E42388_L61C28
 							)
 
 							IL_0000: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/Scope::.ctor()
@@ -471,13 +1180,13 @@
 							IL_00ae: ldelem.ref
 							IL_00af: stelem.ref
 							IL_00b0: stloc.s 4
-							IL_00b2: newobj instance void FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_71E42388_L61C28::.ctor()
+							IL_00b2: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionExpression_L61C27/FunctionObject_FunctionExpression_71E42388_L61C28::.ctor()
 							IL_00b7: ldc.i4.0
 							IL_00b8: conv.r8
 							IL_00b9: ldstr ""
 							IL_00be: ldc.i4.0
 							IL_00bf: ldc.i4.1
-							IL_00c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_71E42388_L61C28>(!!0, float64, string, bool, bool)
+							IL_00c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionExpression_L61C27/FunctionObject_FunctionExpression_71E42388_L61C28>(!!0, float64, string, bool, bool)
 							IL_00c5: stloc.s 5
 							IL_00c7: ldloc.1
 							IL_00c8: ldstr "close"
@@ -517,6 +1226,134 @@
 
 					} // end of class Scope
 
+					.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D91593AD_L48C11
+						extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+					{
+						// Fields
+						.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope _environment0_Http_Agent_KeepAlive_Reuses_Connection
+						.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope _environment1_FunctionExpression_L19C30
+						.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope _environment2_FunctionExpression_L29C4
+						.field private initonly object[] _transitionalScopes
+
+						// Methods
+						.method public hidebysig specialname rtspecialname 
+							instance void .ctor (
+								class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope capture0,
+								class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope capture1,
+								class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope capture2,
+								object[] capture3
+							) cil managed 
+						{
+							// Method begins at RVA 0x2aee
+							// Header size: 1
+							// Code size: 36 (0x24)
+							.maxstack 8
+
+							IL_0000: ldarg.0
+							IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+							IL_0006: ldarg.0
+							IL_0007: ldarg.1
+							IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionObject_FunctionExpression_D91593AD_L48C11::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+							IL_000d: ldarg.0
+							IL_000e: ldarg.2
+							IL_000f: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionObject_FunctionExpression_D91593AD_L48C11::_environment1_FunctionExpression_L19C30
+							IL_0014: ldarg.0
+							IL_0015: ldarg.3
+							IL_0016: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionObject_FunctionExpression_D91593AD_L48C11::_environment2_FunctionExpression_L29C4
+							IL_001b: ldarg.0
+							IL_001c: ldarg.s capture3
+							IL_001e: stfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionObject_FunctionExpression_D91593AD_L48C11::_transitionalScopes
+							IL_0023: ret
+						} // end of method FunctionObject_FunctionExpression_D91593AD_L48C11::.ctor
+
+						.method public hidebysig specialname virtual 
+							instance bool get_IsConstructor () cil managed 
+						{
+							// Method begins at RVA 0x2b13
+							// Header size: 1
+							// Code size: 2 (0x2)
+							.maxstack 8
+
+							IL_0000: ldc.i4.1
+							IL_0001: ret
+						} // end of method FunctionObject_FunctionExpression_D91593AD_L48C11::get_IsConstructor
+
+						.method public hidebysig specialname virtual 
+							instance bool get_RequiresInvocationContext () cil managed 
+						{
+							// Method begins at RVA 0x2b16
+							// Header size: 1
+							// Code size: 2 (0x2)
+							.maxstack 8
+
+							IL_0000: ldc.i4.0
+							IL_0001: ret
+						} // end of method FunctionObject_FunctionExpression_D91593AD_L48C11::get_RequiresInvocationContext
+
+						.method family hidebysig virtual 
+							instance object CallCore (
+								object thisArgument,
+								[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+							) cil managed 
+						{
+							// Method begins at RVA 0x2b19
+							// Header size: 1
+							// Code size: 24 (0x18)
+							.maxstack 8
+
+							IL_0000: ldarg.0
+							IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionObject_FunctionExpression_D91593AD_L48C11::_transitionalScopes
+							IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+							IL_000b: ldarg.2
+							IL_000c: ldc.i4.0
+							IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+							IL_0012: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10::__js_call__(object[], object, object)
+							IL_0017: ret
+						} // end of method FunctionObject_FunctionExpression_D91593AD_L48C11::CallCore
+
+						.method family hidebysig virtual 
+							instance object ConstructBodyCore (
+								object receiver,
+								[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+								object newTarget
+							) cil managed 
+						{
+							// Method begins at RVA 0x2b32
+							// Header size: 1
+							// Code size: 20 (0x14)
+							.maxstack 8
+
+							IL_0000: ldarg.0
+							IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionObject_FunctionExpression_D91593AD_L48C11::_transitionalScopes
+							IL_0006: ldarg.3
+							IL_0007: ldarg.2
+							IL_0008: ldc.i4.0
+							IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+							IL_000e: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10::__js_call__(object[], object, object)
+							IL_0013: ret
+						} // end of method FunctionObject_FunctionExpression_D91593AD_L48C11::ConstructBodyCore
+
+						.method family hidebysig virtual 
+							instance object ConstructCore (
+								[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+								object newTarget
+							) cil managed 
+						{
+							// Method begins at RVA 0x2b47
+							// Header size: 1
+							// Code size: 14 (0xe)
+							.maxstack 8
+
+							IL_0000: ldarg.0
+							IL_0001: ldarg.1
+							IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+							IL_0007: ldarg.2
+							IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+							IL_000d: ret
+						} // end of method FunctionObject_FunctionExpression_D91593AD_L48C11::ConstructCore
+
+					} // end of class FunctionObject_FunctionExpression_D91593AD_L48C11
+
 
 					// Methods
 					.method public hidebysig static 
@@ -539,8 +1376,8 @@
 							[2] object,
 							[3] object,
 							[4] object[],
-							[5] class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_609C8B8A_L53C32,
-							[6] class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_CD92AD5B_L57C31
+							[5] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject_FunctionExpression_609C8B8A_L53C32,
+							[6] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject_FunctionExpression_CD92AD5B_L57C31
 						)
 
 						IL_0000: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope::.ctor()
@@ -626,13 +1463,13 @@
 						IL_00b1: ldelem.ref
 						IL_00b2: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope
 						IL_00b7: ldloc.s 4
-						IL_00b9: newobj instance void FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_609C8B8A_L53C32::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope, object[])
+						IL_00b9: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject_FunctionExpression_609C8B8A_L53C32::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope, object[])
 						IL_00be: ldc.i4.1
 						IL_00bf: conv.r8
 						IL_00c0: ldstr ""
 						IL_00c5: ldc.i4.0
 						IL_00c6: ldc.i4.1
-						IL_00c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_609C8B8A_L53C32>(!!0, float64, string, bool, bool)
+						IL_00c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31/FunctionObject_FunctionExpression_609C8B8A_L53C32>(!!0, float64, string, bool, bool)
 						IL_00cc: stloc.s 5
 						IL_00ce: ldloc.1
 						IL_00cf: ldstr "on"
@@ -691,13 +1528,13 @@
 						IL_012a: ldelem.ref
 						IL_012b: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope
 						IL_0130: ldloc.s 4
-						IL_0132: newobj instance void FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_CD92AD5B_L57C31::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope, object[])
+						IL_0132: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject_FunctionExpression_CD92AD5B_L57C31::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope, object[])
 						IL_0137: ldc.i4.0
 						IL_0138: conv.r8
 						IL_0139: ldstr ""
 						IL_013e: ldc.i4.0
 						IL_013f: ldc.i4.1
-						IL_0140: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_CD92AD5B_L57C31>(!!0, float64, string, bool, bool)
+						IL_0140: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionObject_FunctionExpression_CD92AD5B_L57C31>(!!0, float64, string, bool, bool)
 						IL_0145: stloc.s 6
 						IL_0147: ldloc.1
 						IL_0148: ldstr "on"
@@ -731,6 +1568,128 @@
 
 				} // end of class Scope
 
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D1A28085_L38C21
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope _environment0_Http_Agent_KeepAlive_Reuses_Connection
+					.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope _environment1_FunctionExpression_L19C30
+					.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope _environment2_FunctionExpression_L29C4
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope capture0,
+							class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope capture1,
+							class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope capture2,
+							object[] capture3
+						) cil managed 
+					{
+						// Method begins at RVA 0x2a94
+						// Header size: 1
+						// Code size: 36 (0x24)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject_FunctionExpression_D1A28085_L38C21::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject_FunctionExpression_D1A28085_L38C21::_environment1_FunctionExpression_L19C30
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject_FunctionExpression_D1A28085_L38C21::_environment2_FunctionExpression_L29C4
+						IL_001b: ldarg.0
+						IL_001c: ldarg.s capture3
+						IL_001e: stfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject_FunctionExpression_D1A28085_L38C21::_transitionalScopes
+						IL_0023: ret
+					} // end of method FunctionObject_FunctionExpression_D1A28085_L38C21::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x2ab9
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_D1A28085_L38C21::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x2abc
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_D1A28085_L38C21::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x2abf
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject_FunctionExpression_D1A28085_L38C21::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_D1A28085_L38C21::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x2ad1
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject_FunctionExpression_D1A28085_L38C21::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_D1A28085_L38C21::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x2adf
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_D1A28085_L38C21::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_D1A28085_L38C21
+
 
 				// Methods
 				.method public hidebysig static 
@@ -755,7 +1714,7 @@
 						[5] object,
 						[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 						[7] object[],
-						[8] class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_D91593AD_L48C11
+						[8] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionObject_FunctionExpression_D91593AD_L48C11
 					)
 
 					IL_0000: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/Scope::.ctor()
@@ -863,13 +1822,13 @@
 					IL_00fa: ldelem.ref
 					IL_00fb: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope
 					IL_0100: ldloc.s 7
-					IL_0102: newobj instance void FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_D91593AD_L48C11::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope, object[])
+					IL_0102: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionObject_FunctionExpression_D91593AD_L48C11::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope, object[])
 					IL_0107: ldc.i4.1
 					IL_0108: conv.r8
 					IL_0109: ldstr ""
 					IL_010e: ldc.i4.0
 					IL_010f: ldc.i4.1
-					IL_0110: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_D91593AD_L48C11>(!!0, float64, string, bool, bool)
+					IL_0110: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionObject_FunctionExpression_D91593AD_L48C11>(!!0, float64, string, bool, bool)
 					IL_0115: stloc.s 8
 					IL_0117: ldloc.s 4
 					IL_0119: ldstr "get"
@@ -910,6 +1869,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_40997E85_L29C5
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope _environment0_Http_Agent_KeepAlive_Reuses_Connection
+				.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope _environment1_FunctionExpression_L19C30
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope capture0,
+						class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x29cc
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionObject_FunctionExpression_40997E85_L29C5::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionObject_FunctionExpression_40997E85_L29C5::_environment1_FunctionExpression_L19C30
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionObject_FunctionExpression_40997E85_L29C5::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_40997E85_L29C5::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x29e9
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_40997E85_L29C5::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x29ec
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_40997E85_L29C5::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x29ef
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionObject_FunctionExpression_40997E85_L29C5::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_40997E85_L29C5::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2a08
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionObject_FunctionExpression_40997E85_L29C5::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_40997E85_L29C5::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2a1d
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_40997E85_L29C5::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_40997E85_L29C5
+
 
 			// Methods
 			.method public hidebysig static 
@@ -932,8 +2014,8 @@
 					[2] object,
 					[3] object,
 					[4] object[],
-					[5] class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_83707BD8_L34C22,
-					[6] class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_D1A28085_L38C21
+					[5] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject_FunctionExpression_83707BD8_L34C22,
+					[6] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject_FunctionExpression_D1A28085_L38C21
 				)
 
 				IL_0000: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope::.ctor()
@@ -1003,13 +2085,13 @@
 				IL_009c: ldelem.ref
 				IL_009d: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope
 				IL_00a2: ldloc.s 4
-				IL_00a4: newobj instance void FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_83707BD8_L34C22::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope, object[])
+				IL_00a4: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject_FunctionExpression_83707BD8_L34C22::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope, object[])
 				IL_00a9: ldc.i4.1
 				IL_00aa: conv.r8
 				IL_00ab: ldstr ""
 				IL_00b0: ldc.i4.0
 				IL_00b1: ldc.i4.1
-				IL_00b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_83707BD8_L34C22>(!!0, float64, string, bool, bool)
+				IL_00b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21/FunctionObject_FunctionExpression_83707BD8_L34C22>(!!0, float64, string, bool, bool)
 				IL_00b7: stloc.s 5
 				IL_00b9: ldloc.1
 				IL_00ba: ldstr "on"
@@ -1052,13 +2134,13 @@
 				IL_0100: ldelem.ref
 				IL_0101: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope
 				IL_0106: ldloc.s 4
-				IL_0108: newobj instance void FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_D1A28085_L38C21::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope, object[])
+				IL_0108: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject_FunctionExpression_D1A28085_L38C21::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope, object[])
 				IL_010d: ldc.i4.0
 				IL_010e: conv.r8
 				IL_010f: ldstr ""
 				IL_0114: ldc.i4.0
 				IL_0115: ldc.i4.1
-				IL_0116: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_D1A28085_L38C21>(!!0, float64, string, bool, bool)
+				IL_0116: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionObject_FunctionExpression_D1A28085_L38C21>(!!0, float64, string, bool, bool)
 				IL_011b: stloc.s 6
 				IL_011d: ldloc.1
 				IL_011e: ldstr "on"
@@ -1099,6 +2181,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B82FA783_L19C31
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope _environment0_Http_Agent_KeepAlive_Reuses_Connection
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2988
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionObject_FunctionExpression_B82FA783_L19C31::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_B82FA783_L19C31::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2997
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_B82FA783_L19C31::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x299a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_B82FA783_L19C31::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x299d
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionObject_FunctionExpression_B82FA783_L19C31::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_B82FA783_L19C31::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x29af
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionObject_FunctionExpression_B82FA783_L19C31::_environment0_Http_Agent_KeepAlive_Reuses_Connection
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_B82FA783_L19C31::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x29bd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_B82FA783_L19C31::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_B82FA783_L19C31
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1124,7 +2313,7 @@
 				[4] object,
 				[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[6] object[],
-				[7] class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_40997E85_L29C5
+				[7] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionObject_FunctionExpression_40997E85_L29C5
 			)
 
 			IL_0000: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope::.ctor()
@@ -1192,13 +2381,13 @@
 			IL_00ac: ldelem.ref
 			IL_00ad: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope
 			IL_00b2: ldloc.s 6
-			IL_00b4: newobj instance void FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_40997E85_L29C5::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, object[])
+			IL_00b4: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionObject_FunctionExpression_40997E85_L29C5::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope, object[])
 			IL_00b9: ldc.i4.1
 			IL_00ba: conv.r8
 			IL_00bb: ldstr ""
 			IL_00c0: ldc.i4.0
 			IL_00c1: ldc.i4.1
-			IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_40997E85_L29C5>(!!0, float64, string, bool, bool)
+			IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionObject_FunctionExpression_40997E85_L29C5>(!!0, float64, string, bool, bool)
 			IL_00c7: stloc.s 7
 			IL_00c9: ldloc.2
 			IL_00ca: ldstr "get"
@@ -1268,9 +2457,9 @@
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule,
 			[2] object,
 			[3] object[],
-			[4] class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_AD8A01FB_L9C34,
-			[5] class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_2B9E525E_L15C25,
-			[6] class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_B82FA783_L19C31
+			[4] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_server/FunctionObject_FunctionExpression_AD8A01FB_L9C34,
+			[5] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L15C24/FunctionObject_FunctionExpression_2B9E525E_L15C25,
+			[6] class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionObject_FunctionExpression_B82FA783_L19C31
 		)
 
 		IL_0000: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope::.ctor()
@@ -1327,13 +2516,13 @@
 		IL_008b: ldc.i4.0
 		IL_008c: ldelem.ref
 		IL_008d: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
-		IL_0092: newobj instance void FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_AD8A01FB_L9C34::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope)
+		IL_0092: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_server/FunctionObject_FunctionExpression_AD8A01FB_L9C34::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope)
 		IL_0097: ldc.i4.2
 		IL_0098: conv.r8
 		IL_0099: ldstr ""
 		IL_009e: ldc.i4.0
 		IL_009f: ldc.i4.1
-		IL_00a0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_AD8A01FB_L9C34>(!!0, float64, string, bool, bool)
+		IL_00a0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_server/FunctionObject_FunctionExpression_AD8A01FB_L9C34>(!!0, float64, string, bool, bool)
 		IL_00a5: stloc.s 4
 		IL_00a7: ldloc.1
 		IL_00a8: ldloc.s 4
@@ -1357,13 +2546,13 @@
 		IL_00cf: ldc.i4.0
 		IL_00d0: ldelem.ref
 		IL_00d1: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
-		IL_00d6: newobj instance void FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_2B9E525E_L15C25::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope)
+		IL_00d6: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L15C24/FunctionObject_FunctionExpression_2B9E525E_L15C25::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope)
 		IL_00db: ldc.i4.0
 		IL_00dc: conv.r8
 		IL_00dd: ldstr ""
 		IL_00e2: ldc.i4.0
 		IL_00e3: ldc.i4.1
-		IL_00e4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_2B9E525E_L15C25>(!!0, float64, string, bool, bool)
+		IL_00e4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L15C24/FunctionObject_FunctionExpression_2B9E525E_L15C25>(!!0, float64, string, bool, bool)
 		IL_00e9: stloc.s 5
 		IL_00eb: ldloc.2
 		IL_00ec: ldstr "on"
@@ -1386,13 +2575,13 @@
 		IL_0116: ldc.i4.0
 		IL_0117: ldelem.ref
 		IL_0118: castclass Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope
-		IL_011d: newobj instance void FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_B82FA783_L19C31::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope)
+		IL_011d: newobj instance void Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionObject_FunctionExpression_B82FA783_L19C31::.ctor(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope)
 		IL_0122: ldc.i4.0
 		IL_0123: conv.r8
 		IL_0124: ldstr ""
 		IL_0129: ldc.i4.0
 		IL_012a: ldc.i4.1
-		IL_012b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_B82FA783_L19C31>(!!0, float64, string, bool, bool)
+		IL_012b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionObject_FunctionExpression_B82FA783_L19C31>(!!0, float64, string, bool, bool)
 		IL_0130: stloc.s 6
 		IL_0132: ldloc.2
 		IL_0133: ldstr "listen"
@@ -1406,1195 +2595,6 @@
 	} // end of method Http_Agent_KeepAlive_Reuses_Connection::__js_module_init__
 
 } // end of class Modules.Http_Agent_KeepAlive_Reuses_Connection
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_AD8A01FB_L9C34
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope _environment0_Http_Agent_KeepAlive_Reuses_Connection
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x28e4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_AD8A01FB_L9C34::_environment0_Http_Agent_KeepAlive_Reuses_Connection
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_AD8A01FB_L9C34::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x28f3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_AD8A01FB_L9C34::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x28f6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_AD8A01FB_L9C34::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x28f9
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_AD8A01FB_L9C34::_environment0_Http_Agent_KeepAlive_Reuses_Connection
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_server::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionExpression_AD8A01FB_L9C34::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2919
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_AD8A01FB_L9C34::_environment0_Http_Agent_KeepAlive_Reuses_Connection
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_server::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionExpression_AD8A01FB_L9C34::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2935
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_AD8A01FB_L9C34::ConstructCore
-
-} // end of class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_AD8A01FB_L9C34
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_2B9E525E_L15C25
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope _environment0_Http_Agent_KeepAlive_Reuses_Connection
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2944
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_2B9E525E_L15C25::_environment0_Http_Agent_KeepAlive_Reuses_Connection
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2B9E525E_L15C25::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2953
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2B9E525E_L15C25::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2956
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2B9E525E_L15C25::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2959
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_2B9E525E_L15C25::_environment0_Http_Agent_KeepAlive_Reuses_Connection
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L15C24::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_2B9E525E_L15C25::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x296b
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_2B9E525E_L15C25::_environment0_Http_Agent_KeepAlive_Reuses_Connection
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L15C24::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_2B9E525E_L15C25::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2979
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2B9E525E_L15C25::ConstructCore
-
-} // end of class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_2B9E525E_L15C25
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_B82FA783_L19C31
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope _environment0_Http_Agent_KeepAlive_Reuses_Connection
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2988
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_B82FA783_L19C31::_environment0_Http_Agent_KeepAlive_Reuses_Connection
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_B82FA783_L19C31::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2997
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_B82FA783_L19C31::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x299a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_B82FA783_L19C31::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x299d
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_B82FA783_L19C31::_environment0_Http_Agent_KeepAlive_Reuses_Connection
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_B82FA783_L19C31::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29af
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_B82FA783_L19C31::_environment0_Http_Agent_KeepAlive_Reuses_Connection
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30::__js_call__(class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_B82FA783_L19C31::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29bd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_B82FA783_L19C31::ConstructCore
-
-} // end of class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_B82FA783_L19C31
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_40997E85_L29C5
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope _environment0_Http_Agent_KeepAlive_Reuses_Connection
-	.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope _environment1_FunctionExpression_L19C30
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope capture0,
-			class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x29cc
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_40997E85_L29C5::_environment0_Http_Agent_KeepAlive_Reuses_Connection
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_40997E85_L29C5::_environment1_FunctionExpression_L19C30
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_40997E85_L29C5::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_40997E85_L29C5::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x29e9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_40997E85_L29C5::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x29ec
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_40997E85_L29C5::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x29ef
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_40997E85_L29C5::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_40997E85_L29C5::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a08
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_40997E85_L29C5::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_40997E85_L29C5::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a1d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_40997E85_L29C5::ConstructCore
-
-} // end of class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_40997E85_L29C5
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_83707BD8_L34C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope _environment0_Http_Agent_KeepAlive_Reuses_Connection
-	.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope _environment1_FunctionExpression_L19C30
-	.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope _environment2_FunctionExpression_L29C4
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope capture0,
-			class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope capture1,
-			class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a2c
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_83707BD8_L34C22::_environment0_Http_Agent_KeepAlive_Reuses_Connection
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_83707BD8_L34C22::_environment1_FunctionExpression_L19C30
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_83707BD8_L34C22::_environment2_FunctionExpression_L29C4
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_83707BD8_L34C22::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_83707BD8_L34C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a51
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_83707BD8_L34C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a54
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_83707BD8_L34C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a57
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_83707BD8_L34C22::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_83707BD8_L34C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a70
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_83707BD8_L34C22::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L34C21::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_83707BD8_L34C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a85
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_83707BD8_L34C22::ConstructCore
-
-} // end of class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_83707BD8_L34C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_D1A28085_L38C21
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope _environment0_Http_Agent_KeepAlive_Reuses_Connection
-	.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope _environment1_FunctionExpression_L19C30
-	.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope _environment2_FunctionExpression_L29C4
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope capture0,
-			class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope capture1,
-			class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a94
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_D1A28085_L38C21::_environment0_Http_Agent_KeepAlive_Reuses_Connection
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_D1A28085_L38C21::_environment1_FunctionExpression_L19C30
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_D1A28085_L38C21::_environment2_FunctionExpression_L29C4
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_D1A28085_L38C21::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_D1A28085_L38C21::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2ab9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D1A28085_L38C21::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2abc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D1A28085_L38C21::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2abf
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_D1A28085_L38C21::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_D1A28085_L38C21::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ad1
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_D1A28085_L38C21::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_D1A28085_L38C21::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2adf
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D1A28085_L38C21::ConstructCore
-
-} // end of class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_D1A28085_L38C21
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_D91593AD_L48C11
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope _environment0_Http_Agent_KeepAlive_Reuses_Connection
-	.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope _environment1_FunctionExpression_L19C30
-	.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope _environment2_FunctionExpression_L29C4
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope capture0,
-			class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope capture1,
-			class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope capture2,
-			object[] capture3
-		) cil managed 
-	{
-		// Method begins at RVA 0x2aee
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_D91593AD_L48C11::_environment0_Http_Agent_KeepAlive_Reuses_Connection
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_D91593AD_L48C11::_environment1_FunctionExpression_L19C30
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_D91593AD_L48C11::_environment2_FunctionExpression_L29C4
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld object[] FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_D91593AD_L48C11::_transitionalScopes
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionExpression_D91593AD_L48C11::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2b13
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D91593AD_L48C11::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2b16
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D91593AD_L48C11::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b19
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_D91593AD_L48C11::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_D91593AD_L48C11::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b32
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_D91593AD_L48C11::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_D91593AD_L48C11::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b47
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D91593AD_L48C11::ConstructCore
-
-} // end of class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_D91593AD_L48C11
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_609C8B8A_L53C32
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope _environment0_Http_Agent_KeepAlive_Reuses_Connection
-	.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope _environment1_FunctionExpression_L19C30
-	.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope _environment2_FunctionExpression_L29C4
-	.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope _environment4_FunctionExpression_L48C10
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope capture0,
-			class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope capture1,
-			class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope capture2,
-			class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope capture3,
-			object[] capture4
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b56
-		// Header size: 1
-		// Code size: 44 (0x2c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_609C8B8A_L53C32::_environment0_Http_Agent_KeepAlive_Reuses_Connection
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_609C8B8A_L53C32::_environment1_FunctionExpression_L19C30
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_609C8B8A_L53C32::_environment2_FunctionExpression_L29C4
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_609C8B8A_L53C32::_environment4_FunctionExpression_L48C10
-		IL_0023: ldarg.0
-		IL_0024: ldarg.s capture4
-		IL_0026: stfld object[] FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_609C8B8A_L53C32::_transitionalScopes
-		IL_002b: ret
-	} // end of method FunctionObject_FunctionExpression_609C8B8A_L53C32::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2b83
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_609C8B8A_L53C32::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2b86
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_609C8B8A_L53C32::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b89
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_609C8B8A_L53C32::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_609C8B8A_L53C32::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ba2
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_609C8B8A_L53C32::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L53C31::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_609C8B8A_L53C32::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bb7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_609C8B8A_L53C32::ConstructCore
-
-} // end of class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_609C8B8A_L53C32
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_CD92AD5B_L57C31
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope _environment0_Http_Agent_KeepAlive_Reuses_Connection
-	.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope _environment1_FunctionExpression_L19C30
-	.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope _environment2_FunctionExpression_L29C4
-	.field private initonly class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope _environment4_FunctionExpression_L48C10
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope capture0,
-			class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope capture1,
-			class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope capture2,
-			class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope capture3,
-			object[] capture4
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bc6
-		// Header size: 1
-		// Code size: 44 (0x2c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/Scope FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_CD92AD5B_L57C31::_environment0_Http_Agent_KeepAlive_Reuses_Connection
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/Scope FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_CD92AD5B_L57C31::_environment1_FunctionExpression_L19C30
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/Scope FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_CD92AD5B_L57C31::_environment2_FunctionExpression_L29C4
-		IL_001b: ldarg.0
-		IL_001c: ldarg.s capture3
-		IL_001e: stfld class Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/Scope FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_CD92AD5B_L57C31::_environment4_FunctionExpression_L48C10
-		IL_0023: ldarg.0
-		IL_0024: ldarg.s capture4
-		IL_0026: stfld object[] FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_CD92AD5B_L57C31::_transitionalScopes
-		IL_002b: ret
-	} // end of method FunctionObject_FunctionExpression_CD92AD5B_L57C31::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2bf3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_CD92AD5B_L57C31::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2bf6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_CD92AD5B_L57C31::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bf9
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_CD92AD5B_L57C31::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_CD92AD5B_L57C31::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c0b
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_CD92AD5B_L57C31::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_CD92AD5B_L57C31::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c19
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_CD92AD5B_L57C31::ConstructCore
-
-} // end of class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_CD92AD5B_L57C31
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_71E42388_L61C28
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2c28
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_71E42388_L61C28::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2c30
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_71E42388_L61C28::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2c33
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_71E42388_L61C28::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c36
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionExpression_L61C27::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_71E42388_L61C28::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c42
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Http_Agent_KeepAlive_Reuses_Connection/FunctionExpression_L19C30/FunctionExpression_L29C4/FunctionExpression_L38C20/FunctionExpression_L48C10/FunctionExpression_L57C30/FunctionExpression_L61C27::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_71E42388_L61C28::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c4a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_71E42388_L61C28::ConstructCore
-
-} // end of class FunctionObjects.Http_Agent_KeepAlive_Reuses_Connection_0719F97F.FunctionObject_FunctionExpression_71E42388_L61C28
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_CreateServer_Get_Loopback.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_CreateServer_Get_Loopback.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0CFE5DC0_L5C34
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2614
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_0CFE5DC0_L5C34::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x261c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_0CFE5DC0_L5C34::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x261f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_0CFE5DC0_L5C34::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2622
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_server::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionExpression_0CFE5DC0_L5C34::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x263c
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_server::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionExpression_0CFE5DC0_L5C34::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2652
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_0CFE5DC0_L5C34::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_0CFE5DC0_L5C34
+
 
 		// Methods
 		.method public hidebysig static 
@@ -191,6 +298,129 @@
 
 				} // end of class Scope
 
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C8F0E4C7_L25C20
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Http_CreateServer_Get_Loopback/Scope _environment0_Http_CreateServer_Get_Loopback
+					.field private initonly class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope _environment2_FunctionExpression_L19C76
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Http_CreateServer_Get_Loopback/Scope capture0,
+							class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope capture1,
+							object[] capture2
+						) cil managed 
+					{
+						// Method begins at RVA 0x26fe
+						// Header size: 1
+						// Code size: 28 (0x1c)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Http_CreateServer_Get_Loopback/Scope Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19/FunctionObject_FunctionExpression_C8F0E4C7_L25C20::_environment0_Http_CreateServer_Get_Loopback
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19/FunctionObject_FunctionExpression_C8F0E4C7_L25C20::_environment2_FunctionExpression_L19C76
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld object[] Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19/FunctionObject_FunctionExpression_C8F0E4C7_L25C20::_transitionalScopes
+						IL_001b: ret
+					} // end of method FunctionObject_FunctionExpression_C8F0E4C7_L25C20::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x271b
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_C8F0E4C7_L25C20::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x271e
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_C8F0E4C7_L25C20::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x2721
+						// Header size: 1
+						// Code size: 24 (0x18)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19/FunctionObject_FunctionExpression_C8F0E4C7_L25C20::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: ldarg.2
+						IL_000c: ldc.i4.0
+						IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+						IL_0012: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19::__js_call__(object[], object, object)
+						IL_0017: ret
+					} // end of method FunctionObject_FunctionExpression_C8F0E4C7_L25C20::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x273a
+						// Header size: 1
+						// Code size: 20 (0x14)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19/FunctionObject_FunctionExpression_C8F0E4C7_L25C20::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: ldarg.2
+						IL_0008: ldc.i4.0
+						IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+						IL_000e: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19::__js_call__(object[], object, object)
+						IL_0013: ret
+					} // end of method FunctionObject_FunctionExpression_C8F0E4C7_L25C20::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x274f
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_C8F0E4C7_L25C20::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_C8F0E4C7_L25C20
+
 
 				// Methods
 				.method public hidebysig static 
@@ -262,6 +492,101 @@
 
 					} // end of class Scope
 
+					.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8F7EC3DF_L31C20
+						extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+					{
+						// Methods
+						.method public hidebysig specialname rtspecialname 
+							instance void .ctor () cil managed 
+						{
+							// Method begins at RVA 0x27b0
+							// Header size: 1
+							// Code size: 7 (0x7)
+							.maxstack 8
+
+							IL_0000: ldarg.0
+							IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+							IL_0006: ret
+						} // end of method FunctionObject_FunctionExpression_8F7EC3DF_L31C20::.ctor
+
+						.method public hidebysig specialname virtual 
+							instance bool get_IsConstructor () cil managed 
+						{
+							// Method begins at RVA 0x27b8
+							// Header size: 1
+							// Code size: 2 (0x2)
+							.maxstack 8
+
+							IL_0000: ldc.i4.1
+							IL_0001: ret
+						} // end of method FunctionObject_FunctionExpression_8F7EC3DF_L31C20::get_IsConstructor
+
+						.method public hidebysig specialname virtual 
+							instance bool get_RequiresInvocationContext () cil managed 
+						{
+							// Method begins at RVA 0x27bb
+							// Header size: 1
+							// Code size: 2 (0x2)
+							.maxstack 8
+
+							IL_0000: ldc.i4.0
+							IL_0001: ret
+						} // end of method FunctionObject_FunctionExpression_8F7EC3DF_L31C20::get_RequiresInvocationContext
+
+						.method family hidebysig virtual 
+							instance object CallCore (
+								object thisArgument,
+								[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+							) cil managed 
+						{
+							// Method begins at RVA 0x27be
+							// Header size: 1
+							// Code size: 11 (0xb)
+							.maxstack 8
+
+							IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+							IL_0005: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionExpression_L31C19::__js_call__(object)
+							IL_000a: ret
+						} // end of method FunctionObject_FunctionExpression_8F7EC3DF_L31C20::CallCore
+
+						.method family hidebysig virtual 
+							instance object ConstructBodyCore (
+								object receiver,
+								[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+								object newTarget
+							) cil managed 
+						{
+							// Method begins at RVA 0x27ca
+							// Header size: 1
+							// Code size: 7 (0x7)
+							.maxstack 8
+
+							IL_0000: ldarg.3
+							IL_0001: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionExpression_L31C19::__js_call__(object)
+							IL_0006: ret
+						} // end of method FunctionObject_FunctionExpression_8F7EC3DF_L31C20::ConstructBodyCore
+
+						.method family hidebysig virtual 
+							instance object ConstructCore (
+								[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+								object newTarget
+							) cil managed 
+						{
+							// Method begins at RVA 0x27d2
+							// Header size: 1
+							// Code size: 14 (0xe)
+							.maxstack 8
+
+							IL_0000: ldarg.0
+							IL_0001: ldarg.1
+							IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+							IL_0007: ldarg.2
+							IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+							IL_000d: ret
+						} // end of method FunctionObject_FunctionExpression_8F7EC3DF_L31C20::ConstructCore
+
+					} // end of class FunctionObject_FunctionExpression_8F7EC3DF_L31C20
+
 
 					// Methods
 					.method public hidebysig static 
@@ -310,6 +635,123 @@
 
 				} // end of class Scope
 
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_20E9685B_L29C19
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Http_CreateServer_Get_Loopback/Scope _environment0_Http_CreateServer_Get_Loopback
+					.field private initonly class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope _environment2_FunctionExpression_L19C76
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Http_CreateServer_Get_Loopback/Scope capture0,
+							class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope capture1,
+							object[] capture2
+						) cil managed 
+					{
+						// Method begins at RVA 0x275e
+						// Header size: 1
+						// Code size: 28 (0x1c)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Http_CreateServer_Get_Loopback/Scope Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionObject_FunctionExpression_20E9685B_L29C19::_environment0_Http_CreateServer_Get_Loopback
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionObject_FunctionExpression_20E9685B_L29C19::_environment2_FunctionExpression_L19C76
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld object[] Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionObject_FunctionExpression_20E9685B_L29C19::_transitionalScopes
+						IL_001b: ret
+					} // end of method FunctionObject_FunctionExpression_20E9685B_L29C19::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x277b
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_20E9685B_L29C19::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x277e
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_20E9685B_L29C19::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x2781
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionObject_FunctionExpression_20E9685B_L29C19::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_20E9685B_L29C19::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x2793
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionObject_FunctionExpression_20E9685B_L29C19::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_20E9685B_L29C19::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x27a1
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_20E9685B_L29C19::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_20E9685B_L29C19
+
 
 				// Methods
 				.method public hidebysig static 
@@ -331,7 +773,7 @@
 						[2] object,
 						[3] object,
 						[4] object[],
-						[5] class FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_8F7EC3DF_L31C20
+						[5] class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionExpression_L31C19/FunctionObject_FunctionExpression_8F7EC3DF_L31C20
 					)
 
 					IL_0000: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/Scope::.ctor()
@@ -371,13 +813,13 @@
 					IL_005a: ldelem.ref
 					IL_005b: stelem.ref
 					IL_005c: stloc.s 4
-					IL_005e: newobj instance void FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_8F7EC3DF_L31C20::.ctor()
+					IL_005e: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionExpression_L31C19/FunctionObject_FunctionExpression_8F7EC3DF_L31C20::.ctor()
 					IL_0063: ldc.i4.0
 					IL_0064: conv.r8
 					IL_0065: ldstr ""
 					IL_006a: ldc.i4.0
 					IL_006b: ldc.i4.1
-					IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_8F7EC3DF_L31C20>(!!0, float64, string, bool, bool)
+					IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionExpression_L31C19/FunctionObject_FunctionExpression_8F7EC3DF_L31C20>(!!0, float64, string, bool, bool)
 					IL_0071: stloc.s 5
 					IL_0073: ldloc.1
 					IL_0074: ldstr "close"
@@ -417,6 +859,124 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D2B33758_L19C77
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Http_CreateServer_Get_Loopback/Scope _environment0_Http_CreateServer_Get_Loopback
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Http_CreateServer_Get_Loopback/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x26a5
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Http_CreateServer_Get_Loopback/Scope Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionObject_FunctionExpression_D2B33758_L19C77::_environment0_Http_CreateServer_Get_Loopback
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionObject_FunctionExpression_D2B33758_L19C77::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionExpression_D2B33758_L19C77::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x26bb
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_D2B33758_L19C77::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x26be
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_D2B33758_L19C77::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x26c1
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionObject_FunctionExpression_D2B33758_L19C77::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_D2B33758_L19C77::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x26da
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionObject_FunctionExpression_D2B33758_L19C77::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_D2B33758_L19C77::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x26ef
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_D2B33758_L19C77::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_D2B33758_L19C77
+
 
 			// Methods
 			.method public hidebysig static 
@@ -439,8 +999,8 @@
 					[2] object,
 					[3] object,
 					[4] object[],
-					[5] class FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_C8F0E4C7_L25C20,
-					[6] class FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_20E9685B_L29C19
+					[5] class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19/FunctionObject_FunctionExpression_C8F0E4C7_L25C20,
+					[6] class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionObject_FunctionExpression_20E9685B_L29C19
 				)
 
 				IL_0000: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope::.ctor()
@@ -523,13 +1083,13 @@
 				IL_00c8: ldelem.ref
 				IL_00c9: castclass Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope
 				IL_00ce: ldloc.s 4
-				IL_00d0: newobj instance void FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_C8F0E4C7_L25C20::.ctor(class Modules.Http_CreateServer_Get_Loopback/Scope, class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope, object[])
+				IL_00d0: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19/FunctionObject_FunctionExpression_C8F0E4C7_L25C20::.ctor(class Modules.Http_CreateServer_Get_Loopback/Scope, class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope, object[])
 				IL_00d5: ldc.i4.1
 				IL_00d6: conv.r8
 				IL_00d7: ldstr ""
 				IL_00dc: ldc.i4.0
 				IL_00dd: ldc.i4.1
-				IL_00de: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_C8F0E4C7_L25C20>(!!0, float64, string, bool, bool)
+				IL_00de: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19/FunctionObject_FunctionExpression_C8F0E4C7_L25C20>(!!0, float64, string, bool, bool)
 				IL_00e3: stloc.s 5
 				IL_00e5: ldloc.1
 				IL_00e6: ldstr "on"
@@ -568,13 +1128,13 @@
 				IL_0123: ldelem.ref
 				IL_0124: castclass Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope
 				IL_0129: ldloc.s 4
-				IL_012b: newobj instance void FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_20E9685B_L29C19::.ctor(class Modules.Http_CreateServer_Get_Loopback/Scope, class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope, object[])
+				IL_012b: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionObject_FunctionExpression_20E9685B_L29C19::.ctor(class Modules.Http_CreateServer_Get_Loopback/Scope, class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope, object[])
 				IL_0130: ldc.i4.0
 				IL_0131: conv.r8
 				IL_0132: ldstr ""
 				IL_0137: ldc.i4.0
 				IL_0138: ldc.i4.1
-				IL_0139: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_20E9685B_L29C19>(!!0, float64, string, bool, bool)
+				IL_0139: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionObject_FunctionExpression_20E9685B_L29C19>(!!0, float64, string, bool, bool)
 				IL_013e: stloc.s 6
 				IL_0140: ldloc.1
 				IL_0141: ldstr "on"
@@ -608,6 +1168,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C45B3F96_L15C31
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Http_CreateServer_Get_Loopback/Scope _environment0_Http_CreateServer_Get_Loopback
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Http_CreateServer_Get_Loopback/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2661
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Http_CreateServer_Get_Loopback/Scope Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionObject_FunctionExpression_C45B3F96_L15C31::_environment0_Http_CreateServer_Get_Loopback
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_C45B3F96_L15C31::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2670
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C45B3F96_L15C31::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2673
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C45B3F96_L15C31::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2676
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Http_CreateServer_Get_Loopback/Scope Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionObject_FunctionExpression_C45B3F96_L15C31::_environment0_Http_CreateServer_Get_Loopback
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30::__js_call__(class Modules.Http_CreateServer_Get_Loopback/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_C45B3F96_L15C31::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2688
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Http_CreateServer_Get_Loopback/Scope Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionObject_FunctionExpression_C45B3F96_L15C31::_environment0_Http_CreateServer_Get_Loopback
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30::__js_call__(class Modules.Http_CreateServer_Get_Loopback/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_C45B3F96_L15C31::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2696
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_C45B3F96_L15C31::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_C45B3F96_L15C31
+
 
 		// Methods
 		.method public hidebysig static 
@@ -635,7 +1302,7 @@
 				[6] object,
 				[7] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule,
 				[8] object[],
-				[9] class FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_D2B33758_L19C77
+				[9] class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionObject_FunctionExpression_D2B33758_L19C77
 			)
 
 			IL_0000: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/Scope::.ctor()
@@ -726,13 +1393,13 @@
 			IL_00fa: ldelem.ref
 			IL_00fb: castclass Modules.Http_CreateServer_Get_Loopback/Scope
 			IL_0100: ldloc.s 8
-			IL_0102: newobj instance void FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_D2B33758_L19C77::.ctor(class Modules.Http_CreateServer_Get_Loopback/Scope, object[])
+			IL_0102: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionObject_FunctionExpression_D2B33758_L19C77::.ctor(class Modules.Http_CreateServer_Get_Loopback/Scope, object[])
 			IL_0107: ldc.i4.1
 			IL_0108: conv.r8
 			IL_0109: ldstr ""
 			IL_010e: ldc.i4.0
 			IL_010f: ldc.i4.1
-			IL_0110: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_D2B33758_L19C77>(!!0, float64, string, bool, bool)
+			IL_0110: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionObject_FunctionExpression_D2B33758_L19C77>(!!0, float64, string, bool, bool)
 			IL_0115: stloc.s 9
 			IL_0117: ldloc.s 7
 			IL_0119: ldstr "get"
@@ -794,9 +1461,9 @@
 			[0] class Modules.Http_CreateServer_Get_Loopback/Scope,
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule,
 			[2] object[],
-			[3] class FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_0CFE5DC0_L5C34,
+			[3] class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_server/FunctionObject_FunctionExpression_0CFE5DC0_L5C34,
 			[4] object,
-			[5] class FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_C45B3F96_L15C31
+			[5] class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionObject_FunctionExpression_C45B3F96_L15C31
 		)
 
 		IL_0000: newobj instance void Modules.Http_CreateServer_Get_Loopback/Scope::.ctor()
@@ -819,13 +1486,13 @@
 		IL_0029: ldloc.0
 		IL_002a: stelem.ref
 		IL_002b: stloc.2
-		IL_002c: newobj instance void FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_0CFE5DC0_L5C34::.ctor()
+		IL_002c: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_server/FunctionObject_FunctionExpression_0CFE5DC0_L5C34::.ctor()
 		IL_0031: ldc.i4.2
 		IL_0032: conv.r8
 		IL_0033: ldstr ""
 		IL_0038: ldc.i4.0
 		IL_0039: ldc.i4.1
-		IL_003a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_0CFE5DC0_L5C34>(!!0, float64, string, bool, bool)
+		IL_003a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_server/FunctionObject_FunctionExpression_0CFE5DC0_L5C34>(!!0, float64, string, bool, bool)
 		IL_003f: stloc.3
 		IL_0040: ldloc.1
 		IL_0041: ldloc.3
@@ -849,13 +1516,13 @@
 		IL_006a: ldc.i4.0
 		IL_006b: ldelem.ref
 		IL_006c: castclass Modules.Http_CreateServer_Get_Loopback/Scope
-		IL_0071: newobj instance void FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_C45B3F96_L15C31::.ctor(class Modules.Http_CreateServer_Get_Loopback/Scope)
+		IL_0071: newobj instance void Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionObject_FunctionExpression_C45B3F96_L15C31::.ctor(class Modules.Http_CreateServer_Get_Loopback/Scope)
 		IL_0076: ldc.i4.0
 		IL_0077: conv.r8
 		IL_0078: ldstr ""
 		IL_007d: ldc.i4.0
 		IL_007e: ldc.i4.1
-		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_C45B3F96_L15C31>(!!0, float64, string, bool, bool)
+		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionObject_FunctionExpression_C45B3F96_L15C31>(!!0, float64, string, bool, bool)
 		IL_0084: stloc.s 5
 		IL_0086: ldloc.s 4
 		IL_0088: ldstr "listen"
@@ -869,673 +1536,6 @@
 	} // end of method Http_CreateServer_Get_Loopback::__js_module_init__
 
 } // end of class Modules.Http_CreateServer_Get_Loopback
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_0CFE5DC0_L5C34
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2614
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_0CFE5DC0_L5C34::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x261c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_0CFE5DC0_L5C34::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x261f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_0CFE5DC0_L5C34::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2622
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_server::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_0CFE5DC0_L5C34::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x263c
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_server::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_0CFE5DC0_L5C34::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2652
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_0CFE5DC0_L5C34::ConstructCore
-
-} // end of class FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_0CFE5DC0_L5C34
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_C45B3F96_L15C31
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_CreateServer_Get_Loopback/Scope _environment0_Http_CreateServer_Get_Loopback
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_CreateServer_Get_Loopback/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2661
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_CreateServer_Get_Loopback/Scope FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_C45B3F96_L15C31::_environment0_Http_CreateServer_Get_Loopback
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C45B3F96_L15C31::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2670
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C45B3F96_L15C31::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2673
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C45B3F96_L15C31::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2676
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Http_CreateServer_Get_Loopback/Scope FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_C45B3F96_L15C31::_environment0_Http_CreateServer_Get_Loopback
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30::__js_call__(class Modules.Http_CreateServer_Get_Loopback/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_C45B3F96_L15C31::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2688
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Http_CreateServer_Get_Loopback/Scope FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_C45B3F96_L15C31::_environment0_Http_CreateServer_Get_Loopback
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30::__js_call__(class Modules.Http_CreateServer_Get_Loopback/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_C45B3F96_L15C31::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2696
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C45B3F96_L15C31::ConstructCore
-
-} // end of class FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_C45B3F96_L15C31
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_D2B33758_L19C77
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_CreateServer_Get_Loopback/Scope _environment0_Http_CreateServer_Get_Loopback
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_CreateServer_Get_Loopback/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x26a5
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_CreateServer_Get_Loopback/Scope FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_D2B33758_L19C77::_environment0_Http_CreateServer_Get_Loopback
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_D2B33758_L19C77::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_D2B33758_L19C77::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x26bb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D2B33758_L19C77::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x26be
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D2B33758_L19C77::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x26c1
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_D2B33758_L19C77::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_D2B33758_L19C77::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26da
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_D2B33758_L19C77::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_D2B33758_L19C77::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26ef
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D2B33758_L19C77::ConstructCore
-
-} // end of class FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_D2B33758_L19C77
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_C8F0E4C7_L25C20
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_CreateServer_Get_Loopback/Scope _environment0_Http_CreateServer_Get_Loopback
-	.field private initonly class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope _environment2_FunctionExpression_L19C76
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_CreateServer_Get_Loopback/Scope capture0,
-			class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x26fe
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_CreateServer_Get_Loopback/Scope FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_C8F0E4C7_L25C20::_environment0_Http_CreateServer_Get_Loopback
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_C8F0E4C7_L25C20::_environment2_FunctionExpression_L19C76
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_C8F0E4C7_L25C20::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_C8F0E4C7_L25C20::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x271b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C8F0E4C7_L25C20::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x271e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C8F0E4C7_L25C20::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2721
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_C8F0E4C7_L25C20::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_C8F0E4C7_L25C20::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x273a
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_C8F0E4C7_L25C20::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L25C19::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_C8F0E4C7_L25C20::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x274f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C8F0E4C7_L25C20::ConstructCore
-
-} // end of class FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_C8F0E4C7_L25C20
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_20E9685B_L29C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_CreateServer_Get_Loopback/Scope _environment0_Http_CreateServer_Get_Loopback
-	.field private initonly class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope _environment2_FunctionExpression_L19C76
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_CreateServer_Get_Loopback/Scope capture0,
-			class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x275e
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_CreateServer_Get_Loopback/Scope FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_20E9685B_L29C19::_environment0_Http_CreateServer_Get_Loopback
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/Scope FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_20E9685B_L29C19::_environment2_FunctionExpression_L19C76
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_20E9685B_L29C19::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_20E9685B_L29C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x277b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_20E9685B_L29C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x277e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_20E9685B_L29C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2781
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_20E9685B_L29C19::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_20E9685B_L29C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2793
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_20E9685B_L29C19::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_20E9685B_L29C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27a1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_20E9685B_L29C19::ConstructCore
-
-} // end of class FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_20E9685B_L29C19
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_8F7EC3DF_L31C20
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x27b0
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_8F7EC3DF_L31C20::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x27b8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_8F7EC3DF_L31C20::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x27bb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_8F7EC3DF_L31C20::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x27be
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionExpression_L31C19::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_8F7EC3DF_L31C20::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27ca
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Http_CreateServer_Get_Loopback/FunctionExpression_L15C30/FunctionExpression_L19C76/FunctionExpression_L29C18/FunctionExpression_L31C19::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_8F7EC3DF_L31C20::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27d2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_8F7EC3DF_L31C20::ConstructCore
-
-} // end of class FunctionObjects.Http_CreateServer_Get_Loopback_ADA51E3A.FunctionObject_FunctionExpression_8F7EC3DF_L31C20
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Post_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Post_Basic.verified.txt
@@ -35,6 +35,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_05E6B498_L9C18
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Http_Request_Post_Basic/Scope _environment0_Http_Request_Post_Basic
+				.field private initonly class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope _environment1_FunctionExpression_server
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Http_Request_Post_Basic/Scope capture0,
+						class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x286a
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_05E6B498_L9C18::_environment0_Http_Request_Post_Basic
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_05E6B498_L9C18::_environment1_FunctionExpression_server
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_05E6B498_L9C18::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_05E6B498_L9C18::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2887
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_05E6B498_L9C18::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x288a
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_05E6B498_L9C18::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x288d
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_05E6B498_L9C18::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_05E6B498_L9C18::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x28a6
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_05E6B498_L9C18::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_05E6B498_L9C18::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x28bb
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_05E6B498_L9C18::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_05E6B498_L9C18
+
 
 			// Methods
 			.method public hidebysig static 
@@ -101,6 +224,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9539117E_L13C17
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Http_Request_Post_Basic/Scope _environment0_Http_Request_Post_Basic
+				.field private initonly class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope _environment1_FunctionExpression_server
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Http_Request_Post_Basic/Scope capture0,
+						class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x28ca
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16/FunctionObject_FunctionExpression_9539117E_L13C17::_environment0_Http_Request_Post_Basic
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16/FunctionObject_FunctionExpression_9539117E_L13C17::_environment1_FunctionExpression_server
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16/FunctionObject_FunctionExpression_9539117E_L13C17::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_9539117E_L13C17::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x28e7
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_9539117E_L13C17::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x28ea
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_9539117E_L13C17::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x28ed
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16/FunctionObject_FunctionExpression_9539117E_L13C17::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_9539117E_L13C17::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x28ff
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16/FunctionObject_FunctionExpression_9539117E_L13C17::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_9539117E_L13C17::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x290d
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_9539117E_L13C17::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_9539117E_L13C17
 
 
 			// Methods
@@ -313,6 +553,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A159A473_L5C34
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Http_Request_Post_Basic/Scope _environment0_Http_Request_Post_Basic
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Http_Request_Post_Basic/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x280a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionObject_FunctionExpression_A159A473_L5C34::_environment0_Http_Request_Post_Basic
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_A159A473_L5C34::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2819
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A159A473_L5C34::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x281c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A159A473_L5C34::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x281f
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionObject_FunctionExpression_A159A473_L5C34::_environment0_Http_Request_Post_Basic
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Http_Request_Post_Basic/FunctionExpression_server::__js_call__(class Modules.Http_Request_Post_Basic/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionExpression_A159A473_L5C34::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x283f
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionObject_FunctionExpression_A159A473_L5C34::_environment0_Http_Request_Post_Basic
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Http_Request_Post_Basic/FunctionExpression_server::__js_call__(class Modules.Http_Request_Post_Basic/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionExpression_A159A473_L5C34::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x285b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_A159A473_L5C34::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_A159A473_L5C34
+
 
 		// Methods
 		.method public hidebysig static 
@@ -336,8 +695,8 @@
 				[0] class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope,
 				[1] object,
 				[2] object[],
-				[3] class FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_05E6B498_L9C18,
-				[4] class FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_9539117E_L13C17
+				[3] class Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_05E6B498_L9C18,
+				[4] class Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16/FunctionObject_FunctionExpression_9539117E_L13C17
 			)
 
 			IL_0000: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope::.ctor()
@@ -382,13 +741,13 @@
 			IL_005f: ldelem.ref
 			IL_0060: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
 			IL_0065: ldloc.2
-			IL_0066: newobj instance void FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_05E6B498_L9C18::.ctor(class Modules.Http_Request_Post_Basic/Scope, class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope, object[])
+			IL_0066: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_05E6B498_L9C18::.ctor(class Modules.Http_Request_Post_Basic/Scope, class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope, object[])
 			IL_006b: ldc.i4.1
 			IL_006c: conv.r8
 			IL_006d: ldstr ""
 			IL_0072: ldc.i4.0
 			IL_0073: ldc.i4.1
-			IL_0074: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_05E6B498_L9C18>(!!0, float64, string, bool, bool)
+			IL_0074: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_05E6B498_L9C18>(!!0, float64, string, bool, bool)
 			IL_0079: stloc.3
 			IL_007a: ldloc.1
 			IL_007b: ldstr "on"
@@ -420,13 +779,13 @@
 			IL_00b1: ldelem.ref
 			IL_00b2: castclass Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope
 			IL_00b7: ldloc.2
-			IL_00b8: newobj instance void FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_9539117E_L13C17::.ctor(class Modules.Http_Request_Post_Basic/Scope, class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope, object[])
+			IL_00b8: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16/FunctionObject_FunctionExpression_9539117E_L13C17::.ctor(class Modules.Http_Request_Post_Basic/Scope, class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope, object[])
 			IL_00bd: ldc.i4.0
 			IL_00be: conv.r8
 			IL_00bf: ldstr ""
 			IL_00c4: ldc.i4.0
 			IL_00c5: ldc.i4.1
-			IL_00c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_9539117E_L13C17>(!!0, float64, string, bool, bool)
+			IL_00c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16/FunctionObject_FunctionExpression_9539117E_L13C17>(!!0, float64, string, bool, bool)
 			IL_00cb: stloc.s 4
 			IL_00cd: ldloc.1
 			IL_00ce: ldstr "on"
@@ -471,6 +830,129 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_198EBA5C_L47C22
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Http_Request_Post_Basic/Scope _environment0_Http_Request_Post_Basic
+					.field private initonly class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope _environment2_FunctionExpression_req
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Http_Request_Post_Basic/Scope capture0,
+							class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope capture1,
+							object[] capture2
+						) cil managed 
+					{
+						// Method begins at RVA 0x29b9
+						// Header size: 1
+						// Code size: 28 (0x1c)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_198EBA5C_L47C22::_environment0_Http_Request_Post_Basic
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_198EBA5C_L47C22::_environment2_FunctionExpression_req
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_198EBA5C_L47C22::_transitionalScopes
+						IL_001b: ret
+					} // end of method FunctionObject_FunctionExpression_198EBA5C_L47C22::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x29d6
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_198EBA5C_L47C22::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x29d9
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_198EBA5C_L47C22::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x29dc
+						// Header size: 1
+						// Code size: 24 (0x18)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_198EBA5C_L47C22::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: ldarg.2
+						IL_000c: ldc.i4.0
+						IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+						IL_0012: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req::__js_call__(object[], object, object)
+						IL_0017: ret
+					} // end of method FunctionObject_FunctionExpression_198EBA5C_L47C22::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x29f5
+						// Header size: 1
+						// Code size: 20 (0x14)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_198EBA5C_L47C22::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: ldarg.2
+						IL_0008: ldc.i4.0
+						IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+						IL_000e: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req::__js_call__(object[], object, object)
+						IL_0013: ret
+					} // end of method FunctionObject_FunctionExpression_198EBA5C_L47C22::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x2a0a
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_198EBA5C_L47C22::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_198EBA5C_L47C22
 
 
 				// Methods
@@ -543,6 +1025,101 @@
 
 					} // end of class Scope
 
+					.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1E4A6C5B_L53C22
+						extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+					{
+						// Methods
+						.method public hidebysig specialname rtspecialname 
+							instance void .ctor () cil managed 
+						{
+							// Method begins at RVA 0x2a6b
+							// Header size: 1
+							// Code size: 7 (0x7)
+							.maxstack 8
+
+							IL_0000: ldarg.0
+							IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+							IL_0006: ret
+						} // end of method FunctionObject_FunctionExpression_1E4A6C5B_L53C22::.ctor
+
+						.method public hidebysig specialname virtual 
+							instance bool get_IsConstructor () cil managed 
+						{
+							// Method begins at RVA 0x2a73
+							// Header size: 1
+							// Code size: 2 (0x2)
+							.maxstack 8
+
+							IL_0000: ldc.i4.1
+							IL_0001: ret
+						} // end of method FunctionObject_FunctionExpression_1E4A6C5B_L53C22::get_IsConstructor
+
+						.method public hidebysig specialname virtual 
+							instance bool get_RequiresInvocationContext () cil managed 
+						{
+							// Method begins at RVA 0x2a76
+							// Header size: 1
+							// Code size: 2 (0x2)
+							.maxstack 8
+
+							IL_0000: ldc.i4.0
+							IL_0001: ret
+						} // end of method FunctionObject_FunctionExpression_1E4A6C5B_L53C22::get_RequiresInvocationContext
+
+						.method family hidebysig virtual 
+							instance object CallCore (
+								object thisArgument,
+								[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+							) cil managed 
+						{
+							// Method begins at RVA 0x2a79
+							// Header size: 1
+							// Code size: 11 (0xb)
+							.maxstack 8
+
+							IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+							IL_0005: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionExpression_req::__js_call__(object)
+							IL_000a: ret
+						} // end of method FunctionObject_FunctionExpression_1E4A6C5B_L53C22::CallCore
+
+						.method family hidebysig virtual 
+							instance object ConstructBodyCore (
+								object receiver,
+								[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+								object newTarget
+							) cil managed 
+						{
+							// Method begins at RVA 0x2a85
+							// Header size: 1
+							// Code size: 7 (0x7)
+							.maxstack 8
+
+							IL_0000: ldarg.3
+							IL_0001: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionExpression_req::__js_call__(object)
+							IL_0006: ret
+						} // end of method FunctionObject_FunctionExpression_1E4A6C5B_L53C22::ConstructBodyCore
+
+						.method family hidebysig virtual 
+							instance object ConstructCore (
+								[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+								object newTarget
+							) cil managed 
+						{
+							// Method begins at RVA 0x2a8d
+							// Header size: 1
+							// Code size: 14 (0xe)
+							.maxstack 8
+
+							IL_0000: ldarg.0
+							IL_0001: ldarg.1
+							IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+							IL_0007: ldarg.2
+							IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+							IL_000d: ret
+						} // end of method FunctionObject_FunctionExpression_1E4A6C5B_L53C22::ConstructCore
+
+					} // end of class FunctionObject_FunctionExpression_1E4A6C5B_L53C22
+
 
 					// Methods
 					.method public hidebysig static 
@@ -591,6 +1168,123 @@
 
 				} // end of class Scope
 
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F5C71F38_L51C21
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Http_Request_Post_Basic/Scope _environment0_Http_Request_Post_Basic
+					.field private initonly class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope _environment2_FunctionExpression_req
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Http_Request_Post_Basic/Scope capture0,
+							class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope capture1,
+							object[] capture2
+						) cil managed 
+					{
+						// Method begins at RVA 0x2a19
+						// Header size: 1
+						// Code size: 28 (0x1c)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionObject_FunctionExpression_F5C71F38_L51C21::_environment0_Http_Request_Post_Basic
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionObject_FunctionExpression_F5C71F38_L51C21::_environment2_FunctionExpression_req
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionObject_FunctionExpression_F5C71F38_L51C21::_transitionalScopes
+						IL_001b: ret
+					} // end of method FunctionObject_FunctionExpression_F5C71F38_L51C21::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x2a36
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_F5C71F38_L51C21::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x2a39
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_F5C71F38_L51C21::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x2a3c
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionObject_FunctionExpression_F5C71F38_L51C21::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_F5C71F38_L51C21::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x2a4e
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionObject_FunctionExpression_F5C71F38_L51C21::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_F5C71F38_L51C21::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x2a5c
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_F5C71F38_L51C21::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_F5C71F38_L51C21
+
 
 				// Methods
 				.method public hidebysig static 
@@ -612,7 +1306,7 @@
 						[2] object,
 						[3] object,
 						[4] object[],
-						[5] class FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_1E4A6C5B_L53C22
+						[5] class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionExpression_req/FunctionObject_FunctionExpression_1E4A6C5B_L53C22
 					)
 
 					IL_0000: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/Scope::.ctor()
@@ -652,13 +1346,13 @@
 					IL_005a: ldelem.ref
 					IL_005b: stelem.ref
 					IL_005c: stloc.s 4
-					IL_005e: newobj instance void FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_1E4A6C5B_L53C22::.ctor()
+					IL_005e: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionExpression_req/FunctionObject_FunctionExpression_1E4A6C5B_L53C22::.ctor()
 					IL_0063: ldc.i4.0
 					IL_0064: conv.r8
 					IL_0065: ldstr ""
 					IL_006a: ldc.i4.0
 					IL_006b: ldc.i4.1
-					IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_1E4A6C5B_L53C22>(!!0, float64, string, bool, bool)
+					IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionExpression_req/FunctionObject_FunctionExpression_1E4A6C5B_L53C22>(!!0, float64, string, bool, bool)
 					IL_0071: stloc.s 5
 					IL_0073: ldloc.1
 					IL_0074: ldstr "close"
@@ -699,6 +1393,124 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_15D5C424_L40C5
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Http_Request_Post_Basic/Scope _environment0_Http_Request_Post_Basic
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Http_Request_Post_Basic/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x2960
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionObject_FunctionExpression_15D5C424_L40C5::_environment0_Http_Request_Post_Basic
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionObject_FunctionExpression_15D5C424_L40C5::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionExpression_15D5C424_L40C5::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2976
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_15D5C424_L40C5::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2979
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_15D5C424_L40C5::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x297c
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionObject_FunctionExpression_15D5C424_L40C5::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_15D5C424_L40C5::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2995
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionObject_FunctionExpression_15D5C424_L40C5::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_15D5C424_L40C5::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x29aa
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_15D5C424_L40C5::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_15D5C424_L40C5
+
 
 			// Methods
 			.method public hidebysig static 
@@ -721,8 +1533,8 @@
 					[2] object,
 					[3] object,
 					[4] object[],
-					[5] class FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_198EBA5C_L47C22,
-					[6] class FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_F5C71F38_L51C21
+					[5] class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_198EBA5C_L47C22,
+					[6] class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionObject_FunctionExpression_F5C71F38_L51C21
 				)
 
 				IL_0000: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope::.ctor()
@@ -826,13 +1638,13 @@
 				IL_0109: ldelem.ref
 				IL_010a: castclass Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope
 				IL_010f: ldloc.s 4
-				IL_0111: newobj instance void FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_198EBA5C_L47C22::.ctor(class Modules.Http_Request_Post_Basic/Scope, class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope, object[])
+				IL_0111: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_198EBA5C_L47C22::.ctor(class Modules.Http_Request_Post_Basic/Scope, class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope, object[])
 				IL_0116: ldc.i4.1
 				IL_0117: conv.r8
 				IL_0118: ldstr ""
 				IL_011d: ldc.i4.0
 				IL_011e: ldc.i4.1
-				IL_011f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_198EBA5C_L47C22>(!!0, float64, string, bool, bool)
+				IL_011f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_198EBA5C_L47C22>(!!0, float64, string, bool, bool)
 				IL_0124: stloc.s 5
 				IL_0126: ldloc.1
 				IL_0127: ldstr "on"
@@ -871,13 +1683,13 @@
 				IL_0164: ldelem.ref
 				IL_0165: castclass Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope
 				IL_016a: ldloc.s 4
-				IL_016c: newobj instance void FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_F5C71F38_L51C21::.ctor(class Modules.Http_Request_Post_Basic/Scope, class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope, object[])
+				IL_016c: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionObject_FunctionExpression_F5C71F38_L51C21::.ctor(class Modules.Http_Request_Post_Basic/Scope, class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope, object[])
 				IL_0171: ldc.i4.0
 				IL_0172: conv.r8
 				IL_0173: ldstr ""
 				IL_0178: ldc.i4.0
 				IL_0179: ldc.i4.1
-				IL_017a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_F5C71F38_L51C21>(!!0, float64, string, bool, bool)
+				IL_017a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionObject_FunctionExpression_F5C71F38_L51C21>(!!0, float64, string, bool, bool)
 				IL_017f: stloc.s 6
 				IL_0181: ldloc.1
 				IL_0182: ldstr "on"
@@ -911,6 +1723,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_13DD647B_L28C31
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Http_Request_Post_Basic/Scope _environment0_Http_Request_Post_Basic
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Http_Request_Post_Basic/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x291c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionObject_FunctionExpression_13DD647B_L28C31::_environment0_Http_Request_Post_Basic
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_13DD647B_L28C31::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x292b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_13DD647B_L28C31::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x292e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_13DD647B_L28C31::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2931
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionObject_FunctionExpression_13DD647B_L28C31::_environment0_Http_Request_Post_Basic
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30::__js_call__(class Modules.Http_Request_Post_Basic/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_13DD647B_L28C31::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2943
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Http_Request_Post_Basic/Scope Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionObject_FunctionExpression_13DD647B_L28C31::_environment0_Http_Request_Post_Basic
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30::__js_call__(class Modules.Http_Request_Post_Basic/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_13DD647B_L28C31::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2951
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_13DD647B_L28C31::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_13DD647B_L28C31
+
 
 		// Methods
 		.method public hidebysig static 
@@ -936,7 +1855,7 @@
 				[4] object,
 				[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[6] object[],
-				[7] class FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_15D5C424_L40C5
+				[7] class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionObject_FunctionExpression_15D5C424_L40C5
 			)
 
 			IL_0000: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/Scope::.ctor()
@@ -1001,13 +1920,13 @@
 			IL_00b2: ldelem.ref
 			IL_00b3: castclass Modules.Http_Request_Post_Basic/Scope
 			IL_00b8: ldloc.s 6
-			IL_00ba: newobj instance void FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_15D5C424_L40C5::.ctor(class Modules.Http_Request_Post_Basic/Scope, object[])
+			IL_00ba: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionObject_FunctionExpression_15D5C424_L40C5::.ctor(class Modules.Http_Request_Post_Basic/Scope, object[])
 			IL_00bf: ldc.i4.1
 			IL_00c0: conv.r8
 			IL_00c1: ldstr ""
 			IL_00c6: ldc.i4.0
 			IL_00c7: ldc.i4.1
-			IL_00c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_15D5C424_L40C5>(!!0, float64, string, bool, bool)
+			IL_00c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionObject_FunctionExpression_15D5C424_L40C5>(!!0, float64, string, bool, bool)
 			IL_00cd: stloc.s 7
 			IL_00cf: ldstr "request"
 			IL_00d4: ldloc.s 5
@@ -1080,9 +1999,9 @@
 			[0] class Modules.Http_Request_Post_Basic/Scope,
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule,
 			[2] object[],
-			[3] class FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_A159A473_L5C34,
+			[3] class Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionObject_FunctionExpression_A159A473_L5C34,
 			[4] object,
-			[5] class FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_13DD647B_L28C31
+			[5] class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionObject_FunctionExpression_13DD647B_L28C31
 		)
 
 		IL_0000: newobj instance void Modules.Http_Request_Post_Basic/Scope::.ctor()
@@ -1109,13 +2028,13 @@
 		IL_002d: ldc.i4.0
 		IL_002e: ldelem.ref
 		IL_002f: castclass Modules.Http_Request_Post_Basic/Scope
-		IL_0034: newobj instance void FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_A159A473_L5C34::.ctor(class Modules.Http_Request_Post_Basic/Scope)
+		IL_0034: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionObject_FunctionExpression_A159A473_L5C34::.ctor(class Modules.Http_Request_Post_Basic/Scope)
 		IL_0039: ldc.i4.2
 		IL_003a: conv.r8
 		IL_003b: ldstr ""
 		IL_0040: ldc.i4.0
 		IL_0041: ldc.i4.1
-		IL_0042: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_A159A473_L5C34>(!!0, float64, string, bool, bool)
+		IL_0042: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionObject_FunctionExpression_A159A473_L5C34>(!!0, float64, string, bool, bool)
 		IL_0047: stloc.3
 		IL_0048: ldloc.1
 		IL_0049: ldloc.3
@@ -1139,13 +2058,13 @@
 		IL_0072: ldc.i4.0
 		IL_0073: ldelem.ref
 		IL_0074: castclass Modules.Http_Request_Post_Basic/Scope
-		IL_0079: newobj instance void FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_13DD647B_L28C31::.ctor(class Modules.Http_Request_Post_Basic/Scope)
+		IL_0079: newobj instance void Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionObject_FunctionExpression_13DD647B_L28C31::.ctor(class Modules.Http_Request_Post_Basic/Scope)
 		IL_007e: ldc.i4.0
 		IL_007f: conv.r8
 		IL_0080: ldstr ""
 		IL_0085: ldc.i4.0
 		IL_0086: ldc.i4.1
-		IL_0087: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_13DD647B_L28C31>(!!0, float64, string, bool, bool)
+		IL_0087: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionObject_FunctionExpression_13DD647B_L28C31>(!!0, float64, string, bool, bool)
 		IL_008c: stloc.s 5
 		IL_008e: ldloc.s 4
 		IL_0090: ldstr "listen"
@@ -1159,925 +2078,6 @@
 	} // end of method Http_Request_Post_Basic::__js_module_init__
 
 } // end of class Modules.Http_Request_Post_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_A159A473_L5C34
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_Request_Post_Basic/Scope _environment0_Http_Request_Post_Basic
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_Request_Post_Basic/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x280a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_Request_Post_Basic/Scope FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_A159A473_L5C34::_environment0_Http_Request_Post_Basic
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A159A473_L5C34::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2819
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A159A473_L5C34::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x281c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A159A473_L5C34::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x281f
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Http_Request_Post_Basic/Scope FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_A159A473_L5C34::_environment0_Http_Request_Post_Basic
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Http_Request_Post_Basic/FunctionExpression_server::__js_call__(class Modules.Http_Request_Post_Basic/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionExpression_A159A473_L5C34::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x283f
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Http_Request_Post_Basic/Scope FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_A159A473_L5C34::_environment0_Http_Request_Post_Basic
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Http_Request_Post_Basic/FunctionExpression_server::__js_call__(class Modules.Http_Request_Post_Basic/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionExpression_A159A473_L5C34::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x285b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A159A473_L5C34::ConstructCore
-
-} // end of class FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_A159A473_L5C34
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_05E6B498_L9C18
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_Request_Post_Basic/Scope _environment0_Http_Request_Post_Basic
-	.field private initonly class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope _environment1_FunctionExpression_server
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_Request_Post_Basic/Scope capture0,
-			class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x286a
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_Request_Post_Basic/Scope FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_05E6B498_L9C18::_environment0_Http_Request_Post_Basic
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_05E6B498_L9C18::_environment1_FunctionExpression_server
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_05E6B498_L9C18::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_05E6B498_L9C18::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2887
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_05E6B498_L9C18::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x288a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_05E6B498_L9C18::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x288d
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_05E6B498_L9C18::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_05E6B498_L9C18::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28a6
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_05E6B498_L9C18::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_05E6B498_L9C18::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28bb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_05E6B498_L9C18::ConstructCore
-
-} // end of class FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_05E6B498_L9C18
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_9539117E_L13C17
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_Request_Post_Basic/Scope _environment0_Http_Request_Post_Basic
-	.field private initonly class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope _environment1_FunctionExpression_server
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_Request_Post_Basic/Scope capture0,
-			class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x28ca
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_Request_Post_Basic/Scope FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_9539117E_L13C17::_environment0_Http_Request_Post_Basic
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Http_Request_Post_Basic/FunctionExpression_server/Scope FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_9539117E_L13C17::_environment1_FunctionExpression_server
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_9539117E_L13C17::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_9539117E_L13C17::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x28e7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9539117E_L13C17::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x28ea
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9539117E_L13C17::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x28ed
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_9539117E_L13C17::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_9539117E_L13C17::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28ff
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_9539117E_L13C17::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Http_Request_Post_Basic/FunctionExpression_server/FunctionExpression_server_L13C16::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_9539117E_L13C17::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x290d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_9539117E_L13C17::ConstructCore
-
-} // end of class FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_9539117E_L13C17
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_13DD647B_L28C31
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_Request_Post_Basic/Scope _environment0_Http_Request_Post_Basic
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_Request_Post_Basic/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x291c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_Request_Post_Basic/Scope FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_13DD647B_L28C31::_environment0_Http_Request_Post_Basic
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_13DD647B_L28C31::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x292b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_13DD647B_L28C31::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x292e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_13DD647B_L28C31::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2931
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Http_Request_Post_Basic/Scope FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_13DD647B_L28C31::_environment0_Http_Request_Post_Basic
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30::__js_call__(class Modules.Http_Request_Post_Basic/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_13DD647B_L28C31::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2943
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Http_Request_Post_Basic/Scope FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_13DD647B_L28C31::_environment0_Http_Request_Post_Basic
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30::__js_call__(class Modules.Http_Request_Post_Basic/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_13DD647B_L28C31::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2951
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_13DD647B_L28C31::ConstructCore
-
-} // end of class FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_13DD647B_L28C31
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_15D5C424_L40C5
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_Request_Post_Basic/Scope _environment0_Http_Request_Post_Basic
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_Request_Post_Basic/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x2960
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_Request_Post_Basic/Scope FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_15D5C424_L40C5::_environment0_Http_Request_Post_Basic
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_15D5C424_L40C5::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_15D5C424_L40C5::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2976
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_15D5C424_L40C5::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2979
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_15D5C424_L40C5::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x297c
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_15D5C424_L40C5::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_15D5C424_L40C5::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2995
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_15D5C424_L40C5::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_15D5C424_L40C5::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29aa
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_15D5C424_L40C5::ConstructCore
-
-} // end of class FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_15D5C424_L40C5
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_198EBA5C_L47C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_Request_Post_Basic/Scope _environment0_Http_Request_Post_Basic
-	.field private initonly class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope _environment2_FunctionExpression_req
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_Request_Post_Basic/Scope capture0,
-			class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x29b9
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_Request_Post_Basic/Scope FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_198EBA5C_L47C22::_environment0_Http_Request_Post_Basic
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_198EBA5C_L47C22::_environment2_FunctionExpression_req
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_198EBA5C_L47C22::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_198EBA5C_L47C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x29d6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_198EBA5C_L47C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x29d9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_198EBA5C_L47C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x29dc
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_198EBA5C_L47C22::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_198EBA5C_L47C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29f5
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_198EBA5C_L47C22::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_198EBA5C_L47C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a0a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_198EBA5C_L47C22::ConstructCore
-
-} // end of class FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_198EBA5C_L47C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_F5C71F38_L51C21
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_Request_Post_Basic/Scope _environment0_Http_Request_Post_Basic
-	.field private initonly class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope _environment2_FunctionExpression_req
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_Request_Post_Basic/Scope capture0,
-			class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a19
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_Request_Post_Basic/Scope FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_F5C71F38_L51C21::_environment0_Http_Request_Post_Basic
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/Scope FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_F5C71F38_L51C21::_environment2_FunctionExpression_req
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_F5C71F38_L51C21::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_F5C71F38_L51C21::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a36
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F5C71F38_L51C21::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a39
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F5C71F38_L51C21::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a3c
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_F5C71F38_L51C21::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_F5C71F38_L51C21::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a4e
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_F5C71F38_L51C21::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_F5C71F38_L51C21::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a5c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F5C71F38_L51C21::ConstructCore
-
-} // end of class FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_F5C71F38_L51C21
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_1E4A6C5B_L53C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2a6b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_1E4A6C5B_L53C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a73
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1E4A6C5B_L53C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a76
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1E4A6C5B_L53C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a79
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionExpression_req::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_1E4A6C5B_L53C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a85
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Http_Request_Post_Basic/FunctionExpression_L28C30/FunctionExpression_req/FunctionExpression_req_L51C20/FunctionExpression_req::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_1E4A6C5B_L53C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a8d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1E4A6C5B_L53C22::ConstructCore
-
-} // end of class FunctionObjects.Http_Request_Post_Basic_55CE7D03.FunctionObject_FunctionExpression_1E4A6C5B_L53C22
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Streaming_Chunked_RequestBody.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Request_Streaming_Chunked_RequestBody.verified.txt
@@ -35,6 +35,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_076D9C75_L13C18
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope _environment0_Http_Request_Streaming_Chunked_RequestBody
+				.field private initonly class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope _environment1_FunctionExpression_server
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope capture0,
+						class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2726
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_076D9C75_L13C18::_environment0_Http_Request_Streaming_Chunked_RequestBody
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_076D9C75_L13C18::_environment1_FunctionExpression_server
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_076D9C75_L13C18::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_076D9C75_L13C18::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2743
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_076D9C75_L13C18::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2746
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_076D9C75_L13C18::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2749
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_076D9C75_L13C18::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_076D9C75_L13C18::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2762
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_076D9C75_L13C18::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_076D9C75_L13C18::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2777
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_076D9C75_L13C18::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_076D9C75_L13C18
+
 
 			// Methods
 			.method public hidebysig static 
@@ -146,6 +269,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7DCB19C2_L19C17
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope _environment0_Http_Request_Streaming_Chunked_RequestBody
+				.field private initonly class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope _environment1_FunctionExpression_server
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope capture0,
+						class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2786
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16/FunctionObject_FunctionExpression_7DCB19C2_L19C17::_environment0_Http_Request_Streaming_Chunked_RequestBody
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16/FunctionObject_FunctionExpression_7DCB19C2_L19C17::_environment1_FunctionExpression_server
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16/FunctionObject_FunctionExpression_7DCB19C2_L19C17::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_7DCB19C2_L19C17::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x27a3
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_7DCB19C2_L19C17::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x27a6
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_7DCB19C2_L19C17::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x27a9
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16/FunctionObject_FunctionExpression_7DCB19C2_L19C17::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_7DCB19C2_L19C17::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x27bb
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16/FunctionObject_FunctionExpression_7DCB19C2_L19C17::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_7DCB19C2_L19C17::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x27c9
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_7DCB19C2_L19C17::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_7DCB19C2_L19C17
+
 
 			// Methods
 			.method public hidebysig static 
@@ -252,6 +492,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2B2BC7DD_L5C34
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope _environment0_Http_Request_Streaming_Chunked_RequestBody
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x26c6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionObject_FunctionExpression_2B2BC7DD_L5C34::_environment0_Http_Request_Streaming_Chunked_RequestBody
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_2B2BC7DD_L5C34::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x26d5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_2B2BC7DD_L5C34::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x26d8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_2B2BC7DD_L5C34::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x26db
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionObject_FunctionExpression_2B2BC7DD_L5C34::_environment0_Http_Request_Streaming_Chunked_RequestBody
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server::__js_call__(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionExpression_2B2BC7DD_L5C34::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26fb
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionObject_FunctionExpression_2B2BC7DD_L5C34::_environment0_Http_Request_Streaming_Chunked_RequestBody
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server::__js_call__(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionExpression_2B2BC7DD_L5C34::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2717
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_2B2BC7DD_L5C34::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_2B2BC7DD_L5C34
+
 
 		// Methods
 		.method public hidebysig static 
@@ -277,8 +636,8 @@
 				[2] object,
 				[3] object,
 				[4] object[],
-				[5] class FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_076D9C75_L13C18,
-				[6] class FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_7DCB19C2_L19C17
+				[5] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_076D9C75_L13C18,
+				[6] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16/FunctionObject_FunctionExpression_7DCB19C2_L19C17
 			)
 
 			IL_0000: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope::.ctor()
@@ -343,13 +702,13 @@
 			IL_00a6: ldelem.ref
 			IL_00a7: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope
 			IL_00ac: ldloc.s 4
-			IL_00ae: newobj instance void FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_076D9C75_L13C18::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope, object[])
+			IL_00ae: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_076D9C75_L13C18::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope, object[])
 			IL_00b3: ldc.i4.1
 			IL_00b4: conv.r8
 			IL_00b5: ldstr ""
 			IL_00ba: ldc.i4.0
 			IL_00bb: ldc.i4.1
-			IL_00bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_076D9C75_L13C18>(!!0, float64, string, bool, bool)
+			IL_00bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_076D9C75_L13C18>(!!0, float64, string, bool, bool)
 			IL_00c1: stloc.s 5
 			IL_00c3: ldloc.1
 			IL_00c4: ldstr "on"
@@ -380,13 +739,13 @@
 			IL_00f9: ldelem.ref
 			IL_00fa: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope
 			IL_00ff: ldloc.s 4
-			IL_0101: newobj instance void FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_7DCB19C2_L19C17::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope, object[])
+			IL_0101: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16/FunctionObject_FunctionExpression_7DCB19C2_L19C17::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope, object[])
 			IL_0106: ldc.i4.0
 			IL_0107: conv.r8
 			IL_0108: ldstr ""
 			IL_010d: ldc.i4.0
 			IL_010e: ldc.i4.1
-			IL_010f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_7DCB19C2_L19C17>(!!0, float64, string, bool, bool)
+			IL_010f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16/FunctionObject_FunctionExpression_7DCB19C2_L19C17>(!!0, float64, string, bool, bool)
 			IL_0114: stloc.s 6
 			IL_0116: ldloc.1
 			IL_0117: ldstr "on"
@@ -431,6 +790,129 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FBD7FA11_L42C22
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope _environment0_Http_Request_Streaming_Chunked_RequestBody
+					.field private initonly class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope _environment2_FunctionExpression_req
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope capture0,
+							class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope capture1,
+							object[] capture2
+						) cil managed 
+					{
+						// Method begins at RVA 0x2875
+						// Header size: 1
+						// Code size: 28 (0x1c)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_FBD7FA11_L42C22::_environment0_Http_Request_Streaming_Chunked_RequestBody
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_FBD7FA11_L42C22::_environment2_FunctionExpression_req
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_FBD7FA11_L42C22::_transitionalScopes
+						IL_001b: ret
+					} // end of method FunctionObject_FunctionExpression_FBD7FA11_L42C22::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x2892
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_FBD7FA11_L42C22::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x2895
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_FBD7FA11_L42C22::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x2898
+						// Header size: 1
+						// Code size: 24 (0x18)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_FBD7FA11_L42C22::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: ldarg.2
+						IL_000c: ldc.i4.0
+						IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+						IL_0012: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req::__js_call__(object[], object, object)
+						IL_0017: ret
+					} // end of method FunctionObject_FunctionExpression_FBD7FA11_L42C22::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x28b1
+						// Header size: 1
+						// Code size: 20 (0x14)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_FBD7FA11_L42C22::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: ldarg.2
+						IL_0008: ldc.i4.0
+						IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+						IL_000e: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req::__js_call__(object[], object, object)
+						IL_0013: ret
+					} // end of method FunctionObject_FunctionExpression_FBD7FA11_L42C22::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x28c6
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_FBD7FA11_L42C22::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_FBD7FA11_L42C22
 
 
 				// Methods
@@ -503,6 +985,101 @@
 
 					} // end of class Scope
 
+					.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_BB2FB49F_L48C22
+						extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+					{
+						// Methods
+						.method public hidebysig specialname rtspecialname 
+							instance void .ctor () cil managed 
+						{
+							// Method begins at RVA 0x2927
+							// Header size: 1
+							// Code size: 7 (0x7)
+							.maxstack 8
+
+							IL_0000: ldarg.0
+							IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+							IL_0006: ret
+						} // end of method FunctionObject_FunctionExpression_BB2FB49F_L48C22::.ctor
+
+						.method public hidebysig specialname virtual 
+							instance bool get_IsConstructor () cil managed 
+						{
+							// Method begins at RVA 0x292f
+							// Header size: 1
+							// Code size: 2 (0x2)
+							.maxstack 8
+
+							IL_0000: ldc.i4.1
+							IL_0001: ret
+						} // end of method FunctionObject_FunctionExpression_BB2FB49F_L48C22::get_IsConstructor
+
+						.method public hidebysig specialname virtual 
+							instance bool get_RequiresInvocationContext () cil managed 
+						{
+							// Method begins at RVA 0x2932
+							// Header size: 1
+							// Code size: 2 (0x2)
+							.maxstack 8
+
+							IL_0000: ldc.i4.0
+							IL_0001: ret
+						} // end of method FunctionObject_FunctionExpression_BB2FB49F_L48C22::get_RequiresInvocationContext
+
+						.method family hidebysig virtual 
+							instance object CallCore (
+								object thisArgument,
+								[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+							) cil managed 
+						{
+							// Method begins at RVA 0x2935
+							// Header size: 1
+							// Code size: 11 (0xb)
+							.maxstack 8
+
+							IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+							IL_0005: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionExpression_req::__js_call__(object)
+							IL_000a: ret
+						} // end of method FunctionObject_FunctionExpression_BB2FB49F_L48C22::CallCore
+
+						.method family hidebysig virtual 
+							instance object ConstructBodyCore (
+								object receiver,
+								[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+								object newTarget
+							) cil managed 
+						{
+							// Method begins at RVA 0x2941
+							// Header size: 1
+							// Code size: 7 (0x7)
+							.maxstack 8
+
+							IL_0000: ldarg.3
+							IL_0001: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionExpression_req::__js_call__(object)
+							IL_0006: ret
+						} // end of method FunctionObject_FunctionExpression_BB2FB49F_L48C22::ConstructBodyCore
+
+						.method family hidebysig virtual 
+							instance object ConstructCore (
+								[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+								object newTarget
+							) cil managed 
+						{
+							// Method begins at RVA 0x2949
+							// Header size: 1
+							// Code size: 14 (0xe)
+							.maxstack 8
+
+							IL_0000: ldarg.0
+							IL_0001: ldarg.1
+							IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+							IL_0007: ldarg.2
+							IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+							IL_000d: ret
+						} // end of method FunctionObject_FunctionExpression_BB2FB49F_L48C22::ConstructCore
+
+					} // end of class FunctionObject_FunctionExpression_BB2FB49F_L48C22
+
 
 					// Methods
 					.method public hidebysig static 
@@ -551,6 +1128,123 @@
 
 				} // end of class Scope
 
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_66CE18BC_L46C21
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope _environment0_Http_Request_Streaming_Chunked_RequestBody
+					.field private initonly class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope _environment2_FunctionExpression_req
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope capture0,
+							class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope capture1,
+							object[] capture2
+						) cil managed 
+					{
+						// Method begins at RVA 0x28d5
+						// Header size: 1
+						// Code size: 28 (0x1c)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionObject_FunctionExpression_66CE18BC_L46C21::_environment0_Http_Request_Streaming_Chunked_RequestBody
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionObject_FunctionExpression_66CE18BC_L46C21::_environment2_FunctionExpression_req
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionObject_FunctionExpression_66CE18BC_L46C21::_transitionalScopes
+						IL_001b: ret
+					} // end of method FunctionObject_FunctionExpression_66CE18BC_L46C21::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x28f2
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_66CE18BC_L46C21::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x28f5
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_66CE18BC_L46C21::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x28f8
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionObject_FunctionExpression_66CE18BC_L46C21::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_66CE18BC_L46C21::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x290a
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionObject_FunctionExpression_66CE18BC_L46C21::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_66CE18BC_L46C21::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x2918
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_66CE18BC_L46C21::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_66CE18BC_L46C21
+
 
 				// Methods
 				.method public hidebysig static 
@@ -572,7 +1266,7 @@
 						[2] object,
 						[3] object,
 						[4] object[],
-						[5] class FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_BB2FB49F_L48C22
+						[5] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionExpression_req/FunctionObject_FunctionExpression_BB2FB49F_L48C22
 					)
 
 					IL_0000: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/Scope::.ctor()
@@ -612,13 +1306,13 @@
 					IL_005a: ldelem.ref
 					IL_005b: stelem.ref
 					IL_005c: stloc.s 4
-					IL_005e: newobj instance void FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_BB2FB49F_L48C22::.ctor()
+					IL_005e: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionExpression_req/FunctionObject_FunctionExpression_BB2FB49F_L48C22::.ctor()
 					IL_0063: ldc.i4.0
 					IL_0064: conv.r8
 					IL_0065: ldstr ""
 					IL_006a: ldc.i4.0
 					IL_006b: ldc.i4.1
-					IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_BB2FB49F_L48C22>(!!0, float64, string, bool, bool)
+					IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionExpression_req/FunctionObject_FunctionExpression_BB2FB49F_L48C22>(!!0, float64, string, bool, bool)
 					IL_0071: stloc.s 5
 					IL_0073: ldloc.1
 					IL_0074: ldstr "close"
@@ -659,6 +1353,124 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2B333867_L38C5
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope _environment0_Http_Request_Streaming_Chunked_RequestBody
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x281c
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionObject_FunctionExpression_2B333867_L38C5::_environment0_Http_Request_Streaming_Chunked_RequestBody
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionObject_FunctionExpression_2B333867_L38C5::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionExpression_2B333867_L38C5::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2832
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_2B333867_L38C5::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2835
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_2B333867_L38C5::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2838
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionObject_FunctionExpression_2B333867_L38C5::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_2B333867_L38C5::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2851
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionObject_FunctionExpression_2B333867_L38C5::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_2B333867_L38C5::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2866
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_2B333867_L38C5::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_2B333867_L38C5
+
 
 			// Methods
 			.method public hidebysig static 
@@ -679,8 +1491,8 @@
 					[0] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope,
 					[1] object,
 					[2] object[],
-					[3] class FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_FBD7FA11_L42C22,
-					[4] class FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_66CE18BC_L46C21
+					[3] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_FBD7FA11_L42C22,
+					[4] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionObject_FunctionExpression_66CE18BC_L46C21
 				)
 
 				IL_0000: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope::.ctor()
@@ -725,13 +1537,13 @@
 				IL_004f: ldelem.ref
 				IL_0050: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope
 				IL_0055: ldloc.2
-				IL_0056: newobj instance void FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_FBD7FA11_L42C22::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope, object[])
+				IL_0056: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_FBD7FA11_L42C22::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope, object[])
 				IL_005b: ldc.i4.1
 				IL_005c: conv.r8
 				IL_005d: ldstr ""
 				IL_0062: ldc.i4.0
 				IL_0063: ldc.i4.1
-				IL_0064: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_FBD7FA11_L42C22>(!!0, float64, string, bool, bool)
+				IL_0064: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req/FunctionObject_FunctionExpression_FBD7FA11_L42C22>(!!0, float64, string, bool, bool)
 				IL_0069: stloc.3
 				IL_006a: ldloc.1
 				IL_006b: ldstr "on"
@@ -770,13 +1582,13 @@
 				IL_00a4: ldelem.ref
 				IL_00a5: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope
 				IL_00aa: ldloc.2
-				IL_00ab: newobj instance void FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_66CE18BC_L46C21::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope, object[])
+				IL_00ab: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionObject_FunctionExpression_66CE18BC_L46C21::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope, object[])
 				IL_00b0: ldc.i4.0
 				IL_00b1: conv.r8
 				IL_00b2: ldstr ""
 				IL_00b7: ldc.i4.0
 				IL_00b8: ldc.i4.1
-				IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_66CE18BC_L46C21>(!!0, float64, string, bool, bool)
+				IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionObject_FunctionExpression_66CE18BC_L46C21>(!!0, float64, string, bool, bool)
 				IL_00be: stloc.s 4
 				IL_00c0: ldloc.1
 				IL_00c1: ldstr "on"
@@ -810,6 +1622,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A86A20EB_L26C31
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope _environment0_Http_Request_Streaming_Chunked_RequestBody
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x27d8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionObject_FunctionExpression_A86A20EB_L26C31::_environment0_Http_Request_Streaming_Chunked_RequestBody
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_A86A20EB_L26C31::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x27e7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A86A20EB_L26C31::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x27ea
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A86A20EB_L26C31::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x27ed
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionObject_FunctionExpression_A86A20EB_L26C31::_environment0_Http_Request_Streaming_Chunked_RequestBody
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30::__js_call__(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_A86A20EB_L26C31::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x27ff
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionObject_FunctionExpression_A86A20EB_L26C31::_environment0_Http_Request_Streaming_Chunked_RequestBody
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30::__js_call__(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_A86A20EB_L26C31::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x280d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_A86A20EB_L26C31::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_A86A20EB_L26C31
+
 
 		// Methods
 		.method public hidebysig static 
@@ -835,7 +1754,7 @@
 				[4] object,
 				[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[6] object[],
-				[7] class FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_2B333867_L38C5
+				[7] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionObject_FunctionExpression_2B333867_L38C5
 			)
 
 			IL_0000: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/Scope::.ctor()
@@ -900,13 +1819,13 @@
 			IL_00b2: ldelem.ref
 			IL_00b3: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/Scope
 			IL_00b8: ldloc.s 6
-			IL_00ba: newobj instance void FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_2B333867_L38C5::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, object[])
+			IL_00ba: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionObject_FunctionExpression_2B333867_L38C5::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, object[])
 			IL_00bf: ldc.i4.1
 			IL_00c0: conv.r8
 			IL_00c1: ldstr ""
 			IL_00c6: ldc.i4.0
 			IL_00c7: ldc.i4.1
-			IL_00c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_2B333867_L38C5>(!!0, float64, string, bool, bool)
+			IL_00c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionObject_FunctionExpression_2B333867_L38C5>(!!0, float64, string, bool, bool)
 			IL_00cd: stloc.s 7
 			IL_00cf: ldstr "request"
 			IL_00d4: ldloc.s 5
@@ -979,9 +1898,9 @@
 			[0] class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope,
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule,
 			[2] object[],
-			[3] class FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_2B2BC7DD_L5C34,
+			[3] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionObject_FunctionExpression_2B2BC7DD_L5C34,
 			[4] object,
-			[5] class FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_A86A20EB_L26C31
+			[5] class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionObject_FunctionExpression_A86A20EB_L26C31
 		)
 
 		IL_0000: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/Scope::.ctor()
@@ -1008,13 +1927,13 @@
 		IL_002d: ldc.i4.0
 		IL_002e: ldelem.ref
 		IL_002f: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/Scope
-		IL_0034: newobj instance void FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_2B2BC7DD_L5C34::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope)
+		IL_0034: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionObject_FunctionExpression_2B2BC7DD_L5C34::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope)
 		IL_0039: ldc.i4.2
 		IL_003a: conv.r8
 		IL_003b: ldstr ""
 		IL_0040: ldc.i4.0
 		IL_0041: ldc.i4.1
-		IL_0042: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_2B2BC7DD_L5C34>(!!0, float64, string, bool, bool)
+		IL_0042: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionObject_FunctionExpression_2B2BC7DD_L5C34>(!!0, float64, string, bool, bool)
 		IL_0047: stloc.3
 		IL_0048: ldloc.1
 		IL_0049: ldloc.3
@@ -1038,13 +1957,13 @@
 		IL_0072: ldc.i4.0
 		IL_0073: ldelem.ref
 		IL_0074: castclass Modules.Http_Request_Streaming_Chunked_RequestBody/Scope
-		IL_0079: newobj instance void FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_A86A20EB_L26C31::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope)
+		IL_0079: newobj instance void Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionObject_FunctionExpression_A86A20EB_L26C31::.ctor(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope)
 		IL_007e: ldc.i4.0
 		IL_007f: conv.r8
 		IL_0080: ldstr ""
 		IL_0085: ldc.i4.0
 		IL_0086: ldc.i4.1
-		IL_0087: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_A86A20EB_L26C31>(!!0, float64, string, bool, bool)
+		IL_0087: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionObject_FunctionExpression_A86A20EB_L26C31>(!!0, float64, string, bool, bool)
 		IL_008c: stloc.s 5
 		IL_008e: ldloc.s 4
 		IL_0090: ldstr "listen"
@@ -1058,925 +1977,6 @@
 	} // end of method Http_Request_Streaming_Chunked_RequestBody::__js_module_init__
 
 } // end of class Modules.Http_Request_Streaming_Chunked_RequestBody
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_2B2BC7DD_L5C34
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope _environment0_Http_Request_Streaming_Chunked_RequestBody
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x26c6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_2B2BC7DD_L5C34::_environment0_Http_Request_Streaming_Chunked_RequestBody
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2B2BC7DD_L5C34::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x26d5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2B2BC7DD_L5C34::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x26d8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2B2BC7DD_L5C34::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x26db
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_2B2BC7DD_L5C34::_environment0_Http_Request_Streaming_Chunked_RequestBody
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server::__js_call__(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionExpression_2B2BC7DD_L5C34::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26fb
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_2B2BC7DD_L5C34::_environment0_Http_Request_Streaming_Chunked_RequestBody
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server::__js_call__(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionExpression_2B2BC7DD_L5C34::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2717
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2B2BC7DD_L5C34::ConstructCore
-
-} // end of class FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_2B2BC7DD_L5C34
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_076D9C75_L13C18
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope _environment0_Http_Request_Streaming_Chunked_RequestBody
-	.field private initonly class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope _environment1_FunctionExpression_server
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope capture0,
-			class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2726
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_076D9C75_L13C18::_environment0_Http_Request_Streaming_Chunked_RequestBody
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_076D9C75_L13C18::_environment1_FunctionExpression_server
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_076D9C75_L13C18::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_076D9C75_L13C18::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2743
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_076D9C75_L13C18::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2746
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_076D9C75_L13C18::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2749
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_076D9C75_L13C18::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_076D9C75_L13C18::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2762
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_076D9C75_L13C18::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_076D9C75_L13C18::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2777
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_076D9C75_L13C18::ConstructCore
-
-} // end of class FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_076D9C75_L13C18
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_7DCB19C2_L19C17
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope _environment0_Http_Request_Streaming_Chunked_RequestBody
-	.field private initonly class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope _environment1_FunctionExpression_server
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope capture0,
-			class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2786
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_7DCB19C2_L19C17::_environment0_Http_Request_Streaming_Chunked_RequestBody
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/Scope FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_7DCB19C2_L19C17::_environment1_FunctionExpression_server
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_7DCB19C2_L19C17::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_7DCB19C2_L19C17::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x27a3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7DCB19C2_L19C17::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x27a6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7DCB19C2_L19C17::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x27a9
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_7DCB19C2_L19C17::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_7DCB19C2_L19C17::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27bb
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_7DCB19C2_L19C17::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_server/FunctionExpression_server_L19C16::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_7DCB19C2_L19C17::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27c9
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7DCB19C2_L19C17::ConstructCore
-
-} // end of class FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_7DCB19C2_L19C17
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_A86A20EB_L26C31
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope _environment0_Http_Request_Streaming_Chunked_RequestBody
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x27d8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_A86A20EB_L26C31::_environment0_Http_Request_Streaming_Chunked_RequestBody
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A86A20EB_L26C31::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x27e7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A86A20EB_L26C31::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x27ea
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A86A20EB_L26C31::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x27ed
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_A86A20EB_L26C31::_environment0_Http_Request_Streaming_Chunked_RequestBody
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30::__js_call__(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_A86A20EB_L26C31::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27ff
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_A86A20EB_L26C31::_environment0_Http_Request_Streaming_Chunked_RequestBody
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30::__js_call__(class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_A86A20EB_L26C31::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x280d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A86A20EB_L26C31::ConstructCore
-
-} // end of class FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_A86A20EB_L26C31
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_2B333867_L38C5
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope _environment0_Http_Request_Streaming_Chunked_RequestBody
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x281c
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_2B333867_L38C5::_environment0_Http_Request_Streaming_Chunked_RequestBody
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_2B333867_L38C5::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_2B333867_L38C5::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2832
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2B333867_L38C5::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2835
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2B333867_L38C5::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2838
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_2B333867_L38C5::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_2B333867_L38C5::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2851
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_2B333867_L38C5::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_2B333867_L38C5::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2866
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2B333867_L38C5::ConstructCore
-
-} // end of class FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_2B333867_L38C5
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_FBD7FA11_L42C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope _environment0_Http_Request_Streaming_Chunked_RequestBody
-	.field private initonly class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope _environment2_FunctionExpression_req
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope capture0,
-			class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2875
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_FBD7FA11_L42C22::_environment0_Http_Request_Streaming_Chunked_RequestBody
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_FBD7FA11_L42C22::_environment2_FunctionExpression_req
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_FBD7FA11_L42C22::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_FBD7FA11_L42C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2892
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FBD7FA11_L42C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2895
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FBD7FA11_L42C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2898
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_FBD7FA11_L42C22::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_FBD7FA11_L42C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28b1
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_FBD7FA11_L42C22::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_FBD7FA11_L42C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28c6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_FBD7FA11_L42C22::ConstructCore
-
-} // end of class FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_FBD7FA11_L42C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_66CE18BC_L46C21
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope _environment0_Http_Request_Streaming_Chunked_RequestBody
-	.field private initonly class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope _environment2_FunctionExpression_req
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope capture0,
-			class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x28d5
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/Scope FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_66CE18BC_L46C21::_environment0_Http_Request_Streaming_Chunked_RequestBody
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/Scope FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_66CE18BC_L46C21::_environment2_FunctionExpression_req
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_66CE18BC_L46C21::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_66CE18BC_L46C21::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x28f2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_66CE18BC_L46C21::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x28f5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_66CE18BC_L46C21::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x28f8
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_66CE18BC_L46C21::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_66CE18BC_L46C21::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x290a
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_66CE18BC_L46C21::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_66CE18BC_L46C21::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2918
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_66CE18BC_L46C21::ConstructCore
-
-} // end of class FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_66CE18BC_L46C21
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_BB2FB49F_L48C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2927
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_BB2FB49F_L48C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x292f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_BB2FB49F_L48C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2932
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_BB2FB49F_L48C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2935
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionExpression_req::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_BB2FB49F_L48C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2941
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Http_Request_Streaming_Chunked_RequestBody/FunctionExpression_L26C30/FunctionExpression_req/FunctionExpression_req_L46C20/FunctionExpression_req::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_BB2FB49F_L48C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2949
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_BB2FB49F_L48C22::ConstructCore
-
-} // end of class FunctionObjects.Http_Request_Streaming_Chunked_RequestBody_74290A51.FunctionObject_FunctionExpression_BB2FB49F_L48C22
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Response_Streaming_Chunked_ResponseBody.verified.txt
+++ b/tests/Jroc.Tests/Node/Http/Snapshots/GeneratorTests.Http_Response_Streaming_Chunked_ResponseBody.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C2820861_L5C34
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x252f
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_C2820861_L5C34::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2537
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C2820861_L5C34::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x253a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C2820861_L5C34::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x253d
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_server::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionExpression_C2820861_L5C34::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2557
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_server::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionExpression_C2820861_L5C34::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x256d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_C2820861_L5C34::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_C2820861_L5C34
+
 
 		// Methods
 		.method public hidebysig static 
@@ -104,6 +211,129 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FBD0BEEC_L26C22
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope _environment0_Http_Response_Streaming_Chunked_ResponseBody
+					.field private initonly class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope _environment2_FunctionExpression_L20C4
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope capture0,
+							class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope capture1,
+							object[] capture2
+						) cil managed 
+					{
+						// Method begins at RVA 0x2619
+						// Header size: 1
+						// Code size: 28 (0x1c)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21/FunctionObject_FunctionExpression_FBD0BEEC_L26C22::_environment0_Http_Response_Streaming_Chunked_ResponseBody
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21/FunctionObject_FunctionExpression_FBD0BEEC_L26C22::_environment2_FunctionExpression_L20C4
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld object[] Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21/FunctionObject_FunctionExpression_FBD0BEEC_L26C22::_transitionalScopes
+						IL_001b: ret
+					} // end of method FunctionObject_FunctionExpression_FBD0BEEC_L26C22::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x2636
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_FBD0BEEC_L26C22::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x2639
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_FBD0BEEC_L26C22::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x263c
+						// Header size: 1
+						// Code size: 24 (0x18)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21/FunctionObject_FunctionExpression_FBD0BEEC_L26C22::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: ldarg.2
+						IL_000c: ldc.i4.0
+						IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+						IL_0012: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21::__js_call__(object[], object, object)
+						IL_0017: ret
+					} // end of method FunctionObject_FunctionExpression_FBD0BEEC_L26C22::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x2655
+						// Header size: 1
+						// Code size: 20 (0x14)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21/FunctionObject_FunctionExpression_FBD0BEEC_L26C22::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: ldarg.2
+						IL_0008: ldc.i4.0
+						IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+						IL_000e: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21::__js_call__(object[], object, object)
+						IL_0013: ret
+					} // end of method FunctionObject_FunctionExpression_FBD0BEEC_L26C22::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x266a
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_FBD0BEEC_L26C22::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_FBD0BEEC_L26C22
 
 
 				// Methods
@@ -220,6 +450,101 @@
 
 					} // end of class Scope
 
+					.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2125F824_L35C22
+						extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+					{
+						// Methods
+						.method public hidebysig specialname rtspecialname 
+							instance void .ctor () cil managed 
+						{
+							// Method begins at RVA 0x26cb
+							// Header size: 1
+							// Code size: 7 (0x7)
+							.maxstack 8
+
+							IL_0000: ldarg.0
+							IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+							IL_0006: ret
+						} // end of method FunctionObject_FunctionExpression_2125F824_L35C22::.ctor
+
+						.method public hidebysig specialname virtual 
+							instance bool get_IsConstructor () cil managed 
+						{
+							// Method begins at RVA 0x26d3
+							// Header size: 1
+							// Code size: 2 (0x2)
+							.maxstack 8
+
+							IL_0000: ldc.i4.1
+							IL_0001: ret
+						} // end of method FunctionObject_FunctionExpression_2125F824_L35C22::get_IsConstructor
+
+						.method public hidebysig specialname virtual 
+							instance bool get_RequiresInvocationContext () cil managed 
+						{
+							// Method begins at RVA 0x26d6
+							// Header size: 1
+							// Code size: 2 (0x2)
+							.maxstack 8
+
+							IL_0000: ldc.i4.0
+							IL_0001: ret
+						} // end of method FunctionObject_FunctionExpression_2125F824_L35C22::get_RequiresInvocationContext
+
+						.method family hidebysig virtual 
+							instance object CallCore (
+								object thisArgument,
+								[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+							) cil managed 
+						{
+							// Method begins at RVA 0x26d9
+							// Header size: 1
+							// Code size: 11 (0xb)
+							.maxstack 8
+
+							IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+							IL_0005: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionExpression_L35C21::__js_call__(object)
+							IL_000a: ret
+						} // end of method FunctionObject_FunctionExpression_2125F824_L35C22::CallCore
+
+						.method family hidebysig virtual 
+							instance object ConstructBodyCore (
+								object receiver,
+								[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+								object newTarget
+							) cil managed 
+						{
+							// Method begins at RVA 0x26e5
+							// Header size: 1
+							// Code size: 7 (0x7)
+							.maxstack 8
+
+							IL_0000: ldarg.3
+							IL_0001: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionExpression_L35C21::__js_call__(object)
+							IL_0006: ret
+						} // end of method FunctionObject_FunctionExpression_2125F824_L35C22::ConstructBodyCore
+
+						.method family hidebysig virtual 
+							instance object ConstructCore (
+								[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+								object newTarget
+							) cil managed 
+						{
+							// Method begins at RVA 0x26ed
+							// Header size: 1
+							// Code size: 14 (0xe)
+							.maxstack 8
+
+							IL_0000: ldarg.0
+							IL_0001: ldarg.1
+							IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+							IL_0007: ldarg.2
+							IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+							IL_000d: ret
+						} // end of method FunctionObject_FunctionExpression_2125F824_L35C22::ConstructCore
+
+					} // end of class FunctionObject_FunctionExpression_2125F824_L35C22
+
 
 					// Methods
 					.method public hidebysig static 
@@ -268,6 +593,123 @@
 
 				} // end of class Scope
 
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2CB77A36_L32C21
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope _environment0_Http_Response_Streaming_Chunked_ResponseBody
+					.field private initonly class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope _environment2_FunctionExpression_L20C4
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope capture0,
+							class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope capture1,
+							object[] capture2
+						) cil managed 
+					{
+						// Method begins at RVA 0x2679
+						// Header size: 1
+						// Code size: 28 (0x1c)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionObject_FunctionExpression_2CB77A36_L32C21::_environment0_Http_Response_Streaming_Chunked_ResponseBody
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionObject_FunctionExpression_2CB77A36_L32C21::_environment2_FunctionExpression_L20C4
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld object[] Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionObject_FunctionExpression_2CB77A36_L32C21::_transitionalScopes
+						IL_001b: ret
+					} // end of method FunctionObject_FunctionExpression_2CB77A36_L32C21::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x2696
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_2CB77A36_L32C21::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x2699
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_2CB77A36_L32C21::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x269c
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionObject_FunctionExpression_2CB77A36_L32C21::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_2CB77A36_L32C21::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x26ae
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionObject_FunctionExpression_2CB77A36_L32C21::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_2CB77A36_L32C21::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x26bc
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_2CB77A36_L32C21::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_2CB77A36_L32C21
+
 
 				// Methods
 				.method public hidebysig static 
@@ -289,7 +731,7 @@
 						[2] object,
 						[3] object,
 						[4] object[],
-						[5] class FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_2125F824_L35C22
+						[5] class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionExpression_L35C21/FunctionObject_FunctionExpression_2125F824_L35C22
 					)
 
 					IL_0000: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/Scope::.ctor()
@@ -348,13 +790,13 @@
 					IL_0091: ldelem.ref
 					IL_0092: stelem.ref
 					IL_0093: stloc.s 4
-					IL_0095: newobj instance void FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_2125F824_L35C22::.ctor()
+					IL_0095: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionExpression_L35C21/FunctionObject_FunctionExpression_2125F824_L35C22::.ctor()
 					IL_009a: ldc.i4.0
 					IL_009b: conv.r8
 					IL_009c: ldstr ""
 					IL_00a1: ldc.i4.0
 					IL_00a2: ldc.i4.1
-					IL_00a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_2125F824_L35C22>(!!0, float64, string, bool, bool)
+					IL_00a3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionExpression_L35C21/FunctionObject_FunctionExpression_2125F824_L35C22>(!!0, float64, string, bool, bool)
 					IL_00a8: stloc.s 5
 					IL_00aa: ldloc.1
 					IL_00ab: ldstr "close"
@@ -396,6 +838,124 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8640535C_L20C5
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope _environment0_Http_Response_Streaming_Chunked_ResponseBody
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x25c0
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionObject_FunctionExpression_8640535C_L20C5::_environment0_Http_Response_Streaming_Chunked_ResponseBody
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionObject_FunctionExpression_8640535C_L20C5::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionExpression_8640535C_L20C5::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x25d6
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_8640535C_L20C5::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x25d9
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_8640535C_L20C5::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x25dc
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionObject_FunctionExpression_8640535C_L20C5::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_8640535C_L20C5::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x25f5
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionObject_FunctionExpression_8640535C_L20C5::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_8640535C_L20C5::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x260a
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_8640535C_L20C5::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_8640535C_L20C5
+
 
 			// Methods
 			.method public hidebysig static 
@@ -418,8 +978,8 @@
 					[2] object,
 					[3] object,
 					[4] object[],
-					[5] class FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_FBD0BEEC_L26C22,
-					[6] class FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_2CB77A36_L32C21
+					[5] class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21/FunctionObject_FunctionExpression_FBD0BEEC_L26C22,
+					[6] class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionObject_FunctionExpression_2CB77A36_L32C21
 				)
 
 				IL_0000: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope::.ctor()
@@ -489,13 +1049,13 @@
 				IL_00a7: ldelem.ref
 				IL_00a8: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope
 				IL_00ad: ldloc.s 4
-				IL_00af: newobj instance void FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_FBD0BEEC_L26C22::.ctor(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope, class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope, object[])
+				IL_00af: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21/FunctionObject_FunctionExpression_FBD0BEEC_L26C22::.ctor(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope, class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope, object[])
 				IL_00b4: ldc.i4.1
 				IL_00b5: conv.r8
 				IL_00b6: ldstr ""
 				IL_00bb: ldc.i4.0
 				IL_00bc: ldc.i4.1
-				IL_00bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_FBD0BEEC_L26C22>(!!0, float64, string, bool, bool)
+				IL_00bd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21/FunctionObject_FunctionExpression_FBD0BEEC_L26C22>(!!0, float64, string, bool, bool)
 				IL_00c2: stloc.s 5
 				IL_00c4: ldloc.1
 				IL_00c5: ldstr "on"
@@ -534,13 +1094,13 @@
 				IL_0102: ldelem.ref
 				IL_0103: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope
 				IL_0108: ldloc.s 4
-				IL_010a: newobj instance void FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_2CB77A36_L32C21::.ctor(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope, class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope, object[])
+				IL_010a: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionObject_FunctionExpression_2CB77A36_L32C21::.ctor(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope, class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope, object[])
 				IL_010f: ldc.i4.0
 				IL_0110: conv.r8
 				IL_0111: ldstr ""
 				IL_0116: ldc.i4.0
 				IL_0117: ldc.i4.1
-				IL_0118: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_2CB77A36_L32C21>(!!0, float64, string, bool, bool)
+				IL_0118: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionObject_FunctionExpression_2CB77A36_L32C21>(!!0, float64, string, bool, bool)
 				IL_011d: stloc.s 6
 				IL_011f: ldloc.1
 				IL_0120: ldstr "on"
@@ -574,6 +1134,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6069C9D9_L11C31
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope _environment0_Http_Response_Streaming_Chunked_ResponseBody
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x257c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionObject_FunctionExpression_6069C9D9_L11C31::_environment0_Http_Response_Streaming_Chunked_ResponseBody
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_6069C9D9_L11C31::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x258b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_6069C9D9_L11C31::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x258e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_6069C9D9_L11C31::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2591
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionObject_FunctionExpression_6069C9D9_L11C31::_environment0_Http_Response_Streaming_Chunked_ResponseBody
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30::__js_call__(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_6069C9D9_L11C31::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25a3
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionObject_FunctionExpression_6069C9D9_L11C31::_environment0_Http_Response_Streaming_Chunked_ResponseBody
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30::__js_call__(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_6069C9D9_L11C31::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25b1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_6069C9D9_L11C31::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_6069C9D9_L11C31
+
 
 		// Methods
 		.method public hidebysig static 
@@ -599,7 +1266,7 @@
 				[4] object,
 				[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[6] object[],
-				[7] class FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_8640535C_L20C5
+				[7] class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionObject_FunctionExpression_8640535C_L20C5
 			)
 
 			IL_0000: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/Scope::.ctor()
@@ -651,13 +1318,13 @@
 			IL_007f: ldelem.ref
 			IL_0080: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope
 			IL_0085: ldloc.s 6
-			IL_0087: newobj instance void FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_8640535C_L20C5::.ctor(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope, object[])
+			IL_0087: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionObject_FunctionExpression_8640535C_L20C5::.ctor(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope, object[])
 			IL_008c: ldc.i4.1
 			IL_008d: conv.r8
 			IL_008e: ldstr ""
 			IL_0093: ldc.i4.0
 			IL_0094: ldc.i4.1
-			IL_0095: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_8640535C_L20C5>(!!0, float64, string, bool, bool)
+			IL_0095: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionObject_FunctionExpression_8640535C_L20C5>(!!0, float64, string, bool, bool)
 			IL_009a: stloc.s 7
 			IL_009c: ldloc.2
 			IL_009d: ldstr "get"
@@ -719,9 +1386,9 @@
 			[0] class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope,
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IHttpModule,
 			[2] object[],
-			[3] class FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_C2820861_L5C34,
+			[3] class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_server/FunctionObject_FunctionExpression_C2820861_L5C34,
 			[4] object,
-			[5] class FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_6069C9D9_L11C31
+			[5] class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionObject_FunctionExpression_6069C9D9_L11C31
 		)
 
 		IL_0000: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope::.ctor()
@@ -744,13 +1411,13 @@
 		IL_0029: ldloc.0
 		IL_002a: stelem.ref
 		IL_002b: stloc.2
-		IL_002c: newobj instance void FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_C2820861_L5C34::.ctor()
+		IL_002c: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_server/FunctionObject_FunctionExpression_C2820861_L5C34::.ctor()
 		IL_0031: ldc.i4.2
 		IL_0032: conv.r8
 		IL_0033: ldstr ""
 		IL_0038: ldc.i4.0
 		IL_0039: ldc.i4.1
-		IL_003a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_C2820861_L5C34>(!!0, float64, string, bool, bool)
+		IL_003a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_server/FunctionObject_FunctionExpression_C2820861_L5C34>(!!0, float64, string, bool, bool)
 		IL_003f: stloc.3
 		IL_0040: ldloc.1
 		IL_0041: ldloc.3
@@ -774,13 +1441,13 @@
 		IL_006a: ldc.i4.0
 		IL_006b: ldelem.ref
 		IL_006c: castclass Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope
-		IL_0071: newobj instance void FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_6069C9D9_L11C31::.ctor(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope)
+		IL_0071: newobj instance void Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionObject_FunctionExpression_6069C9D9_L11C31::.ctor(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope)
 		IL_0076: ldc.i4.0
 		IL_0077: conv.r8
 		IL_0078: ldstr ""
 		IL_007d: ldc.i4.0
 		IL_007e: ldc.i4.1
-		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_6069C9D9_L11C31>(!!0, float64, string, bool, bool)
+		IL_007f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionObject_FunctionExpression_6069C9D9_L11C31>(!!0, float64, string, bool, bool)
 		IL_0084: stloc.s 5
 		IL_0086: ldloc.s 4
 		IL_0088: ldstr "listen"
@@ -794,673 +1461,6 @@
 	} // end of method Http_Response_Streaming_Chunked_ResponseBody::__js_module_init__
 
 } // end of class Modules.Http_Response_Streaming_Chunked_ResponseBody
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_C2820861_L5C34
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x252f
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_C2820861_L5C34::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2537
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C2820861_L5C34::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x253a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C2820861_L5C34::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x253d
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_server::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_C2820861_L5C34::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2557
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_server::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_C2820861_L5C34::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x256d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C2820861_L5C34::ConstructCore
-
-} // end of class FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_C2820861_L5C34
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_6069C9D9_L11C31
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope _environment0_Http_Response_Streaming_Chunked_ResponseBody
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x257c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_6069C9D9_L11C31::_environment0_Http_Response_Streaming_Chunked_ResponseBody
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_6069C9D9_L11C31::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x258b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6069C9D9_L11C31::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x258e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6069C9D9_L11C31::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2591
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_6069C9D9_L11C31::_environment0_Http_Response_Streaming_Chunked_ResponseBody
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30::__js_call__(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_6069C9D9_L11C31::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25a3
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_6069C9D9_L11C31::_environment0_Http_Response_Streaming_Chunked_ResponseBody
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30::__js_call__(class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_6069C9D9_L11C31::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25b1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_6069C9D9_L11C31::ConstructCore
-
-} // end of class FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_6069C9D9_L11C31
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_8640535C_L20C5
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope _environment0_Http_Response_Streaming_Chunked_ResponseBody
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x25c0
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_8640535C_L20C5::_environment0_Http_Response_Streaming_Chunked_ResponseBody
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_8640535C_L20C5::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_8640535C_L20C5::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x25d6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_8640535C_L20C5::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x25d9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_8640535C_L20C5::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x25dc
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_8640535C_L20C5::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_8640535C_L20C5::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25f5
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_8640535C_L20C5::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_8640535C_L20C5::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x260a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_8640535C_L20C5::ConstructCore
-
-} // end of class FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_8640535C_L20C5
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_FBD0BEEC_L26C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope _environment0_Http_Response_Streaming_Chunked_ResponseBody
-	.field private initonly class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope _environment2_FunctionExpression_L20C4
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope capture0,
-			class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2619
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_FBD0BEEC_L26C22::_environment0_Http_Response_Streaming_Chunked_ResponseBody
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_FBD0BEEC_L26C22::_environment2_FunctionExpression_L20C4
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_FBD0BEEC_L26C22::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_FBD0BEEC_L26C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2636
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FBD0BEEC_L26C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2639
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FBD0BEEC_L26C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x263c
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_FBD0BEEC_L26C22::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_FBD0BEEC_L26C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2655
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_FBD0BEEC_L26C22::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L26C21::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_FBD0BEEC_L26C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x266a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_FBD0BEEC_L26C22::ConstructCore
-
-} // end of class FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_FBD0BEEC_L26C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_2CB77A36_L32C21
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope _environment0_Http_Response_Streaming_Chunked_ResponseBody
-	.field private initonly class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope _environment2_FunctionExpression_L20C4
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope capture0,
-			class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2679
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/Scope FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_2CB77A36_L32C21::_environment0_Http_Response_Streaming_Chunked_ResponseBody
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/Scope FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_2CB77A36_L32C21::_environment2_FunctionExpression_L20C4
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_2CB77A36_L32C21::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_2CB77A36_L32C21::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2696
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2CB77A36_L32C21::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2699
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2CB77A36_L32C21::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x269c
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_2CB77A36_L32C21::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_2CB77A36_L32C21::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26ae
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_2CB77A36_L32C21::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_2CB77A36_L32C21::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26bc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2CB77A36_L32C21::ConstructCore
-
-} // end of class FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_2CB77A36_L32C21
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_2125F824_L35C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x26cb
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_2125F824_L35C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x26d3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2125F824_L35C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x26d6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2125F824_L35C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x26d9
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionExpression_L35C21::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_2125F824_L35C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26e5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Http_Response_Streaming_Chunked_ResponseBody/FunctionExpression_L11C30/FunctionExpression_L20C4/FunctionExpression_L32C20/FunctionExpression_L35C21::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_2125F824_L35C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26ed
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2125F824_L35C22::ConstructCore
-
-} // end of class FunctionObjects.Http_Response_Streaming_Chunked_ResponseBody_2F1CE42D.FunctionObject_FunctionExpression_2125F824_L35C22
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_AllowHalfOpen_Delayed_Response.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_AllowHalfOpen_Delayed_Response.verified.txt
@@ -35,6 +35,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8ADFF83F_L9C21
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope _environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+				.field private initonly class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope _environment1_FunctionExpression_server
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope capture0,
+						class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2719
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_8ADFF83F_L9C21::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_8ADFF83F_L9C21::_environment1_FunctionExpression_server
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_8ADFF83F_L9C21::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_8ADFF83F_L9C21::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2736
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_8ADFF83F_L9C21::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2739
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_8ADFF83F_L9C21::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x273c
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_8ADFF83F_L9C21::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_8ADFF83F_L9C21::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2755
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_8ADFF83F_L9C21::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_8ADFF83F_L9C21::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x276a
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_8ADFF83F_L9C21::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_8ADFF83F_L9C21
+
 
 			// Methods
 			.method public hidebysig static 
@@ -112,6 +235,123 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C3680A0B_L15C16
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope _environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+					.field private initonly class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope _environment1_FunctionExpression_server
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope capture0,
+							class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope capture1,
+							object[] capture2
+						) cil managed 
+					{
+						// Method begins at RVA 0x27cb
+						// Header size: 1
+						// Code size: 28 (0x1c)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server/FunctionObject_FunctionExpression_C3680A0B_L15C16::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server/FunctionObject_FunctionExpression_C3680A0B_L15C16::_environment1_FunctionExpression_server
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server/FunctionObject_FunctionExpression_C3680A0B_L15C16::_transitionalScopes
+						IL_001b: ret
+					} // end of method FunctionObject_FunctionExpression_C3680A0B_L15C16::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x27e8
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_C3680A0B_L15C16::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x27eb
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_C3680A0B_L15C16::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x27ee
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server/FunctionObject_FunctionExpression_C3680A0B_L15C16::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_C3680A0B_L15C16::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x2800
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server/FunctionObject_FunctionExpression_C3680A0B_L15C16::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_C3680A0B_L15C16::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x280e
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_C3680A0B_L15C16::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_C3680A0B_L15C16
 
 
 				// Methods
@@ -206,6 +446,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C3CAD785_L13C20
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope _environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+				.field private initonly class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope _environment1_FunctionExpression_server
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope capture0,
+						class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2779
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionObject_FunctionExpression_C3CAD785_L13C20::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionObject_FunctionExpression_C3CAD785_L13C20::_environment1_FunctionExpression_server
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionObject_FunctionExpression_C3CAD785_L13C20::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_C3CAD785_L13C20::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2796
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_C3CAD785_L13C20::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2799
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_C3CAD785_L13C20::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x279c
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionObject_FunctionExpression_C3CAD785_L13C20::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_C3CAD785_L13C20::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x27ae
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionObject_FunctionExpression_C3CAD785_L13C20::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_C3CAD785_L13C20::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x27bc
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_C3CAD785_L13C20::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_C3CAD785_L13C20
+
 
 			// Methods
 			.method public hidebysig static 
@@ -227,7 +584,7 @@
 					[2] object,
 					[3] object,
 					[4] object[],
-					[5] class FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_C3680A0B_L15C16
+					[5] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server/FunctionObject_FunctionExpression_C3680A0B_L15C16
 				)
 
 				IL_0000: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/Scope::.ctor()
@@ -279,13 +636,13 @@
 				IL_0061: ldelem.ref
 				IL_0062: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope
 				IL_0067: ldloc.s 4
-				IL_0069: newobj instance void FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_C3680A0B_L15C16::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope, object[])
+				IL_0069: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server/FunctionObject_FunctionExpression_C3680A0B_L15C16::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope, object[])
 				IL_006e: ldc.i4.0
 				IL_006f: conv.r8
 				IL_0070: ldstr ""
 				IL_0075: ldc.i4.0
 				IL_0076: ldc.i4.1
-				IL_0077: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_C3680A0B_L15C16>(!!0, float64, string, bool, bool)
+				IL_0077: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server/FunctionObject_FunctionExpression_C3680A0B_L15C16>(!!0, float64, string, bool, bool)
 				IL_007c: stloc.s 5
 				IL_007e: ldloc.s 5
 				IL_0080: ldc.r8 0.0
@@ -329,6 +686,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_BC7FD036_L5C58
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope _environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x26c7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionObject_FunctionExpression_BC7FD036_L5C58::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_BC7FD036_L5C58::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x26d6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_BC7FD036_L5C58::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x26d9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_BC7FD036_L5C58::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x26dc
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionObject_FunctionExpression_BC7FD036_L5C58::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server::__js_call__(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_BC7FD036_L5C58::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26f5
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionObject_FunctionExpression_BC7FD036_L5C58::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server::__js_call__(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_BC7FD036_L5C58::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x270a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_BC7FD036_L5C58::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_BC7FD036_L5C58
+
 
 		// Methods
 		.method public hidebysig static 
@@ -353,8 +823,8 @@
 				[2] object,
 				[3] object,
 				[4] object[],
-				[5] class FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_8ADFF83F_L9C21,
-				[6] class FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_C3CAD785_L13C20
+				[5] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_8ADFF83F_L9C21,
+				[6] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionObject_FunctionExpression_C3CAD785_L13C20
 			)
 
 			IL_0000: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope::.ctor()
@@ -407,13 +877,13 @@
 			IL_007a: ldelem.ref
 			IL_007b: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope
 			IL_0080: ldloc.s 4
-			IL_0082: newobj instance void FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_8ADFF83F_L9C21::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope, object[])
+			IL_0082: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_8ADFF83F_L9C21::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope, object[])
 			IL_0087: ldc.i4.1
 			IL_0088: conv.r8
 			IL_0089: ldstr ""
 			IL_008e: ldc.i4.0
 			IL_008f: ldc.i4.1
-			IL_0090: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_8ADFF83F_L9C21>(!!0, float64, string, bool, bool)
+			IL_0090: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_8ADFF83F_L9C21>(!!0, float64, string, bool, bool)
 			IL_0095: stloc.s 5
 			IL_0097: ldloc.1
 			IL_0098: ldstr "on"
@@ -445,13 +915,13 @@
 			IL_00d2: ldelem.ref
 			IL_00d3: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope
 			IL_00d8: ldloc.s 4
-			IL_00da: newobj instance void FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_C3CAD785_L13C20::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope, object[])
+			IL_00da: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionObject_FunctionExpression_C3CAD785_L13C20::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope, object[])
 			IL_00df: ldc.i4.0
 			IL_00e0: conv.r8
 			IL_00e1: ldstr ""
 			IL_00e6: ldc.i4.0
 			IL_00e7: ldc.i4.1
-			IL_00e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_C3CAD785_L13C20>(!!0, float64, string, bool, bool)
+			IL_00e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionObject_FunctionExpression_C3CAD785_L13C20>(!!0, float64, string, bool, bool)
 			IL_00ed: stloc.s 6
 			IL_00ef: ldloc.1
 			IL_00f0: ldstr "on"
@@ -492,6 +962,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F2056A7A_L24C55
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope _environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+				.field private initonly class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope _environment1_FunctionExpression_L22C30
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope capture0,
+						class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2861
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client/FunctionObject_FunctionExpression_F2056A7A_L24C55::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client/FunctionObject_FunctionExpression_F2056A7A_L24C55::_environment1_FunctionExpression_L22C30
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client/FunctionObject_FunctionExpression_F2056A7A_L24C55::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_F2056A7A_L24C55::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x287e
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_F2056A7A_L24C55::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2881
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_F2056A7A_L24C55::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2884
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client/FunctionObject_FunctionExpression_F2056A7A_L24C55::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_F2056A7A_L24C55::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2896
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client/FunctionObject_FunctionExpression_F2056A7A_L24C55::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_F2056A7A_L24C55::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x28a4
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_F2056A7A_L24C55::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_F2056A7A_L24C55
 
 
 			// Methods
@@ -550,6 +1137,129 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E3FCF0A6_L30C21
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope _environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+				.field private initonly class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope _environment1_FunctionExpression_L22C30
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope capture0,
+						class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x28b3
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_E3FCF0A6_L30C21::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_E3FCF0A6_L30C21::_environment1_FunctionExpression_L22C30
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_E3FCF0A6_L30C21::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_E3FCF0A6_L30C21::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x28d0
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_E3FCF0A6_L30C21::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x28d3
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_E3FCF0A6_L30C21::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x28d6
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_E3FCF0A6_L30C21::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_E3FCF0A6_L30C21::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x28ef
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_E3FCF0A6_L30C21::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_E3FCF0A6_L30C21::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2904
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_E3FCF0A6_L30C21::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_E3FCF0A6_L30C21
 
 
 			// Methods
@@ -622,6 +1332,101 @@
 
 				} // end of class Scope
 
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F2F79B12_L36C18
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x2965
+						// Header size: 1
+						// Code size: 7 (0x7)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ret
+					} // end of method FunctionObject_FunctionExpression_F2F79B12_L36C18::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x296d
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_F2F79B12_L36C18::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x2970
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_F2F79B12_L36C18::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x2973
+						// Header size: 1
+						// Code size: 11 (0xb)
+						.maxstack 8
+
+						IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_0005: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionExpression_L36C17::__js_call__(object)
+						IL_000a: ret
+					} // end of method FunctionObject_FunctionExpression_F2F79B12_L36C18::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x297f
+						// Header size: 1
+						// Code size: 7 (0x7)
+						.maxstack 8
+
+						IL_0000: ldarg.3
+						IL_0001: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionExpression_L36C17::__js_call__(object)
+						IL_0006: ret
+					} // end of method FunctionObject_FunctionExpression_F2F79B12_L36C18::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x2987
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_F2F79B12_L36C18::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_F2F79B12_L36C18
+
 
 				// Methods
 				.method public hidebysig static 
@@ -670,6 +1475,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_03FCDB35_L34C20
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope _environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+				.field private initonly class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope _environment1_FunctionExpression_L22C30
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope capture0,
+						class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2913
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_03FCDB35_L34C20::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_03FCDB35_L34C20::_environment1_FunctionExpression_L22C30
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_03FCDB35_L34C20::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_03FCDB35_L34C20::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2930
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_03FCDB35_L34C20::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2933
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_03FCDB35_L34C20::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2936
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_03FCDB35_L34C20::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_03FCDB35_L34C20::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2948
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_03FCDB35_L34C20::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_03FCDB35_L34C20::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2956
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_03FCDB35_L34C20::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_03FCDB35_L34C20
+
 
 			// Methods
 			.method public hidebysig static 
@@ -691,7 +1613,7 @@
 					[2] object,
 					[3] object,
 					[4] object[],
-					[5] class FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_F2F79B12_L36C18
+					[5] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionExpression_L36C17/FunctionObject_FunctionExpression_F2F79B12_L36C18
 				)
 
 				IL_0000: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/Scope::.ctor()
@@ -731,13 +1653,13 @@
 				IL_005a: ldelem.ref
 				IL_005b: stelem.ref
 				IL_005c: stloc.s 4
-				IL_005e: newobj instance void FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_F2F79B12_L36C18::.ctor()
+				IL_005e: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionExpression_L36C17/FunctionObject_FunctionExpression_F2F79B12_L36C18::.ctor()
 				IL_0063: ldc.i4.0
 				IL_0064: conv.r8
 				IL_0065: ldstr ""
 				IL_006a: ldc.i4.0
 				IL_006b: ldc.i4.1
-				IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_F2F79B12_L36C18>(!!0, float64, string, bool, bool)
+				IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionExpression_L36C17/FunctionObject_FunctionExpression_F2F79B12_L36C18>(!!0, float64, string, bool, bool)
 				IL_0071: stloc.s 5
 				IL_0073: ldloc.1
 				IL_0074: ldstr "close"
@@ -782,6 +1704,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0BE9B9C0_L22C31
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope _environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x281d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionObject_FunctionExpression_0BE9B9C0_L22C31::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_0BE9B9C0_L22C31::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x282c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_0BE9B9C0_L22C31::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x282f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_0BE9B9C0_L22C31::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2832
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionObject_FunctionExpression_0BE9B9C0_L22C31::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30::__js_call__(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_0BE9B9C0_L22C31::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2844
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionObject_FunctionExpression_0BE9B9C0_L22C31::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30::__js_call__(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_0BE9B9C0_L22C31::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2852
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_0BE9B9C0_L22C31::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_0BE9B9C0_L22C31
+
 
 		// Methods
 		.method public hidebysig static 
@@ -805,9 +1834,9 @@
 				[2] object,
 				[3] object,
 				[4] object[],
-				[5] class FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_F2056A7A_L24C55,
-				[6] class FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_E3FCF0A6_L30C21,
-				[7] class FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_03FCDB35_L34C20
+				[5] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client/FunctionObject_FunctionExpression_F2056A7A_L24C55,
+				[6] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_E3FCF0A6_L30C21,
+				[7] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_03FCDB35_L34C20
 			)
 
 			IL_0000: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope::.ctor()
@@ -848,13 +1877,13 @@
 			IL_0056: ldelem.ref
 			IL_0057: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope
 			IL_005c: ldloc.s 4
-			IL_005e: newobj instance void FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_F2056A7A_L24C55::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope, object[])
+			IL_005e: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client/FunctionObject_FunctionExpression_F2056A7A_L24C55::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope, object[])
 			IL_0063: ldc.i4.0
 			IL_0064: conv.r8
 			IL_0065: ldstr ""
 			IL_006a: ldc.i4.0
 			IL_006b: ldc.i4.1
-			IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_F2056A7A_L24C55>(!!0, float64, string, bool, bool)
+			IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client/FunctionObject_FunctionExpression_F2056A7A_L24C55>(!!0, float64, string, bool, bool)
 			IL_0071: stloc.s 5
 			IL_0073: ldstr "connect"
 			IL_0078: ldloc.2
@@ -903,13 +1932,13 @@
 			IL_00eb: ldelem.ref
 			IL_00ec: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope
 			IL_00f1: ldloc.s 4
-			IL_00f3: newobj instance void FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_E3FCF0A6_L30C21::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope, object[])
+			IL_00f3: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_E3FCF0A6_L30C21::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope, object[])
 			IL_00f8: ldc.i4.1
 			IL_00f9: conv.r8
 			IL_00fa: ldstr ""
 			IL_00ff: ldc.i4.0
 			IL_0100: ldc.i4.1
-			IL_0101: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_E3FCF0A6_L30C21>(!!0, float64, string, bool, bool)
+			IL_0101: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_E3FCF0A6_L30C21>(!!0, float64, string, bool, bool)
 			IL_0106: stloc.s 6
 			IL_0108: ldloc.3
 			IL_0109: ldstr "on"
@@ -943,13 +1972,13 @@
 			IL_014d: ldelem.ref
 			IL_014e: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope
 			IL_0153: ldloc.s 4
-			IL_0155: newobj instance void FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_03FCDB35_L34C20::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope, object[])
+			IL_0155: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_03FCDB35_L34C20::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope, object[])
 			IL_015a: ldc.i4.0
 			IL_015b: conv.r8
 			IL_015c: ldstr ""
 			IL_0161: ldc.i4.0
 			IL_0162: ldc.i4.1
-			IL_0163: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_03FCDB35_L34C20>(!!0, float64, string, bool, bool)
+			IL_0163: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_03FCDB35_L34C20>(!!0, float64, string, bool, bool)
 			IL_0168: stloc.s 7
 			IL_016a: ldloc.3
 			IL_016b: ldstr "on"
@@ -1012,9 +2041,9 @@
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object[],
-			[4] class FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_BC7FD036_L5C58,
+			[4] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionObject_FunctionExpression_BC7FD036_L5C58,
 			[5] object,
-			[6] class FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_0BE9B9C0_L22C31
+			[6] class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionObject_FunctionExpression_0BE9B9C0_L22C31
 		)
 
 		IL_0000: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope::.ctor()
@@ -1046,13 +2075,13 @@
 		IL_003e: ldc.i4.0
 		IL_003f: ldelem.ref
 		IL_0040: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope
-		IL_0045: newobj instance void FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_BC7FD036_L5C58::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope)
+		IL_0045: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionObject_FunctionExpression_BC7FD036_L5C58::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope)
 		IL_004a: ldc.i4.1
 		IL_004b: conv.r8
 		IL_004c: ldstr ""
 		IL_0051: ldc.i4.0
 		IL_0052: ldc.i4.1
-		IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_BC7FD036_L5C58>(!!0, float64, string, bool, bool)
+		IL_0053: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionObject_FunctionExpression_BC7FD036_L5C58>(!!0, float64, string, bool, bool)
 		IL_0058: stloc.s 4
 		IL_005a: ldstr "createServer"
 		IL_005f: ldloc.2
@@ -1077,13 +2106,13 @@
 		IL_008a: ldc.i4.0
 		IL_008b: ldelem.ref
 		IL_008c: castclass Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope
-		IL_0091: newobj instance void FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_0BE9B9C0_L22C31::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope)
+		IL_0091: newobj instance void Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionObject_FunctionExpression_0BE9B9C0_L22C31::.ctor(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope)
 		IL_0096: ldc.i4.0
 		IL_0097: conv.r8
 		IL_0098: ldstr ""
 		IL_009d: ldc.i4.0
 		IL_009e: ldc.i4.1
-		IL_009f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_0BE9B9C0_L22C31>(!!0, float64, string, bool, bool)
+		IL_009f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionObject_FunctionExpression_0BE9B9C0_L22C31>(!!0, float64, string, bool, bool)
 		IL_00a4: stloc.s 6
 		IL_00a6: ldloc.s 5
 		IL_00a8: ldstr "listen"
@@ -1097,1035 +2126,6 @@
 	} // end of method Net_CreateServer_AllowHalfOpen_Delayed_Response::__js_module_init__
 
 } // end of class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_BC7FD036_L5C58
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope _environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x26c7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_BC7FD036_L5C58::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_BC7FD036_L5C58::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x26d6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_BC7FD036_L5C58::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x26d9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_BC7FD036_L5C58::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x26dc
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_BC7FD036_L5C58::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server::__js_call__(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_BC7FD036_L5C58::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26f5
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_BC7FD036_L5C58::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server::__js_call__(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_BC7FD036_L5C58::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x270a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_BC7FD036_L5C58::ConstructCore
-
-} // end of class FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_BC7FD036_L5C58
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_8ADFF83F_L9C21
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope _environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
-	.field private initonly class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope _environment1_FunctionExpression_server
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope capture0,
-			class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2719
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_8ADFF83F_L9C21::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_8ADFF83F_L9C21::_environment1_FunctionExpression_server
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_8ADFF83F_L9C21::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_8ADFF83F_L9C21::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2736
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_8ADFF83F_L9C21::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2739
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_8ADFF83F_L9C21::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x273c
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_8ADFF83F_L9C21::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_8ADFF83F_L9C21::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2755
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_8ADFF83F_L9C21::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_8ADFF83F_L9C21::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x276a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_8ADFF83F_L9C21::ConstructCore
-
-} // end of class FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_8ADFF83F_L9C21
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_C3CAD785_L13C20
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope _environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
-	.field private initonly class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope _environment1_FunctionExpression_server
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope capture0,
-			class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2779
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_C3CAD785_L13C20::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_C3CAD785_L13C20::_environment1_FunctionExpression_server
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_C3CAD785_L13C20::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_C3CAD785_L13C20::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2796
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C3CAD785_L13C20::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2799
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C3CAD785_L13C20::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x279c
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_C3CAD785_L13C20::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_C3CAD785_L13C20::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27ae
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_C3CAD785_L13C20::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_C3CAD785_L13C20::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27bc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C3CAD785_L13C20::ConstructCore
-
-} // end of class FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_C3CAD785_L13C20
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_C3680A0B_L15C16
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope _environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
-	.field private initonly class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope _environment1_FunctionExpression_server
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope capture0,
-			class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x27cb
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_C3680A0B_L15C16::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/Scope FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_C3680A0B_L15C16::_environment1_FunctionExpression_server
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_C3680A0B_L15C16::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_C3680A0B_L15C16::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x27e8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C3680A0B_L15C16::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x27eb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C3680A0B_L15C16::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x27ee
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_C3680A0B_L15C16::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_C3680A0B_L15C16::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2800
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_C3680A0B_L15C16::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_server/FunctionExpression_server_L13C19/FunctionExpression_server::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_C3680A0B_L15C16::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x280e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C3680A0B_L15C16::ConstructCore
-
-} // end of class FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_C3680A0B_L15C16
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_0BE9B9C0_L22C31
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope _environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x281d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_0BE9B9C0_L22C31::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_0BE9B9C0_L22C31::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x282c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_0BE9B9C0_L22C31::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x282f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_0BE9B9C0_L22C31::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2832
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_0BE9B9C0_L22C31::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30::__js_call__(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_0BE9B9C0_L22C31::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2844
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_0BE9B9C0_L22C31::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30::__js_call__(class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_0BE9B9C0_L22C31::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2852
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_0BE9B9C0_L22C31::ConstructCore
-
-} // end of class FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_0BE9B9C0_L22C31
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_F2056A7A_L24C55
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope _environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
-	.field private initonly class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope _environment1_FunctionExpression_L22C30
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope capture0,
-			class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2861
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_F2056A7A_L24C55::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_F2056A7A_L24C55::_environment1_FunctionExpression_L22C30
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_F2056A7A_L24C55::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_F2056A7A_L24C55::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x287e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F2056A7A_L24C55::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2881
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F2056A7A_L24C55::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2884
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_F2056A7A_L24C55::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_F2056A7A_L24C55::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2896
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_F2056A7A_L24C55::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_client::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_F2056A7A_L24C55::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28a4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F2056A7A_L24C55::ConstructCore
-
-} // end of class FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_F2056A7A_L24C55
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_E3FCF0A6_L30C21
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope _environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
-	.field private initonly class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope _environment1_FunctionExpression_L22C30
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope capture0,
-			class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x28b3
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_E3FCF0A6_L30C21::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_E3FCF0A6_L30C21::_environment1_FunctionExpression_L22C30
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_E3FCF0A6_L30C21::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_E3FCF0A6_L30C21::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x28d0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E3FCF0A6_L30C21::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x28d3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E3FCF0A6_L30C21::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x28d6
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_E3FCF0A6_L30C21::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_E3FCF0A6_L30C21::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28ef
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_E3FCF0A6_L30C21::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_E3FCF0A6_L30C21::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2904
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E3FCF0A6_L30C21::ConstructCore
-
-} // end of class FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_E3FCF0A6_L30C21
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_03FCDB35_L34C20
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope _environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
-	.field private initonly class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope _environment1_FunctionExpression_L22C30
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope capture0,
-			class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2913
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/Scope FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_03FCDB35_L34C20::_environment0_Net_CreateServer_AllowHalfOpen_Delayed_Response
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/Scope FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_03FCDB35_L34C20::_environment1_FunctionExpression_L22C30
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_03FCDB35_L34C20::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_03FCDB35_L34C20::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2930
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_03FCDB35_L34C20::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2933
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_03FCDB35_L34C20::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2936
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_03FCDB35_L34C20::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_03FCDB35_L34C20::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2948
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_03FCDB35_L34C20::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_03FCDB35_L34C20::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2956
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_03FCDB35_L34C20::ConstructCore
-
-} // end of class FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_03FCDB35_L34C20
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_F2F79B12_L36C18
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2965
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_F2F79B12_L36C18::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x296d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F2F79B12_L36C18::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2970
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F2F79B12_L36C18::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2973
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionExpression_L36C17::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_F2F79B12_L36C18::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x297f
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Net_CreateServer_AllowHalfOpen_Delayed_Response/FunctionExpression_L22C30/FunctionExpression_L34C19/FunctionExpression_L36C17::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_F2F79B12_L36C18::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2987
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F2F79B12_L36C18::ConstructCore
-
-} // end of class FunctionObjects.Net_CreateServer_AllowHalfOpen_Delayed_Response_755F05A6.FunctionObject_FunctionExpression_F2F79B12_L36C18
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_Connect_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_CreateServer_Connect_Basic.verified.txt
@@ -35,6 +35,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_47F27A5E_L8C21
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Net_CreateServer_Connect_Basic/Scope _environment0_Net_CreateServer_Connect_Basic
+				.field private initonly class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope _environment1_FunctionExpression_server
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Net_CreateServer_Connect_Basic/Scope capture0,
+						class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x26ab
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_47F27A5E_L8C21::_environment0_Net_CreateServer_Connect_Basic
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_47F27A5E_L8C21::_environment1_FunctionExpression_server
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_47F27A5E_L8C21::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_47F27A5E_L8C21::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x26c8
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_47F27A5E_L8C21::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x26cb
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_47F27A5E_L8C21::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x26ce
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_47F27A5E_L8C21::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_47F27A5E_L8C21::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x26e7
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_47F27A5E_L8C21::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_47F27A5E_L8C21::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x26fc
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_47F27A5E_L8C21::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_47F27A5E_L8C21
+
 
 			// Methods
 			.method public hidebysig static 
@@ -108,6 +231,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_91246900_L12C20
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Net_CreateServer_Connect_Basic/Scope _environment0_Net_CreateServer_Connect_Basic
+				.field private initonly class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope _environment1_FunctionExpression_server
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Net_CreateServer_Connect_Basic/Scope capture0,
+						class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x270b
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19/FunctionObject_FunctionExpression_91246900_L12C20::_environment0_Net_CreateServer_Connect_Basic
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19/FunctionObject_FunctionExpression_91246900_L12C20::_environment1_FunctionExpression_server
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19/FunctionObject_FunctionExpression_91246900_L12C20::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_91246900_L12C20::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2728
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_91246900_L12C20::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x272b
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_91246900_L12C20::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x272e
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19/FunctionObject_FunctionExpression_91246900_L12C20::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_91246900_L12C20::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2740
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19/FunctionObject_FunctionExpression_91246900_L12C20::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_91246900_L12C20::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x274e
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_91246900_L12C20::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_91246900_L12C20
 
 
 			// Methods
@@ -218,6 +458,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E00EA35D_L5C33
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Net_CreateServer_Connect_Basic/Scope _environment0_Net_CreateServer_Connect_Basic
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Net_CreateServer_Connect_Basic/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2659
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionObject_FunctionExpression_E00EA35D_L5C33::_environment0_Net_CreateServer_Connect_Basic
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E00EA35D_L5C33::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2668
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E00EA35D_L5C33::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x266b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E00EA35D_L5C33::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x266e
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionObject_FunctionExpression_E00EA35D_L5C33::_environment0_Net_CreateServer_Connect_Basic
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server::__js_call__(class Modules.Net_CreateServer_Connect_Basic/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_E00EA35D_L5C33::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2687
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionObject_FunctionExpression_E00EA35D_L5C33::_environment0_Net_CreateServer_Connect_Basic
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server::__js_call__(class Modules.Net_CreateServer_Connect_Basic/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_E00EA35D_L5C33::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x269c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E00EA35D_L5C33::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_E00EA35D_L5C33
+
 
 		// Methods
 		.method public hidebysig static 
@@ -240,8 +593,8 @@
 				[0] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope,
 				[1] object,
 				[2] object[],
-				[3] class FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_47F27A5E_L8C21,
-				[4] class FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_91246900_L12C20
+				[3] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_47F27A5E_L8C21,
+				[4] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19/FunctionObject_FunctionExpression_91246900_L12C20
 			)
 
 			IL_0000: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope::.ctor()
@@ -276,13 +629,13 @@
 			IL_003d: ldelem.ref
 			IL_003e: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope
 			IL_0043: ldloc.2
-			IL_0044: newobj instance void FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_47F27A5E_L8C21::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope, class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope, object[])
+			IL_0044: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_47F27A5E_L8C21::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope, class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope, object[])
 			IL_0049: ldc.i4.1
 			IL_004a: conv.r8
 			IL_004b: ldstr ""
 			IL_0050: ldc.i4.0
 			IL_0051: ldc.i4.1
-			IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_47F27A5E_L8C21>(!!0, float64, string, bool, bool)
+			IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_47F27A5E_L8C21>(!!0, float64, string, bool, bool)
 			IL_0057: stloc.3
 			IL_0058: ldloc.1
 			IL_0059: ldstr "on"
@@ -314,13 +667,13 @@
 			IL_008f: ldelem.ref
 			IL_0090: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope
 			IL_0095: ldloc.2
-			IL_0096: newobj instance void FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_91246900_L12C20::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope, class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope, object[])
+			IL_0096: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19/FunctionObject_FunctionExpression_91246900_L12C20::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope, class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope, object[])
 			IL_009b: ldc.i4.0
 			IL_009c: conv.r8
 			IL_009d: ldstr ""
 			IL_00a2: ldc.i4.0
 			IL_00a3: ldc.i4.1
-			IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_91246900_L12C20>(!!0, float64, string, bool, bool)
+			IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19/FunctionObject_FunctionExpression_91246900_L12C20>(!!0, float64, string, bool, bool)
 			IL_00a9: stloc.s 4
 			IL_00ab: ldloc.1
 			IL_00ac: ldstr "on"
@@ -361,6 +714,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FCCB5C27_L23C55
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Net_CreateServer_Connect_Basic/Scope _environment0_Net_CreateServer_Connect_Basic
+				.field private initonly class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope _environment1_FunctionExpression_L19C30
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Net_CreateServer_Connect_Basic/Scope capture0,
+						class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x27a1
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client/FunctionObject_FunctionExpression_FCCB5C27_L23C55::_environment0_Net_CreateServer_Connect_Basic
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client/FunctionObject_FunctionExpression_FCCB5C27_L23C55::_environment1_FunctionExpression_L19C30
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client/FunctionObject_FunctionExpression_FCCB5C27_L23C55::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_FCCB5C27_L23C55::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x27be
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_FCCB5C27_L23C55::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x27c1
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_FCCB5C27_L23C55::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x27c4
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client/FunctionObject_FunctionExpression_FCCB5C27_L23C55::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_FCCB5C27_L23C55::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x27d6
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client/FunctionObject_FunctionExpression_FCCB5C27_L23C55::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_FCCB5C27_L23C55::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x27e4
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_FCCB5C27_L23C55::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_FCCB5C27_L23C55
 
 
 			// Methods
@@ -419,6 +889,129 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_AAF4393B_L28C21
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Net_CreateServer_Connect_Basic/Scope _environment0_Net_CreateServer_Connect_Basic
+				.field private initonly class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope _environment1_FunctionExpression_L19C30
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Net_CreateServer_Connect_Basic/Scope capture0,
+						class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x27f3
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20/FunctionObject_FunctionExpression_AAF4393B_L28C21::_environment0_Net_CreateServer_Connect_Basic
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20/FunctionObject_FunctionExpression_AAF4393B_L28C21::_environment1_FunctionExpression_L19C30
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20/FunctionObject_FunctionExpression_AAF4393B_L28C21::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_AAF4393B_L28C21::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2810
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_AAF4393B_L28C21::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2813
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_AAF4393B_L28C21::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2816
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20/FunctionObject_FunctionExpression_AAF4393B_L28C21::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_AAF4393B_L28C21::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x282f
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20/FunctionObject_FunctionExpression_AAF4393B_L28C21::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_AAF4393B_L28C21::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2844
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_AAF4393B_L28C21::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_AAF4393B_L28C21
 
 
 			// Methods
@@ -498,6 +1091,101 @@
 
 				} // end of class Scope
 
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3A83E61C_L34C18
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x28a5
+						// Header size: 1
+						// Code size: 7 (0x7)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ret
+					} // end of method FunctionObject_FunctionExpression_3A83E61C_L34C18::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x28ad
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_3A83E61C_L34C18::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x28b0
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_3A83E61C_L34C18::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x28b3
+						// Header size: 1
+						// Code size: 11 (0xb)
+						.maxstack 8
+
+						IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_0005: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionExpression_L34C17::__js_call__(object)
+						IL_000a: ret
+					} // end of method FunctionObject_FunctionExpression_3A83E61C_L34C18::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x28bf
+						// Header size: 1
+						// Code size: 7 (0x7)
+						.maxstack 8
+
+						IL_0000: ldarg.3
+						IL_0001: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionExpression_L34C17::__js_call__(object)
+						IL_0006: ret
+					} // end of method FunctionObject_FunctionExpression_3A83E61C_L34C18::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x28c7
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_3A83E61C_L34C18::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_3A83E61C_L34C18
+
 
 				// Methods
 				.method public hidebysig static 
@@ -546,6 +1234,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F3DE6889_L32C20
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Net_CreateServer_Connect_Basic/Scope _environment0_Net_CreateServer_Connect_Basic
+				.field private initonly class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope _environment1_FunctionExpression_L19C30
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Net_CreateServer_Connect_Basic/Scope capture0,
+						class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2853
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionObject_FunctionExpression_F3DE6889_L32C20::_environment0_Net_CreateServer_Connect_Basic
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionObject_FunctionExpression_F3DE6889_L32C20::_environment1_FunctionExpression_L19C30
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionObject_FunctionExpression_F3DE6889_L32C20::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_F3DE6889_L32C20::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2870
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_F3DE6889_L32C20::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2873
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_F3DE6889_L32C20::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2876
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionObject_FunctionExpression_F3DE6889_L32C20::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_F3DE6889_L32C20::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2888
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionObject_FunctionExpression_F3DE6889_L32C20::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_F3DE6889_L32C20::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2896
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_F3DE6889_L32C20::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_F3DE6889_L32C20
+
 
 			// Methods
 			.method public hidebysig static 
@@ -567,7 +1372,7 @@
 					[2] object,
 					[3] object,
 					[4] object[],
-					[5] class FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_3A83E61C_L34C18
+					[5] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionExpression_L34C17/FunctionObject_FunctionExpression_3A83E61C_L34C18
 				)
 
 				IL_0000: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/Scope::.ctor()
@@ -607,13 +1412,13 @@
 				IL_005a: ldelem.ref
 				IL_005b: stelem.ref
 				IL_005c: stloc.s 4
-				IL_005e: newobj instance void FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_3A83E61C_L34C18::.ctor()
+				IL_005e: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionExpression_L34C17/FunctionObject_FunctionExpression_3A83E61C_L34C18::.ctor()
 				IL_0063: ldc.i4.0
 				IL_0064: conv.r8
 				IL_0065: ldstr ""
 				IL_006a: ldc.i4.0
 				IL_006b: ldc.i4.1
-				IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_3A83E61C_L34C18>(!!0, float64, string, bool, bool)
+				IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionExpression_L34C17/FunctionObject_FunctionExpression_3A83E61C_L34C18>(!!0, float64, string, bool, bool)
 				IL_0071: stloc.s 5
 				IL_0073: ldloc.1
 				IL_0074: ldstr "close"
@@ -658,6 +1463,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7DD89A92_L19C31
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Net_CreateServer_Connect_Basic/Scope _environment0_Net_CreateServer_Connect_Basic
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Net_CreateServer_Connect_Basic/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x275d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionObject_FunctionExpression_7DD89A92_L19C31::_environment0_Net_CreateServer_Connect_Basic
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_7DD89A92_L19C31::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x276c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7DD89A92_L19C31::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x276f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7DD89A92_L19C31::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2772
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionObject_FunctionExpression_7DD89A92_L19C31::_environment0_Net_CreateServer_Connect_Basic
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30::__js_call__(class Modules.Net_CreateServer_Connect_Basic/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_7DD89A92_L19C31::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2784
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Net_CreateServer_Connect_Basic/Scope Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionObject_FunctionExpression_7DD89A92_L19C31::_environment0_Net_CreateServer_Connect_Basic
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30::__js_call__(class Modules.Net_CreateServer_Connect_Basic/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_7DD89A92_L19C31::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2792
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_7DD89A92_L19C31::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_7DD89A92_L19C31
+
 
 		// Methods
 		.method public hidebysig static 
@@ -684,9 +1596,9 @@
 				[5] bool,
 				[6] object,
 				[7] object[],
-				[8] class FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_FCCB5C27_L23C55,
-				[9] class FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_AAF4393B_L28C21,
-				[10] class FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_F3DE6889_L32C20
+				[8] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client/FunctionObject_FunctionExpression_FCCB5C27_L23C55,
+				[9] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20/FunctionObject_FunctionExpression_AAF4393B_L28C21,
+				[10] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionObject_FunctionExpression_F3DE6889_L32C20
 			)
 
 			IL_0000: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope::.ctor()
@@ -776,13 +1688,13 @@
 			IL_00f2: ldelem.ref
 			IL_00f3: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope
 			IL_00f8: ldloc.s 7
-			IL_00fa: newobj instance void FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_FCCB5C27_L23C55::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope, class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope, object[])
+			IL_00fa: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client/FunctionObject_FunctionExpression_FCCB5C27_L23C55::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope, class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope, object[])
 			IL_00ff: ldc.i4.0
 			IL_0100: conv.r8
 			IL_0101: ldstr ""
 			IL_0106: ldc.i4.0
 			IL_0107: ldc.i4.1
-			IL_0108: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_FCCB5C27_L23C55>(!!0, float64, string, bool, bool)
+			IL_0108: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client/FunctionObject_FunctionExpression_FCCB5C27_L23C55>(!!0, float64, string, bool, bool)
 			IL_010d: stloc.s 8
 			IL_010f: ldstr "connect"
 			IL_0114: ldloc.2
@@ -822,13 +1734,13 @@
 			IL_0162: ldelem.ref
 			IL_0163: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope
 			IL_0168: ldloc.s 7
-			IL_016a: newobj instance void FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_AAF4393B_L28C21::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope, class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope, object[])
+			IL_016a: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20/FunctionObject_FunctionExpression_AAF4393B_L28C21::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope, class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope, object[])
 			IL_016f: ldc.i4.1
 			IL_0170: conv.r8
 			IL_0171: ldstr ""
 			IL_0176: ldc.i4.0
 			IL_0177: ldc.i4.1
-			IL_0178: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_AAF4393B_L28C21>(!!0, float64, string, bool, bool)
+			IL_0178: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20/FunctionObject_FunctionExpression_AAF4393B_L28C21>(!!0, float64, string, bool, bool)
 			IL_017d: stloc.s 9
 			IL_017f: ldloc.3
 			IL_0180: ldstr "on"
@@ -862,13 +1774,13 @@
 			IL_01c4: ldelem.ref
 			IL_01c5: castclass Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope
 			IL_01ca: ldloc.s 7
-			IL_01cc: newobj instance void FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_F3DE6889_L32C20::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope, class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope, object[])
+			IL_01cc: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionObject_FunctionExpression_F3DE6889_L32C20::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope, class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope, object[])
 			IL_01d1: ldc.i4.0
 			IL_01d2: conv.r8
 			IL_01d3: ldstr ""
 			IL_01d8: ldc.i4.0
 			IL_01d9: ldc.i4.1
-			IL_01da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_F3DE6889_L32C20>(!!0, float64, string, bool, bool)
+			IL_01da: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionObject_FunctionExpression_F3DE6889_L32C20>(!!0, float64, string, bool, bool)
 			IL_01df: stloc.s 10
 			IL_01e1: ldloc.3
 			IL_01e2: ldstr "on"
@@ -930,9 +1842,9 @@
 			[0] class Modules.Net_CreateServer_Connect_Basic/Scope,
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule,
 			[2] object[],
-			[3] class FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_E00EA35D_L5C33,
+			[3] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionObject_FunctionExpression_E00EA35D_L5C33,
 			[4] object,
-			[5] class FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_7DD89A92_L19C31
+			[5] class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionObject_FunctionExpression_7DD89A92_L19C31
 		)
 
 		IL_0000: newobj instance void Modules.Net_CreateServer_Connect_Basic/Scope::.ctor()
@@ -958,13 +1870,13 @@
 		IL_002c: ldc.i4.0
 		IL_002d: ldelem.ref
 		IL_002e: castclass Modules.Net_CreateServer_Connect_Basic/Scope
-		IL_0033: newobj instance void FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_E00EA35D_L5C33::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope)
+		IL_0033: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionObject_FunctionExpression_E00EA35D_L5C33::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope)
 		IL_0038: ldc.i4.1
 		IL_0039: conv.r8
 		IL_003a: ldstr ""
 		IL_003f: ldc.i4.0
 		IL_0040: ldc.i4.1
-		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_E00EA35D_L5C33>(!!0, float64, string, bool, bool)
+		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionObject_FunctionExpression_E00EA35D_L5C33>(!!0, float64, string, bool, bool)
 		IL_0046: stloc.3
 		IL_0047: ldstr "createServer"
 		IL_004c: ldloc.3
@@ -988,13 +1900,13 @@
 		IL_0075: ldc.i4.0
 		IL_0076: ldelem.ref
 		IL_0077: castclass Modules.Net_CreateServer_Connect_Basic/Scope
-		IL_007c: newobj instance void FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_7DD89A92_L19C31::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope)
+		IL_007c: newobj instance void Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionObject_FunctionExpression_7DD89A92_L19C31::.ctor(class Modules.Net_CreateServer_Connect_Basic/Scope)
 		IL_0081: ldc.i4.0
 		IL_0082: conv.r8
 		IL_0083: ldstr ""
 		IL_0088: ldc.i4.0
 		IL_0089: ldc.i4.1
-		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_7DD89A92_L19C31>(!!0, float64, string, bool, bool)
+		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionObject_FunctionExpression_7DD89A92_L19C31>(!!0, float64, string, bool, bool)
 		IL_008f: stloc.s 5
 		IL_0091: ldloc.s 4
 		IL_0093: ldstr "listen"
@@ -1008,918 +1920,6 @@
 	} // end of method Net_CreateServer_Connect_Basic::__js_module_init__
 
 } // end of class Modules.Net_CreateServer_Connect_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_E00EA35D_L5C33
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_CreateServer_Connect_Basic/Scope _environment0_Net_CreateServer_Connect_Basic
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_CreateServer_Connect_Basic/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2659
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_CreateServer_Connect_Basic/Scope FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_E00EA35D_L5C33::_environment0_Net_CreateServer_Connect_Basic
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E00EA35D_L5C33::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2668
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E00EA35D_L5C33::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x266b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E00EA35D_L5C33::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x266e
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Net_CreateServer_Connect_Basic/Scope FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_E00EA35D_L5C33::_environment0_Net_CreateServer_Connect_Basic
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server::__js_call__(class Modules.Net_CreateServer_Connect_Basic/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_E00EA35D_L5C33::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2687
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Net_CreateServer_Connect_Basic/Scope FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_E00EA35D_L5C33::_environment0_Net_CreateServer_Connect_Basic
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server::__js_call__(class Modules.Net_CreateServer_Connect_Basic/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_E00EA35D_L5C33::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x269c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E00EA35D_L5C33::ConstructCore
-
-} // end of class FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_E00EA35D_L5C33
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_47F27A5E_L8C21
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_CreateServer_Connect_Basic/Scope _environment0_Net_CreateServer_Connect_Basic
-	.field private initonly class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope _environment1_FunctionExpression_server
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_CreateServer_Connect_Basic/Scope capture0,
-			class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x26ab
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_CreateServer_Connect_Basic/Scope FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_47F27A5E_L8C21::_environment0_Net_CreateServer_Connect_Basic
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_47F27A5E_L8C21::_environment1_FunctionExpression_server
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_47F27A5E_L8C21::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_47F27A5E_L8C21::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x26c8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_47F27A5E_L8C21::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x26cb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_47F27A5E_L8C21::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x26ce
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_47F27A5E_L8C21::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_47F27A5E_L8C21::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26e7
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_47F27A5E_L8C21::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_47F27A5E_L8C21::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26fc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_47F27A5E_L8C21::ConstructCore
-
-} // end of class FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_47F27A5E_L8C21
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_91246900_L12C20
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_CreateServer_Connect_Basic/Scope _environment0_Net_CreateServer_Connect_Basic
-	.field private initonly class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope _environment1_FunctionExpression_server
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_CreateServer_Connect_Basic/Scope capture0,
-			class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x270b
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_CreateServer_Connect_Basic/Scope FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_91246900_L12C20::_environment0_Net_CreateServer_Connect_Basic
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/Scope FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_91246900_L12C20::_environment1_FunctionExpression_server
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_91246900_L12C20::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_91246900_L12C20::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2728
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_91246900_L12C20::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x272b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_91246900_L12C20::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x272e
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_91246900_L12C20::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_91246900_L12C20::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2740
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_91246900_L12C20::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_server/FunctionExpression_server_L12C19::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_91246900_L12C20::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x274e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_91246900_L12C20::ConstructCore
-
-} // end of class FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_91246900_L12C20
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_7DD89A92_L19C31
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_CreateServer_Connect_Basic/Scope _environment0_Net_CreateServer_Connect_Basic
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_CreateServer_Connect_Basic/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x275d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_CreateServer_Connect_Basic/Scope FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_7DD89A92_L19C31::_environment0_Net_CreateServer_Connect_Basic
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7DD89A92_L19C31::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x276c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7DD89A92_L19C31::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x276f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7DD89A92_L19C31::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2772
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Net_CreateServer_Connect_Basic/Scope FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_7DD89A92_L19C31::_environment0_Net_CreateServer_Connect_Basic
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30::__js_call__(class Modules.Net_CreateServer_Connect_Basic/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_7DD89A92_L19C31::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2784
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Net_CreateServer_Connect_Basic/Scope FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_7DD89A92_L19C31::_environment0_Net_CreateServer_Connect_Basic
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30::__js_call__(class Modules.Net_CreateServer_Connect_Basic/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_7DD89A92_L19C31::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2792
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7DD89A92_L19C31::ConstructCore
-
-} // end of class FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_7DD89A92_L19C31
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_FCCB5C27_L23C55
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_CreateServer_Connect_Basic/Scope _environment0_Net_CreateServer_Connect_Basic
-	.field private initonly class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope _environment1_FunctionExpression_L19C30
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_CreateServer_Connect_Basic/Scope capture0,
-			class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x27a1
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_CreateServer_Connect_Basic/Scope FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_FCCB5C27_L23C55::_environment0_Net_CreateServer_Connect_Basic
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_FCCB5C27_L23C55::_environment1_FunctionExpression_L19C30
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_FCCB5C27_L23C55::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_FCCB5C27_L23C55::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x27be
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FCCB5C27_L23C55::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x27c1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FCCB5C27_L23C55::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x27c4
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_FCCB5C27_L23C55::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_FCCB5C27_L23C55::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27d6
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_FCCB5C27_L23C55::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_client::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_FCCB5C27_L23C55::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27e4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_FCCB5C27_L23C55::ConstructCore
-
-} // end of class FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_FCCB5C27_L23C55
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_AAF4393B_L28C21
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_CreateServer_Connect_Basic/Scope _environment0_Net_CreateServer_Connect_Basic
-	.field private initonly class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope _environment1_FunctionExpression_L19C30
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_CreateServer_Connect_Basic/Scope capture0,
-			class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x27f3
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_CreateServer_Connect_Basic/Scope FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_AAF4393B_L28C21::_environment0_Net_CreateServer_Connect_Basic
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_AAF4393B_L28C21::_environment1_FunctionExpression_L19C30
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_AAF4393B_L28C21::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_AAF4393B_L28C21::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2810
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_AAF4393B_L28C21::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2813
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_AAF4393B_L28C21::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2816
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_AAF4393B_L28C21::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_AAF4393B_L28C21::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x282f
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_AAF4393B_L28C21::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L28C20::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_AAF4393B_L28C21::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2844
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_AAF4393B_L28C21::ConstructCore
-
-} // end of class FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_AAF4393B_L28C21
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_F3DE6889_L32C20
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_CreateServer_Connect_Basic/Scope _environment0_Net_CreateServer_Connect_Basic
-	.field private initonly class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope _environment1_FunctionExpression_L19C30
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_CreateServer_Connect_Basic/Scope capture0,
-			class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2853
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_CreateServer_Connect_Basic/Scope FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_F3DE6889_L32C20::_environment0_Net_CreateServer_Connect_Basic
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/Scope FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_F3DE6889_L32C20::_environment1_FunctionExpression_L19C30
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_F3DE6889_L32C20::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_F3DE6889_L32C20::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2870
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F3DE6889_L32C20::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2873
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F3DE6889_L32C20::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2876
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_F3DE6889_L32C20::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_F3DE6889_L32C20::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2888
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_F3DE6889_L32C20::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_F3DE6889_L32C20::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2896
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F3DE6889_L32C20::ConstructCore
-
-} // end of class FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_F3DE6889_L32C20
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_3A83E61C_L34C18
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x28a5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_3A83E61C_L34C18::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x28ad
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3A83E61C_L34C18::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x28b0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3A83E61C_L34C18::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x28b3
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionExpression_L34C17::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_3A83E61C_L34C18::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28bf
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Net_CreateServer_Connect_Basic/FunctionExpression_L19C30/FunctionExpression_L32C19/FunctionExpression_L34C17::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_3A83E61C_L34C18::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28c7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3A83E61C_L34C18::ConstructCore
-
-} // end of class FunctionObjects.Net_CreateServer_Connect_Basic_EAD005D2.FunctionObject_FunctionExpression_3A83E61C_L34C18
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_Binary_Data_Defaults_To_Buffer.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_Binary_Data_Defaults_To_Buffer.verified.txt
@@ -57,6 +57,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_AA8D4FE4_L9C21
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope _environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
+				.field private initonly class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope _environment1_FunctionExpression_server
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope capture0,
+						class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2871
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_AA8D4FE4_L9C21::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_AA8D4FE4_L9C21::_environment1_FunctionExpression_server
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_AA8D4FE4_L9C21::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_AA8D4FE4_L9C21::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x288e
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_AA8D4FE4_L9C21::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2891
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_AA8D4FE4_L9C21::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2894
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_AA8D4FE4_L9C21::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_AA8D4FE4_L9C21::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x28ad
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_AA8D4FE4_L9C21::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_AA8D4FE4_L9C21::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x28c2
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_AA8D4FE4_L9C21::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_AA8D4FE4_L9C21
+
 
 			// Methods
 			.method public hidebysig static 
@@ -318,6 +441,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2A91282E_L5C33
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope _environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x281f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionObject_FunctionExpression_2A91282E_L5C33::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_2A91282E_L5C33::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x282e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_2A91282E_L5C33::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2831
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_2A91282E_L5C33::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2834
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionObject_FunctionExpression_2A91282E_L5C33::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server::__js_call__(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_2A91282E_L5C33::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x284d
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionObject_FunctionExpression_2A91282E_L5C33::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server::__js_call__(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_2A91282E_L5C33::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2862
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_2A91282E_L5C33::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_2A91282E_L5C33
+
 
 		// Methods
 		.method public hidebysig static 
@@ -341,7 +577,7 @@
 				[1] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 				[2] object,
 				[3] object[],
-				[4] class FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_AA8D4FE4_L9C21
+				[4] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_AA8D4FE4_L9C21
 			)
 
 			IL_0000: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope::.ctor()
@@ -383,13 +619,13 @@
 			IL_004c: ldelem.ref
 			IL_004d: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope
 			IL_0052: ldloc.3
-			IL_0053: newobj instance void FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_AA8D4FE4_L9C21::.ctor(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope, object[])
+			IL_0053: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_AA8D4FE4_L9C21::.ctor(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope, object[])
 			IL_0058: ldc.i4.1
 			IL_0059: conv.r8
 			IL_005a: ldstr ""
 			IL_005f: ldc.i4.0
 			IL_0060: ldc.i4.1
-			IL_0061: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_AA8D4FE4_L9C21>(!!0, float64, string, bool, bool)
+			IL_0061: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_AA8D4FE4_L9C21>(!!0, float64, string, bool, bool)
 			IL_0066: stloc.s 4
 			IL_0068: ldloc.2
 			IL_0069: ldstr "on"
@@ -430,6 +666,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_945BE1B3_L25C55
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope _environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
+				.field private initonly class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope _environment1_FunctionExpression_L23C30
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope capture0,
+						class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2915
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client/FunctionObject_FunctionExpression_945BE1B3_L25C55::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client/FunctionObject_FunctionExpression_945BE1B3_L25C55::_environment1_FunctionExpression_L23C30
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client/FunctionObject_FunctionExpression_945BE1B3_L25C55::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_945BE1B3_L25C55::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2932
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_945BE1B3_L25C55::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2935
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_945BE1B3_L25C55::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2938
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client/FunctionObject_FunctionExpression_945BE1B3_L25C55::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_945BE1B3_L25C55::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x294a
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client/FunctionObject_FunctionExpression_945BE1B3_L25C55::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_945BE1B3_L25C55::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2958
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_945BE1B3_L25C55::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_945BE1B3_L25C55
 
 
 			// Methods
@@ -507,6 +860,129 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_895CF472_L30C21
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope _environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
+				.field private initonly class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope _environment1_FunctionExpression_L23C30
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope capture0,
+						class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2967
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_895CF472_L30C21::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_895CF472_L30C21::_environment1_FunctionExpression_L23C30
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_895CF472_L30C21::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_895CF472_L30C21::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2984
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_895CF472_L30C21::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2987
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_895CF472_L30C21::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x298a
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_895CF472_L30C21::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_895CF472_L30C21::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x29a3
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_895CF472_L30C21::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_895CF472_L30C21::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x29b8
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_895CF472_L30C21::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_895CF472_L30C21
 
 
 			// Methods
@@ -603,6 +1079,101 @@
 
 				} // end of class Scope
 
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_56792F9B_L39C18
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x2a19
+						// Header size: 1
+						// Code size: 7 (0x7)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ret
+					} // end of method FunctionObject_FunctionExpression_56792F9B_L39C18::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x2a21
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_56792F9B_L39C18::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x2a24
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_56792F9B_L39C18::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x2a27
+						// Header size: 1
+						// Code size: 11 (0xb)
+						.maxstack 8
+
+						IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_0005: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionExpression_L39C17::__js_call__(object)
+						IL_000a: ret
+					} // end of method FunctionObject_FunctionExpression_56792F9B_L39C18::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x2a33
+						// Header size: 1
+						// Code size: 7 (0x7)
+						.maxstack 8
+
+						IL_0000: ldarg.3
+						IL_0001: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionExpression_L39C17::__js_call__(object)
+						IL_0006: ret
+					} // end of method FunctionObject_FunctionExpression_56792F9B_L39C18::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x2a3b
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_56792F9B_L39C18::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_56792F9B_L39C18
+
 
 				// Methods
 				.method public hidebysig static 
@@ -651,6 +1222,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_CB9F1FB7_L36C20
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope _environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
+				.field private initonly class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope _environment1_FunctionExpression_L23C30
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope capture0,
+						class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x29c7
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_CB9F1FB7_L36C20::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_CB9F1FB7_L36C20::_environment1_FunctionExpression_L23C30
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_CB9F1FB7_L36C20::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_CB9F1FB7_L36C20::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x29e4
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_CB9F1FB7_L36C20::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x29e7
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_CB9F1FB7_L36C20::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x29ea
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_CB9F1FB7_L36C20::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_CB9F1FB7_L36C20::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x29fc
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_CB9F1FB7_L36C20::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_CB9F1FB7_L36C20::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2a0a
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_CB9F1FB7_L36C20::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_CB9F1FB7_L36C20
+
 
 			// Methods
 			.method public hidebysig static 
@@ -675,7 +1363,7 @@
 					[5] object,
 					[6] object,
 					[7] object[],
-					[8] class FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_56792F9B_L39C18
+					[8] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionExpression_L39C17/FunctionObject_FunctionExpression_56792F9B_L39C18
 				)
 
 				IL_0000: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/Scope::.ctor()
@@ -769,13 +1457,13 @@
 				IL_0114: ldelem.ref
 				IL_0115: stelem.ref
 				IL_0116: stloc.s 7
-				IL_0118: newobj instance void FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_56792F9B_L39C18::.ctor()
+				IL_0118: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionExpression_L39C17/FunctionObject_FunctionExpression_56792F9B_L39C18::.ctor()
 				IL_011d: ldc.i4.0
 				IL_011e: conv.r8
 				IL_011f: ldstr ""
 				IL_0124: ldc.i4.0
 				IL_0125: ldc.i4.1
-				IL_0126: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_56792F9B_L39C18>(!!0, float64, string, bool, bool)
+				IL_0126: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionExpression_L39C17/FunctionObject_FunctionExpression_56792F9B_L39C18>(!!0, float64, string, bool, bool)
 				IL_012b: stloc.s 8
 				IL_012d: ldloc.3
 				IL_012e: ldstr "close"
@@ -820,6 +1508,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_990FE208_L23C31
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope _environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x28d1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionObject_FunctionExpression_990FE208_L23C31::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_990FE208_L23C31::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x28e0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_990FE208_L23C31::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x28e3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_990FE208_L23C31::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x28e6
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionObject_FunctionExpression_990FE208_L23C31::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30::__js_call__(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_990FE208_L23C31::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x28f8
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionObject_FunctionExpression_990FE208_L23C31::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30::__js_call__(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_990FE208_L23C31::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2906
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_990FE208_L23C31::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_990FE208_L23C31
+
 
 		// Methods
 		.method public hidebysig static 
@@ -843,10 +1638,10 @@
 				[2] object,
 				[3] object,
 				[4] object[],
-				[5] class FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_945BE1B3_L25C55,
+				[5] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client/FunctionObject_FunctionExpression_945BE1B3_L25C55,
 				[6] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[7] class FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_895CF472_L30C21,
-				[8] class FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_CB9F1FB7_L36C20
+				[7] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_895CF472_L30C21,
+				[8] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_CB9F1FB7_L36C20
 			)
 
 			IL_0000: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope::.ctor()
@@ -887,13 +1682,13 @@
 			IL_0056: ldelem.ref
 			IL_0057: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope
 			IL_005c: ldloc.s 4
-			IL_005e: newobj instance void FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_945BE1B3_L25C55::.ctor(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope, object[])
+			IL_005e: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client/FunctionObject_FunctionExpression_945BE1B3_L25C55::.ctor(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope, object[])
 			IL_0063: ldc.i4.0
 			IL_0064: conv.r8
 			IL_0065: ldstr ""
 			IL_006a: ldc.i4.0
 			IL_006b: ldc.i4.1
-			IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_945BE1B3_L25C55>(!!0, float64, string, bool, bool)
+			IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client/FunctionObject_FunctionExpression_945BE1B3_L25C55>(!!0, float64, string, bool, bool)
 			IL_0071: stloc.s 5
 			IL_0073: ldstr "connect"
 			IL_0078: ldloc.2
@@ -936,13 +1731,13 @@
 			IL_00cb: ldelem.ref
 			IL_00cc: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope
 			IL_00d1: ldloc.s 4
-			IL_00d3: newobj instance void FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_895CF472_L30C21::.ctor(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope, object[])
+			IL_00d3: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_895CF472_L30C21::.ctor(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope, object[])
 			IL_00d8: ldc.i4.1
 			IL_00d9: conv.r8
 			IL_00da: ldstr ""
 			IL_00df: ldc.i4.0
 			IL_00e0: ldc.i4.1
-			IL_00e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_895CF472_L30C21>(!!0, float64, string, bool, bool)
+			IL_00e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_895CF472_L30C21>(!!0, float64, string, bool, bool)
 			IL_00e6: stloc.s 7
 			IL_00e8: ldloc.3
 			IL_00e9: ldstr "on"
@@ -976,13 +1771,13 @@
 			IL_012d: ldelem.ref
 			IL_012e: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope
 			IL_0133: ldloc.s 4
-			IL_0135: newobj instance void FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_CB9F1FB7_L36C20::.ctor(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope, object[])
+			IL_0135: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_CB9F1FB7_L36C20::.ctor(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope, object[])
 			IL_013a: ldc.i4.0
 			IL_013b: conv.r8
 			IL_013c: ldstr ""
 			IL_0141: ldc.i4.0
 			IL_0142: ldc.i4.1
-			IL_0143: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_CB9F1FB7_L36C20>(!!0, float64, string, bool, bool)
+			IL_0143: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_CB9F1FB7_L36C20>(!!0, float64, string, bool, bool)
 			IL_0148: stloc.s 8
 			IL_014a: ldloc.3
 			IL_014b: ldstr "on"
@@ -1044,9 +1839,9 @@
 			[0] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope,
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule,
 			[2] object[],
-			[3] class FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_2A91282E_L5C33,
+			[3] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionObject_FunctionExpression_2A91282E_L5C33,
 			[4] object,
-			[5] class FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_990FE208_L23C31
+			[5] class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionObject_FunctionExpression_990FE208_L23C31
 		)
 
 		IL_0000: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope::.ctor()
@@ -1072,13 +1867,13 @@
 		IL_002c: ldc.i4.0
 		IL_002d: ldelem.ref
 		IL_002e: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope
-		IL_0033: newobj instance void FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_2A91282E_L5C33::.ctor(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope)
+		IL_0033: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionObject_FunctionExpression_2A91282E_L5C33::.ctor(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope)
 		IL_0038: ldc.i4.1
 		IL_0039: conv.r8
 		IL_003a: ldstr ""
 		IL_003f: ldc.i4.0
 		IL_0040: ldc.i4.1
-		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_2A91282E_L5C33>(!!0, float64, string, bool, bool)
+		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionObject_FunctionExpression_2A91282E_L5C33>(!!0, float64, string, bool, bool)
 		IL_0046: stloc.3
 		IL_0047: ldstr "createServer"
 		IL_004c: ldloc.3
@@ -1102,13 +1897,13 @@
 		IL_0075: ldc.i4.0
 		IL_0076: ldelem.ref
 		IL_0077: castclass Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope
-		IL_007c: newobj instance void FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_990FE208_L23C31::.ctor(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope)
+		IL_007c: newobj instance void Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionObject_FunctionExpression_990FE208_L23C31::.ctor(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope)
 		IL_0081: ldc.i4.0
 		IL_0082: conv.r8
 		IL_0083: ldstr ""
 		IL_0088: ldc.i4.0
 		IL_0089: ldc.i4.1
-		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_990FE208_L23C31>(!!0, float64, string, bool, bool)
+		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionObject_FunctionExpression_990FE208_L23C31>(!!0, float64, string, bool, bool)
 		IL_008f: stloc.s 5
 		IL_0091: ldloc.s 4
 		IL_0093: ldstr "listen"
@@ -1122,801 +1917,6 @@
 	} // end of method Net_Socket_Binary_Data_Defaults_To_Buffer::__js_module_init__
 
 } // end of class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_2A91282E_L5C33
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope _environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x281f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_2A91282E_L5C33::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2A91282E_L5C33::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x282e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2A91282E_L5C33::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2831
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2A91282E_L5C33::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2834
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_2A91282E_L5C33::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server::__js_call__(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_2A91282E_L5C33::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x284d
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_2A91282E_L5C33::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server::__js_call__(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_2A91282E_L5C33::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2862
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2A91282E_L5C33::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_2A91282E_L5C33
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_AA8D4FE4_L9C21
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope _environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
-	.field private initonly class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope _environment1_FunctionExpression_server
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope capture0,
-			class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2871
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_AA8D4FE4_L9C21::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/Scope FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_AA8D4FE4_L9C21::_environment1_FunctionExpression_server
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_AA8D4FE4_L9C21::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_AA8D4FE4_L9C21::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x288e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_AA8D4FE4_L9C21::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2891
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_AA8D4FE4_L9C21::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2894
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_AA8D4FE4_L9C21::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_AA8D4FE4_L9C21::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28ad
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_AA8D4FE4_L9C21::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_AA8D4FE4_L9C21::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28c2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_AA8D4FE4_L9C21::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_AA8D4FE4_L9C21
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_990FE208_L23C31
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope _environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x28d1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_990FE208_L23C31::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_990FE208_L23C31::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x28e0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_990FE208_L23C31::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x28e3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_990FE208_L23C31::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x28e6
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_990FE208_L23C31::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30::__js_call__(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_990FE208_L23C31::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28f8
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_990FE208_L23C31::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30::__js_call__(class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_990FE208_L23C31::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2906
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_990FE208_L23C31::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_990FE208_L23C31
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_945BE1B3_L25C55
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope _environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
-	.field private initonly class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope _environment1_FunctionExpression_L23C30
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope capture0,
-			class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2915
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_945BE1B3_L25C55::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_945BE1B3_L25C55::_environment1_FunctionExpression_L23C30
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_945BE1B3_L25C55::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_945BE1B3_L25C55::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2932
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_945BE1B3_L25C55::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2935
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_945BE1B3_L25C55::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2938
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_945BE1B3_L25C55::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_945BE1B3_L25C55::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x294a
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_945BE1B3_L25C55::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_client::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_945BE1B3_L25C55::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2958
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_945BE1B3_L25C55::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_945BE1B3_L25C55
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_895CF472_L30C21
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope _environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
-	.field private initonly class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope _environment1_FunctionExpression_L23C30
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope capture0,
-			class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2967
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_895CF472_L30C21::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_895CF472_L30C21::_environment1_FunctionExpression_L23C30
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_895CF472_L30C21::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_895CF472_L30C21::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2984
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_895CF472_L30C21::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2987
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_895CF472_L30C21::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x298a
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_895CF472_L30C21::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_895CF472_L30C21::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29a3
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_895CF472_L30C21::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_895CF472_L30C21::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29b8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_895CF472_L30C21::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_895CF472_L30C21
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_CB9F1FB7_L36C20
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope _environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
-	.field private initonly class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope _environment1_FunctionExpression_L23C30
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope capture0,
-			class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x29c7
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/Scope FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_CB9F1FB7_L36C20::_environment0_Net_Socket_Binary_Data_Defaults_To_Buffer
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/Scope FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_CB9F1FB7_L36C20::_environment1_FunctionExpression_L23C30
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_CB9F1FB7_L36C20::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_CB9F1FB7_L36C20::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x29e4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_CB9F1FB7_L36C20::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x29e7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_CB9F1FB7_L36C20::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x29ea
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_CB9F1FB7_L36C20::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_CB9F1FB7_L36C20::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29fc
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_CB9F1FB7_L36C20::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_CB9F1FB7_L36C20::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a0a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_CB9F1FB7_L36C20::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_CB9F1FB7_L36C20
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_56792F9B_L39C18
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2a19
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_56792F9B_L39C18::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a21
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_56792F9B_L39C18::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a24
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_56792F9B_L39C18::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a27
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionExpression_L39C17::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_56792F9B_L39C18::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a33
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Net_Socket_Binary_Data_Defaults_To_Buffer/FunctionExpression_L23C30/FunctionExpression_L36C19/FunctionExpression_L39C17::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_56792F9B_L39C18::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a3b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_56792F9B_L39C18::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_Binary_Data_Defaults_To_Buffer_982B0C5F.FunctionObject_FunctionExpression_56792F9B_L39C18
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_KeepAlive_And_Unsupported_Options.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_KeepAlive_And_Unsupported_Options.verified.txt
@@ -31,6 +31,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_EA8659D0_L11C33
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope _environment0_Net_Socket_KeepAlive_And_Unsupported_Options
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x26a8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server/FunctionObject_FunctionExpression_EA8659D0_L11C33::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_EA8659D0_L11C33::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x26b7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_EA8659D0_L11C33::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x26ba
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_EA8659D0_L11C33::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x26bd
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server/FunctionObject_FunctionExpression_EA8659D0_L11C33::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server::__js_call__(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_EA8659D0_L11C33::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26d6
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server/FunctionObject_FunctionExpression_EA8659D0_L11C33::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server::__js_call__(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_EA8659D0_L11C33::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26eb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_EA8659D0_L11C33::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_EA8659D0_L11C33
+
 
 		// Methods
 		.method public hidebysig static 
@@ -158,6 +271,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_ED8227CA_L18C55
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope _environment0_Net_Socket_KeepAlive_And_Unsupported_Options
+				.field private initonly class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope _environment1_FunctionExpression_L16C30
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope capture0,
+						class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x273e
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/FunctionObject_FunctionExpression_ED8227CA_L18C55::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/FunctionObject_FunctionExpression_ED8227CA_L18C55::_environment1_FunctionExpression_L16C30
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/FunctionObject_FunctionExpression_ED8227CA_L18C55::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_ED8227CA_L18C55::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x275b
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_ED8227CA_L18C55::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x275e
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_ED8227CA_L18C55::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2761
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/FunctionObject_FunctionExpression_ED8227CA_L18C55::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_ED8227CA_L18C55::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2773
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/FunctionObject_FunctionExpression_ED8227CA_L18C55::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_ED8227CA_L18C55::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2781
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_ED8227CA_L18C55::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_ED8227CA_L18C55
 
 
 			// Methods
@@ -354,6 +584,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3897B4EB_L30C21
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope _environment0_Net_Socket_KeepAlive_And_Unsupported_Options
+				.field private initonly class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope _environment1_FunctionExpression_L16C30
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope capture0,
+						class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2790
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_3897B4EB_L30C21::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_3897B4EB_L30C21::_environment1_FunctionExpression_L16C30
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_3897B4EB_L30C21::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_3897B4EB_L30C21::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x27ad
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_3897B4EB_L30C21::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x27b0
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_3897B4EB_L30C21::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x27b3
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_3897B4EB_L30C21::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_3897B4EB_L30C21::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x27cc
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_3897B4EB_L30C21::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_3897B4EB_L30C21::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x27e1
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_3897B4EB_L30C21::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_3897B4EB_L30C21
+
 
 			// Methods
 			.method public hidebysig static 
@@ -418,6 +771,101 @@
 
 				} // end of class Scope
 
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E9FDE408_L40C18
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x2842
+						// Header size: 1
+						// Code size: 7 (0x7)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ret
+					} // end of method FunctionObject_FunctionExpression_E9FDE408_L40C18::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x284a
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_E9FDE408_L40C18::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x284d
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_E9FDE408_L40C18::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x2850
+						// Header size: 1
+						// Code size: 11 (0xb)
+						.maxstack 8
+
+						IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_0005: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionExpression_L40C17::__js_call__(object)
+						IL_000a: ret
+					} // end of method FunctionObject_FunctionExpression_E9FDE408_L40C18::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x285c
+						// Header size: 1
+						// Code size: 7 (0x7)
+						.maxstack 8
+
+						IL_0000: ldarg.3
+						IL_0001: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionExpression_L40C17::__js_call__(object)
+						IL_0006: ret
+					} // end of method FunctionObject_FunctionExpression_E9FDE408_L40C18::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x2864
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_E9FDE408_L40C18::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_E9FDE408_L40C18
+
 
 				// Methods
 				.method public hidebysig static 
@@ -466,6 +914,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_49A25974_L34C20
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope _environment0_Net_Socket_KeepAlive_And_Unsupported_Options
+				.field private initonly class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope _environment1_FunctionExpression_L16C30
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope capture0,
+						class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x27f0
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_49A25974_L34C20::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_49A25974_L34C20::_environment1_FunctionExpression_L16C30
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_49A25974_L34C20::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_49A25974_L34C20::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x280d
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_49A25974_L34C20::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2810
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_49A25974_L34C20::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2813
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_49A25974_L34C20::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_49A25974_L34C20::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2825
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_49A25974_L34C20::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_49A25974_L34C20::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2833
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_49A25974_L34C20::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_49A25974_L34C20
+
 
 			// Methods
 			.method public hidebysig static 
@@ -486,7 +1051,7 @@
 					[1] object,
 					[2] object,
 					[3] object[],
-					[4] class FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_E9FDE408_L40C18
+					[4] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionExpression_L40C17/FunctionObject_FunctionExpression_E9FDE408_L40C18
 				)
 
 				IL_0000: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/Scope::.ctor()
@@ -582,13 +1147,13 @@
 				IL_00fa: ldelem.ref
 				IL_00fb: stelem.ref
 				IL_00fc: stloc.3
-				IL_00fd: newobj instance void FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_E9FDE408_L40C18::.ctor()
+				IL_00fd: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionExpression_L40C17/FunctionObject_FunctionExpression_E9FDE408_L40C18::.ctor()
 				IL_0102: ldc.i4.0
 				IL_0103: conv.r8
 				IL_0104: ldstr ""
 				IL_0109: ldc.i4.0
 				IL_010a: ldc.i4.1
-				IL_010b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_E9FDE408_L40C18>(!!0, float64, string, bool, bool)
+				IL_010b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionExpression_L40C17/FunctionObject_FunctionExpression_E9FDE408_L40C18>(!!0, float64, string, bool, bool)
 				IL_0110: stloc.s 4
 				IL_0112: ldloc.2
 				IL_0113: ldstr "close"
@@ -631,6 +1196,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_47229D4D_L16C31
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope _environment0_Net_Socket_KeepAlive_And_Unsupported_Options
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x26fa
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionObject_FunctionExpression_47229D4D_L16C31::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_47229D4D_L16C31::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2709
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_47229D4D_L16C31::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x270c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_47229D4D_L16C31::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x270f
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionObject_FunctionExpression_47229D4D_L16C31::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30::__js_call__(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_47229D4D_L16C31::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2721
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionObject_FunctionExpression_47229D4D_L16C31::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30::__js_call__(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_47229D4D_L16C31::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x272f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_47229D4D_L16C31::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_47229D4D_L16C31
+
 
 		// Methods
 		.method public hidebysig static 
@@ -654,9 +1326,9 @@
 				[2] object,
 				[3] object,
 				[4] object[],
-				[5] class FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_ED8227CA_L18C55,
-				[6] class FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_3897B4EB_L30C21,
-				[7] class FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_49A25974_L34C20
+				[5] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/FunctionObject_FunctionExpression_ED8227CA_L18C55,
+				[6] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_3897B4EB_L30C21,
+				[7] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_49A25974_L34C20
 			)
 
 			IL_0000: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope::.ctor()
@@ -697,13 +1369,13 @@
 			IL_0056: ldelem.ref
 			IL_0057: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope
 			IL_005c: ldloc.s 4
-			IL_005e: newobj instance void FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_ED8227CA_L18C55::.ctor(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope, object[])
+			IL_005e: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/FunctionObject_FunctionExpression_ED8227CA_L18C55::.ctor(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope, object[])
 			IL_0063: ldc.i4.0
 			IL_0064: conv.r8
 			IL_0065: ldstr ""
 			IL_006a: ldc.i4.0
 			IL_006b: ldc.i4.1
-			IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_ED8227CA_L18C55>(!!0, float64, string, bool, bool)
+			IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client/FunctionObject_FunctionExpression_ED8227CA_L18C55>(!!0, float64, string, bool, bool)
 			IL_0071: stloc.s 5
 			IL_0073: ldstr "connect"
 			IL_0078: ldloc.2
@@ -749,13 +1421,13 @@
 			IL_00e0: ldelem.ref
 			IL_00e1: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope
 			IL_00e6: ldloc.s 4
-			IL_00e8: newobj instance void FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_3897B4EB_L30C21::.ctor(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope, object[])
+			IL_00e8: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_3897B4EB_L30C21::.ctor(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope, object[])
 			IL_00ed: ldc.i4.1
 			IL_00ee: conv.r8
 			IL_00ef: ldstr ""
 			IL_00f4: ldc.i4.0
 			IL_00f5: ldc.i4.1
-			IL_00f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_3897B4EB_L30C21>(!!0, float64, string, bool, bool)
+			IL_00f6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20/FunctionObject_FunctionExpression_3897B4EB_L30C21>(!!0, float64, string, bool, bool)
 			IL_00fb: stloc.s 6
 			IL_00fd: ldloc.3
 			IL_00fe: ldstr "on"
@@ -789,13 +1461,13 @@
 			IL_0142: ldelem.ref
 			IL_0143: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope
 			IL_0148: ldloc.s 4
-			IL_014a: newobj instance void FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_49A25974_L34C20::.ctor(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope, object[])
+			IL_014a: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_49A25974_L34C20::.ctor(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope, object[])
 			IL_014f: ldc.i4.0
 			IL_0150: conv.r8
 			IL_0151: ldstr ""
 			IL_0156: ldc.i4.0
 			IL_0157: ldc.i4.1
-			IL_0158: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_49A25974_L34C20>(!!0, float64, string, bool, bool)
+			IL_0158: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionObject_FunctionExpression_49A25974_L34C20>(!!0, float64, string, bool, bool)
 			IL_015d: stloc.s 7
 			IL_015f: ldloc.3
 			IL_0160: ldstr "on"
@@ -875,9 +1547,9 @@
 			[0] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope,
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule,
 			[2] object[],
-			[3] class FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_EA8659D0_L11C33,
+			[3] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server/FunctionObject_FunctionExpression_EA8659D0_L11C33,
 			[4] object,
-			[5] class FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_47229D4D_L16C31
+			[5] class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionObject_FunctionExpression_47229D4D_L16C31
 		)
 
 		IL_0000: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope::.ctor()
@@ -923,13 +1595,13 @@
 		IL_0068: ldc.i4.0
 		IL_0069: ldelem.ref
 		IL_006a: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
-		IL_006f: newobj instance void FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_EA8659D0_L11C33::.ctor(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope)
+		IL_006f: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server/FunctionObject_FunctionExpression_EA8659D0_L11C33::.ctor(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope)
 		IL_0074: ldc.i4.1
 		IL_0075: conv.r8
 		IL_0076: ldstr ""
 		IL_007b: ldc.i4.0
 		IL_007c: ldc.i4.1
-		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_EA8659D0_L11C33>(!!0, float64, string, bool, bool)
+		IL_007d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server/FunctionObject_FunctionExpression_EA8659D0_L11C33>(!!0, float64, string, bool, bool)
 		IL_0082: stloc.3
 		IL_0083: ldstr "createServer"
 		IL_0088: ldloc.3
@@ -953,13 +1625,13 @@
 		IL_00b1: ldc.i4.0
 		IL_00b2: ldelem.ref
 		IL_00b3: castclass Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope
-		IL_00b8: newobj instance void FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_47229D4D_L16C31::.ctor(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope)
+		IL_00b8: newobj instance void Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionObject_FunctionExpression_47229D4D_L16C31::.ctor(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope)
 		IL_00bd: ldc.i4.0
 		IL_00be: conv.r8
 		IL_00bf: ldstr ""
 		IL_00c4: ldc.i4.0
 		IL_00c5: ldc.i4.1
-		IL_00c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_47229D4D_L16C31>(!!0, float64, string, bool, bool)
+		IL_00c6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionObject_FunctionExpression_47229D4D_L16C31>(!!0, float64, string, bool, bool)
 		IL_00cb: stloc.s 5
 		IL_00cd: ldloc.s 4
 		IL_00cf: ldstr "listen"
@@ -973,678 +1645,6 @@
 	} // end of method Net_Socket_KeepAlive_And_Unsupported_Options::__js_module_init__
 
 } // end of class Modules.Net_Socket_KeepAlive_And_Unsupported_Options
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_EA8659D0_L11C33
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope _environment0_Net_Socket_KeepAlive_And_Unsupported_Options
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x26a8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_EA8659D0_L11C33::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_EA8659D0_L11C33::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x26b7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_EA8659D0_L11C33::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x26ba
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_EA8659D0_L11C33::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x26bd
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_EA8659D0_L11C33::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server::__js_call__(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_EA8659D0_L11C33::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26d6
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_EA8659D0_L11C33::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_server::__js_call__(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_EA8659D0_L11C33::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26eb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_EA8659D0_L11C33::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_EA8659D0_L11C33
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_47229D4D_L16C31
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope _environment0_Net_Socket_KeepAlive_And_Unsupported_Options
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x26fa
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_47229D4D_L16C31::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_47229D4D_L16C31::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2709
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_47229D4D_L16C31::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x270c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_47229D4D_L16C31::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x270f
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_47229D4D_L16C31::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30::__js_call__(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_47229D4D_L16C31::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2721
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_47229D4D_L16C31::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30::__js_call__(class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_47229D4D_L16C31::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x272f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_47229D4D_L16C31::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_47229D4D_L16C31
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_ED8227CA_L18C55
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope _environment0_Net_Socket_KeepAlive_And_Unsupported_Options
-	.field private initonly class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope _environment1_FunctionExpression_L16C30
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope capture0,
-			class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x273e
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_ED8227CA_L18C55::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_ED8227CA_L18C55::_environment1_FunctionExpression_L16C30
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_ED8227CA_L18C55::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_ED8227CA_L18C55::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x275b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_ED8227CA_L18C55::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x275e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_ED8227CA_L18C55::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2761
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_ED8227CA_L18C55::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_ED8227CA_L18C55::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2773
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_ED8227CA_L18C55::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_client::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_ED8227CA_L18C55::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2781
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_ED8227CA_L18C55::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_ED8227CA_L18C55
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_3897B4EB_L30C21
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope _environment0_Net_Socket_KeepAlive_And_Unsupported_Options
-	.field private initonly class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope _environment1_FunctionExpression_L16C30
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope capture0,
-			class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2790
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_3897B4EB_L30C21::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_3897B4EB_L30C21::_environment1_FunctionExpression_L16C30
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_3897B4EB_L30C21::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_3897B4EB_L30C21::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x27ad
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3897B4EB_L30C21::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x27b0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3897B4EB_L30C21::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x27b3
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_3897B4EB_L30C21::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_3897B4EB_L30C21::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27cc
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_3897B4EB_L30C21::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L30C20::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_3897B4EB_L30C21::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27e1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3897B4EB_L30C21::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_3897B4EB_L30C21
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_49A25974_L34C20
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope _environment0_Net_Socket_KeepAlive_And_Unsupported_Options
-	.field private initonly class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope _environment1_FunctionExpression_L16C30
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope capture0,
-			class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x27f0
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/Scope FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_49A25974_L34C20::_environment0_Net_Socket_KeepAlive_And_Unsupported_Options
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/Scope FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_49A25974_L34C20::_environment1_FunctionExpression_L16C30
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_49A25974_L34C20::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_49A25974_L34C20::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x280d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_49A25974_L34C20::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2810
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_49A25974_L34C20::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2813
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_49A25974_L34C20::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_49A25974_L34C20::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2825
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_49A25974_L34C20::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_49A25974_L34C20::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2833
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_49A25974_L34C20::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_49A25974_L34C20
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_E9FDE408_L40C18
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2842
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_E9FDE408_L40C18::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x284a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E9FDE408_L40C18::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x284d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E9FDE408_L40C18::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2850
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionExpression_L40C17::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_E9FDE408_L40C18::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x285c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Net_Socket_KeepAlive_And_Unsupported_Options/FunctionExpression_L16C30/FunctionExpression_L34C19/FunctionExpression_L40C17::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_E9FDE408_L40C18::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2864
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E9FDE408_L40C18::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_KeepAlive_And_Unsupported_Options_4E8EC7EE.FunctionObject_FunctionExpression_E9FDE408_L40C18
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_SetEncoding_Utf8.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_SetEncoding_Utf8.verified.txt
@@ -35,6 +35,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2D181329_L9C21
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Net_Socket_SetEncoding_Utf8/Scope _environment0_Net_Socket_SetEncoding_Utf8
+				.field private initonly class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope _environment1_FunctionExpression_server
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Net_Socket_SetEncoding_Utf8/Scope capture0,
+						class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2775
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_2D181329_L9C21::_environment0_Net_Socket_SetEncoding_Utf8
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_2D181329_L9C21::_environment1_FunctionExpression_server
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_2D181329_L9C21::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_2D181329_L9C21::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2792
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_2D181329_L9C21::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2795
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_2D181329_L9C21::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2798
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_2D181329_L9C21::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_2D181329_L9C21::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x27b1
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_2D181329_L9C21::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_2D181329_L9C21::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x27c6
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_2D181329_L9C21::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_2D181329_L9C21
+
 
 			// Methods
 			.method public hidebysig static 
@@ -124,6 +247,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FAB9795C_L14C20
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Net_Socket_SetEncoding_Utf8/Scope _environment0_Net_Socket_SetEncoding_Utf8
+				.field private initonly class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope _environment1_FunctionExpression_server
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Net_Socket_SetEncoding_Utf8/Scope capture0,
+						class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x27d5
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19/FunctionObject_FunctionExpression_FAB9795C_L14C20::_environment0_Net_Socket_SetEncoding_Utf8
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19/FunctionObject_FunctionExpression_FAB9795C_L14C20::_environment1_FunctionExpression_server
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19/FunctionObject_FunctionExpression_FAB9795C_L14C20::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_FAB9795C_L14C20::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x27f2
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_FAB9795C_L14C20::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x27f5
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_FAB9795C_L14C20::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x27f8
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19/FunctionObject_FunctionExpression_FAB9795C_L14C20::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_FAB9795C_L14C20::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x280a
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19/FunctionObject_FunctionExpression_FAB9795C_L14C20::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_FAB9795C_L14C20::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2818
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_FAB9795C_L14C20::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_FAB9795C_L14C20
 
 
 			// Methods
@@ -222,6 +462,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C02347C7_L5C33
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Net_Socket_SetEncoding_Utf8/Scope _environment0_Net_Socket_SetEncoding_Utf8
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Net_Socket_SetEncoding_Utf8/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2723
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionObject_FunctionExpression_C02347C7_L5C33::_environment0_Net_Socket_SetEncoding_Utf8
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_C02347C7_L5C33::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2732
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C02347C7_L5C33::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2735
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C02347C7_L5C33::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2738
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionObject_FunctionExpression_C02347C7_L5C33::_environment0_Net_Socket_SetEncoding_Utf8
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server::__js_call__(class Modules.Net_Socket_SetEncoding_Utf8/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_C02347C7_L5C33::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2751
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionObject_FunctionExpression_C02347C7_L5C33::_environment0_Net_Socket_SetEncoding_Utf8
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server::__js_call__(class Modules.Net_Socket_SetEncoding_Utf8/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_C02347C7_L5C33::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2766
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_C02347C7_L5C33::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_C02347C7_L5C33
+
 
 		// Methods
 		.method public hidebysig static 
@@ -244,8 +597,8 @@
 				[0] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope,
 				[1] object,
 				[2] object[],
-				[3] class FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_2D181329_L9C21,
-				[4] class FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_FAB9795C_L14C20
+				[3] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_2D181329_L9C21,
+				[4] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19/FunctionObject_FunctionExpression_FAB9795C_L14C20
 			)
 
 			IL_0000: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope::.ctor()
@@ -287,13 +640,13 @@
 			IL_0058: ldelem.ref
 			IL_0059: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope
 			IL_005e: ldloc.2
-			IL_005f: newobj instance void FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_2D181329_L9C21::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope, object[])
+			IL_005f: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_2D181329_L9C21::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope, object[])
 			IL_0064: ldc.i4.1
 			IL_0065: conv.r8
 			IL_0066: ldstr ""
 			IL_006b: ldc.i4.0
 			IL_006c: ldc.i4.1
-			IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_2D181329_L9C21>(!!0, float64, string, bool, bool)
+			IL_006d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_2D181329_L9C21>(!!0, float64, string, bool, bool)
 			IL_0072: stloc.3
 			IL_0073: ldloc.1
 			IL_0074: ldstr "on"
@@ -325,13 +678,13 @@
 			IL_00aa: ldelem.ref
 			IL_00ab: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope
 			IL_00b0: ldloc.2
-			IL_00b1: newobj instance void FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_FAB9795C_L14C20::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope, object[])
+			IL_00b1: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19/FunctionObject_FunctionExpression_FAB9795C_L14C20::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope, object[])
 			IL_00b6: ldc.i4.0
 			IL_00b7: conv.r8
 			IL_00b8: ldstr ""
 			IL_00bd: ldc.i4.0
 			IL_00be: ldc.i4.1
-			IL_00bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_FAB9795C_L14C20>(!!0, float64, string, bool, bool)
+			IL_00bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19/FunctionObject_FunctionExpression_FAB9795C_L14C20>(!!0, float64, string, bool, bool)
 			IL_00c4: stloc.s 4
 			IL_00c6: ldloc.1
 			IL_00c7: ldstr "on"
@@ -376,6 +729,123 @@
 					} // end of method Scope::.ctor
 
 				} // end of class Scope
+
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0B722580_L24C16
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Fields
+					.field private initonly class Modules.Net_Socket_SetEncoding_Utf8/Scope _environment0_Net_Socket_SetEncoding_Utf8
+					.field private initonly class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope _environment1_FunctionExpression_L20C30
+					.field private initonly object[] _transitionalScopes
+
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor (
+							class Modules.Net_Socket_SetEncoding_Utf8/Scope capture0,
+							class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope capture1,
+							object[] capture2
+						) cil managed 
+					{
+						// Method begins at RVA 0x28bd
+						// Header size: 1
+						// Code size: 28 (0x1c)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ldarg.0
+						IL_0007: ldarg.1
+						IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client/FunctionObject_FunctionExpression_0B722580_L24C16::_environment0_Net_Socket_SetEncoding_Utf8
+						IL_000d: ldarg.0
+						IL_000e: ldarg.2
+						IL_000f: stfld class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client/FunctionObject_FunctionExpression_0B722580_L24C16::_environment1_FunctionExpression_L20C30
+						IL_0014: ldarg.0
+						IL_0015: ldarg.3
+						IL_0016: stfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client/FunctionObject_FunctionExpression_0B722580_L24C16::_transitionalScopes
+						IL_001b: ret
+					} // end of method FunctionObject_FunctionExpression_0B722580_L24C16::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x28da
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_0B722580_L24C16::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x28dd
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_0B722580_L24C16::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x28e0
+						// Header size: 1
+						// Code size: 17 (0x11)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client/FunctionObject_FunctionExpression_0B722580_L24C16::_transitionalScopes
+						IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_000b: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client::__js_call__(object[], object)
+						IL_0010: ret
+					} // end of method FunctionObject_FunctionExpression_0B722580_L24C16::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x28f2
+						// Header size: 1
+						// Code size: 13 (0xd)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client/FunctionObject_FunctionExpression_0B722580_L24C16::_transitionalScopes
+						IL_0006: ldarg.3
+						IL_0007: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client::__js_call__(object[], object)
+						IL_000c: ret
+					} // end of method FunctionObject_FunctionExpression_0B722580_L24C16::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x2900
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_0B722580_L24C16::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_0B722580_L24C16
 
 
 				// Methods
@@ -444,6 +914,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_4E083AEC_L22C55
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Net_Socket_SetEncoding_Utf8/Scope _environment0_Net_Socket_SetEncoding_Utf8
+				.field private initonly class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope _environment1_FunctionExpression_L20C30
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Net_Socket_SetEncoding_Utf8/Scope capture0,
+						class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x286b
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionObject_FunctionExpression_4E083AEC_L22C55::_environment0_Net_Socket_SetEncoding_Utf8
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionObject_FunctionExpression_4E083AEC_L22C55::_environment1_FunctionExpression_L20C30
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionObject_FunctionExpression_4E083AEC_L22C55::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_4E083AEC_L22C55::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2888
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_4E083AEC_L22C55::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x288b
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_4E083AEC_L22C55::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x288e
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionObject_FunctionExpression_4E083AEC_L22C55::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_4E083AEC_L22C55::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x28a0
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionObject_FunctionExpression_4E083AEC_L22C55::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_4E083AEC_L22C55::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x28ae
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_4E083AEC_L22C55::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_4E083AEC_L22C55
+
 
 			// Methods
 			.method public hidebysig static 
@@ -463,7 +1050,7 @@
 					[0] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/Scope,
 					[1] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
 					[2] object[],
-					[3] class FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_0B722580_L24C16
+					[3] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client/FunctionObject_FunctionExpression_0B722580_L24C16
 				)
 
 				IL_0000: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/Scope::.ctor()
@@ -518,13 +1105,13 @@
 				IL_0079: ldelem.ref
 				IL_007a: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope
 				IL_007f: ldloc.2
-				IL_0080: newobj instance void FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_0B722580_L24C16::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope, object[])
+				IL_0080: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client/FunctionObject_FunctionExpression_0B722580_L24C16::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope, object[])
 				IL_0085: ldc.i4.0
 				IL_0086: conv.r8
 				IL_0087: ldstr ""
 				IL_008c: ldc.i4.0
 				IL_008d: ldc.i4.1
-				IL_008e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_0B722580_L24C16>(!!0, float64, string, bool, bool)
+				IL_008e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client/FunctionObject_FunctionExpression_0B722580_L24C16>(!!0, float64, string, bool, bool)
 				IL_0093: stloc.3
 				IL_0094: ldloc.3
 				IL_0095: ldc.r8 0.0
@@ -562,6 +1149,129 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_646EC19B_L31C21
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Net_Socket_SetEncoding_Utf8/Scope _environment0_Net_Socket_SetEncoding_Utf8
+				.field private initonly class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope _environment1_FunctionExpression_L20C30
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Net_Socket_SetEncoding_Utf8/Scope capture0,
+						class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x290f
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20/FunctionObject_FunctionExpression_646EC19B_L31C21::_environment0_Net_Socket_SetEncoding_Utf8
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20/FunctionObject_FunctionExpression_646EC19B_L31C21::_environment1_FunctionExpression_L20C30
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20/FunctionObject_FunctionExpression_646EC19B_L31C21::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_646EC19B_L31C21::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x292c
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_646EC19B_L31C21::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x292f
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_646EC19B_L31C21::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2932
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20/FunctionObject_FunctionExpression_646EC19B_L31C21::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_646EC19B_L31C21::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x294b
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20/FunctionObject_FunctionExpression_646EC19B_L31C21::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_646EC19B_L31C21::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2960
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_646EC19B_L31C21::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_646EC19B_L31C21
 
 
 			// Methods
@@ -657,6 +1367,101 @@
 
 				} // end of class Scope
 
+				.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5C22CABE_L38C18
+					extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+				{
+					// Methods
+					.method public hidebysig specialname rtspecialname 
+						instance void .ctor () cil managed 
+					{
+						// Method begins at RVA 0x29c1
+						// Header size: 1
+						// Code size: 7 (0x7)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+						IL_0006: ret
+					} // end of method FunctionObject_FunctionExpression_5C22CABE_L38C18::.ctor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_IsConstructor () cil managed 
+					{
+						// Method begins at RVA 0x29c9
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.1
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_5C22CABE_L38C18::get_IsConstructor
+
+					.method public hidebysig specialname virtual 
+						instance bool get_RequiresInvocationContext () cil managed 
+					{
+						// Method begins at RVA 0x29cc
+						// Header size: 1
+						// Code size: 2 (0x2)
+						.maxstack 8
+
+						IL_0000: ldc.i4.0
+						IL_0001: ret
+					} // end of method FunctionObject_FunctionExpression_5C22CABE_L38C18::get_RequiresInvocationContext
+
+					.method family hidebysig virtual 
+						instance object CallCore (
+							object thisArgument,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+						) cil managed 
+					{
+						// Method begins at RVA 0x29cf
+						// Header size: 1
+						// Code size: 11 (0xb)
+						.maxstack 8
+
+						IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+						IL_0005: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionExpression_L38C17::__js_call__(object)
+						IL_000a: ret
+					} // end of method FunctionObject_FunctionExpression_5C22CABE_L38C18::CallCore
+
+					.method family hidebysig virtual 
+						instance object ConstructBodyCore (
+							object receiver,
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x29db
+						// Header size: 1
+						// Code size: 7 (0x7)
+						.maxstack 8
+
+						IL_0000: ldarg.3
+						IL_0001: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionExpression_L38C17::__js_call__(object)
+						IL_0006: ret
+					} // end of method FunctionObject_FunctionExpression_5C22CABE_L38C18::ConstructBodyCore
+
+					.method family hidebysig virtual 
+						instance object ConstructCore (
+							[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+							object newTarget
+						) cil managed 
+					{
+						// Method begins at RVA 0x29e3
+						// Header size: 1
+						// Code size: 14 (0xe)
+						.maxstack 8
+
+						IL_0000: ldarg.0
+						IL_0001: ldarg.1
+						IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+						IL_0007: ldarg.2
+						IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+						IL_000d: ret
+					} // end of method FunctionObject_FunctionExpression_5C22CABE_L38C18::ConstructCore
+
+				} // end of class FunctionObject_FunctionExpression_5C22CABE_L38C18
+
 
 				// Methods
 				.method public hidebysig static 
@@ -705,6 +1510,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A7C13C0B_L36C20
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Net_Socket_SetEncoding_Utf8/Scope _environment0_Net_Socket_SetEncoding_Utf8
+				.field private initonly class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope _environment1_FunctionExpression_L20C30
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Net_Socket_SetEncoding_Utf8/Scope capture0,
+						class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x296f
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_A7C13C0B_L36C20::_environment0_Net_Socket_SetEncoding_Utf8
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_A7C13C0B_L36C20::_environment1_FunctionExpression_L20C30
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_A7C13C0B_L36C20::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_A7C13C0B_L36C20::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x298c
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_A7C13C0B_L36C20::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x298f
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_A7C13C0B_L36C20::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2992
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_A7C13C0B_L36C20::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_A7C13C0B_L36C20::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x29a4
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_A7C13C0B_L36C20::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_A7C13C0B_L36C20::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x29b2
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_A7C13C0B_L36C20::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_A7C13C0B_L36C20
+
 
 			// Methods
 			.method public hidebysig static 
@@ -726,7 +1648,7 @@
 					[2] object,
 					[3] object,
 					[4] object[],
-					[5] class FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_5C22CABE_L38C18
+					[5] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionExpression_L38C17/FunctionObject_FunctionExpression_5C22CABE_L38C18
 				)
 
 				IL_0000: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/Scope::.ctor()
@@ -766,13 +1688,13 @@
 				IL_005a: ldelem.ref
 				IL_005b: stelem.ref
 				IL_005c: stloc.s 4
-				IL_005e: newobj instance void FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_5C22CABE_L38C18::.ctor()
+				IL_005e: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionExpression_L38C17/FunctionObject_FunctionExpression_5C22CABE_L38C18::.ctor()
 				IL_0063: ldc.i4.0
 				IL_0064: conv.r8
 				IL_0065: ldstr ""
 				IL_006a: ldc.i4.0
 				IL_006b: ldc.i4.1
-				IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_5C22CABE_L38C18>(!!0, float64, string, bool, bool)
+				IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionExpression_L38C17/FunctionObject_FunctionExpression_5C22CABE_L38C18>(!!0, float64, string, bool, bool)
 				IL_0071: stloc.s 5
 				IL_0073: ldloc.1
 				IL_0074: ldstr "close"
@@ -817,6 +1739,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6F6DE3BC_L20C31
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Net_Socket_SetEncoding_Utf8/Scope _environment0_Net_Socket_SetEncoding_Utf8
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Net_Socket_SetEncoding_Utf8/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2827
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionObject_FunctionExpression_6F6DE3BC_L20C31::_environment0_Net_Socket_SetEncoding_Utf8
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_6F6DE3BC_L20C31::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2836
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_6F6DE3BC_L20C31::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2839
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_6F6DE3BC_L20C31::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x283c
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionObject_FunctionExpression_6F6DE3BC_L20C31::_environment0_Net_Socket_SetEncoding_Utf8
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30::__js_call__(class Modules.Net_Socket_SetEncoding_Utf8/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_6F6DE3BC_L20C31::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x284e
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Net_Socket_SetEncoding_Utf8/Scope Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionObject_FunctionExpression_6F6DE3BC_L20C31::_environment0_Net_Socket_SetEncoding_Utf8
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30::__js_call__(class Modules.Net_Socket_SetEncoding_Utf8/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_6F6DE3BC_L20C31::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x285c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_6F6DE3BC_L20C31::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_6F6DE3BC_L20C31
+
 
 		// Methods
 		.method public hidebysig static 
@@ -840,9 +1869,9 @@
 				[2] object,
 				[3] object,
 				[4] object[],
-				[5] class FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_4E083AEC_L22C55,
-				[6] class FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_646EC19B_L31C21,
-				[7] class FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_A7C13C0B_L36C20
+				[5] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionObject_FunctionExpression_4E083AEC_L22C55,
+				[6] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20/FunctionObject_FunctionExpression_646EC19B_L31C21,
+				[7] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_A7C13C0B_L36C20
 			)
 
 			IL_0000: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope::.ctor()
@@ -883,13 +1912,13 @@
 			IL_0056: ldelem.ref
 			IL_0057: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope
 			IL_005c: ldloc.s 4
-			IL_005e: newobj instance void FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_4E083AEC_L22C55::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope, object[])
+			IL_005e: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionObject_FunctionExpression_4E083AEC_L22C55::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope, object[])
 			IL_0063: ldc.i4.0
 			IL_0064: conv.r8
 			IL_0065: ldstr ""
 			IL_006a: ldc.i4.0
 			IL_006b: ldc.i4.1
-			IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_4E083AEC_L22C55>(!!0, float64, string, bool, bool)
+			IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionObject_FunctionExpression_4E083AEC_L22C55>(!!0, float64, string, bool, bool)
 			IL_0071: stloc.s 5
 			IL_0073: ldstr "connect"
 			IL_0078: ldloc.2
@@ -938,13 +1967,13 @@
 			IL_00eb: ldelem.ref
 			IL_00ec: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope
 			IL_00f1: ldloc.s 4
-			IL_00f3: newobj instance void FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_646EC19B_L31C21::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope, object[])
+			IL_00f3: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20/FunctionObject_FunctionExpression_646EC19B_L31C21::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope, object[])
 			IL_00f8: ldc.i4.1
 			IL_00f9: conv.r8
 			IL_00fa: ldstr ""
 			IL_00ff: ldc.i4.0
 			IL_0100: ldc.i4.1
-			IL_0101: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_646EC19B_L31C21>(!!0, float64, string, bool, bool)
+			IL_0101: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20/FunctionObject_FunctionExpression_646EC19B_L31C21>(!!0, float64, string, bool, bool)
 			IL_0106: stloc.s 6
 			IL_0108: ldloc.3
 			IL_0109: ldstr "on"
@@ -978,13 +2007,13 @@
 			IL_014d: ldelem.ref
 			IL_014e: castclass Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope
 			IL_0153: ldloc.s 4
-			IL_0155: newobj instance void FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_A7C13C0B_L36C20::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope, object[])
+			IL_0155: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_A7C13C0B_L36C20::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope, class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope, object[])
 			IL_015a: ldc.i4.0
 			IL_015b: conv.r8
 			IL_015c: ldstr ""
 			IL_0161: ldc.i4.0
 			IL_0162: ldc.i4.1
-			IL_0163: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_A7C13C0B_L36C20>(!!0, float64, string, bool, bool)
+			IL_0163: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionObject_FunctionExpression_A7C13C0B_L36C20>(!!0, float64, string, bool, bool)
 			IL_0168: stloc.s 7
 			IL_016a: ldloc.3
 			IL_016b: ldstr "on"
@@ -1046,9 +2075,9 @@
 			[0] class Modules.Net_Socket_SetEncoding_Utf8/Scope,
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule,
 			[2] object[],
-			[3] class FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_C02347C7_L5C33,
+			[3] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionObject_FunctionExpression_C02347C7_L5C33,
 			[4] object,
-			[5] class FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_6F6DE3BC_L20C31
+			[5] class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionObject_FunctionExpression_6F6DE3BC_L20C31
 		)
 
 		IL_0000: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/Scope::.ctor()
@@ -1074,13 +2103,13 @@
 		IL_002c: ldc.i4.0
 		IL_002d: ldelem.ref
 		IL_002e: castclass Modules.Net_Socket_SetEncoding_Utf8/Scope
-		IL_0033: newobj instance void FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_C02347C7_L5C33::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope)
+		IL_0033: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionObject_FunctionExpression_C02347C7_L5C33::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope)
 		IL_0038: ldc.i4.1
 		IL_0039: conv.r8
 		IL_003a: ldstr ""
 		IL_003f: ldc.i4.0
 		IL_0040: ldc.i4.1
-		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_C02347C7_L5C33>(!!0, float64, string, bool, bool)
+		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionObject_FunctionExpression_C02347C7_L5C33>(!!0, float64, string, bool, bool)
 		IL_0046: stloc.3
 		IL_0047: ldstr "createServer"
 		IL_004c: ldloc.3
@@ -1104,13 +2133,13 @@
 		IL_0075: ldc.i4.0
 		IL_0076: ldelem.ref
 		IL_0077: castclass Modules.Net_Socket_SetEncoding_Utf8/Scope
-		IL_007c: newobj instance void FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_6F6DE3BC_L20C31::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope)
+		IL_007c: newobj instance void Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionObject_FunctionExpression_6F6DE3BC_L20C31::.ctor(class Modules.Net_Socket_SetEncoding_Utf8/Scope)
 		IL_0081: ldc.i4.0
 		IL_0082: conv.r8
 		IL_0083: ldstr ""
 		IL_0088: ldc.i4.0
 		IL_0089: ldc.i4.1
-		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_6F6DE3BC_L20C31>(!!0, float64, string, bool, bool)
+		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionObject_FunctionExpression_6F6DE3BC_L20C31>(!!0, float64, string, bool, bool)
 		IL_008f: stloc.s 5
 		IL_0091: ldloc.s 4
 		IL_0093: ldstr "listen"
@@ -1124,1035 +2153,6 @@
 	} // end of method Net_Socket_SetEncoding_Utf8::__js_module_init__
 
 } // end of class Modules.Net_Socket_SetEncoding_Utf8
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_C02347C7_L5C33
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_Socket_SetEncoding_Utf8/Scope _environment0_Net_Socket_SetEncoding_Utf8
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_Socket_SetEncoding_Utf8/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2723
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_C02347C7_L5C33::_environment0_Net_Socket_SetEncoding_Utf8
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C02347C7_L5C33::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2732
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C02347C7_L5C33::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2735
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C02347C7_L5C33::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2738
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Net_Socket_SetEncoding_Utf8/Scope FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_C02347C7_L5C33::_environment0_Net_Socket_SetEncoding_Utf8
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server::__js_call__(class Modules.Net_Socket_SetEncoding_Utf8/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_C02347C7_L5C33::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2751
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Net_Socket_SetEncoding_Utf8/Scope FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_C02347C7_L5C33::_environment0_Net_Socket_SetEncoding_Utf8
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server::__js_call__(class Modules.Net_Socket_SetEncoding_Utf8/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_C02347C7_L5C33::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2766
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C02347C7_L5C33::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_C02347C7_L5C33
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_2D181329_L9C21
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_Socket_SetEncoding_Utf8/Scope _environment0_Net_Socket_SetEncoding_Utf8
-	.field private initonly class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope _environment1_FunctionExpression_server
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_Socket_SetEncoding_Utf8/Scope capture0,
-			class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2775
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_2D181329_L9C21::_environment0_Net_Socket_SetEncoding_Utf8
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_2D181329_L9C21::_environment1_FunctionExpression_server
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_2D181329_L9C21::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_2D181329_L9C21::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2792
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2D181329_L9C21::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2795
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2D181329_L9C21::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2798
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_2D181329_L9C21::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_2D181329_L9C21::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27b1
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_2D181329_L9C21::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_2D181329_L9C21::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27c6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2D181329_L9C21::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_2D181329_L9C21
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_FAB9795C_L14C20
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_Socket_SetEncoding_Utf8/Scope _environment0_Net_Socket_SetEncoding_Utf8
-	.field private initonly class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope _environment1_FunctionExpression_server
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_Socket_SetEncoding_Utf8/Scope capture0,
-			class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x27d5
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_FAB9795C_L14C20::_environment0_Net_Socket_SetEncoding_Utf8
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/Scope FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_FAB9795C_L14C20::_environment1_FunctionExpression_server
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_FAB9795C_L14C20::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_FAB9795C_L14C20::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x27f2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FAB9795C_L14C20::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x27f5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FAB9795C_L14C20::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x27f8
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_FAB9795C_L14C20::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_FAB9795C_L14C20::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x280a
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_FAB9795C_L14C20::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_server/FunctionExpression_server_L14C19::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_FAB9795C_L14C20::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2818
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_FAB9795C_L14C20::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_FAB9795C_L14C20
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_6F6DE3BC_L20C31
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_Socket_SetEncoding_Utf8/Scope _environment0_Net_Socket_SetEncoding_Utf8
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_Socket_SetEncoding_Utf8/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2827
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_6F6DE3BC_L20C31::_environment0_Net_Socket_SetEncoding_Utf8
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_6F6DE3BC_L20C31::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2836
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6F6DE3BC_L20C31::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2839
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6F6DE3BC_L20C31::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x283c
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Net_Socket_SetEncoding_Utf8/Scope FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_6F6DE3BC_L20C31::_environment0_Net_Socket_SetEncoding_Utf8
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30::__js_call__(class Modules.Net_Socket_SetEncoding_Utf8/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_6F6DE3BC_L20C31::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x284e
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Net_Socket_SetEncoding_Utf8/Scope FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_6F6DE3BC_L20C31::_environment0_Net_Socket_SetEncoding_Utf8
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30::__js_call__(class Modules.Net_Socket_SetEncoding_Utf8/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_6F6DE3BC_L20C31::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x285c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_6F6DE3BC_L20C31::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_6F6DE3BC_L20C31
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_4E083AEC_L22C55
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_Socket_SetEncoding_Utf8/Scope _environment0_Net_Socket_SetEncoding_Utf8
-	.field private initonly class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope _environment1_FunctionExpression_L20C30
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_Socket_SetEncoding_Utf8/Scope capture0,
-			class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x286b
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_4E083AEC_L22C55::_environment0_Net_Socket_SetEncoding_Utf8
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_4E083AEC_L22C55::_environment1_FunctionExpression_L20C30
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_4E083AEC_L22C55::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_4E083AEC_L22C55::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2888
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_4E083AEC_L22C55::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x288b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_4E083AEC_L22C55::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x288e
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_4E083AEC_L22C55::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_4E083AEC_L22C55::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28a0
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_4E083AEC_L22C55::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_4E083AEC_L22C55::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28ae
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_4E083AEC_L22C55::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_4E083AEC_L22C55
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_0B722580_L24C16
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_Socket_SetEncoding_Utf8/Scope _environment0_Net_Socket_SetEncoding_Utf8
-	.field private initonly class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope _environment1_FunctionExpression_L20C30
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_Socket_SetEncoding_Utf8/Scope capture0,
-			class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x28bd
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_0B722580_L24C16::_environment0_Net_Socket_SetEncoding_Utf8
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_0B722580_L24C16::_environment1_FunctionExpression_L20C30
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_0B722580_L24C16::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_0B722580_L24C16::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x28da
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_0B722580_L24C16::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x28dd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_0B722580_L24C16::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x28e0
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_0B722580_L24C16::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_0B722580_L24C16::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28f2
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_0B722580_L24C16::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_client/FunctionExpression_client::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_0B722580_L24C16::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2900
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_0B722580_L24C16::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_0B722580_L24C16
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_646EC19B_L31C21
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_Socket_SetEncoding_Utf8/Scope _environment0_Net_Socket_SetEncoding_Utf8
-	.field private initonly class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope _environment1_FunctionExpression_L20C30
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_Socket_SetEncoding_Utf8/Scope capture0,
-			class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x290f
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_646EC19B_L31C21::_environment0_Net_Socket_SetEncoding_Utf8
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_646EC19B_L31C21::_environment1_FunctionExpression_L20C30
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_646EC19B_L31C21::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_646EC19B_L31C21::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x292c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_646EC19B_L31C21::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x292f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_646EC19B_L31C21::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2932
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_646EC19B_L31C21::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_646EC19B_L31C21::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x294b
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_646EC19B_L31C21::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L31C20::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_646EC19B_L31C21::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2960
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_646EC19B_L31C21::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_646EC19B_L31C21
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_A7C13C0B_L36C20
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_Socket_SetEncoding_Utf8/Scope _environment0_Net_Socket_SetEncoding_Utf8
-	.field private initonly class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope _environment1_FunctionExpression_L20C30
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_Socket_SetEncoding_Utf8/Scope capture0,
-			class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x296f
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_Socket_SetEncoding_Utf8/Scope FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_A7C13C0B_L36C20::_environment0_Net_Socket_SetEncoding_Utf8
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/Scope FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_A7C13C0B_L36C20::_environment1_FunctionExpression_L20C30
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_A7C13C0B_L36C20::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_A7C13C0B_L36C20::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x298c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A7C13C0B_L36C20::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x298f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A7C13C0B_L36C20::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2992
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_A7C13C0B_L36C20::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_A7C13C0B_L36C20::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29a4
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_A7C13C0B_L36C20::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_A7C13C0B_L36C20::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29b2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A7C13C0B_L36C20::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_A7C13C0B_L36C20
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_5C22CABE_L38C18
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x29c1
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_5C22CABE_L38C18::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x29c9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5C22CABE_L38C18::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x29cc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5C22CABE_L38C18::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x29cf
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionExpression_L38C17::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_5C22CABE_L38C18::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29db
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Net_Socket_SetEncoding_Utf8/FunctionExpression_L20C30/FunctionExpression_L36C19/FunctionExpression_L38C17::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_5C22CABE_L38C18::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29e3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5C22CABE_L38C18::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_SetEncoding_Utf8_0A79AEBC.FunctionObject_FunctionExpression_5C22CABE_L38C18
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_Timeout_Allows_Graceful_End.verified.txt
+++ b/tests/Jroc.Tests/Node/Net/Snapshots/GeneratorTests.Net_Socket_Timeout_Allows_Graceful_End.verified.txt
@@ -35,6 +35,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B3953B4D_L6C25
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope _environment0_Net_Socket_Timeout_Allows_Graceful_End
+				.field private initonly class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope _environment1_FunctionExpression_server
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope capture0,
+						class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x24e0
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_B3953B4D_L6C25::_environment0_Net_Socket_Timeout_Allows_Graceful_End
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_B3953B4D_L6C25::_environment1_FunctionExpression_server
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_B3953B4D_L6C25::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_B3953B4D_L6C25::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x24fd
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_B3953B4D_L6C25::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2500
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_B3953B4D_L6C25::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2503
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_B3953B4D_L6C25::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_B3953B4D_L6C25::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2515
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_B3953B4D_L6C25::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_B3953B4D_L6C25::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2523
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_B3953B4D_L6C25::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_B3953B4D_L6C25
+
 
 			// Methods
 			.method public hidebysig static 
@@ -124,6 +241,107 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_76ADA745_L12C22
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2532
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_76ADA745_L12C22::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x253a
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_76ADA745_L12C22::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x253d
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_76ADA745_L12C22::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2540
+					// Header size: 1
+					// Code size: 18 (0x12)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: ldarg.2
+					IL_0006: ldc.i4.0
+					IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000c: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server_L12C21::__js_call__(object, object)
+					IL_0011: ret
+				} // end of method FunctionObject_FunctionExpression_76ADA745_L12C22::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2553
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: ldarg.2
+					IL_0002: ldc.i4.0
+					IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0008: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server_L12C21::__js_call__(object, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_76ADA745_L12C22::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2562
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_76ADA745_L12C22::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_76ADA745_L12C22
+
 
 			// Methods
 			.method public hidebysig static 
@@ -190,6 +408,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D224BDC0_L5C33
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope _environment0_Net_Socket_Timeout_Allows_Graceful_End
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x248e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionObject_FunctionExpression_D224BDC0_L5C33::_environment0_Net_Socket_Timeout_Allows_Graceful_End
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_D224BDC0_L5C33::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x249d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D224BDC0_L5C33::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24a0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D224BDC0_L5C33::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24a3
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionObject_FunctionExpression_D224BDC0_L5C33::_environment0_Net_Socket_Timeout_Allows_Graceful_End
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server::__js_call__(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_D224BDC0_L5C33::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24bc
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionObject_FunctionExpression_D224BDC0_L5C33::_environment0_Net_Socket_Timeout_Allows_Graceful_End
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server::__js_call__(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_D224BDC0_L5C33::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24d1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_D224BDC0_L5C33::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_D224BDC0_L5C33
+
 
 		// Methods
 		.method public hidebysig static 
@@ -212,8 +543,8 @@
 				[0] class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope,
 				[1] object,
 				[2] object[],
-				[3] class FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_B3953B4D_L6C25,
-				[4] class FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_76ADA745_L12C22
+				[3] class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_B3953B4D_L6C25,
+				[4] class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server_L12C21/FunctionObject_FunctionExpression_76ADA745_L12C22
 			)
 
 			IL_0000: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope::.ctor()
@@ -245,13 +576,13 @@
 			IL_0032: ldelem.ref
 			IL_0033: castclass Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope
 			IL_0038: ldloc.2
-			IL_0039: newobj instance void FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_B3953B4D_L6C25::.ctor(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope, object[])
+			IL_0039: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_B3953B4D_L6C25::.ctor(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope, object[])
 			IL_003e: ldc.i4.0
 			IL_003f: conv.r8
 			IL_0040: ldstr ""
 			IL_0045: ldc.i4.0
 			IL_0046: ldc.i4.1
-			IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_B3953B4D_L6C25>(!!0, float64, string, bool, bool)
+			IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server/FunctionObject_FunctionExpression_B3953B4D_L6C25>(!!0, float64, string, bool, bool)
 			IL_004c: stloc.3
 			IL_004d: ldloc.1
 			IL_004e: ldstr "setTimeout"
@@ -271,13 +602,13 @@
 			IL_007c: ldarg.0
 			IL_007d: stelem.ref
 			IL_007e: stloc.2
-			IL_007f: newobj instance void FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_76ADA745_L12C22::.ctor()
+			IL_007f: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server_L12C21/FunctionObject_FunctionExpression_76ADA745_L12C22::.ctor()
 			IL_0084: ldc.i4.1
 			IL_0085: conv.r8
 			IL_0086: ldstr ""
 			IL_008b: ldc.i4.0
 			IL_008c: ldc.i4.1
-			IL_008d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_76ADA745_L12C22>(!!0, float64, string, bool, bool)
+			IL_008d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server_L12C21/FunctionObject_FunctionExpression_76ADA745_L12C22>(!!0, float64, string, bool, bool)
 			IL_0092: stloc.s 4
 			IL_0094: ldloc.1
 			IL_0095: ldstr "on"
@@ -318,6 +649,101 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7DA5D9C5_L19C55
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x25b5
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_7DA5D9C5_L19C55::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x25bd
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_7DA5D9C5_L19C55::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x25c0
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_7DA5D9C5_L19C55::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x25c3
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_client::__js_call__(object)
+					IL_000a: ret
+				} // end of method FunctionObject_FunctionExpression_7DA5D9C5_L19C55::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x25cf
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_client::__js_call__(object)
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_7DA5D9C5_L19C55::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x25d7
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_7DA5D9C5_L19C55::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_7DA5D9C5_L19C55
 
 
 			// Methods
@@ -370,6 +796,107 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2AD4A0E6_L24C21
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x25e6
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_2AD4A0E6_L24C21::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x25ee
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_2AD4A0E6_L24C21::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x25f1
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_2AD4A0E6_L24C21::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x25f4
+					// Header size: 1
+					// Code size: 18 (0x12)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: ldarg.2
+					IL_0006: ldc.i4.0
+					IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000c: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L24C20::__js_call__(object, object)
+					IL_0011: ret
+				} // end of method FunctionObject_FunctionExpression_2AD4A0E6_L24C21::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2607
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: ldarg.2
+					IL_0002: ldc.i4.0
+					IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0008: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L24C20::__js_call__(object, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_2AD4A0E6_L24C21::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2616
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_2AD4A0E6_L24C21::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_2AD4A0E6_L24C21
 
 
 			// Methods
@@ -434,6 +961,118 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9F410EBD_L28C20
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope _environment0_Net_Socket_Timeout_Allows_Graceful_End
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x2625
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19/FunctionObject_FunctionExpression_9F410EBD_L28C20::_environment0_Net_Socket_Timeout_Allows_Graceful_End
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19/FunctionObject_FunctionExpression_9F410EBD_L28C20::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionExpression_9F410EBD_L28C20::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x263b
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_9F410EBD_L28C20::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x263e
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_9F410EBD_L28C20::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2641
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19/FunctionObject_FunctionExpression_9F410EBD_L28C20::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_9F410EBD_L28C20::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2653
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19/FunctionObject_FunctionExpression_9F410EBD_L28C20::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_9F410EBD_L28C20::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2661
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_9F410EBD_L28C20::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_9F410EBD_L28C20
+
 
 			// Methods
 			.method public hidebysig static 
@@ -492,6 +1131,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_AACE2D1B_L17C31
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope _environment0_Net_Socket_Timeout_Allows_Graceful_End
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2571
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionObject_FunctionExpression_AACE2D1B_L17C31::_environment0_Net_Socket_Timeout_Allows_Graceful_End
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_AACE2D1B_L17C31::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2580
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_AACE2D1B_L17C31::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2583
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_AACE2D1B_L17C31::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2586
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionObject_FunctionExpression_AACE2D1B_L17C31::_environment0_Net_Socket_Timeout_Allows_Graceful_End
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30::__js_call__(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_AACE2D1B_L17C31::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2598
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionObject_FunctionExpression_AACE2D1B_L17C31::_environment0_Net_Socket_Timeout_Allows_Graceful_End
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30::__js_call__(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_AACE2D1B_L17C31::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25a6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_AACE2D1B_L17C31::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_AACE2D1B_L17C31
+
 
 		// Methods
 		.method public hidebysig static 
@@ -516,9 +1262,9 @@
 				[3] object,
 				[4] object,
 				[5] object[],
-				[6] class FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_7DA5D9C5_L19C55,
-				[7] class FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_2AD4A0E6_L24C21,
-				[8] class FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_9F410EBD_L28C20
+				[6] class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_client/FunctionObject_FunctionExpression_7DA5D9C5_L19C55,
+				[7] class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L24C20/FunctionObject_FunctionExpression_2AD4A0E6_L24C21,
+				[8] class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19/FunctionObject_FunctionExpression_9F410EBD_L28C20
 			)
 
 			IL_0000: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/Scope::.ctor()
@@ -546,13 +1292,13 @@
 			IL_0043: ldarg.0
 			IL_0044: stelem.ref
 			IL_0045: stloc.s 5
-			IL_0047: newobj instance void FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_7DA5D9C5_L19C55::.ctor()
+			IL_0047: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_client/FunctionObject_FunctionExpression_7DA5D9C5_L19C55::.ctor()
 			IL_004c: ldc.i4.0
 			IL_004d: conv.r8
 			IL_004e: ldstr ""
 			IL_0053: ldc.i4.0
 			IL_0054: ldc.i4.1
-			IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_7DA5D9C5_L19C55>(!!0, float64, string, bool, bool)
+			IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_client/FunctionObject_FunctionExpression_7DA5D9C5_L19C55>(!!0, float64, string, bool, bool)
 			IL_005a: stloc.s 6
 			IL_005c: ldstr "connect"
 			IL_0061: ldloc.3
@@ -576,13 +1322,13 @@
 			IL_0092: ldarg.0
 			IL_0093: stelem.ref
 			IL_0094: stloc.s 5
-			IL_0096: newobj instance void FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_2AD4A0E6_L24C21::.ctor()
+			IL_0096: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L24C20/FunctionObject_FunctionExpression_2AD4A0E6_L24C21::.ctor()
 			IL_009b: ldc.i4.1
 			IL_009c: conv.r8
 			IL_009d: ldstr ""
 			IL_00a2: ldc.i4.0
 			IL_00a3: ldc.i4.1
-			IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_2AD4A0E6_L24C21>(!!0, float64, string, bool, bool)
+			IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L24C20/FunctionObject_FunctionExpression_2AD4A0E6_L24C21>(!!0, float64, string, bool, bool)
 			IL_00a9: stloc.s 7
 			IL_00ab: ldloc.s 4
 			IL_00ad: ldstr "on"
@@ -609,13 +1355,13 @@
 			IL_00da: ldelem.ref
 			IL_00db: castclass Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope
 			IL_00e0: ldloc.s 5
-			IL_00e2: newobj instance void FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_9F410EBD_L28C20::.ctor(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, object[])
+			IL_00e2: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19/FunctionObject_FunctionExpression_9F410EBD_L28C20::.ctor(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, object[])
 			IL_00e7: ldc.i4.0
 			IL_00e8: conv.r8
 			IL_00e9: ldstr ""
 			IL_00ee: ldc.i4.0
 			IL_00ef: ldc.i4.1
-			IL_00f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_9F410EBD_L28C20>(!!0, float64, string, bool, bool)
+			IL_00f0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19/FunctionObject_FunctionExpression_9F410EBD_L28C20>(!!0, float64, string, bool, bool)
 			IL_00f5: stloc.s 8
 			IL_00f7: ldloc.s 4
 			IL_00f9: ldstr "on"
@@ -677,9 +1423,9 @@
 			[0] class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope,
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.INetModule,
 			[2] object[],
-			[3] class FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_D224BDC0_L5C33,
+			[3] class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionObject_FunctionExpression_D224BDC0_L5C33,
 			[4] object,
-			[5] class FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_AACE2D1B_L17C31
+			[5] class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionObject_FunctionExpression_AACE2D1B_L17C31
 		)
 
 		IL_0000: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope::.ctor()
@@ -705,13 +1451,13 @@
 		IL_002c: ldc.i4.0
 		IL_002d: ldelem.ref
 		IL_002e: castclass Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope
-		IL_0033: newobj instance void FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_D224BDC0_L5C33::.ctor(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope)
+		IL_0033: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionObject_FunctionExpression_D224BDC0_L5C33::.ctor(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope)
 		IL_0038: ldc.i4.1
 		IL_0039: conv.r8
 		IL_003a: ldstr ""
 		IL_003f: ldc.i4.0
 		IL_0040: ldc.i4.1
-		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_D224BDC0_L5C33>(!!0, float64, string, bool, bool)
+		IL_0041: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionObject_FunctionExpression_D224BDC0_L5C33>(!!0, float64, string, bool, bool)
 		IL_0046: stloc.3
 		IL_0047: ldstr "createServer"
 		IL_004c: ldloc.3
@@ -735,13 +1481,13 @@
 		IL_0075: ldc.i4.0
 		IL_0076: ldelem.ref
 		IL_0077: castclass Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope
-		IL_007c: newobj instance void FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_AACE2D1B_L17C31::.ctor(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope)
+		IL_007c: newobj instance void Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionObject_FunctionExpression_AACE2D1B_L17C31::.ctor(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope)
 		IL_0081: ldc.i4.0
 		IL_0082: conv.r8
 		IL_0083: ldstr ""
 		IL_0088: ldc.i4.0
 		IL_0089: ldc.i4.1
-		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_AACE2D1B_L17C31>(!!0, float64, string, bool, bool)
+		IL_008a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionObject_FunctionExpression_AACE2D1B_L17C31>(!!0, float64, string, bool, bool)
 		IL_008f: stloc.s 5
 		IL_0091: ldloc.s 4
 		IL_0093: ldstr "listen"
@@ -755,752 +1501,6 @@
 	} // end of method Net_Socket_Timeout_Allows_Graceful_End::__js_module_init__
 
 } // end of class Modules.Net_Socket_Timeout_Allows_Graceful_End
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_D224BDC0_L5C33
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope _environment0_Net_Socket_Timeout_Allows_Graceful_End
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x248e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_D224BDC0_L5C33::_environment0_Net_Socket_Timeout_Allows_Graceful_End
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D224BDC0_L5C33::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x249d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D224BDC0_L5C33::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24a0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D224BDC0_L5C33::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24a3
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_D224BDC0_L5C33::_environment0_Net_Socket_Timeout_Allows_Graceful_End
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server::__js_call__(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_D224BDC0_L5C33::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24bc
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_D224BDC0_L5C33::_environment0_Net_Socket_Timeout_Allows_Graceful_End
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server::__js_call__(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_D224BDC0_L5C33::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24d1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D224BDC0_L5C33::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_D224BDC0_L5C33
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_B3953B4D_L6C25
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope _environment0_Net_Socket_Timeout_Allows_Graceful_End
-	.field private initonly class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope _environment1_FunctionExpression_server
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope capture0,
-			class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x24e0
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_B3953B4D_L6C25::_environment0_Net_Socket_Timeout_Allows_Graceful_End
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/Scope FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_B3953B4D_L6C25::_environment1_FunctionExpression_server
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_B3953B4D_L6C25::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_B3953B4D_L6C25::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24fd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_B3953B4D_L6C25::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2500
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_B3953B4D_L6C25::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2503
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_B3953B4D_L6C25::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_B3953B4D_L6C25::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2515
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_B3953B4D_L6C25::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_B3953B4D_L6C25::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2523
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_B3953B4D_L6C25::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_B3953B4D_L6C25
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_76ADA745_L12C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2532
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_76ADA745_L12C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x253a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_76ADA745_L12C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x253d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_76ADA745_L12C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2540
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server_L12C21::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_76ADA745_L12C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2553
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_server/FunctionExpression_server_L12C21::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_76ADA745_L12C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2562
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_76ADA745_L12C22::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_76ADA745_L12C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_AACE2D1B_L17C31
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope _environment0_Net_Socket_Timeout_Allows_Graceful_End
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2571
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_AACE2D1B_L17C31::_environment0_Net_Socket_Timeout_Allows_Graceful_End
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_AACE2D1B_L17C31::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2580
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_AACE2D1B_L17C31::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2583
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_AACE2D1B_L17C31::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2586
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_AACE2D1B_L17C31::_environment0_Net_Socket_Timeout_Allows_Graceful_End
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30::__js_call__(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_AACE2D1B_L17C31::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2598
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_AACE2D1B_L17C31::_environment0_Net_Socket_Timeout_Allows_Graceful_End
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30::__js_call__(class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_AACE2D1B_L17C31::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25a6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_AACE2D1B_L17C31::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_AACE2D1B_L17C31
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_7DA5D9C5_L19C55
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x25b5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_7DA5D9C5_L19C55::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x25bd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7DA5D9C5_L19C55::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x25c0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7DA5D9C5_L19C55::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x25c3
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_client::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_7DA5D9C5_L19C55::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25cf
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_client::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_7DA5D9C5_L19C55::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25d7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7DA5D9C5_L19C55::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_7DA5D9C5_L19C55
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_2AD4A0E6_L24C21
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x25e6
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_2AD4A0E6_L24C21::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x25ee
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2AD4A0E6_L24C21::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x25f1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2AD4A0E6_L24C21::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x25f4
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L24C20::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_2AD4A0E6_L24C21::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2607
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L24C20::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2AD4A0E6_L24C21::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2616
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2AD4A0E6_L24C21::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_2AD4A0E6_L24C21
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_9F410EBD_L28C20
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope _environment0_Net_Socket_Timeout_Allows_Graceful_End
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x2625
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Net_Socket_Timeout_Allows_Graceful_End/Scope FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_9F410EBD_L28C20::_environment0_Net_Socket_Timeout_Allows_Graceful_End
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_9F410EBD_L28C20::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_9F410EBD_L28C20::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x263b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9F410EBD_L28C20::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x263e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9F410EBD_L28C20::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2641
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_9F410EBD_L28C20::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_9F410EBD_L28C20::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2653
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_9F410EBD_L28C20::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Net_Socket_Timeout_Allows_Graceful_End/FunctionExpression_L17C30/FunctionExpression_L28C19::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_9F410EBD_L28C20::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2661
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_9F410EBD_L28C20::ConstructCore
-
-} // end of class FunctionObjects.Net_Socket_Timeout_Allows_Graceful_End_27992359.FunctionObject_FunctionExpression_9F410EBD_L28C20
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_DefaultParameterOverride.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_DefaultParameterOverride.verified.txt
@@ -178,6 +178,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2695CFF7_patchPath
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Require_Path_DefaultParameterOverride/Scope _environment0_Require_Path_DefaultParameterOverride
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Require_Path_DefaultParameterOverride/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21e3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Require_Path_DefaultParameterOverride/Scope Modules.Require_Path_DefaultParameterOverride/patchPath/FunctionObject_FunctionDeclaration_2695CFF7_patchPath::_environment0_Require_Path_DefaultParameterOverride
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_2695CFF7_patchPath::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21f2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2695CFF7_patchPath::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21f5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2695CFF7_patchPath::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f8
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Require_Path_DefaultParameterOverride/Scope Modules.Require_Path_DefaultParameterOverride/patchPath/FunctionObject_FunctionDeclaration_2695CFF7_patchPath::_environment0_Require_Path_DefaultParameterOverride
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Require_Path_DefaultParameterOverride/patchPath::__js_call__(class Modules.Require_Path_DefaultParameterOverride/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_2695CFF7_patchPath::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2211
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Require_Path_DefaultParameterOverride/Scope Modules.Require_Path_DefaultParameterOverride/patchPath/FunctionObject_FunctionDeclaration_2695CFF7_patchPath::_environment0_Require_Path_DefaultParameterOverride
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Require_Path_DefaultParameterOverride/patchPath::__js_call__(class Modules.Require_Path_DefaultParameterOverride/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_2695CFF7_patchPath::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2226
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_2695CFF7_patchPath::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_2695CFF7_patchPath
+
 
 		// Methods
 		.method public hidebysig static 
@@ -286,7 +399,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Path_DefaultParameterOverride/Scope,
-			[1] class FunctionObjects.Require_Path_DefaultParameterOverride_D7B98D47.FunctionObject_FunctionDeclaration_2695CFF7_patchPath,
+			[1] class Modules.Require_Path_DefaultParameterOverride/patchPath/FunctionObject_FunctionDeclaration_2695CFF7_patchPath,
 			[2] object[],
 			[3] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule,
 			[4] object,
@@ -306,13 +419,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Require_Path_DefaultParameterOverride/Scope
-		IL_0019: newobj instance void FunctionObjects.Require_Path_DefaultParameterOverride_D7B98D47.FunctionObject_FunctionDeclaration_2695CFF7_patchPath::.ctor(class Modules.Require_Path_DefaultParameterOverride/Scope)
+		IL_0019: newobj instance void Modules.Require_Path_DefaultParameterOverride/patchPath/FunctionObject_FunctionDeclaration_2695CFF7_patchPath::.ctor(class Modules.Require_Path_DefaultParameterOverride/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "patchPath"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Require_Path_DefaultParameterOverride_D7B98D47.FunctionObject_FunctionDeclaration_2695CFF7_patchPath>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Path_DefaultParameterOverride/patchPath/FunctionObject_FunctionDeclaration_2695CFF7_patchPath>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldarg.1
@@ -378,119 +491,6 @@
 	} // end of method Require_Path_DefaultParameterOverride::__js_module_init__
 
 } // end of class Modules.Require_Path_DefaultParameterOverride
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Require_Path_DefaultParameterOverride_D7B98D47.FunctionObject_FunctionDeclaration_2695CFF7_patchPath
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Require_Path_DefaultParameterOverride/Scope _environment0_Require_Path_DefaultParameterOverride
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Require_Path_DefaultParameterOverride/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21e3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Require_Path_DefaultParameterOverride/Scope FunctionObjects.Require_Path_DefaultParameterOverride_D7B98D47.FunctionObject_FunctionDeclaration_2695CFF7_patchPath::_environment0_Require_Path_DefaultParameterOverride
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_2695CFF7_patchPath::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21f2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2695CFF7_patchPath::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21f5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2695CFF7_patchPath::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f8
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Require_Path_DefaultParameterOverride/Scope FunctionObjects.Require_Path_DefaultParameterOverride_D7B98D47.FunctionObject_FunctionDeclaration_2695CFF7_patchPath::_environment0_Require_Path_DefaultParameterOverride
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Require_Path_DefaultParameterOverride/patchPath::__js_call__(class Modules.Require_Path_DefaultParameterOverride/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_2695CFF7_patchPath::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2211
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Require_Path_DefaultParameterOverride/Scope FunctionObjects.Require_Path_DefaultParameterOverride_D7B98D47.FunctionObject_FunctionDeclaration_2695CFF7_patchPath::_environment0_Require_Path_DefaultParameterOverride
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Require_Path_DefaultParameterOverride/patchPath::__js_call__(class Modules.Require_Path_DefaultParameterOverride/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_2695CFF7_patchPath::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2226
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_2695CFF7_patchPath::ConstructCore
-
-} // end of class FunctionObjects.Require_Path_DefaultParameterOverride_D7B98D47.FunctionObject_FunctionDeclaration_2695CFF7_patchPath
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Join_NestedFunction.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_Join_NestedFunction.verified.txt
@@ -31,6 +31,129 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Require_Path_Join_NestedFunction/Scope _environment0_Require_Path_Join_NestedFunction
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Require_Path_Join_NestedFunction/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2130
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Require_Path_Join_NestedFunction/Scope Modules.Require_Path_Join_NestedFunction/joinWrapper/FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::_environment0_Require_Path_Join_NestedFunction
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x213f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2142
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2145
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Require_Path_Join_NestedFunction/Scope Modules.Require_Path_Join_NestedFunction/joinWrapper/FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::_environment0_Require_Path_Join_NestedFunction
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0017: ldarg.2
+				IL_0018: ldc.i4.1
+				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0023: call object Modules.Require_Path_Join_NestedFunction/joinWrapper::__js_call__(class Modules.Require_Path_Join_NestedFunction/Scope, object, string, string)
+				IL_0028: ret
+			} // end of method FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x216f
+				// Header size: 1
+				// Code size: 37 (0x25)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Require_Path_Join_NestedFunction/Scope Modules.Require_Path_Join_NestedFunction/joinWrapper/FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::_environment0_Require_Path_Join_NestedFunction
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.1
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_001f: call object Modules.Require_Path_Join_NestedFunction/joinWrapper::__js_call__(class Modules.Require_Path_Join_NestedFunction/Scope, object, string, string)
+				IL_0024: ret
+			} // end of method FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2195
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper
+
 
 		// Methods
 		.method public hidebysig static 
@@ -123,7 +246,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Path_Join_NestedFunction/Scope,
-			[1] class FunctionObjects.Require_Path_Join_NestedFunction_AA09F56B.FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper,
+			[1] class Modules.Require_Path_Join_NestedFunction/joinWrapper/FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper,
 			[2] object,
 			[3] object[],
 			[4] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IPathModule,
@@ -143,13 +266,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Require_Path_Join_NestedFunction/Scope
-		IL_0019: newobj instance void FunctionObjects.Require_Path_Join_NestedFunction_AA09F56B.FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::.ctor(class Modules.Require_Path_Join_NestedFunction/Scope)
+		IL_0019: newobj instance void Modules.Require_Path_Join_NestedFunction/joinWrapper/FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::.ctor(class Modules.Require_Path_Join_NestedFunction/Scope)
 		IL_001e: ldc.i4.2
 		IL_001f: conv.r8
 		IL_0020: ldstr "joinWrapper"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Require_Path_Join_NestedFunction_AA09F56B.FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Path_Join_NestedFunction/joinWrapper/FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldarg.1
@@ -186,129 +309,6 @@
 	} // end of method Require_Path_Join_NestedFunction::__js_module_init__
 
 } // end of class Modules.Require_Path_Join_NestedFunction
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Require_Path_Join_NestedFunction_AA09F56B.FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Require_Path_Join_NestedFunction/Scope _environment0_Require_Path_Join_NestedFunction
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Require_Path_Join_NestedFunction/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2130
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Require_Path_Join_NestedFunction/Scope FunctionObjects.Require_Path_Join_NestedFunction_AA09F56B.FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::_environment0_Require_Path_Join_NestedFunction
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x213f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2142
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2145
-		// Header size: 1
-		// Code size: 41 (0x29)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Require_Path_Join_NestedFunction/Scope FunctionObjects.Require_Path_Join_NestedFunction_AA09F56B.FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::_environment0_Require_Path_Join_NestedFunction
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0017: ldarg.2
-		IL_0018: ldc.i4.1
-		IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0023: call object Modules.Require_Path_Join_NestedFunction/joinWrapper::__js_call__(class Modules.Require_Path_Join_NestedFunction/Scope, object, string, string)
-		IL_0028: ret
-	} // end of method FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x216f
-		// Header size: 1
-		// Code size: 37 (0x25)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Require_Path_Join_NestedFunction/Scope FunctionObjects.Require_Path_Join_NestedFunction_AA09F56B.FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::_environment0_Require_Path_Join_NestedFunction
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.1
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_001f: call object Modules.Require_Path_Join_NestedFunction/joinWrapper::__js_call__(class Modules.Require_Path_Join_NestedFunction/Scope, object, string, string)
-		IL_0024: ret
-	} // end of method FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2195
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper::ConstructCore
-
-} // end of class FunctionObjects.Require_Path_Join_NestedFunction_AA09F56B.FunctionObject_FunctionDeclaration_650D6C1D_joinWrapper
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_MemberOverrides.verified.txt
+++ b/tests/Jroc.Tests/Node/Path/Snapshots/GeneratorTests.Require_Path_MemberOverrides.verified.txt
@@ -31,6 +31,121 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2DB7A438_normalize
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Require_Path_MemberOverrides/Scope _environment0_Require_Path_MemberOverrides
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Require_Path_MemberOverrides/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2576
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Require_Path_MemberOverrides/Scope Modules.Require_Path_MemberOverrides/normalize/FunctionObject_FunctionDeclaration_2DB7A438_normalize::_environment0_Require_Path_MemberOverrides
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_2DB7A438_normalize::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2585
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2DB7A438_normalize::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2588
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2DB7A438_normalize::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x258b
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Require_Path_MemberOverrides/Scope Modules.Require_Path_MemberOverrides/normalize/FunctionObject_FunctionDeclaration_2DB7A438_normalize::_environment0_Require_Path_MemberOverrides
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: call object Modules.Require_Path_MemberOverrides/normalize::__js_call__(class Modules.Require_Path_MemberOverrides/Scope, object, float64)
+				IL_001c: ret
+			} // end of method FunctionObject_FunctionDeclaration_2DB7A438_normalize::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25a9
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Require_Path_MemberOverrides/Scope Modules.Require_Path_MemberOverrides/normalize/FunctionObject_FunctionDeclaration_2DB7A438_normalize::_environment0_Require_Path_MemberOverrides
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0013: call object Modules.Require_Path_MemberOverrides/normalize::__js_call__(class Modules.Require_Path_MemberOverrides/Scope, object, float64)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_2DB7A438_normalize::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25c3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_2DB7A438_normalize::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_2DB7A438_normalize
+
 
 		// Methods
 		.method public hidebysig static 
@@ -319,7 +434,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Path_MemberOverrides/Scope,
-			[1] class FunctionObjects.Require_Path_MemberOverrides_0C4995F2.FunctionObject_FunctionDeclaration_2DB7A438_normalize,
+			[1] class Modules.Require_Path_MemberOverrides/normalize/FunctionObject_FunctionDeclaration_2DB7A438_normalize,
 			[2] object,
 			[3] object,
 			[4] class [System.Runtime]System.Exception,
@@ -351,13 +466,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Require_Path_MemberOverrides/Scope
-		IL_001b: newobj instance void FunctionObjects.Require_Path_MemberOverrides_0C4995F2.FunctionObject_FunctionDeclaration_2DB7A438_normalize::.ctor(class Modules.Require_Path_MemberOverrides/Scope)
+		IL_001b: newobj instance void Modules.Require_Path_MemberOverrides/normalize/FunctionObject_FunctionDeclaration_2DB7A438_normalize::.ctor(class Modules.Require_Path_MemberOverrides/Scope)
 		IL_0020: ldc.i4.1
 		IL_0021: conv.r8
 		IL_0022: ldstr "normalize"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Require_Path_MemberOverrides_0C4995F2.FunctionObject_FunctionDeclaration_2DB7A438_normalize>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Path_MemberOverrides/normalize/FunctionObject_FunctionDeclaration_2DB7A438_normalize>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: nop
 		IL_0030: ldarg.1
@@ -749,121 +864,6 @@
 	} // end of method Require_Path_MemberOverrides::__js_module_init__
 
 } // end of class Modules.Require_Path_MemberOverrides
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Require_Path_MemberOverrides_0C4995F2.FunctionObject_FunctionDeclaration_2DB7A438_normalize
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Require_Path_MemberOverrides/Scope _environment0_Require_Path_MemberOverrides
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Require_Path_MemberOverrides/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2576
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Require_Path_MemberOverrides/Scope FunctionObjects.Require_Path_MemberOverrides_0C4995F2.FunctionObject_FunctionDeclaration_2DB7A438_normalize::_environment0_Require_Path_MemberOverrides
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_2DB7A438_normalize::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2585
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2DB7A438_normalize::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2588
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2DB7A438_normalize::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x258b
-		// Header size: 1
-		// Code size: 29 (0x1d)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Require_Path_MemberOverrides/Scope FunctionObjects.Require_Path_MemberOverrides_0C4995F2.FunctionObject_FunctionDeclaration_2DB7A438_normalize::_environment0_Require_Path_MemberOverrides
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0017: call object Modules.Require_Path_MemberOverrides/normalize::__js_call__(class Modules.Require_Path_MemberOverrides/Scope, object, float64)
-		IL_001c: ret
-	} // end of method FunctionObject_FunctionDeclaration_2DB7A438_normalize::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25a9
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Require_Path_MemberOverrides/Scope FunctionObjects.Require_Path_MemberOverrides_0C4995F2.FunctionObject_FunctionDeclaration_2DB7A438_normalize::_environment0_Require_Path_MemberOverrides
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0013: call object Modules.Require_Path_MemberOverrides/normalize::__js_call__(class Modules.Require_Path_MemberOverrides/Scope, object, float64)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_2DB7A438_normalize::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25c3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_2DB7A438_normalize::ConstructCore
-
-} // end of class FunctionObjects.Require_Path_MemberOverrides_0C4995F2.FunctionObject_FunctionDeclaration_2DB7A438_normalize
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Snapshots/GeneratorTests.PerfHooks_DestructuredPerformanceOverride.verified.txt
+++ b/tests/Jroc.Tests/Node/Snapshots/GeneratorTests.PerfHooks_DestructuredPerformanceOverride.verified.txt
@@ -31,6 +31,103 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_60CA76E0_L5C8
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2185
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_60CA76E0_L5C8::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x218d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_60CA76E0_L5C8::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2190
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_60CA76E0_L5C8::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2193
+				// Header size: 1
+				// Code size: 16 (0x10)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call float64 Modules.PerfHooks_DestructuredPerformanceOverride/FunctionExpression_L5C7::__js_call__(object)
+				IL_000a: box [System.Runtime]System.Double
+				IL_000f: ret
+			} // end of method FunctionObject_FunctionExpression_60CA76E0_L5C8::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21a4
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call float64 Modules.PerfHooks_DestructuredPerformanceOverride/FunctionExpression_L5C7::__js_call__(object)
+				IL_0006: box [System.Runtime]System.Double
+				IL_000b: ret
+			} // end of method FunctionObject_FunctionExpression_60CA76E0_L5C8::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21b1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_60CA76E0_L5C8::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_60CA76E0_L5C8
+
 
 		// Methods
 		.method public hidebysig static 
@@ -194,103 +291,6 @@
 	} // end of method PerfHooks_DestructuredPerformanceOverride::__js_module_init__
 
 } // end of class Modules.PerfHooks_DestructuredPerformanceOverride
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.PerfHooks_DestructuredPerformanceOverride_3EAEAB77.FunctionObject_FunctionExpression_60CA76E0_L5C8
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2185
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_60CA76E0_L5C8::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x218d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_60CA76E0_L5C8::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2190
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_60CA76E0_L5C8::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2193
-		// Header size: 1
-		// Code size: 16 (0x10)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call float64 Modules.PerfHooks_DestructuredPerformanceOverride/FunctionExpression_L5C7::__js_call__(object)
-		IL_000a: box [System.Runtime]System.Double
-		IL_000f: ret
-	} // end of method FunctionObject_FunctionExpression_60CA76E0_L5C8::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21a4
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call float64 Modules.PerfHooks_DestructuredPerformanceOverride/FunctionExpression_L5C7::__js_call__(object)
-		IL_0006: box [System.Runtime]System.Double
-		IL_000b: ret
-	} // end of method FunctionObject_FunctionExpression_60CA76E0_L5C8::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21b1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_60CA76E0_L5C8::ConstructCore
-
-} // end of class FunctionObjects.PerfHooks_DestructuredPerformanceOverride_3EAEAB77.FunctionObject_FunctionExpression_60CA76E0_L5C8
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Finished_Callback_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Finished_Callback_Basic.verified.txt
@@ -31,6 +31,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F5E4395D_L6C19
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2212
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_F5E4395D_L6C19::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x221a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F5E4395D_L6C19::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x221d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F5E4395D_L6C19::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2220
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Stream_Finished_Callback_Basic/FunctionExpression_L6C18::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_F5E4395D_L6C19::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x222c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Stream_Finished_Callback_Basic/FunctionExpression_L6C18::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_F5E4395D_L6C19::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2234
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_F5E4395D_L6C19::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_F5E4395D_L6C19
+
 
 		// Methods
 		.method public hidebysig static 
@@ -75,6 +170,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9F4085BA_L8C27
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Finished_Callback_Basic/Scope _environment0_Stream_Finished_Callback_Basic
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Finished_Callback_Basic/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2243
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Finished_Callback_Basic/Scope Modules.Stream_Finished_Callback_Basic/FunctionExpression_L8C26/FunctionObject_FunctionExpression_9F4085BA_L8C27::_environment0_Stream_Finished_Callback_Basic
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_9F4085BA_L8C27::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2252
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_9F4085BA_L8C27::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2255
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_9F4085BA_L8C27::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2258
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Finished_Callback_Basic/Scope Modules.Stream_Finished_Callback_Basic/FunctionExpression_L8C26/FunctionObject_FunctionExpression_9F4085BA_L8C27::_environment0_Stream_Finished_Callback_Basic
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Stream_Finished_Callback_Basic/FunctionExpression_L8C26::__js_call__(class Modules.Stream_Finished_Callback_Basic/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_9F4085BA_L8C27::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2271
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Finished_Callback_Basic/Scope Modules.Stream_Finished_Callback_Basic/FunctionExpression_L8C26/FunctionObject_FunctionExpression_9F4085BA_L8C27::_environment0_Stream_Finished_Callback_Basic
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Stream_Finished_Callback_Basic/FunctionExpression_L8C26::__js_call__(class Modules.Stream_Finished_Callback_Basic/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_9F4085BA_L8C27::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2286
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_9F4085BA_L8C27::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_9F4085BA_L8C27
 
 
 		// Methods
@@ -203,8 +411,8 @@
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule,
 			[2] object,
 			[3] object[],
-			[4] class FunctionObjects.Stream_Finished_Callback_Basic_F602AC73.FunctionObject_FunctionExpression_F5E4395D_L6C19,
-			[5] class FunctionObjects.Stream_Finished_Callback_Basic_F602AC73.FunctionObject_FunctionExpression_9F4085BA_L8C27,
+			[4] class Modules.Stream_Finished_Callback_Basic/FunctionExpression_L6C18/FunctionObject_FunctionExpression_F5E4395D_L6C19,
+			[5] class Modules.Stream_Finished_Callback_Basic/FunctionExpression_L8C26/FunctionObject_FunctionExpression_9F4085BA_L8C27,
 			[6] object,
 			[7] object
 		)
@@ -237,13 +445,13 @@
 		IL_003d: ldloc.0
 		IL_003e: stelem.ref
 		IL_003f: stloc.3
-		IL_0040: newobj instance void FunctionObjects.Stream_Finished_Callback_Basic_F602AC73.FunctionObject_FunctionExpression_F5E4395D_L6C19::.ctor()
+		IL_0040: newobj instance void Modules.Stream_Finished_Callback_Basic/FunctionExpression_L6C18/FunctionObject_FunctionExpression_F5E4395D_L6C19::.ctor()
 		IL_0045: ldc.i4.0
 		IL_0046: conv.r8
 		IL_0047: ldstr ""
 		IL_004c: ldc.i4.0
 		IL_004d: ldc.i4.1
-		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Finished_Callback_Basic_F602AC73.FunctionObject_FunctionExpression_F5E4395D_L6C19>(!!0, float64, string, bool, bool)
+		IL_004e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Finished_Callback_Basic/FunctionExpression_L6C18/FunctionObject_FunctionExpression_F5E4395D_L6C19>(!!0, float64, string, bool, bool)
 		IL_0053: stloc.s 4
 		IL_0055: ldloc.2
 		IL_0056: ldstr "_write"
@@ -265,13 +473,13 @@
 		IL_0077: ldc.i4.0
 		IL_0078: ldelem.ref
 		IL_0079: castclass Modules.Stream_Finished_Callback_Basic/Scope
-		IL_007e: newobj instance void FunctionObjects.Stream_Finished_Callback_Basic_F602AC73.FunctionObject_FunctionExpression_9F4085BA_L8C27::.ctor(class Modules.Stream_Finished_Callback_Basic/Scope)
+		IL_007e: newobj instance void Modules.Stream_Finished_Callback_Basic/FunctionExpression_L8C26/FunctionObject_FunctionExpression_9F4085BA_L8C27::.ctor(class Modules.Stream_Finished_Callback_Basic/Scope)
 		IL_0083: ldc.i4.1
 		IL_0084: conv.r8
 		IL_0085: ldstr ""
 		IL_008a: ldc.i4.0
 		IL_008b: ldc.i4.1
-		IL_008c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Finished_Callback_Basic_F602AC73.FunctionObject_FunctionExpression_9F4085BA_L8C27>(!!0, float64, string, bool, bool)
+		IL_008c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Finished_Callback_Basic/FunctionExpression_L8C26/FunctionObject_FunctionExpression_9F4085BA_L8C27>(!!0, float64, string, bool, bool)
 		IL_0091: stloc.s 5
 		IL_0093: ldloc.1
 		IL_0094: ldstr "finished"
@@ -308,214 +516,6 @@
 	} // end of method Stream_Finished_Callback_Basic::__js_module_init__
 
 } // end of class Modules.Stream_Finished_Callback_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Finished_Callback_Basic_F602AC73.FunctionObject_FunctionExpression_F5E4395D_L6C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2212
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_F5E4395D_L6C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x221a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F5E4395D_L6C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x221d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F5E4395D_L6C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2220
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Stream_Finished_Callback_Basic/FunctionExpression_L6C18::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_F5E4395D_L6C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x222c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Stream_Finished_Callback_Basic/FunctionExpression_L6C18::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_F5E4395D_L6C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2234
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F5E4395D_L6C19::ConstructCore
-
-} // end of class FunctionObjects.Stream_Finished_Callback_Basic_F602AC73.FunctionObject_FunctionExpression_F5E4395D_L6C19
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Finished_Callback_Basic_F602AC73.FunctionObject_FunctionExpression_9F4085BA_L8C27
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Finished_Callback_Basic/Scope _environment0_Stream_Finished_Callback_Basic
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Finished_Callback_Basic/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2243
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Finished_Callback_Basic/Scope FunctionObjects.Stream_Finished_Callback_Basic_F602AC73.FunctionObject_FunctionExpression_9F4085BA_L8C27::_environment0_Stream_Finished_Callback_Basic
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_9F4085BA_L8C27::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2252
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9F4085BA_L8C27::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2255
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9F4085BA_L8C27::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2258
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Finished_Callback_Basic/Scope FunctionObjects.Stream_Finished_Callback_Basic_F602AC73.FunctionObject_FunctionExpression_9F4085BA_L8C27::_environment0_Stream_Finished_Callback_Basic
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Stream_Finished_Callback_Basic/FunctionExpression_L8C26::__js_call__(class Modules.Stream_Finished_Callback_Basic/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_9F4085BA_L8C27::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2271
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Finished_Callback_Basic/Scope FunctionObjects.Stream_Finished_Callback_Basic_F602AC73.FunctionObject_FunctionExpression_9F4085BA_L8C27::_environment0_Stream_Finished_Callback_Basic
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Stream_Finished_Callback_Basic/FunctionExpression_L8C26::__js_call__(class Modules.Stream_Finished_Callback_Basic/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_9F4085BA_L8C27::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2286
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_9F4085BA_L8C27::ConstructCore
-
-} // end of class FunctionObjects.Stream_Finished_Callback_Basic_F602AC73.FunctionObject_FunctionExpression_9F4085BA_L8C27
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Finished_Callback_DestroyError.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Finished_Callback_DestroyError.verified.txt
@@ -31,6 +31,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2D614845_L7C27
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Finished_Callback_DestroyError/Scope _environment0_Stream_Finished_Callback_DestroyError
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Finished_Callback_DestroyError/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x219d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Finished_Callback_DestroyError/Scope Modules.Stream_Finished_Callback_DestroyError/FunctionExpression_L7C26/FunctionObject_FunctionExpression_2D614845_L7C27::_environment0_Stream_Finished_Callback_DestroyError
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_2D614845_L7C27::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21ac
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_2D614845_L7C27::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21af
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_2D614845_L7C27::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21b2
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Finished_Callback_DestroyError/Scope Modules.Stream_Finished_Callback_DestroyError/FunctionExpression_L7C26/FunctionObject_FunctionExpression_2D614845_L7C27::_environment0_Stream_Finished_Callback_DestroyError
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Stream_Finished_Callback_DestroyError/FunctionExpression_L7C26::__js_call__(class Modules.Stream_Finished_Callback_DestroyError/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_2D614845_L7C27::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21cb
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Finished_Callback_DestroyError/Scope Modules.Stream_Finished_Callback_DestroyError/FunctionExpression_L7C26/FunctionObject_FunctionExpression_2D614845_L7C27::_environment0_Stream_Finished_Callback_DestroyError
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Stream_Finished_Callback_DestroyError/FunctionExpression_L7C26::__js_call__(class Modules.Stream_Finished_Callback_DestroyError/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_2D614845_L7C27::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21e0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_2D614845_L7C27::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_2D614845_L7C27
+
 
 		// Methods
 		.method public hidebysig static 
@@ -158,7 +271,7 @@
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule,
 			[2] object,
 			[3] object[],
-			[4] class FunctionObjects.Stream_Finished_Callback_DestroyError_9AA3C343.FunctionObject_FunctionExpression_2D614845_L7C27,
+			[4] class Modules.Stream_Finished_Callback_DestroyError/FunctionExpression_L7C26/FunctionObject_FunctionExpression_2D614845_L7C27,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Error
 		)
 
@@ -194,13 +307,13 @@
 		IL_0041: ldc.i4.0
 		IL_0042: ldelem.ref
 		IL_0043: castclass Modules.Stream_Finished_Callback_DestroyError/Scope
-		IL_0048: newobj instance void FunctionObjects.Stream_Finished_Callback_DestroyError_9AA3C343.FunctionObject_FunctionExpression_2D614845_L7C27::.ctor(class Modules.Stream_Finished_Callback_DestroyError/Scope)
+		IL_0048: newobj instance void Modules.Stream_Finished_Callback_DestroyError/FunctionExpression_L7C26/FunctionObject_FunctionExpression_2D614845_L7C27::.ctor(class Modules.Stream_Finished_Callback_DestroyError/Scope)
 		IL_004d: ldc.i4.1
 		IL_004e: conv.r8
 		IL_004f: ldstr ""
 		IL_0054: ldc.i4.0
 		IL_0055: ldc.i4.1
-		IL_0056: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Finished_Callback_DestroyError_9AA3C343.FunctionObject_FunctionExpression_2D614845_L7C27>(!!0, float64, string, bool, bool)
+		IL_0056: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Finished_Callback_DestroyError/FunctionExpression_L7C26/FunctionObject_FunctionExpression_2D614845_L7C27>(!!0, float64, string, bool, bool)
 		IL_005b: stloc.s 4
 		IL_005d: ldloc.1
 		IL_005e: ldstr "finished"
@@ -224,119 +337,6 @@
 	} // end of method Stream_Finished_Callback_DestroyError::__js_module_init__
 
 } // end of class Modules.Stream_Finished_Callback_DestroyError
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Finished_Callback_DestroyError_9AA3C343.FunctionObject_FunctionExpression_2D614845_L7C27
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Finished_Callback_DestroyError/Scope _environment0_Stream_Finished_Callback_DestroyError
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Finished_Callback_DestroyError/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x219d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Finished_Callback_DestroyError/Scope FunctionObjects.Stream_Finished_Callback_DestroyError_9AA3C343.FunctionObject_FunctionExpression_2D614845_L7C27::_environment0_Stream_Finished_Callback_DestroyError
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2D614845_L7C27::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21ac
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2D614845_L7C27::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21af
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2D614845_L7C27::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21b2
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Finished_Callback_DestroyError/Scope FunctionObjects.Stream_Finished_Callback_DestroyError_9AA3C343.FunctionObject_FunctionExpression_2D614845_L7C27::_environment0_Stream_Finished_Callback_DestroyError
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Stream_Finished_Callback_DestroyError/FunctionExpression_L7C26::__js_call__(class Modules.Stream_Finished_Callback_DestroyError/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_2D614845_L7C27::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21cb
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Finished_Callback_DestroyError/Scope FunctionObjects.Stream_Finished_Callback_DestroyError_9AA3C343.FunctionObject_FunctionExpression_2D614845_L7C27::_environment0_Stream_Finished_Callback_DestroyError
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Stream_Finished_Callback_DestroyError/FunctionExpression_L7C26::__js_call__(class Modules.Stream_Finished_Callback_DestroyError/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_2D614845_L7C27::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21e0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2D614845_L7C27::ConstructCore
-
-} // end of class FunctionObjects.Stream_Finished_Callback_DestroyError_9AA3C343.FunctionObject_FunctionExpression_2D614845_L7C27
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Helper_Signal_Requires_AbortSignal.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Helper_Signal_Requires_AbortSignal.verified.txt
@@ -35,6 +35,107 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A4A90E5B_L8C21
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2b74
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_A4A90E5B_L8C21::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2b7c
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_A4A90E5B_L8C21::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2b7f
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_A4A90E5B_L8C21::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2b82
+					// Header size: 1
+					// Code size: 18 (0x12)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: ldarg.2
+					IL_0006: ldc.i4.0
+					IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000c: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionExpression_L8C20::__js_call__(object, object)
+					IL_0011: ret
+				} // end of method FunctionObject_FunctionExpression_A4A90E5B_L8C21::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2b95
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: ldarg.2
+					IL_0002: ldc.i4.0
+					IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0008: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionExpression_L8C20::__js_call__(object, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_A4A90E5B_L8C21::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2ba4
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_A4A90E5B_L8C21::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_A4A90E5B_L8C21
+
 
 			// Methods
 			.method public hidebysig static 
@@ -77,6 +178,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CEE88488_createWritable
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope _environment0_Stream_Helper_Signal_Requires_AbortSignal
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b30
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionObject_FunctionDeclaration_CEE88488_createWritable::_environment0_Stream_Helper_Signal_Requires_AbortSignal
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_CEE88488_createWritable::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2b3f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CEE88488_createWritable::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2b42
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CEE88488_createWritable::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b45
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionObject_FunctionDeclaration_CEE88488_createWritable::_environment0_Stream_Helper_Signal_Requires_AbortSignal
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_CEE88488_createWritable::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b57
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionObject_FunctionDeclaration_CEE88488_createWritable::_environment0_Stream_Helper_Signal_Requires_AbortSignal
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_CEE88488_createWritable::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b65
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_CEE88488_createWritable::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_CEE88488_createWritable
+
 
 		// Methods
 		.method public hidebysig static 
@@ -100,7 +308,7 @@
 				[2] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule,
 				[3] object,
 				[4] object[],
-				[5] class FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionExpression_A4A90E5B_L8C21
+				[5] class Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionExpression_L8C20/FunctionObject_FunctionExpression_A4A90E5B_L8C21
 			)
 
 			IL_0000: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/Scope::.ctor()
@@ -131,13 +339,13 @@
 			IL_003d: ldarg.0
 			IL_003e: stelem.ref
 			IL_003f: stloc.s 4
-			IL_0041: newobj instance void FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionExpression_A4A90E5B_L8C21::.ctor()
+			IL_0041: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionExpression_L8C20/FunctionObject_FunctionExpression_A4A90E5B_L8C21::.ctor()
 			IL_0046: ldc.i4.1
 			IL_0047: conv.r8
 			IL_0048: ldstr ""
 			IL_004d: ldc.i4.0
 			IL_004e: ldc.i4.1
-			IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionExpression_A4A90E5B_L8C21>(!!0, float64, string, bool, bool)
+			IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionExpression_L8C20/FunctionObject_FunctionExpression_A4A90E5B_L8C21>(!!0, float64, string, bool, bool)
 			IL_0054: stloc.s 5
 			IL_0056: ldloc.1
 			IL_0057: ldstr "_write"
@@ -174,6 +382,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_ECED33DC_createReadable
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope _environment0_Stream_Helper_Signal_Requires_AbortSignal
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bb3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable/FunctionObject_FunctionDeclaration_ECED33DC_createReadable::_environment0_Stream_Helper_Signal_Requires_AbortSignal
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_ECED33DC_createReadable::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2bc2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_ECED33DC_createReadable::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2bc5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_ECED33DC_createReadable::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bc8
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable/FunctionObject_FunctionDeclaration_ECED33DC_createReadable::_environment0_Stream_Helper_Signal_Requires_AbortSignal
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_ECED33DC_createReadable::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bda
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable/FunctionObject_FunctionDeclaration_ECED33DC_createReadable::_environment0_Stream_Helper_Signal_Requires_AbortSignal
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_ECED33DC_createReadable::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2be8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_ECED33DC_createReadable::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_ECED33DC_createReadable
 
 
 		// Methods
@@ -250,6 +565,101 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9E17276A_L18C57
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2c33
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_9E17276A_L18C57::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2c3b
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_9E17276A_L18C57::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2c3e
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_9E17276A_L18C57::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2c41
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56::__js_call__(object)
+					IL_000a: ret
+				} // end of method FunctionObject_FunctionExpression_9E17276A_L18C57::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2c4d
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56::__js_call__(object)
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_9E17276A_L18C57::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2c55
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_9E17276A_L18C57::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_9E17276A_L18C57
+
 
 			// Methods
 			.method public hidebysig static 
@@ -294,6 +704,101 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_68D4A142_L26C73
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2c64
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_68D4A142_L26C73::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2c6c
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_68D4A142_L26C73::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2c6f
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_68D4A142_L26C73::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2c72
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72::__js_call__(object)
+					IL_000a: ret
+				} // end of method FunctionObject_FunctionExpression_68D4A142_L26C73::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2c7e
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72::__js_call__(object)
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_68D4A142_L26C73::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2c86
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_68D4A142_L26C73::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_68D4A142_L26C73
 
 
 			// Methods
@@ -523,6 +1028,99 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1D6C2B21_main
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope _environment0_Stream_Helper_Signal_Requires_AbortSignal
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bf7
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionObject_FunctionDeclaration_1D6C2B21_main::_environment0_Stream_Helper_Signal_Requires_AbortSignal
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionObject_FunctionDeclaration_1D6C2B21_main::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_1D6C2B21_main::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2c0d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1D6C2B21_main::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2c10
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1D6C2B21_main::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c13
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionObject_FunctionDeclaration_1D6C2B21_main::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/main::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_1D6C2B21_main::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c25
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionObject_FunctionDeclaration_1D6C2B21_main::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/main::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_1D6C2B21_main::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_1D6C2B21_main
+
 
 		// Methods
 		.method public hidebysig static 
@@ -555,10 +1153,10 @@
 				[13] object[],
 				[14] object,
 				[15] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-				[16] class FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionExpression_9E17276A_L18C57,
+				[16] class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56/FunctionObject_FunctionExpression_9E17276A_L18C57,
 				[17] object,
 				[18] object,
-				[19] class FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionExpression_68D4A142_L26C73,
+				[19] class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72/FunctionObject_FunctionExpression_68D4A142_L26C73,
 				[20] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule
 			)
 
@@ -671,7 +1269,7 @@
 			IL_00cd: dup
 			IL_00ce: ldc.i4.s 15
 			IL_00d0: ldelem.ref
-			IL_00d1: castclass FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionExpression_9E17276A_L18C57
+			IL_00d1: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56/FunctionObject_FunctionExpression_9E17276A_L18C57
 			IL_00d6: stloc.s 16
 			IL_00d8: dup
 			IL_00d9: ldc.i4.s 16
@@ -684,7 +1282,7 @@
 			IL_00e4: dup
 			IL_00e5: ldc.i4.s 18
 			IL_00e7: ldelem.ref
-			IL_00e8: castclass FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionExpression_68D4A142_L26C73
+			IL_00e8: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72/FunctionObject_FunctionExpression_68D4A142_L26C73
 			IL_00ed: stloc.s 19
 			IL_00ef: dup
 			IL_00f0: ldc.i4.s 19
@@ -738,13 +1336,13 @@
 				IL_0170: ldelem.ref
 				IL_0171: stelem.ref
 				IL_0172: stloc.s 13
-				IL_0174: newobj instance void FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionExpression_9E17276A_L18C57::.ctor()
+				IL_0174: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56/FunctionObject_FunctionExpression_9E17276A_L18C57::.ctor()
 				IL_0179: ldc.i4.0
 				IL_017a: conv.r8
 				IL_017b: ldstr ""
 				IL_0180: ldc.i4.0
 				IL_0181: ldc.i4.1
-				IL_0182: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionExpression_9E17276A_L18C57>(!!0, float64, string, bool, bool)
+				IL_0182: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56/FunctionObject_FunctionExpression_9E17276A_L18C57>(!!0, float64, string, bool, bool)
 				IL_0187: stloc.s 16
 				IL_0189: ldloc.s 12
 				IL_018b: ldstr "finished"
@@ -899,13 +1497,13 @@
 				IL_030b: ldelem.ref
 				IL_030c: stelem.ref
 				IL_030d: stloc.s 13
-				IL_030f: newobj instance void FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionExpression_68D4A142_L26C73::.ctor()
+				IL_030f: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72/FunctionObject_FunctionExpression_68D4A142_L26C73::.ctor()
 				IL_0314: ldc.i4.0
 				IL_0315: conv.r8
 				IL_0316: ldstr ""
 				IL_031b: ldc.i4.0
 				IL_031c: ldc.i4.1
-				IL_031d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionExpression_68D4A142_L26C73>(!!0, float64, string, bool, bool)
+				IL_031d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72/FunctionObject_FunctionExpression_68D4A142_L26C73>(!!0, float64, string, bool, bool)
 				IL_0322: stloc.s 19
 				IL_0324: ldloc.s 12
 				IL_0326: ldc.i4.4
@@ -1560,8 +2158,8 @@
 			[0] class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
 			[2] object[],
-			[3] class FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionDeclaration_CEE88488_createWritable,
-			[4] class FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionDeclaration_ECED33DC_createReadable,
+			[3] class Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionObject_FunctionDeclaration_CEE88488_createWritable,
+			[4] class Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable/FunctionObject_FunctionDeclaration_ECED33DC_createReadable,
 			[5] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule,
 			[6] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule
 		)
@@ -1579,13 +2177,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-		IL_0019: newobj instance void FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionDeclaration_CEE88488_createWritable::.ctor(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope)
+		IL_0019: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionObject_FunctionDeclaration_CEE88488_createWritable::.ctor(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "createWritable"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionDeclaration_CEE88488_createWritable>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionObject_FunctionDeclaration_CEE88488_createWritable>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.3
 		IL_002d: ldloc.0
 		IL_002e: ldloc.3
@@ -1601,13 +2199,13 @@
 		IL_0040: ldc.i4.0
 		IL_0041: ldelem.ref
 		IL_0042: castclass Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope
-		IL_0047: newobj instance void FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionDeclaration_ECED33DC_createReadable::.ctor(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope)
+		IL_0047: newobj instance void Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable/FunctionObject_FunctionDeclaration_ECED33DC_createReadable::.ctor(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope)
 		IL_004c: ldc.i4.0
 		IL_004d: conv.r8
 		IL_004e: ldstr "createReadable"
 		IL_0053: ldc.i4.0
 		IL_0054: ldc.i4.1
-		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionDeclaration_ECED33DC_createReadable>(!!0, float64, string, bool, bool)
+		IL_0055: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable/FunctionObject_FunctionDeclaration_ECED33DC_createReadable>(!!0, float64, string, bool, bool)
 		IL_005a: stloc.s 4
 		IL_005c: ldloc.0
 		IL_005d: ldloc.s 4
@@ -1656,604 +2254,6 @@
 	} // end of method Stream_Helper_Signal_Requires_AbortSignal::__js_module_init__
 
 } // end of class Modules.Stream_Helper_Signal_Requires_AbortSignal
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionDeclaration_CEE88488_createWritable
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope _environment0_Stream_Helper_Signal_Requires_AbortSignal
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b30
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionDeclaration_CEE88488_createWritable::_environment0_Stream_Helper_Signal_Requires_AbortSignal
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_CEE88488_createWritable::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2b3f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CEE88488_createWritable::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2b42
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CEE88488_createWritable::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b45
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionDeclaration_CEE88488_createWritable::_environment0_Stream_Helper_Signal_Requires_AbortSignal
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_CEE88488_createWritable::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b57
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionDeclaration_CEE88488_createWritable::_environment0_Stream_Helper_Signal_Requires_AbortSignal
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_CEE88488_createWritable::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b65
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_CEE88488_createWritable::ConstructCore
-
-} // end of class FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionDeclaration_CEE88488_createWritable
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionExpression_A4A90E5B_L8C21
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2b74
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_A4A90E5B_L8C21::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2b7c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A4A90E5B_L8C21::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2b7f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A4A90E5B_L8C21::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b82
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionExpression_L8C20::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_A4A90E5B_L8C21::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b95
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createWritable/FunctionExpression_L8C20::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A4A90E5B_L8C21::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ba4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A4A90E5B_L8C21::ConstructCore
-
-} // end of class FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionExpression_A4A90E5B_L8C21
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionDeclaration_ECED33DC_createReadable
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope _environment0_Stream_Helper_Signal_Requires_AbortSignal
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bb3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionDeclaration_ECED33DC_createReadable::_environment0_Stream_Helper_Signal_Requires_AbortSignal
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_ECED33DC_createReadable::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2bc2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_ECED33DC_createReadable::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2bc5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_ECED33DC_createReadable::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bc8
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionDeclaration_ECED33DC_createReadable::_environment0_Stream_Helper_Signal_Requires_AbortSignal
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_ECED33DC_createReadable::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bda
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionDeclaration_ECED33DC_createReadable::_environment0_Stream_Helper_Signal_Requires_AbortSignal
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/createReadable::__js_call__(class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_ECED33DC_createReadable::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2be8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_ECED33DC_createReadable::ConstructCore
-
-} // end of class FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionDeclaration_ECED33DC_createReadable
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionDeclaration_1D6C2B21_main
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope _environment0_Stream_Helper_Signal_Requires_AbortSignal
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bf7
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Helper_Signal_Requires_AbortSignal/Scope FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionDeclaration_1D6C2B21_main::_environment0_Stream_Helper_Signal_Requires_AbortSignal
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionDeclaration_1D6C2B21_main::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_1D6C2B21_main::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2c0d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1D6C2B21_main::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2c10
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1D6C2B21_main::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c13
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionDeclaration_1D6C2B21_main::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/main::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_1D6C2B21_main::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c25
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionDeclaration_1D6C2B21_main::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/main::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_1D6C2B21_main::ConstructBodyCore
-
-} // end of class FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionDeclaration_1D6C2B21_main
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionExpression_9E17276A_L18C57
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2c33
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_9E17276A_L18C57::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2c3b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9E17276A_L18C57::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2c3e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9E17276A_L18C57::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c41
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_9E17276A_L18C57::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c4d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L18C56::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_9E17276A_L18C57::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c55
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_9E17276A_L18C57::ConstructCore
-
-} // end of class FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionExpression_9E17276A_L18C57
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionExpression_68D4A142_L26C73
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2c64
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_68D4A142_L26C73::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2c6c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_68D4A142_L26C73::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2c6f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_68D4A142_L26C73::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c72
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_68D4A142_L26C73::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c7e
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Stream_Helper_Signal_Requires_AbortSignal/main/FunctionExpression_L26C72::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_68D4A142_L26C73::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c86
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_68D4A142_L26C73::ConstructCore
-
-} // end of class FunctionObjects.Stream_Helper_Signal_Requires_AbortSignal_5B366171.FunctionObject_FunctionExpression_68D4A142_L26C73
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_PassThrough_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_PassThrough_Basic.verified.txt
@@ -31,6 +31,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_EAEB5E6E_L10C19
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_PassThrough_Basic/Scope _environment0_Stream_PassThrough_Basic
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_PassThrough_Basic/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x22aa
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_PassThrough_Basic/Scope Modules.Stream_PassThrough_Basic/FunctionExpression_L10C18/FunctionObject_FunctionExpression_EAEB5E6E_L10C19::_environment0_Stream_PassThrough_Basic
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_EAEB5E6E_L10C19::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22b9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_EAEB5E6E_L10C19::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22bc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_EAEB5E6E_L10C19::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22bf
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_PassThrough_Basic/Scope Modules.Stream_PassThrough_Basic/FunctionExpression_L10C18/FunctionObject_FunctionExpression_EAEB5E6E_L10C19::_environment0_Stream_PassThrough_Basic
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Stream_PassThrough_Basic/FunctionExpression_L10C18::__js_call__(class Modules.Stream_PassThrough_Basic/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_EAEB5E6E_L10C19::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22d8
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_PassThrough_Basic/Scope Modules.Stream_PassThrough_Basic/FunctionExpression_L10C18/FunctionObject_FunctionExpression_EAEB5E6E_L10C19::_environment0_Stream_PassThrough_Basic
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Stream_PassThrough_Basic/FunctionExpression_L10C18::__js_call__(class Modules.Stream_PassThrough_Basic/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_EAEB5E6E_L10C19::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22ed
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_EAEB5E6E_L10C19::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_EAEB5E6E_L10C19
+
 
 		// Methods
 		.method public hidebysig static 
@@ -89,6 +202,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3C59D3C3_L14C23
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_PassThrough_Basic/Scope _environment0_Stream_PassThrough_Basic
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_PassThrough_Basic/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x22fc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_PassThrough_Basic/Scope Modules.Stream_PassThrough_Basic/FunctionExpression_L14C22/FunctionObject_FunctionExpression_3C59D3C3_L14C23::_environment0_Stream_PassThrough_Basic
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_3C59D3C3_L14C23::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x230b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_3C59D3C3_L14C23::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x230e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_3C59D3C3_L14C23::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2311
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_PassThrough_Basic/Scope Modules.Stream_PassThrough_Basic/FunctionExpression_L14C22/FunctionObject_FunctionExpression_3C59D3C3_L14C23::_environment0_Stream_PassThrough_Basic
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Stream_PassThrough_Basic/FunctionExpression_L14C22::__js_call__(class Modules.Stream_PassThrough_Basic/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_3C59D3C3_L14C23::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2323
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_PassThrough_Basic/Scope Modules.Stream_PassThrough_Basic/FunctionExpression_L14C22/FunctionObject_FunctionExpression_3C59D3C3_L14C23::_environment0_Stream_PassThrough_Basic
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Stream_PassThrough_Basic/FunctionExpression_L14C22::__js_call__(class Modules.Stream_PassThrough_Basic/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_3C59D3C3_L14C23::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2331
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_3C59D3C3_L14C23::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_3C59D3C3_L14C23
 
 
 		// Methods
@@ -219,8 +439,8 @@
 			[5] object,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[7] object[],
-			[8] class FunctionObjects.Stream_PassThrough_Basic_E73049F1.FunctionObject_FunctionExpression_EAEB5E6E_L10C19,
-			[9] class FunctionObjects.Stream_PassThrough_Basic_E73049F1.FunctionObject_FunctionExpression_3C59D3C3_L14C23
+			[8] class Modules.Stream_PassThrough_Basic/FunctionExpression_L10C18/FunctionObject_FunctionExpression_EAEB5E6E_L10C19,
+			[9] class Modules.Stream_PassThrough_Basic/FunctionExpression_L14C22/FunctionObject_FunctionExpression_3C59D3C3_L14C23
 		)
 
 		IL_0000: newobj instance void Modules.Stream_PassThrough_Basic/Scope::.ctor()
@@ -271,13 +491,13 @@
 		IL_0074: ldc.i4.0
 		IL_0075: ldelem.ref
 		IL_0076: castclass Modules.Stream_PassThrough_Basic/Scope
-		IL_007b: newobj instance void FunctionObjects.Stream_PassThrough_Basic_E73049F1.FunctionObject_FunctionExpression_EAEB5E6E_L10C19::.ctor(class Modules.Stream_PassThrough_Basic/Scope)
+		IL_007b: newobj instance void Modules.Stream_PassThrough_Basic/FunctionExpression_L10C18/FunctionObject_FunctionExpression_EAEB5E6E_L10C19::.ctor(class Modules.Stream_PassThrough_Basic/Scope)
 		IL_0080: ldc.i4.1
 		IL_0081: conv.r8
 		IL_0082: ldstr ""
 		IL_0087: ldc.i4.0
 		IL_0088: ldc.i4.1
-		IL_0089: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_PassThrough_Basic_E73049F1.FunctionObject_FunctionExpression_EAEB5E6E_L10C19>(!!0, float64, string, bool, bool)
+		IL_0089: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_PassThrough_Basic/FunctionExpression_L10C18/FunctionObject_FunctionExpression_EAEB5E6E_L10C19>(!!0, float64, string, bool, bool)
 		IL_008e: stloc.s 8
 		IL_0090: ldloc.s 4
 		IL_0092: ldstr "_write"
@@ -299,13 +519,13 @@
 		IL_00b7: ldc.i4.0
 		IL_00b8: ldelem.ref
 		IL_00b9: castclass Modules.Stream_PassThrough_Basic/Scope
-		IL_00be: newobj instance void FunctionObjects.Stream_PassThrough_Basic_E73049F1.FunctionObject_FunctionExpression_3C59D3C3_L14C23::.ctor(class Modules.Stream_PassThrough_Basic/Scope)
+		IL_00be: newobj instance void Modules.Stream_PassThrough_Basic/FunctionExpression_L14C22/FunctionObject_FunctionExpression_3C59D3C3_L14C23::.ctor(class Modules.Stream_PassThrough_Basic/Scope)
 		IL_00c3: ldc.i4.0
 		IL_00c4: conv.r8
 		IL_00c5: ldstr ""
 		IL_00ca: ldc.i4.0
 		IL_00cb: ldc.i4.1
-		IL_00cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_PassThrough_Basic_E73049F1.FunctionObject_FunctionExpression_3C59D3C3_L14C23>(!!0, float64, string, bool, bool)
+		IL_00cc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_PassThrough_Basic/FunctionExpression_L14C22/FunctionObject_FunctionExpression_3C59D3C3_L14C23>(!!0, float64, string, bool, bool)
 		IL_00d1: stloc.s 9
 		IL_00d3: ldloc.s 5
 		IL_00d5: ldstr "on"
@@ -348,226 +568,6 @@
 	} // end of method Stream_PassThrough_Basic::__js_module_init__
 
 } // end of class Modules.Stream_PassThrough_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_PassThrough_Basic_E73049F1.FunctionObject_FunctionExpression_EAEB5E6E_L10C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_PassThrough_Basic/Scope _environment0_Stream_PassThrough_Basic
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_PassThrough_Basic/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x22aa
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_PassThrough_Basic/Scope FunctionObjects.Stream_PassThrough_Basic_E73049F1.FunctionObject_FunctionExpression_EAEB5E6E_L10C19::_environment0_Stream_PassThrough_Basic
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_EAEB5E6E_L10C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22b9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_EAEB5E6E_L10C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22bc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_EAEB5E6E_L10C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22bf
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_PassThrough_Basic/Scope FunctionObjects.Stream_PassThrough_Basic_E73049F1.FunctionObject_FunctionExpression_EAEB5E6E_L10C19::_environment0_Stream_PassThrough_Basic
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Stream_PassThrough_Basic/FunctionExpression_L10C18::__js_call__(class Modules.Stream_PassThrough_Basic/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_EAEB5E6E_L10C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22d8
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_PassThrough_Basic/Scope FunctionObjects.Stream_PassThrough_Basic_E73049F1.FunctionObject_FunctionExpression_EAEB5E6E_L10C19::_environment0_Stream_PassThrough_Basic
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Stream_PassThrough_Basic/FunctionExpression_L10C18::__js_call__(class Modules.Stream_PassThrough_Basic/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_EAEB5E6E_L10C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22ed
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_EAEB5E6E_L10C19::ConstructCore
-
-} // end of class FunctionObjects.Stream_PassThrough_Basic_E73049F1.FunctionObject_FunctionExpression_EAEB5E6E_L10C19
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_PassThrough_Basic_E73049F1.FunctionObject_FunctionExpression_3C59D3C3_L14C23
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_PassThrough_Basic/Scope _environment0_Stream_PassThrough_Basic
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_PassThrough_Basic/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x22fc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_PassThrough_Basic/Scope FunctionObjects.Stream_PassThrough_Basic_E73049F1.FunctionObject_FunctionExpression_3C59D3C3_L14C23::_environment0_Stream_PassThrough_Basic
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3C59D3C3_L14C23::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x230b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3C59D3C3_L14C23::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x230e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3C59D3C3_L14C23::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2311
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_PassThrough_Basic/Scope FunctionObjects.Stream_PassThrough_Basic_E73049F1.FunctionObject_FunctionExpression_3C59D3C3_L14C23::_environment0_Stream_PassThrough_Basic
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Stream_PassThrough_Basic/FunctionExpression_L14C22::__js_call__(class Modules.Stream_PassThrough_Basic/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_3C59D3C3_L14C23::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2323
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_PassThrough_Basic/Scope FunctionObjects.Stream_PassThrough_Basic_E73049F1.FunctionObject_FunctionExpression_3C59D3C3_L14C23::_environment0_Stream_PassThrough_Basic
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Stream_PassThrough_Basic/FunctionExpression_L14C22::__js_call__(class Modules.Stream_PassThrough_Basic/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_3C59D3C3_L14C23::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2331
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3C59D3C3_L14C23::ConstructCore
-
-} // end of class FunctionObjects.Stream_PassThrough_Basic_E73049F1.FunctionObject_FunctionExpression_3C59D3C3_L14C23
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipe_Backpressure_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipe_Backpressure_Basic.verified.txt
@@ -31,6 +31,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_381BECE4_L11C19
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Pipe_Backpressure_Basic/Scope _environment0_Stream_Pipe_Backpressure_Basic
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Pipe_Backpressure_Basic/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x23ea
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Pipe_Backpressure_Basic/Scope Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L11C18/FunctionObject_FunctionExpression_381BECE4_L11C19::_environment0_Stream_Pipe_Backpressure_Basic
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_381BECE4_L11C19::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x23f9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_381BECE4_L11C19::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x23fc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_381BECE4_L11C19::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x23ff
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Pipe_Backpressure_Basic/Scope Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L11C18/FunctionObject_FunctionExpression_381BECE4_L11C19::_environment0_Stream_Pipe_Backpressure_Basic
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L11C18::__js_call__(class Modules.Stream_Pipe_Backpressure_Basic/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_381BECE4_L11C19::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2418
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Pipe_Backpressure_Basic/Scope Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L11C18/FunctionObject_FunctionExpression_381BECE4_L11C19::_environment0_Stream_Pipe_Backpressure_Basic
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L11C18::__js_call__(class Modules.Stream_Pipe_Backpressure_Basic/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_381BECE4_L11C19::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x242d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_381BECE4_L11C19::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_381BECE4_L11C19
+
 
 		// Methods
 		.method public hidebysig static 
@@ -90,6 +203,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_15BDE42E_L15C22
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x243c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_15BDE42E_L15C22::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2444
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_15BDE42E_L15C22::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2447
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_15BDE42E_L15C22::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x244a
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L15C21::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_15BDE42E_L15C22::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2456
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L15C21::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_15BDE42E_L15C22::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x245e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_15BDE42E_L15C22::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_15BDE42E_L15C22
+
 
 		// Methods
 		.method public hidebysig static 
@@ -141,6 +349,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D45C0895_L19C23
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Pipe_Backpressure_Basic/Scope _environment0_Stream_Pipe_Backpressure_Basic
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Pipe_Backpressure_Basic/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x246d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Pipe_Backpressure_Basic/Scope Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L19C22/FunctionObject_FunctionExpression_D45C0895_L19C23::_environment0_Stream_Pipe_Backpressure_Basic
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_D45C0895_L19C23::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x247c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D45C0895_L19C23::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x247f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D45C0895_L19C23::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2482
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Pipe_Backpressure_Basic/Scope Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L19C22/FunctionObject_FunctionExpression_D45C0895_L19C23::_environment0_Stream_Pipe_Backpressure_Basic
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L19C22::__js_call__(class Modules.Stream_Pipe_Backpressure_Basic/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_D45C0895_L19C23::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2494
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Pipe_Backpressure_Basic/Scope Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L19C22/FunctionObject_FunctionExpression_D45C0895_L19C23::_environment0_Stream_Pipe_Backpressure_Basic
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L19C22::__js_call__(class Modules.Stream_Pipe_Backpressure_Basic/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_D45C0895_L19C23::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24a2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_D45C0895_L19C23::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_D45C0895_L19C23
 
 
 		// Methods
@@ -265,6 +580,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_48135A79_L27C22
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Pipe_Backpressure_Basic/Scope _environment0_Stream_Pipe_Backpressure_Basic
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Pipe_Backpressure_Basic/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x24b1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Pipe_Backpressure_Basic/Scope Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/FunctionObject_FunctionExpression_48135A79_L27C22::_environment0_Stream_Pipe_Backpressure_Basic
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_48135A79_L27C22::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24c0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_48135A79_L27C22::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24c3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_48135A79_L27C22::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24c6
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Pipe_Backpressure_Basic/Scope Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/FunctionObject_FunctionExpression_48135A79_L27C22::_environment0_Stream_Pipe_Backpressure_Basic
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21::__js_call__(class Modules.Stream_Pipe_Backpressure_Basic/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_48135A79_L27C22::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24d8
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Pipe_Backpressure_Basic/Scope Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/FunctionObject_FunctionExpression_48135A79_L27C22::_environment0_Stream_Pipe_Backpressure_Basic
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21::__js_call__(class Modules.Stream_Pipe_Backpressure_Basic/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_48135A79_L27C22::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24e6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_48135A79_L27C22::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_48135A79_L27C22
 
 
 		// Methods
@@ -407,10 +829,10 @@
 			[3] object,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[5] object[],
-			[6] class FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_381BECE4_L11C19,
-			[7] class FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_15BDE42E_L15C22,
-			[8] class FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_D45C0895_L19C23,
-			[9] class FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_48135A79_L27C22,
+			[6] class Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L11C18/FunctionObject_FunctionExpression_381BECE4_L11C19,
+			[7] class Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L15C21/FunctionObject_FunctionExpression_15BDE42E_L15C22,
+			[8] class Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L19C22/FunctionObject_FunctionExpression_D45C0895_L19C23,
+			[9] class Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/FunctionObject_FunctionExpression_48135A79_L27C22,
 			[10] string
 		)
 
@@ -463,13 +885,13 @@
 		IL_0076: ldc.i4.0
 		IL_0077: ldelem.ref
 		IL_0078: castclass Modules.Stream_Pipe_Backpressure_Basic/Scope
-		IL_007d: newobj instance void FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_381BECE4_L11C19::.ctor(class Modules.Stream_Pipe_Backpressure_Basic/Scope)
+		IL_007d: newobj instance void Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L11C18/FunctionObject_FunctionExpression_381BECE4_L11C19::.ctor(class Modules.Stream_Pipe_Backpressure_Basic/Scope)
 		IL_0082: ldc.i4.1
 		IL_0083: conv.r8
 		IL_0084: ldstr ""
 		IL_0089: ldc.i4.0
 		IL_008a: ldc.i4.1
-		IL_008b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_381BECE4_L11C19>(!!0, float64, string, bool, bool)
+		IL_008b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L11C18/FunctionObject_FunctionExpression_381BECE4_L11C19>(!!0, float64, string, bool, bool)
 		IL_0090: stloc.s 6
 		IL_0092: ldloc.2
 		IL_0093: ldstr "_write"
@@ -487,13 +909,13 @@
 		IL_00b0: ldloc.0
 		IL_00b1: stelem.ref
 		IL_00b2: stloc.s 5
-		IL_00b4: newobj instance void FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_15BDE42E_L15C22::.ctor()
+		IL_00b4: newobj instance void Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L15C21/FunctionObject_FunctionExpression_15BDE42E_L15C22::.ctor()
 		IL_00b9: ldc.i4.0
 		IL_00ba: conv.r8
 		IL_00bb: ldstr ""
 		IL_00c0: ldc.i4.0
 		IL_00c1: ldc.i4.1
-		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_15BDE42E_L15C22>(!!0, float64, string, bool, bool)
+		IL_00c2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L15C21/FunctionObject_FunctionExpression_15BDE42E_L15C22>(!!0, float64, string, bool, bool)
 		IL_00c7: stloc.s 7
 		IL_00c9: ldloc.3
 		IL_00ca: ldstr "on"
@@ -515,13 +937,13 @@
 		IL_00f1: ldc.i4.0
 		IL_00f2: ldelem.ref
 		IL_00f3: castclass Modules.Stream_Pipe_Backpressure_Basic/Scope
-		IL_00f8: newobj instance void FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_D45C0895_L19C23::.ctor(class Modules.Stream_Pipe_Backpressure_Basic/Scope)
+		IL_00f8: newobj instance void Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L19C22/FunctionObject_FunctionExpression_D45C0895_L19C23::.ctor(class Modules.Stream_Pipe_Backpressure_Basic/Scope)
 		IL_00fd: ldc.i4.0
 		IL_00fe: conv.r8
 		IL_00ff: ldstr ""
 		IL_0104: ldc.i4.0
 		IL_0105: ldc.i4.1
-		IL_0106: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_D45C0895_L19C23>(!!0, float64, string, bool, bool)
+		IL_0106: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L19C22/FunctionObject_FunctionExpression_D45C0895_L19C23>(!!0, float64, string, bool, bool)
 		IL_010b: stloc.s 8
 		IL_010d: ldloc.3
 		IL_010e: ldstr "on"
@@ -562,13 +984,13 @@
 		IL_017a: ldc.i4.0
 		IL_017b: ldelem.ref
 		IL_017c: castclass Modules.Stream_Pipe_Backpressure_Basic/Scope
-		IL_0181: newobj instance void FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_48135A79_L27C22::.ctor(class Modules.Stream_Pipe_Backpressure_Basic/Scope)
+		IL_0181: newobj instance void Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/FunctionObject_FunctionExpression_48135A79_L27C22::.ctor(class Modules.Stream_Pipe_Backpressure_Basic/Scope)
 		IL_0186: ldc.i4.0
 		IL_0187: conv.r8
 		IL_0188: ldstr ""
 		IL_018d: ldc.i4.0
 		IL_018e: ldc.i4.1
-		IL_018f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_48135A79_L27C22>(!!0, float64, string, bool, bool)
+		IL_018f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21/FunctionObject_FunctionExpression_48135A79_L27C22>(!!0, float64, string, bool, bool)
 		IL_0194: stloc.s 9
 		IL_0196: ldloc.3
 		IL_0197: ldstr "on"
@@ -602,428 +1024,6 @@
 	} // end of method Stream_Pipe_Backpressure_Basic::__js_module_init__
 
 } // end of class Modules.Stream_Pipe_Backpressure_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_381BECE4_L11C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Pipe_Backpressure_Basic/Scope _environment0_Stream_Pipe_Backpressure_Basic
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Pipe_Backpressure_Basic/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x23ea
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Pipe_Backpressure_Basic/Scope FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_381BECE4_L11C19::_environment0_Stream_Pipe_Backpressure_Basic
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_381BECE4_L11C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23f9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_381BECE4_L11C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23fc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_381BECE4_L11C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23ff
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Pipe_Backpressure_Basic/Scope FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_381BECE4_L11C19::_environment0_Stream_Pipe_Backpressure_Basic
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L11C18::__js_call__(class Modules.Stream_Pipe_Backpressure_Basic/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_381BECE4_L11C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2418
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Pipe_Backpressure_Basic/Scope FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_381BECE4_L11C19::_environment0_Stream_Pipe_Backpressure_Basic
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L11C18::__js_call__(class Modules.Stream_Pipe_Backpressure_Basic/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_381BECE4_L11C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x242d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_381BECE4_L11C19::ConstructCore
-
-} // end of class FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_381BECE4_L11C19
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_15BDE42E_L15C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x243c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_15BDE42E_L15C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2444
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_15BDE42E_L15C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2447
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_15BDE42E_L15C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x244a
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L15C21::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_15BDE42E_L15C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2456
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L15C21::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_15BDE42E_L15C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x245e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_15BDE42E_L15C22::ConstructCore
-
-} // end of class FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_15BDE42E_L15C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_D45C0895_L19C23
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Pipe_Backpressure_Basic/Scope _environment0_Stream_Pipe_Backpressure_Basic
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Pipe_Backpressure_Basic/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x246d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Pipe_Backpressure_Basic/Scope FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_D45C0895_L19C23::_environment0_Stream_Pipe_Backpressure_Basic
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D45C0895_L19C23::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x247c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D45C0895_L19C23::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x247f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D45C0895_L19C23::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2482
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Pipe_Backpressure_Basic/Scope FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_D45C0895_L19C23::_environment0_Stream_Pipe_Backpressure_Basic
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L19C22::__js_call__(class Modules.Stream_Pipe_Backpressure_Basic/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_D45C0895_L19C23::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2494
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Pipe_Backpressure_Basic/Scope FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_D45C0895_L19C23::_environment0_Stream_Pipe_Backpressure_Basic
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L19C22::__js_call__(class Modules.Stream_Pipe_Backpressure_Basic/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_D45C0895_L19C23::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24a2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D45C0895_L19C23::ConstructCore
-
-} // end of class FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_D45C0895_L19C23
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_48135A79_L27C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Pipe_Backpressure_Basic/Scope _environment0_Stream_Pipe_Backpressure_Basic
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Pipe_Backpressure_Basic/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x24b1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Pipe_Backpressure_Basic/Scope FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_48135A79_L27C22::_environment0_Stream_Pipe_Backpressure_Basic
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_48135A79_L27C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24c0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_48135A79_L27C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24c3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_48135A79_L27C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24c6
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Pipe_Backpressure_Basic/Scope FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_48135A79_L27C22::_environment0_Stream_Pipe_Backpressure_Basic
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21::__js_call__(class Modules.Stream_Pipe_Backpressure_Basic/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_48135A79_L27C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24d8
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Pipe_Backpressure_Basic/Scope FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_48135A79_L27C22::_environment0_Stream_Pipe_Backpressure_Basic
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Stream_Pipe_Backpressure_Basic/FunctionExpression_L27C21::__js_call__(class Modules.Stream_Pipe_Backpressure_Basic/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_48135A79_L27C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24e6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_48135A79_L27C22::ConstructCore
-
-} // end of class FunctionObjects.Stream_Pipe_Backpressure_Basic_E1565C92.FunctionObject_FunctionExpression_48135A79_L27C22
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipe_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipe_Basic.verified.txt
@@ -31,6 +31,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D9C40067_L13C19
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Pipe_Basic/Scope _environment0_Stream_Pipe_Basic
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Pipe_Basic/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2255
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Pipe_Basic/Scope Modules.Stream_Pipe_Basic/FunctionExpression_L13C18/FunctionObject_FunctionExpression_D9C40067_L13C19::_environment0_Stream_Pipe_Basic
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_D9C40067_L13C19::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2264
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D9C40067_L13C19::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2267
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D9C40067_L13C19::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x226a
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Pipe_Basic/Scope Modules.Stream_Pipe_Basic/FunctionExpression_L13C18/FunctionObject_FunctionExpression_D9C40067_L13C19::_environment0_Stream_Pipe_Basic
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Stream_Pipe_Basic/FunctionExpression_L13C18::__js_call__(class Modules.Stream_Pipe_Basic/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_D9C40067_L13C19::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2283
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Pipe_Basic/Scope Modules.Stream_Pipe_Basic/FunctionExpression_L13C18/FunctionObject_FunctionExpression_D9C40067_L13C19::_environment0_Stream_Pipe_Basic
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Stream_Pipe_Basic/FunctionExpression_L13C18::__js_call__(class Modules.Stream_Pipe_Basic/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_D9C40067_L13C19::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2298
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_D9C40067_L13C19::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_D9C40067_L13C19
+
 
 		// Methods
 		.method public hidebysig static 
@@ -161,7 +274,7 @@
 			[6] float64,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[8] object[],
-			[9] class FunctionObjects.Stream_Pipe_Basic_52BF7477.FunctionObject_FunctionExpression_D9C40067_L13C19,
+			[9] class Modules.Stream_Pipe_Basic/FunctionExpression_L13C18/FunctionObject_FunctionExpression_D9C40067_L13C19,
 			[10] object,
 			[11] object,
 			[12] float64,
@@ -210,13 +323,13 @@
 		IL_005b: ldc.i4.0
 		IL_005c: ldelem.ref
 		IL_005d: castclass Modules.Stream_Pipe_Basic/Scope
-		IL_0062: newobj instance void FunctionObjects.Stream_Pipe_Basic_52BF7477.FunctionObject_FunctionExpression_D9C40067_L13C19::.ctor(class Modules.Stream_Pipe_Basic/Scope)
+		IL_0062: newobj instance void Modules.Stream_Pipe_Basic/FunctionExpression_L13C18/FunctionObject_FunctionExpression_D9C40067_L13C19::.ctor(class Modules.Stream_Pipe_Basic/Scope)
 		IL_0067: ldc.i4.1
 		IL_0068: conv.r8
 		IL_0069: ldstr ""
 		IL_006e: ldc.i4.0
 		IL_006f: ldc.i4.1
-		IL_0070: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Pipe_Basic_52BF7477.FunctionObject_FunctionExpression_D9C40067_L13C19>(!!0, float64, string, bool, bool)
+		IL_0070: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipe_Basic/FunctionExpression_L13C18/FunctionObject_FunctionExpression_D9C40067_L13C19>(!!0, float64, string, bool, bool)
 		IL_0075: stloc.s 9
 		IL_0077: ldloc.s 5
 		IL_0079: ldstr "_write"
@@ -318,119 +431,6 @@
 	} // end of method Stream_Pipe_Basic::__js_module_init__
 
 } // end of class Modules.Stream_Pipe_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Pipe_Basic_52BF7477.FunctionObject_FunctionExpression_D9C40067_L13C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Pipe_Basic/Scope _environment0_Stream_Pipe_Basic
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Pipe_Basic/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2255
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Pipe_Basic/Scope FunctionObjects.Stream_Pipe_Basic_52BF7477.FunctionObject_FunctionExpression_D9C40067_L13C19::_environment0_Stream_Pipe_Basic
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D9C40067_L13C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2264
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D9C40067_L13C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2267
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D9C40067_L13C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x226a
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Pipe_Basic/Scope FunctionObjects.Stream_Pipe_Basic_52BF7477.FunctionObject_FunctionExpression_D9C40067_L13C19::_environment0_Stream_Pipe_Basic
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Stream_Pipe_Basic/FunctionExpression_L13C18::__js_call__(class Modules.Stream_Pipe_Basic/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_D9C40067_L13C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2283
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Pipe_Basic/Scope FunctionObjects.Stream_Pipe_Basic_52BF7477.FunctionObject_FunctionExpression_D9C40067_L13C19::_environment0_Stream_Pipe_Basic
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Stream_Pipe_Basic/FunctionExpression_L13C18::__js_call__(class Modules.Stream_Pipe_Basic/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_D9C40067_L13C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2298
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D9C40067_L13C19::ConstructCore
-
-} // end of class FunctionObjects.Stream_Pipe_Basic_52BF7477.FunctionObject_FunctionExpression_D9C40067_L13C19
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Basic.verified.txt
@@ -31,6 +31,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FE7C800A_L10C19
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Pipeline_Basic/Scope _environment0_Stream_Pipeline_Basic
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Pipeline_Basic/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x22b5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Pipeline_Basic/Scope Modules.Stream_Pipeline_Basic/FunctionExpression_L10C18/FunctionObject_FunctionExpression_FE7C800A_L10C19::_environment0_Stream_Pipeline_Basic
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_FE7C800A_L10C19::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22c4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_FE7C800A_L10C19::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22c7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_FE7C800A_L10C19::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22ca
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Pipeline_Basic/Scope Modules.Stream_Pipeline_Basic/FunctionExpression_L10C18/FunctionObject_FunctionExpression_FE7C800A_L10C19::_environment0_Stream_Pipeline_Basic
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Stream_Pipeline_Basic/FunctionExpression_L10C18::__js_call__(class Modules.Stream_Pipeline_Basic/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_FE7C800A_L10C19::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22e3
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Pipeline_Basic/Scope Modules.Stream_Pipeline_Basic/FunctionExpression_L10C18/FunctionObject_FunctionExpression_FE7C800A_L10C19::_environment0_Stream_Pipeline_Basic
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Stream_Pipeline_Basic/FunctionExpression_L10C18::__js_call__(class Modules.Stream_Pipeline_Basic/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_FE7C800A_L10C19::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22f8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_FE7C800A_L10C19::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_FE7C800A_L10C19
+
 
 		// Methods
 		.method public hidebysig static 
@@ -89,6 +202,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7FCBC395_L14C43
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Pipeline_Basic/Scope _environment0_Stream_Pipeline_Basic
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Pipeline_Basic/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2307
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Pipeline_Basic/Scope Modules.Stream_Pipeline_Basic/FunctionExpression_L14C42/FunctionObject_FunctionExpression_7FCBC395_L14C43::_environment0_Stream_Pipeline_Basic
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_7FCBC395_L14C43::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2316
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7FCBC395_L14C43::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2319
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7FCBC395_L14C43::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x231c
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Pipeline_Basic/Scope Modules.Stream_Pipeline_Basic/FunctionExpression_L14C42/FunctionObject_FunctionExpression_7FCBC395_L14C43::_environment0_Stream_Pipeline_Basic
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Stream_Pipeline_Basic/FunctionExpression_L14C42::__js_call__(class Modules.Stream_Pipeline_Basic/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_7FCBC395_L14C43::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2335
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Pipeline_Basic/Scope Modules.Stream_Pipeline_Basic/FunctionExpression_L14C42/FunctionObject_FunctionExpression_7FCBC395_L14C43::_environment0_Stream_Pipeline_Basic
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Stream_Pipeline_Basic/FunctionExpression_L14C42::__js_call__(class Modules.Stream_Pipeline_Basic/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_7FCBC395_L14C43::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x234a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_7FCBC395_L14C43::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_7FCBC395_L14C43
 
 
 		// Methods
@@ -246,8 +472,8 @@
 			[4] object,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[6] object[],
-			[7] class FunctionObjects.Stream_Pipeline_Basic_0621E95D.FunctionObject_FunctionExpression_FE7C800A_L10C19,
-			[8] class FunctionObjects.Stream_Pipeline_Basic_0621E95D.FunctionObject_FunctionExpression_7FCBC395_L14C43
+			[7] class Modules.Stream_Pipeline_Basic/FunctionExpression_L10C18/FunctionObject_FunctionExpression_FE7C800A_L10C19,
+			[8] class Modules.Stream_Pipeline_Basic/FunctionExpression_L14C42/FunctionObject_FunctionExpression_7FCBC395_L14C43
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Pipeline_Basic/Scope::.ctor()
@@ -301,13 +527,13 @@
 		IL_007c: ldc.i4.0
 		IL_007d: ldelem.ref
 		IL_007e: castclass Modules.Stream_Pipeline_Basic/Scope
-		IL_0083: newobj instance void FunctionObjects.Stream_Pipeline_Basic_0621E95D.FunctionObject_FunctionExpression_FE7C800A_L10C19::.ctor(class Modules.Stream_Pipeline_Basic/Scope)
+		IL_0083: newobj instance void Modules.Stream_Pipeline_Basic/FunctionExpression_L10C18/FunctionObject_FunctionExpression_FE7C800A_L10C19::.ctor(class Modules.Stream_Pipeline_Basic/Scope)
 		IL_0088: ldc.i4.1
 		IL_0089: conv.r8
 		IL_008a: ldstr ""
 		IL_008f: ldc.i4.0
 		IL_0090: ldc.i4.1
-		IL_0091: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Pipeline_Basic_0621E95D.FunctionObject_FunctionExpression_FE7C800A_L10C19>(!!0, float64, string, bool, bool)
+		IL_0091: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Basic/FunctionExpression_L10C18/FunctionObject_FunctionExpression_FE7C800A_L10C19>(!!0, float64, string, bool, bool)
 		IL_0096: stloc.s 7
 		IL_0098: ldloc.3
 		IL_0099: ldstr "_write"
@@ -329,13 +555,13 @@
 		IL_00bd: ldc.i4.0
 		IL_00be: ldelem.ref
 		IL_00bf: castclass Modules.Stream_Pipeline_Basic/Scope
-		IL_00c4: newobj instance void FunctionObjects.Stream_Pipeline_Basic_0621E95D.FunctionObject_FunctionExpression_7FCBC395_L14C43::.ctor(class Modules.Stream_Pipeline_Basic/Scope)
+		IL_00c4: newobj instance void Modules.Stream_Pipeline_Basic/FunctionExpression_L14C42/FunctionObject_FunctionExpression_7FCBC395_L14C43::.ctor(class Modules.Stream_Pipeline_Basic/Scope)
 		IL_00c9: ldc.i4.1
 		IL_00ca: conv.r8
 		IL_00cb: ldstr ""
 		IL_00d0: ldc.i4.0
 		IL_00d1: ldc.i4.1
-		IL_00d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Pipeline_Basic_0621E95D.FunctionObject_FunctionExpression_7FCBC395_L14C43>(!!0, float64, string, bool, bool)
+		IL_00d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Basic/FunctionExpression_L14C42/FunctionObject_FunctionExpression_7FCBC395_L14C43>(!!0, float64, string, bool, bool)
 		IL_00d7: stloc.s 8
 		IL_00d9: ldloc.1
 		IL_00da: ldc.i4.4
@@ -381,232 +607,6 @@
 	} // end of method Stream_Pipeline_Basic::__js_module_init__
 
 } // end of class Modules.Stream_Pipeline_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Pipeline_Basic_0621E95D.FunctionObject_FunctionExpression_FE7C800A_L10C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Pipeline_Basic/Scope _environment0_Stream_Pipeline_Basic
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Pipeline_Basic/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x22b5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Pipeline_Basic/Scope FunctionObjects.Stream_Pipeline_Basic_0621E95D.FunctionObject_FunctionExpression_FE7C800A_L10C19::_environment0_Stream_Pipeline_Basic
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_FE7C800A_L10C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22c4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FE7C800A_L10C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22c7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FE7C800A_L10C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22ca
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Pipeline_Basic/Scope FunctionObjects.Stream_Pipeline_Basic_0621E95D.FunctionObject_FunctionExpression_FE7C800A_L10C19::_environment0_Stream_Pipeline_Basic
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Stream_Pipeline_Basic/FunctionExpression_L10C18::__js_call__(class Modules.Stream_Pipeline_Basic/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_FE7C800A_L10C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22e3
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Pipeline_Basic/Scope FunctionObjects.Stream_Pipeline_Basic_0621E95D.FunctionObject_FunctionExpression_FE7C800A_L10C19::_environment0_Stream_Pipeline_Basic
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Stream_Pipeline_Basic/FunctionExpression_L10C18::__js_call__(class Modules.Stream_Pipeline_Basic/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_FE7C800A_L10C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22f8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_FE7C800A_L10C19::ConstructCore
-
-} // end of class FunctionObjects.Stream_Pipeline_Basic_0621E95D.FunctionObject_FunctionExpression_FE7C800A_L10C19
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Pipeline_Basic_0621E95D.FunctionObject_FunctionExpression_7FCBC395_L14C43
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Pipeline_Basic/Scope _environment0_Stream_Pipeline_Basic
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Pipeline_Basic/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2307
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Pipeline_Basic/Scope FunctionObjects.Stream_Pipeline_Basic_0621E95D.FunctionObject_FunctionExpression_7FCBC395_L14C43::_environment0_Stream_Pipeline_Basic
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7FCBC395_L14C43::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2316
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7FCBC395_L14C43::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2319
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7FCBC395_L14C43::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x231c
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Pipeline_Basic/Scope FunctionObjects.Stream_Pipeline_Basic_0621E95D.FunctionObject_FunctionExpression_7FCBC395_L14C43::_environment0_Stream_Pipeline_Basic
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Stream_Pipeline_Basic/FunctionExpression_L14C42::__js_call__(class Modules.Stream_Pipeline_Basic/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_7FCBC395_L14C43::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2335
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Pipeline_Basic/Scope FunctionObjects.Stream_Pipeline_Basic_0621E95D.FunctionObject_FunctionExpression_7FCBC395_L14C43::_environment0_Stream_Pipeline_Basic
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Stream_Pipeline_Basic/FunctionExpression_L14C42::__js_call__(class Modules.Stream_Pipeline_Basic/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_7FCBC395_L14C43::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x234a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7FCBC395_L14C43::ConstructCore
-
-} // end of class FunctionObjects.Stream_Pipeline_Basic_0621E95D.FunctionObject_FunctionExpression_7FCBC395_L14C43
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Error.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Error.verified.txt
@@ -31,6 +31,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3399A9B0_L9C24
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2313
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_3399A9B0_L9C24::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x231b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_3399A9B0_L9C24::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x231e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_3399A9B0_L9C24::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2321
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Stream_Pipeline_Error/FunctionExpression_L9C23::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_3399A9B0_L9C24::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x232d
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Stream_Pipeline_Error/FunctionExpression_L9C23::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_3399A9B0_L9C24::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2335
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_3399A9B0_L9C24::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_3399A9B0_L9C24
+
 
 		// Methods
 		.method public hidebysig static 
@@ -94,6 +189,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5E6E3F19_L13C19
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2344
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_5E6E3F19_L13C19::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x234c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5E6E3F19_L13C19::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x234f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5E6E3F19_L13C19::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2352
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Stream_Pipeline_Error/FunctionExpression_L13C18::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_5E6E3F19_L13C19::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x235e
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Stream_Pipeline_Error/FunctionExpression_L13C18::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_5E6E3F19_L13C19::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2366
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_5E6E3F19_L13C19::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_5E6E3F19_L13C19
+
 
 		// Methods
 		.method public hidebysig static 
@@ -138,6 +328,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_06BB7F59_L15C48
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Pipeline_Error/Scope _environment0_Stream_Pipeline_Error
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Pipeline_Error/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2375
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Pipeline_Error/Scope Modules.Stream_Pipeline_Error/FunctionExpression_L15C47/FunctionObject_FunctionExpression_06BB7F59_L15C48::_environment0_Stream_Pipeline_Error
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_06BB7F59_L15C48::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2384
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_06BB7F59_L15C48::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2387
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_06BB7F59_L15C48::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x238a
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Pipeline_Error/Scope Modules.Stream_Pipeline_Error/FunctionExpression_L15C47/FunctionObject_FunctionExpression_06BB7F59_L15C48::_environment0_Stream_Pipeline_Error
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Stream_Pipeline_Error/FunctionExpression_L15C47::__js_call__(class Modules.Stream_Pipeline_Error/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_06BB7F59_L15C48::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23a3
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Pipeline_Error/Scope Modules.Stream_Pipeline_Error/FunctionExpression_L15C47/FunctionObject_FunctionExpression_06BB7F59_L15C48::_environment0_Stream_Pipeline_Error
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Stream_Pipeline_Error/FunctionExpression_L15C47::__js_call__(class Modules.Stream_Pipeline_Error/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_06BB7F59_L15C48::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23b8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_06BB7F59_L15C48::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_06BB7F59_L15C48
 
 
 		// Methods
@@ -307,11 +610,11 @@
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule,
 			[2] object,
 			[3] object[],
-			[4] class FunctionObjects.Stream_Pipeline_Error_22800171.FunctionObject_FunctionExpression_3399A9B0_L9C24,
-			[5] class FunctionObjects.Stream_Pipeline_Error_22800171.FunctionObject_FunctionExpression_5E6E3F19_L13C19,
+			[4] class Modules.Stream_Pipeline_Error/FunctionExpression_L9C23/FunctionObject_FunctionExpression_3399A9B0_L9C24,
+			[5] class Modules.Stream_Pipeline_Error/FunctionExpression_L13C18/FunctionObject_FunctionExpression_5E6E3F19_L13C19,
 			[6] object,
 			[7] object,
-			[8] class FunctionObjects.Stream_Pipeline_Error_22800171.FunctionObject_FunctionExpression_06BB7F59_L15C48
+			[8] class Modules.Stream_Pipeline_Error/FunctionExpression_L15C47/FunctionObject_FunctionExpression_06BB7F59_L15C48
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Pipeline_Error/Scope::.ctor()
@@ -364,13 +667,13 @@
 		IL_0073: ldloc.0
 		IL_0074: stelem.ref
 		IL_0075: stloc.3
-		IL_0076: newobj instance void FunctionObjects.Stream_Pipeline_Error_22800171.FunctionObject_FunctionExpression_3399A9B0_L9C24::.ctor()
+		IL_0076: newobj instance void Modules.Stream_Pipeline_Error/FunctionExpression_L9C23/FunctionObject_FunctionExpression_3399A9B0_L9C24::.ctor()
 		IL_007b: ldc.i4.0
 		IL_007c: conv.r8
 		IL_007d: ldstr ""
 		IL_0082: ldc.i4.0
 		IL_0083: ldc.i4.1
-		IL_0084: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Pipeline_Error_22800171.FunctionObject_FunctionExpression_3399A9B0_L9C24>(!!0, float64, string, bool, bool)
+		IL_0084: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Error/FunctionExpression_L9C23/FunctionObject_FunctionExpression_3399A9B0_L9C24>(!!0, float64, string, bool, bool)
 		IL_0089: stloc.s 4
 		IL_008b: ldloc.2
 		IL_008c: ldstr "_transform"
@@ -388,13 +691,13 @@
 		IL_00a9: ldloc.0
 		IL_00aa: stelem.ref
 		IL_00ab: stloc.3
-		IL_00ac: newobj instance void FunctionObjects.Stream_Pipeline_Error_22800171.FunctionObject_FunctionExpression_5E6E3F19_L13C19::.ctor()
+		IL_00ac: newobj instance void Modules.Stream_Pipeline_Error/FunctionExpression_L13C18/FunctionObject_FunctionExpression_5E6E3F19_L13C19::.ctor()
 		IL_00b1: ldc.i4.0
 		IL_00b2: conv.r8
 		IL_00b3: ldstr ""
 		IL_00b8: ldc.i4.0
 		IL_00b9: ldc.i4.1
-		IL_00ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Pipeline_Error_22800171.FunctionObject_FunctionExpression_5E6E3F19_L13C19>(!!0, float64, string, bool, bool)
+		IL_00ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Error/FunctionExpression_L13C18/FunctionObject_FunctionExpression_5E6E3F19_L13C19>(!!0, float64, string, bool, bool)
 		IL_00bf: stloc.s 5
 		IL_00c1: ldloc.2
 		IL_00c2: ldstr "_write"
@@ -422,13 +725,13 @@
 		IL_00f3: ldc.i4.0
 		IL_00f4: ldelem.ref
 		IL_00f5: castclass Modules.Stream_Pipeline_Error/Scope
-		IL_00fa: newobj instance void FunctionObjects.Stream_Pipeline_Error_22800171.FunctionObject_FunctionExpression_06BB7F59_L15C48::.ctor(class Modules.Stream_Pipeline_Error/Scope)
+		IL_00fa: newobj instance void Modules.Stream_Pipeline_Error/FunctionExpression_L15C47/FunctionObject_FunctionExpression_06BB7F59_L15C48::.ctor(class Modules.Stream_Pipeline_Error/Scope)
 		IL_00ff: ldc.i4.1
 		IL_0100: conv.r8
 		IL_0101: ldstr ""
 		IL_0106: ldc.i4.0
 		IL_0107: ldc.i4.1
-		IL_0108: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Pipeline_Error_22800171.FunctionObject_FunctionExpression_06BB7F59_L15C48>(!!0, float64, string, bool, bool)
+		IL_0108: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Error/FunctionExpression_L15C47/FunctionObject_FunctionExpression_06BB7F59_L15C48>(!!0, float64, string, bool, bool)
 		IL_010d: stloc.s 8
 		IL_010f: ldloc.1
 		IL_0110: ldc.i4.4
@@ -462,309 +765,6 @@
 	} // end of method Stream_Pipeline_Error::__js_module_init__
 
 } // end of class Modules.Stream_Pipeline_Error
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Pipeline_Error_22800171.FunctionObject_FunctionExpression_3399A9B0_L9C24
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2313
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_3399A9B0_L9C24::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x231b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3399A9B0_L9C24::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x231e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3399A9B0_L9C24::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2321
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Stream_Pipeline_Error/FunctionExpression_L9C23::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_3399A9B0_L9C24::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x232d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Stream_Pipeline_Error/FunctionExpression_L9C23::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_3399A9B0_L9C24::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2335
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3399A9B0_L9C24::ConstructCore
-
-} // end of class FunctionObjects.Stream_Pipeline_Error_22800171.FunctionObject_FunctionExpression_3399A9B0_L9C24
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Pipeline_Error_22800171.FunctionObject_FunctionExpression_5E6E3F19_L13C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2344
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_5E6E3F19_L13C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x234c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5E6E3F19_L13C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x234f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5E6E3F19_L13C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2352
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Stream_Pipeline_Error/FunctionExpression_L13C18::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_5E6E3F19_L13C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x235e
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Stream_Pipeline_Error/FunctionExpression_L13C18::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_5E6E3F19_L13C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2366
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5E6E3F19_L13C19::ConstructCore
-
-} // end of class FunctionObjects.Stream_Pipeline_Error_22800171.FunctionObject_FunctionExpression_5E6E3F19_L13C19
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Pipeline_Error_22800171.FunctionObject_FunctionExpression_06BB7F59_L15C48
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Pipeline_Error/Scope _environment0_Stream_Pipeline_Error
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Pipeline_Error/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2375
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Pipeline_Error/Scope FunctionObjects.Stream_Pipeline_Error_22800171.FunctionObject_FunctionExpression_06BB7F59_L15C48::_environment0_Stream_Pipeline_Error
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_06BB7F59_L15C48::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2384
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_06BB7F59_L15C48::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2387
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_06BB7F59_L15C48::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x238a
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Pipeline_Error/Scope FunctionObjects.Stream_Pipeline_Error_22800171.FunctionObject_FunctionExpression_06BB7F59_L15C48::_environment0_Stream_Pipeline_Error
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Stream_Pipeline_Error/FunctionExpression_L15C47::__js_call__(class Modules.Stream_Pipeline_Error/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_06BB7F59_L15C48::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23a3
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Pipeline_Error/Scope FunctionObjects.Stream_Pipeline_Error_22800171.FunctionObject_FunctionExpression_06BB7F59_L15C48::_environment0_Stream_Pipeline_Error
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Stream_Pipeline_Error/FunctionExpression_L15C47::__js_call__(class Modules.Stream_Pipeline_Error/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_06BB7F59_L15C48::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23b8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_06BB7F59_L15C48::ConstructCore
-
-} // end of class FunctionObjects.Stream_Pipeline_Error_22800171.FunctionObject_FunctionExpression_06BB7F59_L15C48
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Error_PropagatesToPeers.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Pipeline_Error_PropagatesToPeers.verified.txt
@@ -31,6 +31,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E9912D3B_L9C19
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2475
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_E9912D3B_L9C19::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x247d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E9912D3B_L9C19::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2480
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E9912D3B_L9C19::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2483
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L9C18::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_E9912D3B_L9C19::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x248f
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L9C18::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_E9912D3B_L9C19::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2497
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E9912D3B_L9C19::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_E9912D3B_L9C19
+
 
 		// Methods
 		.method public hidebysig static 
@@ -93,6 +188,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_41CC1C92_L13C22
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x24a6
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_41CC1C92_L13C22::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24ae
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_41CC1C92_L13C22::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24b1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_41CC1C92_L13C22::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24b4
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L13C21::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_41CC1C92_L13C22::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24c7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L13C21::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_41CC1C92_L13C22::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24d6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_41CC1C92_L13C22::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_41CC1C92_L13C22
 
 
 		// Methods
@@ -162,6 +358,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1E2D6AF3_L17C18
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x24e5
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_1E2D6AF3_L17C18::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24ed
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_1E2D6AF3_L17C18::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24f0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_1E2D6AF3_L17C18::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24f3
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L17C17::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_1E2D6AF3_L17C18::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2506
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L17C17::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_1E2D6AF3_L17C18::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2515
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_1E2D6AF3_L17C18::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_1E2D6AF3_L17C18
+
 
 		// Methods
 		.method public hidebysig static 
@@ -230,6 +527,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_637A1D91_L21C22
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2524
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_637A1D91_L21C22::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x252c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_637A1D91_L21C22::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x252f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_637A1D91_L21C22::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2532
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L21C21::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_637A1D91_L21C22::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2545
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L21C21::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_637A1D91_L21C22::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2554
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_637A1D91_L21C22::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_637A1D91_L21C22
+
 
 		// Methods
 		.method public hidebysig static 
@@ -297,6 +695,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C8612840_L25C43
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope _environment0_Stream_Pipeline_Error_PropagatesToPeers
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2563
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L25C42/FunctionObject_FunctionExpression_C8612840_L25C43::_environment0_Stream_Pipeline_Error_PropagatesToPeers
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_C8612840_L25C43::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2572
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C8612840_L25C43::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2575
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C8612840_L25C43::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2578
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L25C42/FunctionObject_FunctionExpression_C8612840_L25C43::_environment0_Stream_Pipeline_Error_PropagatesToPeers
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L25C42::__js_call__(class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_C8612840_L25C43::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2591
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L25C42/FunctionObject_FunctionExpression_C8612840_L25C43::_environment0_Stream_Pipeline_Error_PropagatesToPeers
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L25C42::__js_call__(class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_C8612840_L25C43::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25a6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_C8612840_L25C43::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_C8612840_L25C43
 
 
 		// Methods
@@ -465,13 +976,13 @@
 			[1] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule,
 			[2] object,
 			[3] object[],
-			[4] class FunctionObjects.Stream_Pipeline_Error_PropagatesToPeers_A2B0B820.FunctionObject_FunctionExpression_E9912D3B_L9C19,
-			[5] class FunctionObjects.Stream_Pipeline_Error_PropagatesToPeers_A2B0B820.FunctionObject_FunctionExpression_41CC1C92_L13C22,
-			[6] class FunctionObjects.Stream_Pipeline_Error_PropagatesToPeers_A2B0B820.FunctionObject_FunctionExpression_1E2D6AF3_L17C18,
-			[7] class FunctionObjects.Stream_Pipeline_Error_PropagatesToPeers_A2B0B820.FunctionObject_FunctionExpression_637A1D91_L21C22,
+			[4] class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L9C18/FunctionObject_FunctionExpression_E9912D3B_L9C19,
+			[5] class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L13C21/FunctionObject_FunctionExpression_41CC1C92_L13C22,
+			[6] class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L17C17/FunctionObject_FunctionExpression_1E2D6AF3_L17C18,
+			[7] class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L21C21/FunctionObject_FunctionExpression_637A1D91_L21C22,
 			[8] object,
 			[9] object,
-			[10] class FunctionObjects.Stream_Pipeline_Error_PropagatesToPeers_A2B0B820.FunctionObject_FunctionExpression_C8612840_L25C43
+			[10] class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L25C42/FunctionObject_FunctionExpression_C8612840_L25C43
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope::.ctor()
@@ -524,13 +1035,13 @@
 		IL_0073: ldloc.0
 		IL_0074: stelem.ref
 		IL_0075: stloc.3
-		IL_0076: newobj instance void FunctionObjects.Stream_Pipeline_Error_PropagatesToPeers_A2B0B820.FunctionObject_FunctionExpression_E9912D3B_L9C19::.ctor()
+		IL_0076: newobj instance void Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L9C18/FunctionObject_FunctionExpression_E9912D3B_L9C19::.ctor()
 		IL_007b: ldc.i4.0
 		IL_007c: conv.r8
 		IL_007d: ldstr ""
 		IL_0082: ldc.i4.0
 		IL_0083: ldc.i4.1
-		IL_0084: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Pipeline_Error_PropagatesToPeers_A2B0B820.FunctionObject_FunctionExpression_E9912D3B_L9C19>(!!0, float64, string, bool, bool)
+		IL_0084: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L9C18/FunctionObject_FunctionExpression_E9912D3B_L9C19>(!!0, float64, string, bool, bool)
 		IL_0089: stloc.s 4
 		IL_008b: ldloc.2
 		IL_008c: ldstr "_write"
@@ -549,13 +1060,13 @@
 		IL_00ae: ldloc.0
 		IL_00af: stelem.ref
 		IL_00b0: stloc.3
-		IL_00b1: newobj instance void FunctionObjects.Stream_Pipeline_Error_PropagatesToPeers_A2B0B820.FunctionObject_FunctionExpression_41CC1C92_L13C22::.ctor()
+		IL_00b1: newobj instance void Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L13C21/FunctionObject_FunctionExpression_41CC1C92_L13C22::.ctor()
 		IL_00b6: ldc.i4.1
 		IL_00b7: conv.r8
 		IL_00b8: ldstr ""
 		IL_00bd: ldc.i4.0
 		IL_00be: ldc.i4.1
-		IL_00bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Pipeline_Error_PropagatesToPeers_A2B0B820.FunctionObject_FunctionExpression_41CC1C92_L13C22>(!!0, float64, string, bool, bool)
+		IL_00bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L13C21/FunctionObject_FunctionExpression_41CC1C92_L13C22>(!!0, float64, string, bool, bool)
 		IL_00c4: stloc.s 5
 		IL_00c6: ldloc.2
 		IL_00c7: ldstr "on"
@@ -574,13 +1085,13 @@
 		IL_00ed: ldloc.0
 		IL_00ee: stelem.ref
 		IL_00ef: stloc.3
-		IL_00f0: newobj instance void FunctionObjects.Stream_Pipeline_Error_PropagatesToPeers_A2B0B820.FunctionObject_FunctionExpression_1E2D6AF3_L17C18::.ctor()
+		IL_00f0: newobj instance void Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L17C17/FunctionObject_FunctionExpression_1E2D6AF3_L17C18::.ctor()
 		IL_00f5: ldc.i4.1
 		IL_00f6: conv.r8
 		IL_00f7: ldstr ""
 		IL_00fc: ldc.i4.0
 		IL_00fd: ldc.i4.1
-		IL_00fe: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Pipeline_Error_PropagatesToPeers_A2B0B820.FunctionObject_FunctionExpression_1E2D6AF3_L17C18>(!!0, float64, string, bool, bool)
+		IL_00fe: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L17C17/FunctionObject_FunctionExpression_1E2D6AF3_L17C18>(!!0, float64, string, bool, bool)
 		IL_0103: stloc.s 6
 		IL_0105: ldloc.2
 		IL_0106: ldstr "on"
@@ -599,13 +1110,13 @@
 		IL_012c: ldloc.0
 		IL_012d: stelem.ref
 		IL_012e: stloc.3
-		IL_012f: newobj instance void FunctionObjects.Stream_Pipeline_Error_PropagatesToPeers_A2B0B820.FunctionObject_FunctionExpression_637A1D91_L21C22::.ctor()
+		IL_012f: newobj instance void Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L21C21/FunctionObject_FunctionExpression_637A1D91_L21C22::.ctor()
 		IL_0134: ldc.i4.1
 		IL_0135: conv.r8
 		IL_0136: ldstr ""
 		IL_013b: ldc.i4.0
 		IL_013c: ldc.i4.1
-		IL_013d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Pipeline_Error_PropagatesToPeers_A2B0B820.FunctionObject_FunctionExpression_637A1D91_L21C22>(!!0, float64, string, bool, bool)
+		IL_013d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L21C21/FunctionObject_FunctionExpression_637A1D91_L21C22>(!!0, float64, string, bool, bool)
 		IL_0142: stloc.s 7
 		IL_0144: ldloc.2
 		IL_0145: ldstr "on"
@@ -633,13 +1144,13 @@
 		IL_017a: ldc.i4.0
 		IL_017b: ldelem.ref
 		IL_017c: castclass Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope
-		IL_0181: newobj instance void FunctionObjects.Stream_Pipeline_Error_PropagatesToPeers_A2B0B820.FunctionObject_FunctionExpression_C8612840_L25C43::.ctor(class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope)
+		IL_0181: newobj instance void Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L25C42/FunctionObject_FunctionExpression_C8612840_L25C43::.ctor(class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope)
 		IL_0186: ldc.i4.1
 		IL_0187: conv.r8
 		IL_0188: ldstr ""
 		IL_018d: ldc.i4.0
 		IL_018e: ldc.i4.1
-		IL_018f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Pipeline_Error_PropagatesToPeers_A2B0B820.FunctionObject_FunctionExpression_C8612840_L25C43>(!!0, float64, string, bool, bool)
+		IL_018f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L25C42/FunctionObject_FunctionExpression_C8612840_L25C43>(!!0, float64, string, bool, bool)
 		IL_0194: stloc.s 10
 		IL_0196: ldloc.1
 		IL_0197: ldc.i4.4
@@ -673,517 +1184,6 @@
 	} // end of method Stream_Pipeline_Error_PropagatesToPeers::__js_module_init__
 
 } // end of class Modules.Stream_Pipeline_Error_PropagatesToPeers
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Pipeline_Error_PropagatesToPeers_A2B0B820.FunctionObject_FunctionExpression_E9912D3B_L9C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2475
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_E9912D3B_L9C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x247d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E9912D3B_L9C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2480
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E9912D3B_L9C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2483
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L9C18::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_E9912D3B_L9C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x248f
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L9C18::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_E9912D3B_L9C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2497
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E9912D3B_L9C19::ConstructCore
-
-} // end of class FunctionObjects.Stream_Pipeline_Error_PropagatesToPeers_A2B0B820.FunctionObject_FunctionExpression_E9912D3B_L9C19
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Pipeline_Error_PropagatesToPeers_A2B0B820.FunctionObject_FunctionExpression_41CC1C92_L13C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x24a6
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_41CC1C92_L13C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24ae
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_41CC1C92_L13C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24b1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_41CC1C92_L13C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24b4
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L13C21::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_41CC1C92_L13C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24c7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L13C21::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_41CC1C92_L13C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24d6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_41CC1C92_L13C22::ConstructCore
-
-} // end of class FunctionObjects.Stream_Pipeline_Error_PropagatesToPeers_A2B0B820.FunctionObject_FunctionExpression_41CC1C92_L13C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Pipeline_Error_PropagatesToPeers_A2B0B820.FunctionObject_FunctionExpression_1E2D6AF3_L17C18
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x24e5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_1E2D6AF3_L17C18::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24ed
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1E2D6AF3_L17C18::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24f0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1E2D6AF3_L17C18::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24f3
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L17C17::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_1E2D6AF3_L17C18::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2506
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L17C17::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1E2D6AF3_L17C18::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2515
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1E2D6AF3_L17C18::ConstructCore
-
-} // end of class FunctionObjects.Stream_Pipeline_Error_PropagatesToPeers_A2B0B820.FunctionObject_FunctionExpression_1E2D6AF3_L17C18
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Pipeline_Error_PropagatesToPeers_A2B0B820.FunctionObject_FunctionExpression_637A1D91_L21C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2524
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_637A1D91_L21C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x252c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_637A1D91_L21C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x252f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_637A1D91_L21C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2532
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L21C21::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_637A1D91_L21C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2545
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L21C21::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_637A1D91_L21C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2554
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_637A1D91_L21C22::ConstructCore
-
-} // end of class FunctionObjects.Stream_Pipeline_Error_PropagatesToPeers_A2B0B820.FunctionObject_FunctionExpression_637A1D91_L21C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Pipeline_Error_PropagatesToPeers_A2B0B820.FunctionObject_FunctionExpression_C8612840_L25C43
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope _environment0_Stream_Pipeline_Error_PropagatesToPeers
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2563
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope FunctionObjects.Stream_Pipeline_Error_PropagatesToPeers_A2B0B820.FunctionObject_FunctionExpression_C8612840_L25C43::_environment0_Stream_Pipeline_Error_PropagatesToPeers
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C8612840_L25C43::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2572
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C8612840_L25C43::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2575
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C8612840_L25C43::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2578
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope FunctionObjects.Stream_Pipeline_Error_PropagatesToPeers_A2B0B820.FunctionObject_FunctionExpression_C8612840_L25C43::_environment0_Stream_Pipeline_Error_PropagatesToPeers
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L25C42::__js_call__(class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_C8612840_L25C43::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2591
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope FunctionObjects.Stream_Pipeline_Error_PropagatesToPeers_A2B0B820.FunctionObject_FunctionExpression_C8612840_L25C43::_environment0_Stream_Pipeline_Error_PropagatesToPeers
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Stream_Pipeline_Error_PropagatesToPeers/FunctionExpression_L25C42::__js_call__(class Modules.Stream_Pipeline_Error_PropagatesToPeers/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_C8612840_L25C43::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25a6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C8612840_L25C43::ConstructCore
-
-} // end of class FunctionObjects.Stream_Pipeline_Error_PropagatesToPeers_A2B0B820.FunctionObject_FunctionExpression_C8612840_L25C43
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Finished_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Finished_Basic.verified.txt
@@ -35,6 +35,101 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1748DE8B_L8C21
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2371
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_1748DE8B_L8C21::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2379
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_1748DE8B_L8C21::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x237c
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_1748DE8B_L8C21::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x237f
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: call object Modules.Stream_Promises_Finished_Basic/main/FunctionExpression_L8C20::__js_call__(object)
+					IL_000a: ret
+				} // end of method FunctionObject_FunctionExpression_1748DE8B_L8C21::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x238b
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: call object Modules.Stream_Promises_Finished_Basic/main/FunctionExpression_L8C20::__js_call__(object)
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_1748DE8B_L8C21::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2393
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_1748DE8B_L8C21::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_1748DE8B_L8C21
+
 
 			// Methods
 			.method public hidebysig static 
@@ -86,6 +181,99 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F84A6898_main
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Promises_Finished_Basic/Scope _environment0_Stream_Promises_Finished_Basic
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Promises_Finished_Basic/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x2335
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Promises_Finished_Basic/Scope Modules.Stream_Promises_Finished_Basic/main/FunctionObject_FunctionDeclaration_F84A6898_main::_environment0_Stream_Promises_Finished_Basic
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.Stream_Promises_Finished_Basic/main/FunctionObject_FunctionDeclaration_F84A6898_main::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_F84A6898_main::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x234b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F84A6898_main::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x234e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F84A6898_main::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2351
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Stream_Promises_Finished_Basic/main/FunctionObject_FunctionDeclaration_F84A6898_main::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Stream_Promises_Finished_Basic/main::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_F84A6898_main::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2363
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Stream_Promises_Finished_Basic/main/FunctionObject_FunctionDeclaration_F84A6898_main::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Stream_Promises_Finished_Basic/main::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_F84A6898_main::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_F84A6898_main
+
 
 		// Methods
 		.method public hidebysig static 
@@ -108,7 +296,7 @@
 				[3] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamModule,
 				[4] object,
 				[5] object[],
-				[6] class FunctionObjects.Stream_Promises_Finished_Basic_89478C66.FunctionObject_FunctionExpression_1748DE8B_L8C21,
+				[6] class Modules.Stream_Promises_Finished_Basic/main/FunctionExpression_L8C20/FunctionObject_FunctionExpression_1748DE8B_L8C21,
 				[7] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule,
 				[8] object,
 				[9] object
@@ -180,7 +368,7 @@
 			IL_0086: dup
 			IL_0087: ldc.i4.5
 			IL_0088: ldelem.ref
-			IL_0089: castclass FunctionObjects.Stream_Promises_Finished_Basic_89478C66.FunctionObject_FunctionExpression_1748DE8B_L8C21
+			IL_0089: castclass Modules.Stream_Promises_Finished_Basic/main/FunctionExpression_L8C20/FunctionObject_FunctionExpression_1748DE8B_L8C21
 			IL_008e: stloc.s 6
 			IL_0090: dup
 			IL_0091: ldc.i4.6
@@ -226,13 +414,13 @@
 			IL_00ea: ldelem.ref
 			IL_00eb: stelem.ref
 			IL_00ec: stloc.s 5
-			IL_00ee: newobj instance void FunctionObjects.Stream_Promises_Finished_Basic_89478C66.FunctionObject_FunctionExpression_1748DE8B_L8C21::.ctor()
+			IL_00ee: newobj instance void Modules.Stream_Promises_Finished_Basic/main/FunctionExpression_L8C20/FunctionObject_FunctionExpression_1748DE8B_L8C21::.ctor()
 			IL_00f3: ldc.i4.0
 			IL_00f4: conv.r8
 			IL_00f5: ldstr ""
 			IL_00fa: ldc.i4.0
 			IL_00fb: ldc.i4.1
-			IL_00fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Promises_Finished_Basic_89478C66.FunctionObject_FunctionExpression_1748DE8B_L8C21>(!!0, float64, string, bool, bool)
+			IL_00fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Promises_Finished_Basic/main/FunctionExpression_L8C20/FunctionObject_FunctionExpression_1748DE8B_L8C21>(!!0, float64, string, bool, bool)
 			IL_0101: stloc.s 6
 			IL_0103: ldloc.1
 			IL_0104: ldstr "_write"
@@ -471,194 +659,6 @@
 	} // end of method Stream_Promises_Finished_Basic::__js_module_init__
 
 } // end of class Modules.Stream_Promises_Finished_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Promises_Finished_Basic_89478C66.FunctionObject_FunctionDeclaration_F84A6898_main
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Promises_Finished_Basic/Scope _environment0_Stream_Promises_Finished_Basic
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Promises_Finished_Basic/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x2335
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Promises_Finished_Basic/Scope FunctionObjects.Stream_Promises_Finished_Basic_89478C66.FunctionObject_FunctionDeclaration_F84A6898_main::_environment0_Stream_Promises_Finished_Basic
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Stream_Promises_Finished_Basic_89478C66.FunctionObject_FunctionDeclaration_F84A6898_main::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_F84A6898_main::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x234b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F84A6898_main::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x234e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F84A6898_main::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2351
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Stream_Promises_Finished_Basic_89478C66.FunctionObject_FunctionDeclaration_F84A6898_main::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Stream_Promises_Finished_Basic/main::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_F84A6898_main::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2363
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Stream_Promises_Finished_Basic_89478C66.FunctionObject_FunctionDeclaration_F84A6898_main::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Stream_Promises_Finished_Basic/main::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_F84A6898_main::ConstructBodyCore
-
-} // end of class FunctionObjects.Stream_Promises_Finished_Basic_89478C66.FunctionObject_FunctionDeclaration_F84A6898_main
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Promises_Finished_Basic_89478C66.FunctionObject_FunctionExpression_1748DE8B_L8C21
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2371
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_1748DE8B_L8C21::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2379
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1748DE8B_L8C21::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x237c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1748DE8B_L8C21::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x237f
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Stream_Promises_Finished_Basic/main/FunctionExpression_L8C20::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_1748DE8B_L8C21::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x238b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Stream_Promises_Finished_Basic/main/FunctionExpression_L8C20::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_1748DE8B_L8C21::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2393
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1748DE8B_L8C21::ConstructCore
-
-} // end of class FunctionObjects.Stream_Promises_Finished_Basic_89478C66.FunctionObject_FunctionExpression_1748DE8B_L8C21
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Pipeline_AbortSignal.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Pipeline_AbortSignal.verified.txt
@@ -31,6 +31,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3167102B_L12C19
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Promises_Pipeline_AbortSignal/Scope _environment0_Stream_Promises_Pipeline_AbortSignal
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Promises_Pipeline_AbortSignal/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2508
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L12C18/FunctionObject_FunctionExpression_3167102B_L12C19::_environment0_Stream_Promises_Pipeline_AbortSignal
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_3167102B_L12C19::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2517
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_3167102B_L12C19::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x251a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_3167102B_L12C19::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x251d
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L12C18/FunctionObject_FunctionExpression_3167102B_L12C19::_environment0_Stream_Promises_Pipeline_AbortSignal
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L12C18::__js_call__(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_3167102B_L12C19::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2536
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L12C18/FunctionObject_FunctionExpression_3167102B_L12C19::_environment0_Stream_Promises_Pipeline_AbortSignal
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L12C18::__js_call__(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_3167102B_L12C19::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x254b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_3167102B_L12C19::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_3167102B_L12C19
+
 
 		// Methods
 		.method public hidebysig static 
@@ -95,6 +208,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FD81F687_L22C9
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x255a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_FD81F687_L22C9::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2562
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_FD81F687_L22C9::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2565
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_FD81F687_L22C9::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2568
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L22C8::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_FD81F687_L22C9::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2574
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L22C8::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_FD81F687_L22C9::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x257c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_FD81F687_L22C9::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_FD81F687_L22C9
+
 
 		// Methods
 		.method public hidebysig static 
@@ -146,6 +354,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_87CE6C7E_L25C10
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x258b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_87CE6C7E_L25C10::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2593
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_87CE6C7E_L25C10::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2596
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_87CE6C7E_L25C10::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2599
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L25C9::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_87CE6C7E_L25C10::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25ac
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L25C9::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_87CE6C7E_L25C10::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25bb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_87CE6C7E_L25C10::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_87CE6C7E_L25C10
 
 
 		// Methods
@@ -235,6 +544,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_45713D2C_L30C9
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Promises_Pipeline_AbortSignal/Scope _environment0_Stream_Promises_Pipeline_AbortSignal
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Promises_Pipeline_AbortSignal/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x25ca
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8/FunctionObject_FunctionExpression_45713D2C_L30C9::_environment0_Stream_Promises_Pipeline_AbortSignal
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_45713D2C_L30C9::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x25d9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_45713D2C_L30C9::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x25dc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_45713D2C_L30C9::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x25df
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8/FunctionObject_FunctionExpression_45713D2C_L30C9::_environment0_Stream_Promises_Pipeline_AbortSignal
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8::__js_call__(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_45713D2C_L30C9::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25f1
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8/FunctionObject_FunctionExpression_45713D2C_L30C9::_environment0_Stream_Promises_Pipeline_AbortSignal
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8::__js_call__(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_45713D2C_L30C9::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25ff
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_45713D2C_L30C9::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_45713D2C_L30C9
 
 
 		// Methods
@@ -401,14 +817,14 @@
 			[5] object,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[7] object[],
-			[8] class FunctionObjects.Stream_Promises_Pipeline_AbortSignal_099FBB22.FunctionObject_FunctionExpression_3167102B_L12C19,
+			[8] class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L12C18/FunctionObject_FunctionExpression_3167102B_L12C19,
 			[9] object,
 			[10] object,
 			[11] object,
 			[12] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[13] class FunctionObjects.Stream_Promises_Pipeline_AbortSignal_099FBB22.FunctionObject_FunctionExpression_FD81F687_L22C9,
-			[14] class FunctionObjects.Stream_Promises_Pipeline_AbortSignal_099FBB22.FunctionObject_FunctionExpression_87CE6C7E_L25C10,
-			[15] class FunctionObjects.Stream_Promises_Pipeline_AbortSignal_099FBB22.FunctionObject_FunctionExpression_45713D2C_L30C9
+			[13] class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L22C8/FunctionObject_FunctionExpression_FD81F687_L22C9,
+			[14] class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L25C9/FunctionObject_FunctionExpression_87CE6C7E_L25C10,
+			[15] class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8/FunctionObject_FunctionExpression_45713D2C_L30C9
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Promises_Pipeline_AbortSignal/Scope::.ctor()
@@ -515,13 +931,13 @@
 		IL_0120: ldc.i4.0
 		IL_0121: ldelem.ref
 		IL_0122: castclass Modules.Stream_Promises_Pipeline_AbortSignal/Scope
-		IL_0127: newobj instance void FunctionObjects.Stream_Promises_Pipeline_AbortSignal_099FBB22.FunctionObject_FunctionExpression_3167102B_L12C19::.ctor(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope)
+		IL_0127: newobj instance void Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L12C18/FunctionObject_FunctionExpression_3167102B_L12C19::.ctor(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope)
 		IL_012c: ldc.i4.1
 		IL_012d: conv.r8
 		IL_012e: ldstr ""
 		IL_0133: ldc.i4.0
 		IL_0134: ldc.i4.1
-		IL_0135: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Promises_Pipeline_AbortSignal_099FBB22.FunctionObject_FunctionExpression_3167102B_L12C19>(!!0, float64, string, bool, bool)
+		IL_0135: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L12C18/FunctionObject_FunctionExpression_3167102B_L12C19>(!!0, float64, string, bool, bool)
 		IL_013a: stloc.s 8
 		IL_013c: ldloc.s 5
 		IL_013e: ldstr "_write"
@@ -598,13 +1014,13 @@
 		IL_0201: ldloc.0
 		IL_0202: stelem.ref
 		IL_0203: stloc.s 7
-		IL_0205: newobj instance void FunctionObjects.Stream_Promises_Pipeline_AbortSignal_099FBB22.FunctionObject_FunctionExpression_FD81F687_L22C9::.ctor()
+		IL_0205: newobj instance void Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L22C8/FunctionObject_FunctionExpression_FD81F687_L22C9::.ctor()
 		IL_020a: ldc.i4.0
 		IL_020b: conv.r8
 		IL_020c: ldstr ""
 		IL_0211: ldc.i4.0
 		IL_0212: ldc.i4.1
-		IL_0213: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Promises_Pipeline_AbortSignal_099FBB22.FunctionObject_FunctionExpression_FD81F687_L22C9>(!!0, float64, string, bool, bool)
+		IL_0213: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L22C8/FunctionObject_FunctionExpression_FD81F687_L22C9>(!!0, float64, string, bool, bool)
 		IL_0218: stloc.s 13
 		IL_021a: ldloc.s 10
 		IL_021c: ldstr "then"
@@ -621,13 +1037,13 @@
 		IL_023b: ldloc.0
 		IL_023c: stelem.ref
 		IL_023d: stloc.s 7
-		IL_023f: newobj instance void FunctionObjects.Stream_Promises_Pipeline_AbortSignal_099FBB22.FunctionObject_FunctionExpression_87CE6C7E_L25C10::.ctor()
+		IL_023f: newobj instance void Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L25C9/FunctionObject_FunctionExpression_87CE6C7E_L25C10::.ctor()
 		IL_0244: ldc.i4.1
 		IL_0245: conv.r8
 		IL_0246: ldstr ""
 		IL_024b: ldc.i4.0
 		IL_024c: ldc.i4.1
-		IL_024d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Promises_Pipeline_AbortSignal_099FBB22.FunctionObject_FunctionExpression_87CE6C7E_L25C10>(!!0, float64, string, bool, bool)
+		IL_024d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L25C9/FunctionObject_FunctionExpression_87CE6C7E_L25C10>(!!0, float64, string, bool, bool)
 		IL_0252: stloc.s 14
 		IL_0254: ldloc.s 10
 		IL_0256: ldstr "catch"
@@ -648,13 +1064,13 @@
 		IL_027b: ldc.i4.0
 		IL_027c: ldelem.ref
 		IL_027d: castclass Modules.Stream_Promises_Pipeline_AbortSignal/Scope
-		IL_0282: newobj instance void FunctionObjects.Stream_Promises_Pipeline_AbortSignal_099FBB22.FunctionObject_FunctionExpression_45713D2C_L30C9::.ctor(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope)
+		IL_0282: newobj instance void Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8/FunctionObject_FunctionExpression_45713D2C_L30C9::.ctor(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope)
 		IL_0287: ldc.i4.0
 		IL_0288: conv.r8
 		IL_0289: ldstr ""
 		IL_028e: ldc.i4.0
 		IL_028f: ldc.i4.1
-		IL_0290: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Promises_Pipeline_AbortSignal_099FBB22.FunctionObject_FunctionExpression_45713D2C_L30C9>(!!0, float64, string, bool, bool)
+		IL_0290: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8/FunctionObject_FunctionExpression_45713D2C_L30C9>(!!0, float64, string, bool, bool)
 		IL_0295: stloc.s 15
 		IL_0297: ldloc.s 10
 		IL_0299: ldstr "then"
@@ -665,422 +1081,6 @@
 	} // end of method Stream_Promises_Pipeline_AbortSignal::__js_module_init__
 
 } // end of class Modules.Stream_Promises_Pipeline_AbortSignal
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Promises_Pipeline_AbortSignal_099FBB22.FunctionObject_FunctionExpression_3167102B_L12C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Promises_Pipeline_AbortSignal/Scope _environment0_Stream_Promises_Pipeline_AbortSignal
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Promises_Pipeline_AbortSignal/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2508
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope FunctionObjects.Stream_Promises_Pipeline_AbortSignal_099FBB22.FunctionObject_FunctionExpression_3167102B_L12C19::_environment0_Stream_Promises_Pipeline_AbortSignal
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3167102B_L12C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2517
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3167102B_L12C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x251a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3167102B_L12C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x251d
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope FunctionObjects.Stream_Promises_Pipeline_AbortSignal_099FBB22.FunctionObject_FunctionExpression_3167102B_L12C19::_environment0_Stream_Promises_Pipeline_AbortSignal
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L12C18::__js_call__(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_3167102B_L12C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2536
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope FunctionObjects.Stream_Promises_Pipeline_AbortSignal_099FBB22.FunctionObject_FunctionExpression_3167102B_L12C19::_environment0_Stream_Promises_Pipeline_AbortSignal
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L12C18::__js_call__(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_3167102B_L12C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x254b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3167102B_L12C19::ConstructCore
-
-} // end of class FunctionObjects.Stream_Promises_Pipeline_AbortSignal_099FBB22.FunctionObject_FunctionExpression_3167102B_L12C19
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Promises_Pipeline_AbortSignal_099FBB22.FunctionObject_FunctionExpression_FD81F687_L22C9
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x255a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_FD81F687_L22C9::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2562
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FD81F687_L22C9::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2565
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FD81F687_L22C9::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2568
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L22C8::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_FD81F687_L22C9::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2574
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L22C8::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_FD81F687_L22C9::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x257c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_FD81F687_L22C9::ConstructCore
-
-} // end of class FunctionObjects.Stream_Promises_Pipeline_AbortSignal_099FBB22.FunctionObject_FunctionExpression_FD81F687_L22C9
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Promises_Pipeline_AbortSignal_099FBB22.FunctionObject_FunctionExpression_87CE6C7E_L25C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x258b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_87CE6C7E_L25C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2593
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_87CE6C7E_L25C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2596
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_87CE6C7E_L25C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2599
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L25C9::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_87CE6C7E_L25C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25ac
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L25C9::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_87CE6C7E_L25C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25bb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_87CE6C7E_L25C10::ConstructCore
-
-} // end of class FunctionObjects.Stream_Promises_Pipeline_AbortSignal_099FBB22.FunctionObject_FunctionExpression_87CE6C7E_L25C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Promises_Pipeline_AbortSignal_099FBB22.FunctionObject_FunctionExpression_45713D2C_L30C9
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Promises_Pipeline_AbortSignal/Scope _environment0_Stream_Promises_Pipeline_AbortSignal
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Promises_Pipeline_AbortSignal/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x25ca
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope FunctionObjects.Stream_Promises_Pipeline_AbortSignal_099FBB22.FunctionObject_FunctionExpression_45713D2C_L30C9::_environment0_Stream_Promises_Pipeline_AbortSignal
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_45713D2C_L30C9::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x25d9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_45713D2C_L30C9::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x25dc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_45713D2C_L30C9::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x25df
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope FunctionObjects.Stream_Promises_Pipeline_AbortSignal_099FBB22.FunctionObject_FunctionExpression_45713D2C_L30C9::_environment0_Stream_Promises_Pipeline_AbortSignal
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8::__js_call__(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_45713D2C_L30C9::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25f1
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Promises_Pipeline_AbortSignal/Scope FunctionObjects.Stream_Promises_Pipeline_AbortSignal_099FBB22.FunctionObject_FunctionExpression_45713D2C_L30C9::_environment0_Stream_Promises_Pipeline_AbortSignal
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Stream_Promises_Pipeline_AbortSignal/FunctionExpression_L30C8::__js_call__(class Modules.Stream_Promises_Pipeline_AbortSignal/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_45713D2C_L30C9::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25ff
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_45713D2C_L30C9::ConstructCore
-
-} // end of class FunctionObjects.Stream_Promises_Pipeline_AbortSignal_099FBB22.FunctionObject_FunctionExpression_45713D2C_L30C9
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Pipeline_ObjectMode.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Promises_Pipeline_ObjectMode.verified.txt
@@ -35,6 +35,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6DDAF3C3_L12C26
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Stream_Promises_Pipeline_ObjectMode/Scope _environment0_Stream_Promises_Pipeline_ObjectMode
+				.field private initonly class Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope _environment1_main
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Stream_Promises_Pipeline_ObjectMode/Scope capture0,
+						class Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x26b4
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Stream_Promises_Pipeline_ObjectMode/Scope Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25/FunctionObject_FunctionExpression_6DDAF3C3_L12C26::_environment0_Stream_Promises_Pipeline_ObjectMode
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25/FunctionObject_FunctionExpression_6DDAF3C3_L12C26::_environment1_main
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25/FunctionObject_FunctionExpression_6DDAF3C3_L12C26::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_6DDAF3C3_L12C26::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x26d1
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_6DDAF3C3_L12C26::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x26d4
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_6DDAF3C3_L12C26::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x26d7
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25/FunctionObject_FunctionExpression_6DDAF3C3_L12C26::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_6DDAF3C3_L12C26::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x26f0
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25/FunctionObject_FunctionExpression_6DDAF3C3_L12C26::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_6DDAF3C3_L12C26::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2705
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_6DDAF3C3_L12C26::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_6DDAF3C3_L12C26
+
 
 			// Methods
 			.method public hidebysig static 
@@ -111,6 +234,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_53DB12A6_L16C21
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Stream_Promises_Pipeline_ObjectMode/Scope _environment0_Stream_Promises_Pipeline_ObjectMode
+				.field private initonly class Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope _environment1_main
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Stream_Promises_Pipeline_ObjectMode/Scope capture0,
+						class Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2714
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Stream_Promises_Pipeline_ObjectMode/Scope Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20/FunctionObject_FunctionExpression_53DB12A6_L16C21::_environment0_Stream_Promises_Pipeline_ObjectMode
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20/FunctionObject_FunctionExpression_53DB12A6_L16C21::_environment1_main
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20/FunctionObject_FunctionExpression_53DB12A6_L16C21::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_53DB12A6_L16C21::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2731
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_53DB12A6_L16C21::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2734
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_53DB12A6_L16C21::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2737
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20/FunctionObject_FunctionExpression_53DB12A6_L16C21::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_53DB12A6_L16C21::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2750
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20/FunctionObject_FunctionExpression_53DB12A6_L16C21::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_53DB12A6_L16C21::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2765
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_53DB12A6_L16C21::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_53DB12A6_L16C21
+
 
 			// Methods
 			.method public hidebysig static 
@@ -181,6 +427,99 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8763DEC6_main
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Promises_Pipeline_ObjectMode/Scope _environment0_Stream_Promises_Pipeline_ObjectMode
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Promises_Pipeline_ObjectMode/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x2678
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Promises_Pipeline_ObjectMode/Scope Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionObject_FunctionDeclaration_8763DEC6_main::_environment0_Stream_Promises_Pipeline_ObjectMode
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionObject_FunctionDeclaration_8763DEC6_main::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_8763DEC6_main::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x268e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8763DEC6_main::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2691
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8763DEC6_main::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2694
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionObject_FunctionDeclaration_8763DEC6_main::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Stream_Promises_Pipeline_ObjectMode/main::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_8763DEC6_main::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26a6
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionObject_FunctionDeclaration_8763DEC6_main::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Stream_Promises_Pipeline_ObjectMode/main::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_8763DEC6_main::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_8763DEC6_main
+
 
 		// Methods
 		.method public hidebysig static 
@@ -207,8 +546,8 @@
 				[7] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[8] object[],
 				[9] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-				[10] class FunctionObjects.Stream_Promises_Pipeline_ObjectMode_710391A0.FunctionObject_FunctionExpression_6DDAF3C3_L12C26,
-				[11] class FunctionObjects.Stream_Promises_Pipeline_ObjectMode_710391A0.FunctionObject_FunctionExpression_53DB12A6_L16C21,
+				[10] class Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25/FunctionObject_FunctionExpression_6DDAF3C3_L12C26,
+				[11] class Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20/FunctionObject_FunctionExpression_53DB12A6_L16C21,
 				[12] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStreamPromisesModule,
 				[13] object,
 				[14] object,
@@ -299,12 +638,12 @@
 			IL_00a4: dup
 			IL_00a5: ldc.i4.s 9
 			IL_00a7: ldelem.ref
-			IL_00a8: castclass FunctionObjects.Stream_Promises_Pipeline_ObjectMode_710391A0.FunctionObject_FunctionExpression_6DDAF3C3_L12C26
+			IL_00a8: castclass Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25/FunctionObject_FunctionExpression_6DDAF3C3_L12C26
 			IL_00ad: stloc.s 10
 			IL_00af: dup
 			IL_00b0: ldc.i4.s 10
 			IL_00b2: ldelem.ref
-			IL_00b3: castclass FunctionObjects.Stream_Promises_Pipeline_ObjectMode_710391A0.FunctionObject_FunctionExpression_53DB12A6_L16C21
+			IL_00b3: castclass Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20/FunctionObject_FunctionExpression_53DB12A6_L16C21
 			IL_00b8: stloc.s 11
 			IL_00ba: dup
 			IL_00bb: ldc.i4.s 11
@@ -436,13 +775,13 @@
 			IL_01e4: ldelem.ref
 			IL_01e5: castclass Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope
 			IL_01ea: ldloc.s 8
-			IL_01ec: newobj instance void FunctionObjects.Stream_Promises_Pipeline_ObjectMode_710391A0.FunctionObject_FunctionExpression_6DDAF3C3_L12C26::.ctor(class Modules.Stream_Promises_Pipeline_ObjectMode/Scope, class Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope, object[])
+			IL_01ec: newobj instance void Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25/FunctionObject_FunctionExpression_6DDAF3C3_L12C26::.ctor(class Modules.Stream_Promises_Pipeline_ObjectMode/Scope, class Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope, object[])
 			IL_01f1: ldc.i4.1
 			IL_01f2: conv.r8
 			IL_01f3: ldstr ""
 			IL_01f8: ldc.i4.1
 			IL_01f9: ldc.i4.1
-			IL_01fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Promises_Pipeline_ObjectMode_710391A0.FunctionObject_FunctionExpression_6DDAF3C3_L12C26>(!!0, float64, string, bool, bool)
+			IL_01fa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25/FunctionObject_FunctionExpression_6DDAF3C3_L12C26>(!!0, float64, string, bool, bool)
 			IL_01ff: stloc.s 10
 			IL_0201: ldloc.2
 			IL_0202: ldstr "_transform"
@@ -472,13 +811,13 @@
 			IL_022e: ldelem.ref
 			IL_022f: castclass Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope
 			IL_0234: ldloc.s 8
-			IL_0236: newobj instance void FunctionObjects.Stream_Promises_Pipeline_ObjectMode_710391A0.FunctionObject_FunctionExpression_53DB12A6_L16C21::.ctor(class Modules.Stream_Promises_Pipeline_ObjectMode/Scope, class Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope, object[])
+			IL_0236: newobj instance void Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20/FunctionObject_FunctionExpression_53DB12A6_L16C21::.ctor(class Modules.Stream_Promises_Pipeline_ObjectMode/Scope, class Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope, object[])
 			IL_023b: ldc.i4.1
 			IL_023c: conv.r8
 			IL_023d: ldstr ""
 			IL_0242: ldc.i4.0
 			IL_0243: ldc.i4.1
-			IL_0244: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Promises_Pipeline_ObjectMode_710391A0.FunctionObject_FunctionExpression_53DB12A6_L16C21>(!!0, float64, string, bool, bool)
+			IL_0244: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20/FunctionObject_FunctionExpression_53DB12A6_L16C21>(!!0, float64, string, bool, bool)
 			IL_0249: stloc.s 11
 			IL_024b: ldloc.3
 			IL_024c: ldstr "_write"
@@ -846,345 +1185,6 @@
 	} // end of method Stream_Promises_Pipeline_ObjectMode::__js_module_init__
 
 } // end of class Modules.Stream_Promises_Pipeline_ObjectMode
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Promises_Pipeline_ObjectMode_710391A0.FunctionObject_FunctionDeclaration_8763DEC6_main
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Promises_Pipeline_ObjectMode/Scope _environment0_Stream_Promises_Pipeline_ObjectMode
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Promises_Pipeline_ObjectMode/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x2678
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Promises_Pipeline_ObjectMode/Scope FunctionObjects.Stream_Promises_Pipeline_ObjectMode_710391A0.FunctionObject_FunctionDeclaration_8763DEC6_main::_environment0_Stream_Promises_Pipeline_ObjectMode
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Stream_Promises_Pipeline_ObjectMode_710391A0.FunctionObject_FunctionDeclaration_8763DEC6_main::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_8763DEC6_main::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x268e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8763DEC6_main::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2691
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8763DEC6_main::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2694
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Stream_Promises_Pipeline_ObjectMode_710391A0.FunctionObject_FunctionDeclaration_8763DEC6_main::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Stream_Promises_Pipeline_ObjectMode/main::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_8763DEC6_main::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26a6
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Stream_Promises_Pipeline_ObjectMode_710391A0.FunctionObject_FunctionDeclaration_8763DEC6_main::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Stream_Promises_Pipeline_ObjectMode/main::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_8763DEC6_main::ConstructBodyCore
-
-} // end of class FunctionObjects.Stream_Promises_Pipeline_ObjectMode_710391A0.FunctionObject_FunctionDeclaration_8763DEC6_main
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Promises_Pipeline_ObjectMode_710391A0.FunctionObject_FunctionExpression_6DDAF3C3_L12C26
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Promises_Pipeline_ObjectMode/Scope _environment0_Stream_Promises_Pipeline_ObjectMode
-	.field private initonly class Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope _environment1_main
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Promises_Pipeline_ObjectMode/Scope capture0,
-			class Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x26b4
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Promises_Pipeline_ObjectMode/Scope FunctionObjects.Stream_Promises_Pipeline_ObjectMode_710391A0.FunctionObject_FunctionExpression_6DDAF3C3_L12C26::_environment0_Stream_Promises_Pipeline_ObjectMode
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope FunctionObjects.Stream_Promises_Pipeline_ObjectMode_710391A0.FunctionObject_FunctionExpression_6DDAF3C3_L12C26::_environment1_main
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Stream_Promises_Pipeline_ObjectMode_710391A0.FunctionObject_FunctionExpression_6DDAF3C3_L12C26::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_6DDAF3C3_L12C26::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x26d1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6DDAF3C3_L12C26::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x26d4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6DDAF3C3_L12C26::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x26d7
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Stream_Promises_Pipeline_ObjectMode_710391A0.FunctionObject_FunctionExpression_6DDAF3C3_L12C26::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_6DDAF3C3_L12C26::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26f0
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Stream_Promises_Pipeline_ObjectMode_710391A0.FunctionObject_FunctionExpression_6DDAF3C3_L12C26::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L12C25::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_6DDAF3C3_L12C26::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2705
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_6DDAF3C3_L12C26::ConstructCore
-
-} // end of class FunctionObjects.Stream_Promises_Pipeline_ObjectMode_710391A0.FunctionObject_FunctionExpression_6DDAF3C3_L12C26
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Promises_Pipeline_ObjectMode_710391A0.FunctionObject_FunctionExpression_53DB12A6_L16C21
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Promises_Pipeline_ObjectMode/Scope _environment0_Stream_Promises_Pipeline_ObjectMode
-	.field private initonly class Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope _environment1_main
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Promises_Pipeline_ObjectMode/Scope capture0,
-			class Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2714
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Promises_Pipeline_ObjectMode/Scope FunctionObjects.Stream_Promises_Pipeline_ObjectMode_710391A0.FunctionObject_FunctionExpression_53DB12A6_L16C21::_environment0_Stream_Promises_Pipeline_ObjectMode
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Stream_Promises_Pipeline_ObjectMode/main/Scope FunctionObjects.Stream_Promises_Pipeline_ObjectMode_710391A0.FunctionObject_FunctionExpression_53DB12A6_L16C21::_environment1_main
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Stream_Promises_Pipeline_ObjectMode_710391A0.FunctionObject_FunctionExpression_53DB12A6_L16C21::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_53DB12A6_L16C21::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2731
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_53DB12A6_L16C21::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2734
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_53DB12A6_L16C21::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2737
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Stream_Promises_Pipeline_ObjectMode_710391A0.FunctionObject_FunctionExpression_53DB12A6_L16C21::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_53DB12A6_L16C21::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2750
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Stream_Promises_Pipeline_ObjectMode_710391A0.FunctionObject_FunctionExpression_53DB12A6_L16C21::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Stream_Promises_Pipeline_ObjectMode/main/FunctionExpression_L16C20::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_53DB12A6_L16C21::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2765
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_53DB12A6_L16C21::ConstructCore
-
-} // end of class FunctionObjects.Stream_Promises_Pipeline_ObjectMode_710391A0.FunctionObject_FunctionExpression_53DB12A6_L16C21
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_Basic.verified.txt
@@ -31,6 +31,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_39A55734_L13C21
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Readable_Basic/Scope _environment0_Stream_Readable_Basic
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Readable_Basic/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x227b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Readable_Basic/Scope Modules.Stream_Readable_Basic/FunctionExpression_L13C20/FunctionObject_FunctionExpression_39A55734_L13C21::_environment0_Stream_Readable_Basic
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_39A55734_L13C21::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x228a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_39A55734_L13C21::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x228d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_39A55734_L13C21::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2290
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Readable_Basic/Scope Modules.Stream_Readable_Basic/FunctionExpression_L13C20/FunctionObject_FunctionExpression_39A55734_L13C21::_environment0_Stream_Readable_Basic
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Stream_Readable_Basic/FunctionExpression_L13C20::__js_call__(class Modules.Stream_Readable_Basic/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_39A55734_L13C21::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22a9
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Readable_Basic/Scope Modules.Stream_Readable_Basic/FunctionExpression_L13C20/FunctionObject_FunctionExpression_39A55734_L13C21::_environment0_Stream_Readable_Basic
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Stream_Readable_Basic/FunctionExpression_L13C20::__js_call__(class Modules.Stream_Readable_Basic/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_39A55734_L13C21::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22be
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_39A55734_L13C21::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_39A55734_L13C21
+
 
 		// Methods
 		.method public hidebysig static 
@@ -103,6 +216,101 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D752F3C8_L18C20
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x22cd
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_D752F3C8_L18C20::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22d5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D752F3C8_L18C20::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22d8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D752F3C8_L18C20::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22db
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Stream_Readable_Basic/FunctionExpression_L18C19::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_D752F3C8_L18C20::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22e7
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Stream_Readable_Basic/FunctionExpression_L18C19::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_D752F3C8_L18C20::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22ef
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_D752F3C8_L18C20::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_D752F3C8_L18C20
 
 
 		// Methods
@@ -183,8 +391,8 @@
 			[4] object,
 			[5] object,
 			[6] object[],
-			[7] class FunctionObjects.Stream_Readable_Basic_667796A7.FunctionObject_FunctionExpression_39A55734_L13C21,
-			[8] class FunctionObjects.Stream_Readable_Basic_667796A7.FunctionObject_FunctionExpression_D752F3C8_L18C20
+			[7] class Modules.Stream_Readable_Basic/FunctionExpression_L13C20/FunctionObject_FunctionExpression_39A55734_L13C21,
+			[8] class Modules.Stream_Readable_Basic/FunctionExpression_L18C19/FunctionObject_FunctionExpression_D752F3C8_L18C20
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Readable_Basic/Scope::.ctor()
@@ -233,13 +441,13 @@
 		IL_007e: ldc.i4.0
 		IL_007f: ldelem.ref
 		IL_0080: castclass Modules.Stream_Readable_Basic/Scope
-		IL_0085: newobj instance void FunctionObjects.Stream_Readable_Basic_667796A7.FunctionObject_FunctionExpression_39A55734_L13C21::.ctor(class Modules.Stream_Readable_Basic/Scope)
+		IL_0085: newobj instance void Modules.Stream_Readable_Basic/FunctionExpression_L13C20/FunctionObject_FunctionExpression_39A55734_L13C21::.ctor(class Modules.Stream_Readable_Basic/Scope)
 		IL_008a: ldc.i4.1
 		IL_008b: conv.r8
 		IL_008c: ldstr ""
 		IL_0091: ldc.i4.0
 		IL_0092: ldc.i4.1
-		IL_0093: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Readable_Basic_667796A7.FunctionObject_FunctionExpression_39A55734_L13C21>(!!0, float64, string, bool, bool)
+		IL_0093: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Readable_Basic/FunctionExpression_L13C20/FunctionObject_FunctionExpression_39A55734_L13C21>(!!0, float64, string, bool, bool)
 		IL_0098: stloc.s 7
 		IL_009a: ldloc.s 5
 		IL_009c: ldstr "on"
@@ -257,13 +465,13 @@
 		IL_00be: ldloc.0
 		IL_00bf: stelem.ref
 		IL_00c0: stloc.s 6
-		IL_00c2: newobj instance void FunctionObjects.Stream_Readable_Basic_667796A7.FunctionObject_FunctionExpression_D752F3C8_L18C20::.ctor()
+		IL_00c2: newobj instance void Modules.Stream_Readable_Basic/FunctionExpression_L18C19/FunctionObject_FunctionExpression_D752F3C8_L18C20::.ctor()
 		IL_00c7: ldc.i4.0
 		IL_00c8: conv.r8
 		IL_00c9: ldstr ""
 		IL_00ce: ldc.i4.0
 		IL_00cf: ldc.i4.1
-		IL_00d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Readable_Basic_667796A7.FunctionObject_FunctionExpression_D752F3C8_L18C20>(!!0, float64, string, bool, bool)
+		IL_00d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Readable_Basic/FunctionExpression_L18C19/FunctionObject_FunctionExpression_D752F3C8_L18C20>(!!0, float64, string, bool, bool)
 		IL_00d5: stloc.s 8
 		IL_00d7: ldloc.s 5
 		IL_00d9: ldstr "on"
@@ -321,214 +529,6 @@
 	} // end of method Stream_Readable_Basic::__js_module_init__
 
 } // end of class Modules.Stream_Readable_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Readable_Basic_667796A7.FunctionObject_FunctionExpression_39A55734_L13C21
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Readable_Basic/Scope _environment0_Stream_Readable_Basic
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Readable_Basic/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x227b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Readable_Basic/Scope FunctionObjects.Stream_Readable_Basic_667796A7.FunctionObject_FunctionExpression_39A55734_L13C21::_environment0_Stream_Readable_Basic
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_39A55734_L13C21::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x228a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_39A55734_L13C21::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x228d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_39A55734_L13C21::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2290
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Readable_Basic/Scope FunctionObjects.Stream_Readable_Basic_667796A7.FunctionObject_FunctionExpression_39A55734_L13C21::_environment0_Stream_Readable_Basic
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Stream_Readable_Basic/FunctionExpression_L13C20::__js_call__(class Modules.Stream_Readable_Basic/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_39A55734_L13C21::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22a9
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Readable_Basic/Scope FunctionObjects.Stream_Readable_Basic_667796A7.FunctionObject_FunctionExpression_39A55734_L13C21::_environment0_Stream_Readable_Basic
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Stream_Readable_Basic/FunctionExpression_L13C20::__js_call__(class Modules.Stream_Readable_Basic/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_39A55734_L13C21::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22be
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_39A55734_L13C21::ConstructCore
-
-} // end of class FunctionObjects.Stream_Readable_Basic_667796A7.FunctionObject_FunctionExpression_39A55734_L13C21
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Readable_Basic_667796A7.FunctionObject_FunctionExpression_D752F3C8_L18C20
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x22cd
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_D752F3C8_L18C20::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22d5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D752F3C8_L18C20::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22d8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D752F3C8_L18C20::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22db
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Stream_Readable_Basic/FunctionExpression_L18C19::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_D752F3C8_L18C20::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22e7
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Stream_Readable_Basic/FunctionExpression_L18C19::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_D752F3C8_L18C20::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22ef
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D752F3C8_L18C20::ConstructCore
-
-} // end of class FunctionObjects.Stream_Readable_Basic_667796A7.FunctionObject_FunctionExpression_D752F3C8_L18C20
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_Pause_Resume.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_Pause_Resume.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C97404D1_L8C22
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Readable_Pause_Resume/Scope _environment0_Stream_Readable_Pause_Resume
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Readable_Pause_Resume/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2355
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Readable_Pause_Resume/Scope Modules.Stream_Readable_Pause_Resume/FunctionExpression_L8C21/FunctionObject_FunctionExpression_C97404D1_L8C22::_environment0_Stream_Readable_Pause_Resume
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_C97404D1_L8C22::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2364
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C97404D1_L8C22::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2367
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C97404D1_L8C22::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x236a
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Readable_Pause_Resume/Scope Modules.Stream_Readable_Pause_Resume/FunctionExpression_L8C21/FunctionObject_FunctionExpression_C97404D1_L8C22::_environment0_Stream_Readable_Pause_Resume
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Stream_Readable_Pause_Resume/FunctionExpression_L8C21::__js_call__(class Modules.Stream_Readable_Pause_Resume/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_C97404D1_L8C22::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x237c
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Readable_Pause_Resume/Scope Modules.Stream_Readable_Pause_Resume/FunctionExpression_L8C21/FunctionObject_FunctionExpression_C97404D1_L8C22::_environment0_Stream_Readable_Pause_Resume
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Stream_Readable_Pause_Resume/FunctionExpression_L8C21::__js_call__(class Modules.Stream_Readable_Pause_Resume/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_C97404D1_L8C22::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x238a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_C97404D1_L8C22::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_C97404D1_L8C22
+
 
 		// Methods
 		.method public hidebysig static 
@@ -89,6 +196,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D5D9C11F_L12C23
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Readable_Pause_Resume/Scope _environment0_Stream_Readable_Pause_Resume
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Readable_Pause_Resume/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2399
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Readable_Pause_Resume/Scope Modules.Stream_Readable_Pause_Resume/FunctionExpression_L12C22/FunctionObject_FunctionExpression_D5D9C11F_L12C23::_environment0_Stream_Readable_Pause_Resume
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_D5D9C11F_L12C23::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x23a8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D5D9C11F_L12C23::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x23ab
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D5D9C11F_L12C23::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x23ae
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Readable_Pause_Resume/Scope Modules.Stream_Readable_Pause_Resume/FunctionExpression_L12C22/FunctionObject_FunctionExpression_D5D9C11F_L12C23::_environment0_Stream_Readable_Pause_Resume
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Stream_Readable_Pause_Resume/FunctionExpression_L12C22::__js_call__(class Modules.Stream_Readable_Pause_Resume/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_D5D9C11F_L12C23::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23c0
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Readable_Pause_Resume/Scope Modules.Stream_Readable_Pause_Resume/FunctionExpression_L12C22/FunctionObject_FunctionExpression_D5D9C11F_L12C23::_environment0_Stream_Readable_Pause_Resume
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Stream_Readable_Pause_Resume/FunctionExpression_L12C22::__js_call__(class Modules.Stream_Readable_Pause_Resume/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_D5D9C11F_L12C23::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23ce
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_D5D9C11F_L12C23::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_D5D9C11F_L12C23
+
 
 		// Methods
 		.method public hidebysig static 
@@ -146,6 +360,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_4492B329_L16C21
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x23dd
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_4492B329_L16C21::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x23e5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_4492B329_L16C21::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x23e8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_4492B329_L16C21::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x23eb
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Stream_Readable_Pause_Resume/FunctionExpression_L16C20::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_4492B329_L16C21::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23fe
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Stream_Readable_Pause_Resume/FunctionExpression_L16C20::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_4492B329_L16C21::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x240d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_4492B329_L16C21::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_4492B329_L16C21
 
 
 		// Methods
@@ -209,6 +524,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7D772049_L20C20
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Readable_Pause_Resume/Scope _environment0_Stream_Readable_Pause_Resume
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Readable_Pause_Resume/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x241c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Readable_Pause_Resume/Scope Modules.Stream_Readable_Pause_Resume/FunctionExpression_L20C19/FunctionObject_FunctionExpression_7D772049_L20C20::_environment0_Stream_Readable_Pause_Resume
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_7D772049_L20C20::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x242b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7D772049_L20C20::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x242e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7D772049_L20C20::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2431
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Readable_Pause_Resume/Scope Modules.Stream_Readable_Pause_Resume/FunctionExpression_L20C19/FunctionObject_FunctionExpression_7D772049_L20C20::_environment0_Stream_Readable_Pause_Resume
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Stream_Readable_Pause_Resume/FunctionExpression_L20C19::__js_call__(class Modules.Stream_Readable_Pause_Resume/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_7D772049_L20C20::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2443
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Readable_Pause_Resume/Scope Modules.Stream_Readable_Pause_Resume/FunctionExpression_L20C19/FunctionObject_FunctionExpression_7D772049_L20C20::_environment0_Stream_Readable_Pause_Resume
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Stream_Readable_Pause_Resume/FunctionExpression_L20C19::__js_call__(class Modules.Stream_Readable_Pause_Resume/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_7D772049_L20C20::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2451
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_7D772049_L20C20::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_7D772049_L20C20
 
 
 		// Methods
@@ -317,10 +739,10 @@
 			[3] object,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[5] object[],
-			[6] class FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_C97404D1_L8C22,
-			[7] class FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_D5D9C11F_L12C23,
-			[8] class FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_4492B329_L16C21,
-			[9] class FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_7D772049_L20C20
+			[6] class Modules.Stream_Readable_Pause_Resume/FunctionExpression_L8C21/FunctionObject_FunctionExpression_C97404D1_L8C22,
+			[7] class Modules.Stream_Readable_Pause_Resume/FunctionExpression_L12C22/FunctionObject_FunctionExpression_D5D9C11F_L12C23,
+			[8] class Modules.Stream_Readable_Pause_Resume/FunctionExpression_L16C20/FunctionObject_FunctionExpression_4492B329_L16C21,
+			[9] class Modules.Stream_Readable_Pause_Resume/FunctionExpression_L20C19/FunctionObject_FunctionExpression_7D772049_L20C20
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Readable_Pause_Resume/Scope::.ctor()
@@ -358,13 +780,13 @@
 		IL_004c: ldc.i4.0
 		IL_004d: ldelem.ref
 		IL_004e: castclass Modules.Stream_Readable_Pause_Resume/Scope
-		IL_0053: newobj instance void FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_C97404D1_L8C22::.ctor(class Modules.Stream_Readable_Pause_Resume/Scope)
+		IL_0053: newobj instance void Modules.Stream_Readable_Pause_Resume/FunctionExpression_L8C21/FunctionObject_FunctionExpression_C97404D1_L8C22::.ctor(class Modules.Stream_Readable_Pause_Resume/Scope)
 		IL_0058: ldc.i4.0
 		IL_0059: conv.r8
 		IL_005a: ldstr ""
 		IL_005f: ldc.i4.0
 		IL_0060: ldc.i4.1
-		IL_0061: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_C97404D1_L8C22>(!!0, float64, string, bool, bool)
+		IL_0061: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Readable_Pause_Resume/FunctionExpression_L8C21/FunctionObject_FunctionExpression_C97404D1_L8C22>(!!0, float64, string, bool, bool)
 		IL_0066: stloc.s 6
 		IL_0068: ldloc.3
 		IL_0069: ldstr "on"
@@ -386,13 +808,13 @@
 		IL_0090: ldc.i4.0
 		IL_0091: ldelem.ref
 		IL_0092: castclass Modules.Stream_Readable_Pause_Resume/Scope
-		IL_0097: newobj instance void FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_D5D9C11F_L12C23::.ctor(class Modules.Stream_Readable_Pause_Resume/Scope)
+		IL_0097: newobj instance void Modules.Stream_Readable_Pause_Resume/FunctionExpression_L12C22/FunctionObject_FunctionExpression_D5D9C11F_L12C23::.ctor(class Modules.Stream_Readable_Pause_Resume/Scope)
 		IL_009c: ldc.i4.0
 		IL_009d: conv.r8
 		IL_009e: ldstr ""
 		IL_00a3: ldc.i4.0
 		IL_00a4: ldc.i4.1
-		IL_00a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_D5D9C11F_L12C23>(!!0, float64, string, bool, bool)
+		IL_00a5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Readable_Pause_Resume/FunctionExpression_L12C22/FunctionObject_FunctionExpression_D5D9C11F_L12C23>(!!0, float64, string, bool, bool)
 		IL_00aa: stloc.s 7
 		IL_00ac: ldloc.3
 		IL_00ad: ldstr "on"
@@ -410,13 +832,13 @@
 		IL_00ce: ldloc.0
 		IL_00cf: stelem.ref
 		IL_00d0: stloc.s 5
-		IL_00d2: newobj instance void FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_4492B329_L16C21::.ctor()
+		IL_00d2: newobj instance void Modules.Stream_Readable_Pause_Resume/FunctionExpression_L16C20/FunctionObject_FunctionExpression_4492B329_L16C21::.ctor()
 		IL_00d7: ldc.i4.1
 		IL_00d8: conv.r8
 		IL_00d9: ldstr ""
 		IL_00de: ldc.i4.0
 		IL_00df: ldc.i4.1
-		IL_00e0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_4492B329_L16C21>(!!0, float64, string, bool, bool)
+		IL_00e0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Readable_Pause_Resume/FunctionExpression_L16C20/FunctionObject_FunctionExpression_4492B329_L16C21>(!!0, float64, string, bool, bool)
 		IL_00e5: stloc.s 8
 		IL_00e7: ldloc.3
 		IL_00e8: ldstr "on"
@@ -438,13 +860,13 @@
 		IL_010f: ldc.i4.0
 		IL_0110: ldelem.ref
 		IL_0111: castclass Modules.Stream_Readable_Pause_Resume/Scope
-		IL_0116: newobj instance void FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_7D772049_L20C20::.ctor(class Modules.Stream_Readable_Pause_Resume/Scope)
+		IL_0116: newobj instance void Modules.Stream_Readable_Pause_Resume/FunctionExpression_L20C19/FunctionObject_FunctionExpression_7D772049_L20C20::.ctor(class Modules.Stream_Readable_Pause_Resume/Scope)
 		IL_011b: ldc.i4.0
 		IL_011c: conv.r8
 		IL_011d: ldstr ""
 		IL_0122: ldc.i4.0
 		IL_0123: ldc.i4.1
-		IL_0124: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_7D772049_L20C20>(!!0, float64, string, bool, bool)
+		IL_0124: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Readable_Pause_Resume/FunctionExpression_L20C19/FunctionObject_FunctionExpression_7D772049_L20C20>(!!0, float64, string, bool, bool)
 		IL_0129: stloc.s 9
 		IL_012b: ldloc.3
 		IL_012c: ldstr "on"
@@ -498,428 +920,6 @@
 	} // end of method Stream_Readable_Pause_Resume::__js_module_init__
 
 } // end of class Modules.Stream_Readable_Pause_Resume
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_C97404D1_L8C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Readable_Pause_Resume/Scope _environment0_Stream_Readable_Pause_Resume
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Readable_Pause_Resume/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2355
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Readable_Pause_Resume/Scope FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_C97404D1_L8C22::_environment0_Stream_Readable_Pause_Resume
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C97404D1_L8C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2364
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C97404D1_L8C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2367
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C97404D1_L8C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x236a
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Readable_Pause_Resume/Scope FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_C97404D1_L8C22::_environment0_Stream_Readable_Pause_Resume
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Stream_Readable_Pause_Resume/FunctionExpression_L8C21::__js_call__(class Modules.Stream_Readable_Pause_Resume/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_C97404D1_L8C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x237c
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Readable_Pause_Resume/Scope FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_C97404D1_L8C22::_environment0_Stream_Readable_Pause_Resume
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Stream_Readable_Pause_Resume/FunctionExpression_L8C21::__js_call__(class Modules.Stream_Readable_Pause_Resume/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_C97404D1_L8C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x238a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C97404D1_L8C22::ConstructCore
-
-} // end of class FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_C97404D1_L8C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_D5D9C11F_L12C23
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Readable_Pause_Resume/Scope _environment0_Stream_Readable_Pause_Resume
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Readable_Pause_Resume/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2399
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Readable_Pause_Resume/Scope FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_D5D9C11F_L12C23::_environment0_Stream_Readable_Pause_Resume
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D5D9C11F_L12C23::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23a8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D5D9C11F_L12C23::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23ab
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D5D9C11F_L12C23::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23ae
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Readable_Pause_Resume/Scope FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_D5D9C11F_L12C23::_environment0_Stream_Readable_Pause_Resume
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Stream_Readable_Pause_Resume/FunctionExpression_L12C22::__js_call__(class Modules.Stream_Readable_Pause_Resume/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_D5D9C11F_L12C23::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23c0
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Readable_Pause_Resume/Scope FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_D5D9C11F_L12C23::_environment0_Stream_Readable_Pause_Resume
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Stream_Readable_Pause_Resume/FunctionExpression_L12C22::__js_call__(class Modules.Stream_Readable_Pause_Resume/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_D5D9C11F_L12C23::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23ce
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D5D9C11F_L12C23::ConstructCore
-
-} // end of class FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_D5D9C11F_L12C23
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_4492B329_L16C21
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x23dd
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_4492B329_L16C21::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23e5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_4492B329_L16C21::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23e8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_4492B329_L16C21::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23eb
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Stream_Readable_Pause_Resume/FunctionExpression_L16C20::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_4492B329_L16C21::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23fe
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Stream_Readable_Pause_Resume/FunctionExpression_L16C20::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_4492B329_L16C21::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x240d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_4492B329_L16C21::ConstructCore
-
-} // end of class FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_4492B329_L16C21
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_7D772049_L20C20
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Readable_Pause_Resume/Scope _environment0_Stream_Readable_Pause_Resume
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Readable_Pause_Resume/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x241c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Readable_Pause_Resume/Scope FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_7D772049_L20C20::_environment0_Stream_Readable_Pause_Resume
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7D772049_L20C20::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x242b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7D772049_L20C20::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x242e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7D772049_L20C20::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2431
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Readable_Pause_Resume/Scope FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_7D772049_L20C20::_environment0_Stream_Readable_Pause_Resume
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Stream_Readable_Pause_Resume/FunctionExpression_L20C19::__js_call__(class Modules.Stream_Readable_Pause_Resume/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_7D772049_L20C20::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2443
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Readable_Pause_Resume/Scope FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_7D772049_L20C20::_environment0_Stream_Readable_Pause_Resume
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Stream_Readable_Pause_Resume/FunctionExpression_L20C19::__js_call__(class Modules.Stream_Readable_Pause_Resume/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_7D772049_L20C20::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2451
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7D772049_L20C20::ConstructCore
-
-} // end of class FunctionObjects.Stream_Readable_Pause_Resume_F0D66303.FunctionObject_FunctionExpression_7D772049_L20C20
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_SetEncoding_Utf8.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Readable_SetEncoding_Utf8.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_01F99F03_L15C21
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2313
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_01F99F03_L15C21::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x231b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_01F99F03_L15C21::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x231e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_01F99F03_L15C21::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2321
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L15C20::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_01F99F03_L15C21::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2334
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L15C20::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_01F99F03_L15C21::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2343
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_01F99F03_L15C21::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_01F99F03_L15C21
+
 
 		// Methods
 		.method public hidebysig static 
@@ -105,6 +206,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8DB2BEB4_L19C20
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Readable_SetEncoding_Utf8/Scope _environment0_Stream_Readable_SetEncoding_Utf8
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Readable_SetEncoding_Utf8/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2352
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Readable_SetEncoding_Utf8/Scope Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19/FunctionObject_FunctionExpression_8DB2BEB4_L19C20::_environment0_Stream_Readable_SetEncoding_Utf8
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_8DB2BEB4_L19C20::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2361
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_8DB2BEB4_L19C20::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2364
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_8DB2BEB4_L19C20::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2367
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Readable_SetEncoding_Utf8/Scope Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19/FunctionObject_FunctionExpression_8DB2BEB4_L19C20::_environment0_Stream_Readable_SetEncoding_Utf8
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19::__js_call__(class Modules.Stream_Readable_SetEncoding_Utf8/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_8DB2BEB4_L19C20::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2379
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Readable_SetEncoding_Utf8/Scope Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19/FunctionObject_FunctionExpression_8DB2BEB4_L19C20::_environment0_Stream_Readable_SetEncoding_Utf8
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19::__js_call__(class Modules.Stream_Readable_SetEncoding_Utf8/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_8DB2BEB4_L19C20::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2387
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_8DB2BEB4_L19C20::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_8DB2BEB4_L19C20
 
 
 		// Methods
@@ -204,8 +412,8 @@
 			[5] object,
 			[6] string,
 			[7] object[],
-			[8] class FunctionObjects.Stream_Readable_SetEncoding_Utf8_B99C690A.FunctionObject_FunctionExpression_01F99F03_L15C21,
-			[9] class FunctionObjects.Stream_Readable_SetEncoding_Utf8_B99C690A.FunctionObject_FunctionExpression_8DB2BEB4_L19C20
+			[8] class Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L15C20/FunctionObject_FunctionExpression_01F99F03_L15C21,
+			[9] class Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19/FunctionObject_FunctionExpression_8DB2BEB4_L19C20
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Readable_SetEncoding_Utf8/Scope::.ctor()
@@ -310,13 +518,13 @@
 		IL_0149: ldloc.0
 		IL_014a: stelem.ref
 		IL_014b: stloc.s 7
-		IL_014d: newobj instance void FunctionObjects.Stream_Readable_SetEncoding_Utf8_B99C690A.FunctionObject_FunctionExpression_01F99F03_L15C21::.ctor()
+		IL_014d: newobj instance void Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L15C20/FunctionObject_FunctionExpression_01F99F03_L15C21::.ctor()
 		IL_0152: ldc.i4.1
 		IL_0153: conv.r8
 		IL_0154: ldstr ""
 		IL_0159: ldc.i4.0
 		IL_015a: ldc.i4.1
-		IL_015b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Readable_SetEncoding_Utf8_B99C690A.FunctionObject_FunctionExpression_01F99F03_L15C21>(!!0, float64, string, bool, bool)
+		IL_015b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L15C20/FunctionObject_FunctionExpression_01F99F03_L15C21>(!!0, float64, string, bool, bool)
 		IL_0160: stloc.s 8
 		IL_0162: ldloc.3
 		IL_0163: ldstr "on"
@@ -339,13 +547,13 @@
 		IL_018f: ldc.i4.0
 		IL_0190: ldelem.ref
 		IL_0191: castclass Modules.Stream_Readable_SetEncoding_Utf8/Scope
-		IL_0196: newobj instance void FunctionObjects.Stream_Readable_SetEncoding_Utf8_B99C690A.FunctionObject_FunctionExpression_8DB2BEB4_L19C20::.ctor(class Modules.Stream_Readable_SetEncoding_Utf8/Scope)
+		IL_0196: newobj instance void Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19/FunctionObject_FunctionExpression_8DB2BEB4_L19C20::.ctor(class Modules.Stream_Readable_SetEncoding_Utf8/Scope)
 		IL_019b: ldc.i4.0
 		IL_019c: conv.r8
 		IL_019d: ldstr ""
 		IL_01a2: ldc.i4.0
 		IL_01a3: ldc.i4.1
-		IL_01a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Readable_SetEncoding_Utf8_B99C690A.FunctionObject_FunctionExpression_8DB2BEB4_L19C20>(!!0, float64, string, bool, bool)
+		IL_01a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19/FunctionObject_FunctionExpression_8DB2BEB4_L19C20>(!!0, float64, string, bool, bool)
 		IL_01a9: stloc.s 9
 		IL_01ab: ldloc.3
 		IL_01ac: ldstr "on"
@@ -375,214 +583,6 @@
 	} // end of method Stream_Readable_SetEncoding_Utf8::__js_module_init__
 
 } // end of class Modules.Stream_Readable_SetEncoding_Utf8
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Readable_SetEncoding_Utf8_B99C690A.FunctionObject_FunctionExpression_01F99F03_L15C21
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2313
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_01F99F03_L15C21::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x231b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_01F99F03_L15C21::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x231e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_01F99F03_L15C21::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2321
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L15C20::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_01F99F03_L15C21::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2334
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L15C20::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_01F99F03_L15C21::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2343
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_01F99F03_L15C21::ConstructCore
-
-} // end of class FunctionObjects.Stream_Readable_SetEncoding_Utf8_B99C690A.FunctionObject_FunctionExpression_01F99F03_L15C21
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Readable_SetEncoding_Utf8_B99C690A.FunctionObject_FunctionExpression_8DB2BEB4_L19C20
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Readable_SetEncoding_Utf8/Scope _environment0_Stream_Readable_SetEncoding_Utf8
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Readable_SetEncoding_Utf8/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2352
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Readable_SetEncoding_Utf8/Scope FunctionObjects.Stream_Readable_SetEncoding_Utf8_B99C690A.FunctionObject_FunctionExpression_8DB2BEB4_L19C20::_environment0_Stream_Readable_SetEncoding_Utf8
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_8DB2BEB4_L19C20::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2361
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_8DB2BEB4_L19C20::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2364
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_8DB2BEB4_L19C20::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2367
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Readable_SetEncoding_Utf8/Scope FunctionObjects.Stream_Readable_SetEncoding_Utf8_B99C690A.FunctionObject_FunctionExpression_8DB2BEB4_L19C20::_environment0_Stream_Readable_SetEncoding_Utf8
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19::__js_call__(class Modules.Stream_Readable_SetEncoding_Utf8/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_8DB2BEB4_L19C20::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2379
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Readable_SetEncoding_Utf8/Scope FunctionObjects.Stream_Readable_SetEncoding_Utf8_B99C690A.FunctionObject_FunctionExpression_8DB2BEB4_L19C20::_environment0_Stream_Readable_SetEncoding_Utf8
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Stream_Readable_SetEncoding_Utf8/FunctionExpression_L19C19::__js_call__(class Modules.Stream_Readable_SetEncoding_Utf8/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_8DB2BEB4_L19C20::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2387
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_8DB2BEB4_L19C20::ConstructCore
-
-} // end of class FunctionObjects.Stream_Readable_SetEncoding_Utf8_B99C690A.FunctionObject_FunctionExpression_8DB2BEB4_L19C20
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Transform_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Transform_Basic.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6B603F66_L9C24
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x22d0
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_6B603F66_L9C24::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22d8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_6B603F66_L9C24::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22db
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_6B603F66_L9C24::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22de
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Stream_Transform_Basic/FunctionExpression_L9C23::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_6B603F66_L9C24::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22f1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Stream_Transform_Basic/FunctionExpression_L9C23::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_6B603F66_L9C24::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2300
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_6B603F66_L9C24::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_6B603F66_L9C24
+
 
 		// Methods
 		.method public hidebysig static 
@@ -95,6 +196,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1E7D8B98_L14C19
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Transform_Basic/Scope _environment0_Stream_Transform_Basic
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Transform_Basic/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x230f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Transform_Basic/Scope Modules.Stream_Transform_Basic/FunctionExpression_L14C18/FunctionObject_FunctionExpression_1E7D8B98_L14C19::_environment0_Stream_Transform_Basic
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_1E7D8B98_L14C19::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x231e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_1E7D8B98_L14C19::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2321
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_1E7D8B98_L14C19::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2324
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Transform_Basic/Scope Modules.Stream_Transform_Basic/FunctionExpression_L14C18/FunctionObject_FunctionExpression_1E7D8B98_L14C19::_environment0_Stream_Transform_Basic
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Stream_Transform_Basic/FunctionExpression_L14C18::__js_call__(class Modules.Stream_Transform_Basic/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_1E7D8B98_L14C19::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x233d
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Transform_Basic/Scope Modules.Stream_Transform_Basic/FunctionExpression_L14C18/FunctionObject_FunctionExpression_1E7D8B98_L14C19::_environment0_Stream_Transform_Basic
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Stream_Transform_Basic/FunctionExpression_L14C18::__js_call__(class Modules.Stream_Transform_Basic/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_1E7D8B98_L14C19::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2352
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_1E7D8B98_L14C19::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_1E7D8B98_L14C19
+
 
 		// Methods
 		.method public hidebysig static 
@@ -153,6 +367,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D96DDE65_L18C23
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Transform_Basic/Scope _environment0_Stream_Transform_Basic
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Transform_Basic/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2361
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Transform_Basic/Scope Modules.Stream_Transform_Basic/FunctionExpression_L18C22/FunctionObject_FunctionExpression_D96DDE65_L18C23::_environment0_Stream_Transform_Basic
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_D96DDE65_L18C23::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2370
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D96DDE65_L18C23::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2373
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D96DDE65_L18C23::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2376
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Transform_Basic/Scope Modules.Stream_Transform_Basic/FunctionExpression_L18C22/FunctionObject_FunctionExpression_D96DDE65_L18C23::_environment0_Stream_Transform_Basic
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Stream_Transform_Basic/FunctionExpression_L18C22::__js_call__(class Modules.Stream_Transform_Basic/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_D96DDE65_L18C23::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2388
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Transform_Basic/Scope Modules.Stream_Transform_Basic/FunctionExpression_L18C22/FunctionObject_FunctionExpression_D96DDE65_L18C23::_environment0_Stream_Transform_Basic
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Stream_Transform_Basic/FunctionExpression_L18C22::__js_call__(class Modules.Stream_Transform_Basic/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_D96DDE65_L18C23::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2396
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_D96DDE65_L18C23::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_D96DDE65_L18C23
 
 
 		// Methods
@@ -262,10 +583,10 @@
 			[4] object,
 			[5] object,
 			[6] object[],
-			[7] class FunctionObjects.Stream_Transform_Basic_B886344B.FunctionObject_FunctionExpression_6B603F66_L9C24,
+			[7] class Modules.Stream_Transform_Basic/FunctionExpression_L9C23/FunctionObject_FunctionExpression_6B603F66_L9C24,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[9] class FunctionObjects.Stream_Transform_Basic_B886344B.FunctionObject_FunctionExpression_1E7D8B98_L14C19,
-			[10] class FunctionObjects.Stream_Transform_Basic_B886344B.FunctionObject_FunctionExpression_D96DDE65_L18C23
+			[9] class Modules.Stream_Transform_Basic/FunctionExpression_L14C18/FunctionObject_FunctionExpression_1E7D8B98_L14C19,
+			[10] class Modules.Stream_Transform_Basic/FunctionExpression_L18C22/FunctionObject_FunctionExpression_D96DDE65_L18C23
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Transform_Basic/Scope::.ctor()
@@ -306,13 +627,13 @@
 		IL_005e: ldloc.0
 		IL_005f: stelem.ref
 		IL_0060: stloc.s 6
-		IL_0062: newobj instance void FunctionObjects.Stream_Transform_Basic_B886344B.FunctionObject_FunctionExpression_6B603F66_L9C24::.ctor()
+		IL_0062: newobj instance void Modules.Stream_Transform_Basic/FunctionExpression_L9C23/FunctionObject_FunctionExpression_6B603F66_L9C24::.ctor()
 		IL_0067: ldc.i4.1
 		IL_0068: conv.r8
 		IL_0069: ldstr ""
 		IL_006e: ldc.i4.1
 		IL_006f: ldc.i4.1
-		IL_0070: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Transform_Basic_B886344B.FunctionObject_FunctionExpression_6B603F66_L9C24>(!!0, float64, string, bool, bool)
+		IL_0070: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Transform_Basic/FunctionExpression_L9C23/FunctionObject_FunctionExpression_6B603F66_L9C24>(!!0, float64, string, bool, bool)
 		IL_0075: stloc.s 7
 		IL_0077: ldloc.3
 		IL_0078: ldstr "_transform"
@@ -337,13 +658,13 @@
 		IL_00a4: ldc.i4.0
 		IL_00a5: ldelem.ref
 		IL_00a6: castclass Modules.Stream_Transform_Basic/Scope
-		IL_00ab: newobj instance void FunctionObjects.Stream_Transform_Basic_B886344B.FunctionObject_FunctionExpression_1E7D8B98_L14C19::.ctor(class Modules.Stream_Transform_Basic/Scope)
+		IL_00ab: newobj instance void Modules.Stream_Transform_Basic/FunctionExpression_L14C18/FunctionObject_FunctionExpression_1E7D8B98_L14C19::.ctor(class Modules.Stream_Transform_Basic/Scope)
 		IL_00b0: ldc.i4.1
 		IL_00b1: conv.r8
 		IL_00b2: ldstr ""
 		IL_00b7: ldc.i4.0
 		IL_00b8: ldc.i4.1
-		IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Transform_Basic_B886344B.FunctionObject_FunctionExpression_1E7D8B98_L14C19>(!!0, float64, string, bool, bool)
+		IL_00b9: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Transform_Basic/FunctionExpression_L14C18/FunctionObject_FunctionExpression_1E7D8B98_L14C19>(!!0, float64, string, bool, bool)
 		IL_00be: stloc.s 9
 		IL_00c0: ldloc.s 4
 		IL_00c2: ldstr "_write"
@@ -365,13 +686,13 @@
 		IL_00e7: ldc.i4.0
 		IL_00e8: ldelem.ref
 		IL_00e9: castclass Modules.Stream_Transform_Basic/Scope
-		IL_00ee: newobj instance void FunctionObjects.Stream_Transform_Basic_B886344B.FunctionObject_FunctionExpression_D96DDE65_L18C23::.ctor(class Modules.Stream_Transform_Basic/Scope)
+		IL_00ee: newobj instance void Modules.Stream_Transform_Basic/FunctionExpression_L18C22/FunctionObject_FunctionExpression_D96DDE65_L18C23::.ctor(class Modules.Stream_Transform_Basic/Scope)
 		IL_00f3: ldc.i4.0
 		IL_00f4: conv.r8
 		IL_00f5: ldstr ""
 		IL_00fa: ldc.i4.0
 		IL_00fb: ldc.i4.1
-		IL_00fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Transform_Basic_B886344B.FunctionObject_FunctionExpression_D96DDE65_L18C23>(!!0, float64, string, bool, bool)
+		IL_00fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Transform_Basic/FunctionExpression_L18C22/FunctionObject_FunctionExpression_D96DDE65_L18C23>(!!0, float64, string, bool, bool)
 		IL_0101: stloc.s 10
 		IL_0103: ldloc.s 5
 		IL_0105: ldstr "on"
@@ -414,327 +735,6 @@
 	} // end of method Stream_Transform_Basic::__js_module_init__
 
 } // end of class Modules.Stream_Transform_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Transform_Basic_B886344B.FunctionObject_FunctionExpression_6B603F66_L9C24
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x22d0
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_6B603F66_L9C24::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22d8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6B603F66_L9C24::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22db
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6B603F66_L9C24::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22de
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Stream_Transform_Basic/FunctionExpression_L9C23::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_6B603F66_L9C24::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22f1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Stream_Transform_Basic/FunctionExpression_L9C23::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_6B603F66_L9C24::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2300
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_6B603F66_L9C24::ConstructCore
-
-} // end of class FunctionObjects.Stream_Transform_Basic_B886344B.FunctionObject_FunctionExpression_6B603F66_L9C24
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Transform_Basic_B886344B.FunctionObject_FunctionExpression_1E7D8B98_L14C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Transform_Basic/Scope _environment0_Stream_Transform_Basic
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Transform_Basic/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x230f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Transform_Basic/Scope FunctionObjects.Stream_Transform_Basic_B886344B.FunctionObject_FunctionExpression_1E7D8B98_L14C19::_environment0_Stream_Transform_Basic
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1E7D8B98_L14C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x231e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1E7D8B98_L14C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2321
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1E7D8B98_L14C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2324
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Transform_Basic/Scope FunctionObjects.Stream_Transform_Basic_B886344B.FunctionObject_FunctionExpression_1E7D8B98_L14C19::_environment0_Stream_Transform_Basic
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Stream_Transform_Basic/FunctionExpression_L14C18::__js_call__(class Modules.Stream_Transform_Basic/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_1E7D8B98_L14C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x233d
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Transform_Basic/Scope FunctionObjects.Stream_Transform_Basic_B886344B.FunctionObject_FunctionExpression_1E7D8B98_L14C19::_environment0_Stream_Transform_Basic
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Stream_Transform_Basic/FunctionExpression_L14C18::__js_call__(class Modules.Stream_Transform_Basic/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_1E7D8B98_L14C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2352
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1E7D8B98_L14C19::ConstructCore
-
-} // end of class FunctionObjects.Stream_Transform_Basic_B886344B.FunctionObject_FunctionExpression_1E7D8B98_L14C19
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Transform_Basic_B886344B.FunctionObject_FunctionExpression_D96DDE65_L18C23
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Transform_Basic/Scope _environment0_Stream_Transform_Basic
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Transform_Basic/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2361
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Transform_Basic/Scope FunctionObjects.Stream_Transform_Basic_B886344B.FunctionObject_FunctionExpression_D96DDE65_L18C23::_environment0_Stream_Transform_Basic
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D96DDE65_L18C23::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2370
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D96DDE65_L18C23::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2373
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D96DDE65_L18C23::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2376
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Transform_Basic/Scope FunctionObjects.Stream_Transform_Basic_B886344B.FunctionObject_FunctionExpression_D96DDE65_L18C23::_environment0_Stream_Transform_Basic
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Stream_Transform_Basic/FunctionExpression_L18C22::__js_call__(class Modules.Stream_Transform_Basic/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_D96DDE65_L18C23::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2388
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Transform_Basic/Scope FunctionObjects.Stream_Transform_Basic_B886344B.FunctionObject_FunctionExpression_D96DDE65_L18C23::_environment0_Stream_Transform_Basic
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Stream_Transform_Basic/FunctionExpression_L18C22::__js_call__(class Modules.Stream_Transform_Basic/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_D96DDE65_L18C23::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2396
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D96DDE65_L18C23::ConstructCore
-
-} // end of class FunctionObjects.Stream_Transform_Basic_B886344B.FunctionObject_FunctionExpression_D96DDE65_L18C23
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_Basic.verified.txt
@@ -31,6 +31,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5E924A40_L12C22
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2240
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_5E924A40_L12C22::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2248
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5E924A40_L12C22::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x224b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5E924A40_L12C22::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x224e
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Stream_Writable_Basic/FunctionExpression_L12C21::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_5E924A40_L12C22::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x225a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Stream_Writable_Basic/FunctionExpression_L12C21::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_5E924A40_L12C22::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2262
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_5E924A40_L12C22::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_5E924A40_L12C22
+
 
 		// Methods
 		.method public hidebysig static 
@@ -82,6 +177,101 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_57623C26_L17C23
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2271
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_57623C26_L17C23::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2279
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_57623C26_L17C23::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x227c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_57623C26_L17C23::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x227f
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Stream_Writable_Basic/FunctionExpression_L17C22::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_57623C26_L17C23::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x228b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Stream_Writable_Basic/FunctionExpression_L17C22::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_57623C26_L17C23::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2293
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_57623C26_L17C23::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_57623C26_L17C23
 
 
 		// Methods
@@ -154,8 +344,8 @@
 			[4] object,
 			[5] object,
 			[6] object[],
-			[7] class FunctionObjects.Stream_Writable_Basic_A6F86F77.FunctionObject_FunctionExpression_5E924A40_L12C22,
-			[8] class FunctionObjects.Stream_Writable_Basic_A6F86F77.FunctionObject_FunctionExpression_57623C26_L17C23
+			[7] class Modules.Stream_Writable_Basic/FunctionExpression_L12C21/FunctionObject_FunctionExpression_5E924A40_L12C22,
+			[8] class Modules.Stream_Writable_Basic/FunctionExpression_L17C22/FunctionObject_FunctionExpression_57623C26_L17C23
 		)
 
 		IL_0000: newobj instance void Modules.Stream_Writable_Basic/Scope::.ctor()
@@ -196,13 +386,13 @@
 		IL_0064: ldloc.0
 		IL_0065: stelem.ref
 		IL_0066: stloc.s 6
-		IL_0068: newobj instance void FunctionObjects.Stream_Writable_Basic_A6F86F77.FunctionObject_FunctionExpression_5E924A40_L12C22::.ctor()
+		IL_0068: newobj instance void Modules.Stream_Writable_Basic/FunctionExpression_L12C21/FunctionObject_FunctionExpression_5E924A40_L12C22::.ctor()
 		IL_006d: ldc.i4.0
 		IL_006e: conv.r8
 		IL_006f: ldstr ""
 		IL_0074: ldc.i4.0
 		IL_0075: ldc.i4.1
-		IL_0076: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Writable_Basic_A6F86F77.FunctionObject_FunctionExpression_5E924A40_L12C22>(!!0, float64, string, bool, bool)
+		IL_0076: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_Basic/FunctionExpression_L12C21/FunctionObject_FunctionExpression_5E924A40_L12C22>(!!0, float64, string, bool, bool)
 		IL_007b: stloc.s 7
 		IL_007d: ldloc.s 5
 		IL_007f: ldstr "on"
@@ -220,13 +410,13 @@
 		IL_00a1: ldloc.0
 		IL_00a2: stelem.ref
 		IL_00a3: stloc.s 6
-		IL_00a5: newobj instance void FunctionObjects.Stream_Writable_Basic_A6F86F77.FunctionObject_FunctionExpression_57623C26_L17C23::.ctor()
+		IL_00a5: newobj instance void Modules.Stream_Writable_Basic/FunctionExpression_L17C22/FunctionObject_FunctionExpression_57623C26_L17C23::.ctor()
 		IL_00aa: ldc.i4.0
 		IL_00ab: conv.r8
 		IL_00ac: ldstr ""
 		IL_00b1: ldc.i4.0
 		IL_00b2: ldc.i4.1
-		IL_00b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Writable_Basic_A6F86F77.FunctionObject_FunctionExpression_57623C26_L17C23>(!!0, float64, string, bool, bool)
+		IL_00b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_Basic/FunctionExpression_L17C22/FunctionObject_FunctionExpression_57623C26_L17C23>(!!0, float64, string, bool, bool)
 		IL_00b8: stloc.s 8
 		IL_00ba: ldloc.s 5
 		IL_00bc: ldstr "on"
@@ -288,196 +478,6 @@
 	} // end of method Stream_Writable_Basic::__js_module_init__
 
 } // end of class Modules.Stream_Writable_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Writable_Basic_A6F86F77.FunctionObject_FunctionExpression_5E924A40_L12C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2240
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_5E924A40_L12C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2248
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5E924A40_L12C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x224b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5E924A40_L12C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x224e
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Stream_Writable_Basic/FunctionExpression_L12C21::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_5E924A40_L12C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x225a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Stream_Writable_Basic/FunctionExpression_L12C21::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_5E924A40_L12C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2262
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5E924A40_L12C22::ConstructCore
-
-} // end of class FunctionObjects.Stream_Writable_Basic_A6F86F77.FunctionObject_FunctionExpression_5E924A40_L12C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Writable_Basic_A6F86F77.FunctionObject_FunctionExpression_57623C26_L17C23
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2271
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_57623C26_L17C23::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2279
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_57623C26_L17C23::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x227c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_57623C26_L17C23::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x227f
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Stream_Writable_Basic/FunctionExpression_L17C22::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_57623C26_L17C23::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x228b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Stream_Writable_Basic/FunctionExpression_L17C22::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_57623C26_L17C23::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2293
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_57623C26_L17C23::ConstructCore
-
-} // end of class FunctionObjects.Stream_Writable_Basic_A6F86F77.FunctionObject_FunctionExpression_57623C26_L17C23
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_CustomWrite.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_CustomWrite.verified.txt
@@ -31,6 +31,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7D100CD1_L11C19
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Writable_CustomWrite/Scope _environment0_Stream_Writable_CustomWrite
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Writable_CustomWrite/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2229
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Writable_CustomWrite/Scope Modules.Stream_Writable_CustomWrite/FunctionExpression_L11C18/FunctionObject_FunctionExpression_7D100CD1_L11C19::_environment0_Stream_Writable_CustomWrite
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_7D100CD1_L11C19::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2238
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7D100CD1_L11C19::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x223b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7D100CD1_L11C19::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x223e
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Writable_CustomWrite/Scope Modules.Stream_Writable_CustomWrite/FunctionExpression_L11C18/FunctionObject_FunctionExpression_7D100CD1_L11C19::_environment0_Stream_Writable_CustomWrite
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Stream_Writable_CustomWrite/FunctionExpression_L11C18::__js_call__(class Modules.Stream_Writable_CustomWrite/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_7D100CD1_L11C19::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2257
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Writable_CustomWrite/Scope Modules.Stream_Writable_CustomWrite/FunctionExpression_L11C18/FunctionObject_FunctionExpression_7D100CD1_L11C19::_environment0_Stream_Writable_CustomWrite
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Stream_Writable_CustomWrite/FunctionExpression_L11C18::__js_call__(class Modules.Stream_Writable_CustomWrite/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_7D100CD1_L11C19::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x226c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_7D100CD1_L11C19::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_7D100CD1_L11C19
+
 
 		// Methods
 		.method public hidebysig static 
@@ -167,7 +280,7 @@
 			[4] float64,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[6] object[],
-			[7] class FunctionObjects.Stream_Writable_CustomWrite_F1C86F1B.FunctionObject_FunctionExpression_7D100CD1_L11C19,
+			[7] class Modules.Stream_Writable_CustomWrite/FunctionExpression_L11C18/FunctionObject_FunctionExpression_7D100CD1_L11C19,
 			[8] object,
 			[9] object,
 			[10] float64,
@@ -208,13 +321,13 @@
 		IL_0045: ldc.i4.0
 		IL_0046: ldelem.ref
 		IL_0047: castclass Modules.Stream_Writable_CustomWrite/Scope
-		IL_004c: newobj instance void FunctionObjects.Stream_Writable_CustomWrite_F1C86F1B.FunctionObject_FunctionExpression_7D100CD1_L11C19::.ctor(class Modules.Stream_Writable_CustomWrite/Scope)
+		IL_004c: newobj instance void Modules.Stream_Writable_CustomWrite/FunctionExpression_L11C18/FunctionObject_FunctionExpression_7D100CD1_L11C19::.ctor(class Modules.Stream_Writable_CustomWrite/Scope)
 		IL_0051: ldc.i4.1
 		IL_0052: conv.r8
 		IL_0053: ldstr ""
 		IL_0058: ldc.i4.0
 		IL_0059: ldc.i4.1
-		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Writable_CustomWrite_F1C86F1B.FunctionObject_FunctionExpression_7D100CD1_L11C19>(!!0, float64, string, bool, bool)
+		IL_005a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_CustomWrite/FunctionExpression_L11C18/FunctionObject_FunctionExpression_7D100CD1_L11C19>(!!0, float64, string, bool, bool)
 		IL_005f: stloc.s 7
 		IL_0061: ldloc.3
 		IL_0062: ldstr "_write"
@@ -302,119 +415,6 @@
 	} // end of method Stream_Writable_CustomWrite::__js_module_init__
 
 } // end of class Modules.Stream_Writable_CustomWrite
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Writable_CustomWrite_F1C86F1B.FunctionObject_FunctionExpression_7D100CD1_L11C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Writable_CustomWrite/Scope _environment0_Stream_Writable_CustomWrite
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Writable_CustomWrite/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2229
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Writable_CustomWrite/Scope FunctionObjects.Stream_Writable_CustomWrite_F1C86F1B.FunctionObject_FunctionExpression_7D100CD1_L11C19::_environment0_Stream_Writable_CustomWrite
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7D100CD1_L11C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2238
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7D100CD1_L11C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x223b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7D100CD1_L11C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x223e
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Writable_CustomWrite/Scope FunctionObjects.Stream_Writable_CustomWrite_F1C86F1B.FunctionObject_FunctionExpression_7D100CD1_L11C19::_environment0_Stream_Writable_CustomWrite
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Stream_Writable_CustomWrite/FunctionExpression_L11C18::__js_call__(class Modules.Stream_Writable_CustomWrite/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_7D100CD1_L11C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2257
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Writable_CustomWrite/Scope FunctionObjects.Stream_Writable_CustomWrite_F1C86F1B.FunctionObject_FunctionExpression_7D100CD1_L11C19::_environment0_Stream_Writable_CustomWrite
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Stream_Writable_CustomWrite/FunctionExpression_L11C18::__js_call__(class Modules.Stream_Writable_CustomWrite/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_7D100CD1_L11C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x226c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7D100CD1_L11C19::ConstructCore
-
-} // end of class FunctionObjects.Stream_Writable_CustomWrite_F1C86F1B.FunctionObject_FunctionExpression_7D100CD1_L11C19
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_Destroy_Error.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_Destroy_Error.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3D3F853C_L8C19
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2349
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_3D3F853C_L8C19::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2351
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_3D3F853C_L8C19::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2354
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_3D3F853C_L8C19::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2357
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L8C18::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_3D3F853C_L8C19::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x236a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L8C18::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_3D3F853C_L8C19::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2379
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_3D3F853C_L8C19::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_3D3F853C_L8C19
+
 
 		// Methods
 		.method public hidebysig static 
@@ -99,6 +200,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_88247D05_L12C22
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Writable_Destroy_Error/Scope _environment0_Stream_Writable_Destroy_Error
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Writable_Destroy_Error/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2388
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Writable_Destroy_Error/Scope Modules.Stream_Writable_Destroy_Error/FunctionExpression_L12C21/FunctionObject_FunctionExpression_88247D05_L12C22::_environment0_Stream_Writable_Destroy_Error
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_88247D05_L12C22::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2397
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_88247D05_L12C22::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x239a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_88247D05_L12C22::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x239d
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Writable_Destroy_Error/Scope Modules.Stream_Writable_Destroy_Error/FunctionExpression_L12C21/FunctionObject_FunctionExpression_88247D05_L12C22::_environment0_Stream_Writable_Destroy_Error
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L12C21::__js_call__(class Modules.Stream_Writable_Destroy_Error/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_88247D05_L12C22::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23b6
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Writable_Destroy_Error/Scope Modules.Stream_Writable_Destroy_Error/FunctionExpression_L12C21/FunctionObject_FunctionExpression_88247D05_L12C22::_environment0_Stream_Writable_Destroy_Error
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L12C21::__js_call__(class Modules.Stream_Writable_Destroy_Error/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_88247D05_L12C22::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23cb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_88247D05_L12C22::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_88247D05_L12C22
 
 
 		// Methods
@@ -169,6 +383,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B3B90B0E_L16C23
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Writable_Destroy_Error/Scope _environment0_Stream_Writable_Destroy_Error
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Writable_Destroy_Error/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x23da
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Writable_Destroy_Error/Scope Modules.Stream_Writable_Destroy_Error/FunctionExpression_L16C22/FunctionObject_FunctionExpression_B3B90B0E_L16C23::_environment0_Stream_Writable_Destroy_Error
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_B3B90B0E_L16C23::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x23e9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_B3B90B0E_L16C23::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x23ec
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_B3B90B0E_L16C23::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x23ef
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Writable_Destroy_Error/Scope Modules.Stream_Writable_Destroy_Error/FunctionExpression_L16C22/FunctionObject_FunctionExpression_B3B90B0E_L16C23::_environment0_Stream_Writable_Destroy_Error
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L16C22::__js_call__(class Modules.Stream_Writable_Destroy_Error/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_B3B90B0E_L16C23::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2401
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Writable_Destroy_Error/Scope Modules.Stream_Writable_Destroy_Error/FunctionExpression_L16C22/FunctionObject_FunctionExpression_B3B90B0E_L16C23::_environment0_Stream_Writable_Destroy_Error
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L16C22::__js_call__(class Modules.Stream_Writable_Destroy_Error/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_B3B90B0E_L16C23::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x240f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_B3B90B0E_L16C23::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_B3B90B0E_L16C23
+
 
 		// Methods
 		.method public hidebysig static 
@@ -226,6 +547,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5E2C9FCA_L20C22
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Writable_Destroy_Error/Scope _environment0_Stream_Writable_Destroy_Error
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Writable_Destroy_Error/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x241e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Writable_Destroy_Error/Scope Modules.Stream_Writable_Destroy_Error/FunctionExpression_L20C21/FunctionObject_FunctionExpression_5E2C9FCA_L20C22::_environment0_Stream_Writable_Destroy_Error
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_5E2C9FCA_L20C22::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x242d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5E2C9FCA_L20C22::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2430
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5E2C9FCA_L20C22::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2433
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Writable_Destroy_Error/Scope Modules.Stream_Writable_Destroy_Error/FunctionExpression_L20C21/FunctionObject_FunctionExpression_5E2C9FCA_L20C22::_environment0_Stream_Writable_Destroy_Error
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L20C21::__js_call__(class Modules.Stream_Writable_Destroy_Error/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_5E2C9FCA_L20C22::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2445
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Writable_Destroy_Error/Scope Modules.Stream_Writable_Destroy_Error/FunctionExpression_L20C21/FunctionObject_FunctionExpression_5E2C9FCA_L20C22::_environment0_Stream_Writable_Destroy_Error
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L20C21::__js_call__(class Modules.Stream_Writable_Destroy_Error/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_5E2C9FCA_L20C22::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2453
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_5E2C9FCA_L20C22::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_5E2C9FCA_L20C22
 
 
 		// Methods
@@ -353,10 +781,10 @@
 			[2] object,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[4] object[],
-			[5] class FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_3D3F853C_L8C19,
-			[6] class FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_88247D05_L12C22,
-			[7] class FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_B3B90B0E_L16C23,
-			[8] class FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_5E2C9FCA_L20C22,
+			[5] class Modules.Stream_Writable_Destroy_Error/FunctionExpression_L8C18/FunctionObject_FunctionExpression_3D3F853C_L8C19,
+			[6] class Modules.Stream_Writable_Destroy_Error/FunctionExpression_L12C21/FunctionObject_FunctionExpression_88247D05_L12C22,
+			[7] class Modules.Stream_Writable_Destroy_Error/FunctionExpression_L16C22/FunctionObject_FunctionExpression_B3B90B0E_L16C23,
+			[8] class Modules.Stream_Writable_Destroy_Error/FunctionExpression_L20C21/FunctionObject_FunctionExpression_5E2C9FCA_L20C22,
 			[9] object,
 			[10] object
 		)
@@ -395,13 +823,13 @@
 		IL_004b: ldloc.0
 		IL_004c: stelem.ref
 		IL_004d: stloc.s 4
-		IL_004f: newobj instance void FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_3D3F853C_L8C19::.ctor()
+		IL_004f: newobj instance void Modules.Stream_Writable_Destroy_Error/FunctionExpression_L8C18/FunctionObject_FunctionExpression_3D3F853C_L8C19::.ctor()
 		IL_0054: ldc.i4.1
 		IL_0055: conv.r8
 		IL_0056: ldstr ""
 		IL_005b: ldc.i4.0
 		IL_005c: ldc.i4.1
-		IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_3D3F853C_L8C19>(!!0, float64, string, bool, bool)
+		IL_005d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_Destroy_Error/FunctionExpression_L8C18/FunctionObject_FunctionExpression_3D3F853C_L8C19>(!!0, float64, string, bool, bool)
 		IL_0062: stloc.s 5
 		IL_0064: ldloc.2
 		IL_0065: ldstr "_write"
@@ -424,13 +852,13 @@
 		IL_008d: ldc.i4.0
 		IL_008e: ldelem.ref
 		IL_008f: castclass Modules.Stream_Writable_Destroy_Error/Scope
-		IL_0094: newobj instance void FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_88247D05_L12C22::.ctor(class Modules.Stream_Writable_Destroy_Error/Scope)
+		IL_0094: newobj instance void Modules.Stream_Writable_Destroy_Error/FunctionExpression_L12C21/FunctionObject_FunctionExpression_88247D05_L12C22::.ctor(class Modules.Stream_Writable_Destroy_Error/Scope)
 		IL_0099: ldc.i4.1
 		IL_009a: conv.r8
 		IL_009b: ldstr ""
 		IL_00a0: ldc.i4.0
 		IL_00a1: ldc.i4.1
-		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_88247D05_L12C22>(!!0, float64, string, bool, bool)
+		IL_00a2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_Destroy_Error/FunctionExpression_L12C21/FunctionObject_FunctionExpression_88247D05_L12C22>(!!0, float64, string, bool, bool)
 		IL_00a7: stloc.s 6
 		IL_00a9: ldloc.2
 		IL_00aa: ldstr "on"
@@ -453,13 +881,13 @@
 		IL_00d6: ldc.i4.0
 		IL_00d7: ldelem.ref
 		IL_00d8: castclass Modules.Stream_Writable_Destroy_Error/Scope
-		IL_00dd: newobj instance void FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_B3B90B0E_L16C23::.ctor(class Modules.Stream_Writable_Destroy_Error/Scope)
+		IL_00dd: newobj instance void Modules.Stream_Writable_Destroy_Error/FunctionExpression_L16C22/FunctionObject_FunctionExpression_B3B90B0E_L16C23::.ctor(class Modules.Stream_Writable_Destroy_Error/Scope)
 		IL_00e2: ldc.i4.0
 		IL_00e3: conv.r8
 		IL_00e4: ldstr ""
 		IL_00e9: ldc.i4.0
 		IL_00ea: ldc.i4.1
-		IL_00eb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_B3B90B0E_L16C23>(!!0, float64, string, bool, bool)
+		IL_00eb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_Destroy_Error/FunctionExpression_L16C22/FunctionObject_FunctionExpression_B3B90B0E_L16C23>(!!0, float64, string, bool, bool)
 		IL_00f0: stloc.s 7
 		IL_00f2: ldloc.2
 		IL_00f3: ldstr "on"
@@ -482,13 +910,13 @@
 		IL_011f: ldc.i4.0
 		IL_0120: ldelem.ref
 		IL_0121: castclass Modules.Stream_Writable_Destroy_Error/Scope
-		IL_0126: newobj instance void FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_5E2C9FCA_L20C22::.ctor(class Modules.Stream_Writable_Destroy_Error/Scope)
+		IL_0126: newobj instance void Modules.Stream_Writable_Destroy_Error/FunctionExpression_L20C21/FunctionObject_FunctionExpression_5E2C9FCA_L20C22::.ctor(class Modules.Stream_Writable_Destroy_Error/Scope)
 		IL_012b: ldc.i4.0
 		IL_012c: conv.r8
 		IL_012d: ldstr ""
 		IL_0132: ldc.i4.0
 		IL_0133: ldc.i4.1
-		IL_0134: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_5E2C9FCA_L20C22>(!!0, float64, string, bool, bool)
+		IL_0134: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_Destroy_Error/FunctionExpression_L20C21/FunctionObject_FunctionExpression_5E2C9FCA_L20C22>(!!0, float64, string, bool, bool)
 		IL_0139: stloc.s 8
 		IL_013b: ldloc.2
 		IL_013c: ldstr "on"
@@ -520,434 +948,6 @@
 	} // end of method Stream_Writable_Destroy_Error::__js_module_init__
 
 } // end of class Modules.Stream_Writable_Destroy_Error
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_3D3F853C_L8C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2349
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_3D3F853C_L8C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2351
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3D3F853C_L8C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2354
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3D3F853C_L8C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2357
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L8C18::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_3D3F853C_L8C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x236a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L8C18::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3D3F853C_L8C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2379
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3D3F853C_L8C19::ConstructCore
-
-} // end of class FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_3D3F853C_L8C19
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_88247D05_L12C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Writable_Destroy_Error/Scope _environment0_Stream_Writable_Destroy_Error
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Writable_Destroy_Error/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2388
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Writable_Destroy_Error/Scope FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_88247D05_L12C22::_environment0_Stream_Writable_Destroy_Error
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_88247D05_L12C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2397
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_88247D05_L12C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x239a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_88247D05_L12C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x239d
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Writable_Destroy_Error/Scope FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_88247D05_L12C22::_environment0_Stream_Writable_Destroy_Error
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L12C21::__js_call__(class Modules.Stream_Writable_Destroy_Error/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_88247D05_L12C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23b6
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Writable_Destroy_Error/Scope FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_88247D05_L12C22::_environment0_Stream_Writable_Destroy_Error
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L12C21::__js_call__(class Modules.Stream_Writable_Destroy_Error/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_88247D05_L12C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23cb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_88247D05_L12C22::ConstructCore
-
-} // end of class FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_88247D05_L12C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_B3B90B0E_L16C23
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Writable_Destroy_Error/Scope _environment0_Stream_Writable_Destroy_Error
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Writable_Destroy_Error/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x23da
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Writable_Destroy_Error/Scope FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_B3B90B0E_L16C23::_environment0_Stream_Writable_Destroy_Error
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_B3B90B0E_L16C23::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23e9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_B3B90B0E_L16C23::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23ec
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_B3B90B0E_L16C23::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23ef
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Writable_Destroy_Error/Scope FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_B3B90B0E_L16C23::_environment0_Stream_Writable_Destroy_Error
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L16C22::__js_call__(class Modules.Stream_Writable_Destroy_Error/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_B3B90B0E_L16C23::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2401
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Writable_Destroy_Error/Scope FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_B3B90B0E_L16C23::_environment0_Stream_Writable_Destroy_Error
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L16C22::__js_call__(class Modules.Stream_Writable_Destroy_Error/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_B3B90B0E_L16C23::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x240f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_B3B90B0E_L16C23::ConstructCore
-
-} // end of class FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_B3B90B0E_L16C23
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_5E2C9FCA_L20C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Writable_Destroy_Error/Scope _environment0_Stream_Writable_Destroy_Error
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Writable_Destroy_Error/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x241e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Writable_Destroy_Error/Scope FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_5E2C9FCA_L20C22::_environment0_Stream_Writable_Destroy_Error
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5E2C9FCA_L20C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x242d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5E2C9FCA_L20C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2430
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5E2C9FCA_L20C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2433
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Writable_Destroy_Error/Scope FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_5E2C9FCA_L20C22::_environment0_Stream_Writable_Destroy_Error
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L20C21::__js_call__(class Modules.Stream_Writable_Destroy_Error/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_5E2C9FCA_L20C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2445
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Writable_Destroy_Error/Scope FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_5E2C9FCA_L20C22::_environment0_Stream_Writable_Destroy_Error
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Stream_Writable_Destroy_Error/FunctionExpression_L20C21::__js_call__(class Modules.Stream_Writable_Destroy_Error/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_5E2C9FCA_L20C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2453
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5E2C9FCA_L20C22::ConstructCore
-
-} // end of class FunctionObjects.Stream_Writable_Destroy_Error_5FED0656.FunctionObject_FunctionExpression_5E2C9FCA_L20C22
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_Drain_Finish_Order.verified.txt
+++ b/tests/Jroc.Tests/Node/Stream/Snapshots/GeneratorTests.Stream_Writable_Drain_Finish_Order.verified.txt
@@ -31,6 +31,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_01444ED3_L10C19
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Writable_Drain_Finish_Order/Scope _environment0_Stream_Writable_Drain_Finish_Order
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Writable_Drain_Finish_Order/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x231f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Writable_Drain_Finish_Order/Scope Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L10C18/FunctionObject_FunctionExpression_01444ED3_L10C19::_environment0_Stream_Writable_Drain_Finish_Order
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_01444ED3_L10C19::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x232e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_01444ED3_L10C19::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2331
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_01444ED3_L10C19::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2334
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Writable_Drain_Finish_Order/Scope Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L10C18/FunctionObject_FunctionExpression_01444ED3_L10C19::_environment0_Stream_Writable_Drain_Finish_Order
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L10C18::__js_call__(class Modules.Stream_Writable_Drain_Finish_Order/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_01444ED3_L10C19::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x234d
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Writable_Drain_Finish_Order/Scope Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L10C18/FunctionObject_FunctionExpression_01444ED3_L10C19::_environment0_Stream_Writable_Drain_Finish_Order
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L10C18::__js_call__(class Modules.Stream_Writable_Drain_Finish_Order/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_01444ED3_L10C19::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2362
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_01444ED3_L10C19::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_01444ED3_L10C19
+
 
 		// Methods
 		.method public hidebysig static 
@@ -90,6 +203,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_EFB8387D_L14C22
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Writable_Drain_Finish_Order/Scope _environment0_Stream_Writable_Drain_Finish_Order
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Writable_Drain_Finish_Order/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2371
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Writable_Drain_Finish_Order/Scope Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L14C21/FunctionObject_FunctionExpression_EFB8387D_L14C22::_environment0_Stream_Writable_Drain_Finish_Order
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_EFB8387D_L14C22::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2380
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_EFB8387D_L14C22::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2383
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_EFB8387D_L14C22::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2386
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Writable_Drain_Finish_Order/Scope Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L14C21/FunctionObject_FunctionExpression_EFB8387D_L14C22::_environment0_Stream_Writable_Drain_Finish_Order
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L14C21::__js_call__(class Modules.Stream_Writable_Drain_Finish_Order/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_EFB8387D_L14C22::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2398
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Writable_Drain_Finish_Order/Scope Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L14C21/FunctionObject_FunctionExpression_EFB8387D_L14C22::_environment0_Stream_Writable_Drain_Finish_Order
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L14C21::__js_call__(class Modules.Stream_Writable_Drain_Finish_Order/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_EFB8387D_L14C22::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23a6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_EFB8387D_L14C22::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_EFB8387D_L14C22
+
 
 		// Methods
 		.method public hidebysig static 
@@ -147,6 +367,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5C5EA86E_L18C23
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Stream_Writable_Drain_Finish_Order/Scope _environment0_Stream_Writable_Drain_Finish_Order
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Stream_Writable_Drain_Finish_Order/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x23b5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Stream_Writable_Drain_Finish_Order/Scope Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L18C22/FunctionObject_FunctionExpression_5C5EA86E_L18C23::_environment0_Stream_Writable_Drain_Finish_Order
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_5C5EA86E_L18C23::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x23c4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5C5EA86E_L18C23::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x23c7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5C5EA86E_L18C23::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x23ca
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Writable_Drain_Finish_Order/Scope Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L18C22/FunctionObject_FunctionExpression_5C5EA86E_L18C23::_environment0_Stream_Writable_Drain_Finish_Order
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L18C22::__js_call__(class Modules.Stream_Writable_Drain_Finish_Order/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_5C5EA86E_L18C23::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23dc
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Stream_Writable_Drain_Finish_Order/Scope Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L18C22/FunctionObject_FunctionExpression_5C5EA86E_L18C23::_environment0_Stream_Writable_Drain_Finish_Order
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L18C22::__js_call__(class Modules.Stream_Writable_Drain_Finish_Order/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_5C5EA86E_L18C23::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23ea
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_5C5EA86E_L18C23::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_5C5EA86E_L18C23
 
 
 		// Methods
@@ -281,9 +608,9 @@
 			[3] object,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[5] object[],
-			[6] class FunctionObjects.Stream_Writable_Drain_Finish_Order_869E6EE0.FunctionObject_FunctionExpression_01444ED3_L10C19,
-			[7] class FunctionObjects.Stream_Writable_Drain_Finish_Order_869E6EE0.FunctionObject_FunctionExpression_EFB8387D_L14C22,
-			[8] class FunctionObjects.Stream_Writable_Drain_Finish_Order_869E6EE0.FunctionObject_FunctionExpression_5C5EA86E_L18C23,
+			[6] class Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L10C18/FunctionObject_FunctionExpression_01444ED3_L10C19,
+			[7] class Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L14C21/FunctionObject_FunctionExpression_EFB8387D_L14C22,
+			[8] class Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L18C22/FunctionObject_FunctionExpression_5C5EA86E_L18C23,
 			[9] object,
 			[10] object
 		)
@@ -332,13 +659,13 @@
 		IL_006b: ldc.i4.0
 		IL_006c: ldelem.ref
 		IL_006d: castclass Modules.Stream_Writable_Drain_Finish_Order/Scope
-		IL_0072: newobj instance void FunctionObjects.Stream_Writable_Drain_Finish_Order_869E6EE0.FunctionObject_FunctionExpression_01444ED3_L10C19::.ctor(class Modules.Stream_Writable_Drain_Finish_Order/Scope)
+		IL_0072: newobj instance void Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L10C18/FunctionObject_FunctionExpression_01444ED3_L10C19::.ctor(class Modules.Stream_Writable_Drain_Finish_Order/Scope)
 		IL_0077: ldc.i4.1
 		IL_0078: conv.r8
 		IL_0079: ldstr ""
 		IL_007e: ldc.i4.0
 		IL_007f: ldc.i4.1
-		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Writable_Drain_Finish_Order_869E6EE0.FunctionObject_FunctionExpression_01444ED3_L10C19>(!!0, float64, string, bool, bool)
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L10C18/FunctionObject_FunctionExpression_01444ED3_L10C19>(!!0, float64, string, bool, bool)
 		IL_0085: stloc.s 6
 		IL_0087: ldloc.2
 		IL_0088: ldstr "_write"
@@ -360,13 +687,13 @@
 		IL_00ab: ldc.i4.0
 		IL_00ac: ldelem.ref
 		IL_00ad: castclass Modules.Stream_Writable_Drain_Finish_Order/Scope
-		IL_00b2: newobj instance void FunctionObjects.Stream_Writable_Drain_Finish_Order_869E6EE0.FunctionObject_FunctionExpression_EFB8387D_L14C22::.ctor(class Modules.Stream_Writable_Drain_Finish_Order/Scope)
+		IL_00b2: newobj instance void Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L14C21/FunctionObject_FunctionExpression_EFB8387D_L14C22::.ctor(class Modules.Stream_Writable_Drain_Finish_Order/Scope)
 		IL_00b7: ldc.i4.0
 		IL_00b8: conv.r8
 		IL_00b9: ldstr ""
 		IL_00be: ldc.i4.0
 		IL_00bf: ldc.i4.1
-		IL_00c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Writable_Drain_Finish_Order_869E6EE0.FunctionObject_FunctionExpression_EFB8387D_L14C22>(!!0, float64, string, bool, bool)
+		IL_00c0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L14C21/FunctionObject_FunctionExpression_EFB8387D_L14C22>(!!0, float64, string, bool, bool)
 		IL_00c5: stloc.s 7
 		IL_00c7: ldloc.3
 		IL_00c8: ldstr "on"
@@ -388,13 +715,13 @@
 		IL_00ef: ldc.i4.0
 		IL_00f0: ldelem.ref
 		IL_00f1: castclass Modules.Stream_Writable_Drain_Finish_Order/Scope
-		IL_00f6: newobj instance void FunctionObjects.Stream_Writable_Drain_Finish_Order_869E6EE0.FunctionObject_FunctionExpression_5C5EA86E_L18C23::.ctor(class Modules.Stream_Writable_Drain_Finish_Order/Scope)
+		IL_00f6: newobj instance void Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L18C22/FunctionObject_FunctionExpression_5C5EA86E_L18C23::.ctor(class Modules.Stream_Writable_Drain_Finish_Order/Scope)
 		IL_00fb: ldc.i4.0
 		IL_00fc: conv.r8
 		IL_00fd: ldstr ""
 		IL_0102: ldc.i4.0
 		IL_0103: ldc.i4.1
-		IL_0104: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Stream_Writable_Drain_Finish_Order_869E6EE0.FunctionObject_FunctionExpression_5C5EA86E_L18C23>(!!0, float64, string, bool, bool)
+		IL_0104: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L18C22/FunctionObject_FunctionExpression_5C5EA86E_L18C23>(!!0, float64, string, bool, bool)
 		IL_0109: stloc.s 8
 		IL_010b: ldloc.3
 		IL_010c: ldstr "on"
@@ -448,333 +775,6 @@
 	} // end of method Stream_Writable_Drain_Finish_Order::__js_module_init__
 
 } // end of class Modules.Stream_Writable_Drain_Finish_Order
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Writable_Drain_Finish_Order_869E6EE0.FunctionObject_FunctionExpression_01444ED3_L10C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Writable_Drain_Finish_Order/Scope _environment0_Stream_Writable_Drain_Finish_Order
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Writable_Drain_Finish_Order/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x231f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Writable_Drain_Finish_Order/Scope FunctionObjects.Stream_Writable_Drain_Finish_Order_869E6EE0.FunctionObject_FunctionExpression_01444ED3_L10C19::_environment0_Stream_Writable_Drain_Finish_Order
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_01444ED3_L10C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x232e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_01444ED3_L10C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2331
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_01444ED3_L10C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2334
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Writable_Drain_Finish_Order/Scope FunctionObjects.Stream_Writable_Drain_Finish_Order_869E6EE0.FunctionObject_FunctionExpression_01444ED3_L10C19::_environment0_Stream_Writable_Drain_Finish_Order
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L10C18::__js_call__(class Modules.Stream_Writable_Drain_Finish_Order/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_01444ED3_L10C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x234d
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Writable_Drain_Finish_Order/Scope FunctionObjects.Stream_Writable_Drain_Finish_Order_869E6EE0.FunctionObject_FunctionExpression_01444ED3_L10C19::_environment0_Stream_Writable_Drain_Finish_Order
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L10C18::__js_call__(class Modules.Stream_Writable_Drain_Finish_Order/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_01444ED3_L10C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2362
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_01444ED3_L10C19::ConstructCore
-
-} // end of class FunctionObjects.Stream_Writable_Drain_Finish_Order_869E6EE0.FunctionObject_FunctionExpression_01444ED3_L10C19
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Writable_Drain_Finish_Order_869E6EE0.FunctionObject_FunctionExpression_EFB8387D_L14C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Writable_Drain_Finish_Order/Scope _environment0_Stream_Writable_Drain_Finish_Order
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Writable_Drain_Finish_Order/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2371
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Writable_Drain_Finish_Order/Scope FunctionObjects.Stream_Writable_Drain_Finish_Order_869E6EE0.FunctionObject_FunctionExpression_EFB8387D_L14C22::_environment0_Stream_Writable_Drain_Finish_Order
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_EFB8387D_L14C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2380
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_EFB8387D_L14C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2383
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_EFB8387D_L14C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2386
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Writable_Drain_Finish_Order/Scope FunctionObjects.Stream_Writable_Drain_Finish_Order_869E6EE0.FunctionObject_FunctionExpression_EFB8387D_L14C22::_environment0_Stream_Writable_Drain_Finish_Order
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L14C21::__js_call__(class Modules.Stream_Writable_Drain_Finish_Order/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_EFB8387D_L14C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2398
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Writable_Drain_Finish_Order/Scope FunctionObjects.Stream_Writable_Drain_Finish_Order_869E6EE0.FunctionObject_FunctionExpression_EFB8387D_L14C22::_environment0_Stream_Writable_Drain_Finish_Order
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L14C21::__js_call__(class Modules.Stream_Writable_Drain_Finish_Order/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_EFB8387D_L14C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23a6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_EFB8387D_L14C22::ConstructCore
-
-} // end of class FunctionObjects.Stream_Writable_Drain_Finish_Order_869E6EE0.FunctionObject_FunctionExpression_EFB8387D_L14C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Stream_Writable_Drain_Finish_Order_869E6EE0.FunctionObject_FunctionExpression_5C5EA86E_L18C23
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Stream_Writable_Drain_Finish_Order/Scope _environment0_Stream_Writable_Drain_Finish_Order
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Stream_Writable_Drain_Finish_Order/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x23b5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Stream_Writable_Drain_Finish_Order/Scope FunctionObjects.Stream_Writable_Drain_Finish_Order_869E6EE0.FunctionObject_FunctionExpression_5C5EA86E_L18C23::_environment0_Stream_Writable_Drain_Finish_Order
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5C5EA86E_L18C23::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23c4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5C5EA86E_L18C23::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23c7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5C5EA86E_L18C23::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23ca
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Writable_Drain_Finish_Order/Scope FunctionObjects.Stream_Writable_Drain_Finish_Order_869E6EE0.FunctionObject_FunctionExpression_5C5EA86E_L18C23::_environment0_Stream_Writable_Drain_Finish_Order
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L18C22::__js_call__(class Modules.Stream_Writable_Drain_Finish_Order/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_5C5EA86E_L18C23::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23dc
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Stream_Writable_Drain_Finish_Order/Scope FunctionObjects.Stream_Writable_Drain_Finish_Order_869E6EE0.FunctionObject_FunctionExpression_5C5EA86E_L18C23::_environment0_Stream_Writable_Drain_Finish_Order
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Stream_Writable_Drain_Finish_Order/FunctionExpression_L18C22::__js_call__(class Modules.Stream_Writable_Drain_Finish_Order/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_5C5EA86E_L18C23::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23ea
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5C5EA86E_L18C23::ConstructCore
-
-} // end of class FunctionObjects.Stream_Writable_Drain_Finish_Order_869E6EE0.FunctionObject_FunctionExpression_5C5EA86E_L18C23
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/StringDecoder/Snapshots/GeneratorTests.Require_StringDecoder_MemoryStreamStyle.verified.txt
+++ b/tests/Jroc.Tests/Node/StringDecoder/Snapshots/GeneratorTests.Require_StringDecoder_MemoryStreamStyle.verified.txt
@@ -31,6 +31,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x22a6
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22ae
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22b1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22b4
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Require_StringDecoder_MemoryStreamStyle/MemoryWritableStream::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22c0
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Require_StringDecoder_MemoryStreamStyle/MemoryWritableStream::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22c8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream
+
 
 		// Methods
 		.method public hidebysig static 
@@ -83,6 +178,125 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3F80BDEB_L9C41
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Require_StringDecoder_MemoryStreamStyle/Scope _environment0_Require_StringDecoder_MemoryStreamStyle
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Require_StringDecoder_MemoryStreamStyle/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x22d7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Require_StringDecoder_MemoryStreamStyle/Scope Modules.Require_StringDecoder_MemoryStreamStyle/FunctionExpression_L9C40/FunctionObject_FunctionExpression_3F80BDEB_L9C41::_environment0_Require_StringDecoder_MemoryStreamStyle
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_3F80BDEB_L9C41::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22e6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_3F80BDEB_L9C41::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22e9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_3F80BDEB_L9C41::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22ec
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Require_StringDecoder_MemoryStreamStyle/Scope Modules.Require_StringDecoder_MemoryStreamStyle/FunctionExpression_L9C40/FunctionObject_FunctionExpression_3F80BDEB_L9C41::_environment0_Require_StringDecoder_MemoryStreamStyle
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Require_StringDecoder_MemoryStreamStyle/FunctionExpression_L9C40::__js_call__(class Modules.Require_StringDecoder_MemoryStreamStyle/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionExpression_3F80BDEB_L9C41::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x230c
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Require_StringDecoder_MemoryStreamStyle/Scope Modules.Require_StringDecoder_MemoryStreamStyle/FunctionExpression_L9C40/FunctionObject_FunctionExpression_3F80BDEB_L9C41::_environment0_Require_StringDecoder_MemoryStreamStyle
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Require_StringDecoder_MemoryStreamStyle/FunctionExpression_L9C40::__js_call__(class Modules.Require_StringDecoder_MemoryStreamStyle/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionExpression_3F80BDEB_L9C41::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2328
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_3F80BDEB_L9C41::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_3F80BDEB_L9C41
 
 
 		// Methods
@@ -238,12 +452,12 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_StringDecoder_MemoryStreamStyle/Scope,
-			[1] class FunctionObjects.Require_StringDecoder_MemoryStreamStyle_ED7DB06F.FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream,
+			[1] class Modules.Require_StringDecoder_MemoryStreamStyle/MemoryWritableStream/FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream,
 			[2] object,
 			[3] object[],
 			[4] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IStringDecoderModule,
 			[5] object,
-			[6] class FunctionObjects.Require_StringDecoder_MemoryStreamStyle_ED7DB06F.FunctionObject_FunctionExpression_3F80BDEB_L9C41,
+			[6] class Modules.Require_StringDecoder_MemoryStreamStyle/FunctionExpression_L9C40/FunctionObject_FunctionExpression_3F80BDEB_L9C41,
 			[7] bool,
 			[8] object,
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer,
@@ -259,13 +473,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.Require_StringDecoder_MemoryStreamStyle_ED7DB06F.FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream::.ctor()
+		IL_0011: newobj instance void Modules.Require_StringDecoder_MemoryStreamStyle/MemoryWritableStream/FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "MemoryWritableStream"
 		IL_001d: ldc.i4.1
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Require_StringDecoder_MemoryStreamStyle_ED7DB06F.FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_StringDecoder_MemoryStreamStyle/MemoryWritableStream/FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: ldarg.1
@@ -306,13 +520,13 @@
 		IL_0082: ldc.i4.0
 		IL_0083: ldelem.ref
 		IL_0084: castclass Modules.Require_StringDecoder_MemoryStreamStyle/Scope
-		IL_0089: newobj instance void FunctionObjects.Require_StringDecoder_MemoryStreamStyle_ED7DB06F.FunctionObject_FunctionExpression_3F80BDEB_L9C41::.ctor(class Modules.Require_StringDecoder_MemoryStreamStyle/Scope)
+		IL_0089: newobj instance void Modules.Require_StringDecoder_MemoryStreamStyle/FunctionExpression_L9C40/FunctionObject_FunctionExpression_3F80BDEB_L9C41::.ctor(class Modules.Require_StringDecoder_MemoryStreamStyle/Scope)
 		IL_008e: ldc.i4.2
 		IL_008f: conv.r8
 		IL_0090: ldstr ""
 		IL_0095: ldc.i4.1
 		IL_0096: ldc.i4.1
-		IL_0097: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Require_StringDecoder_MemoryStreamStyle_ED7DB06F.FunctionObject_FunctionExpression_3F80BDEB_L9C41>(!!0, float64, string, bool, bool)
+		IL_0097: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_StringDecoder_MemoryStreamStyle/FunctionExpression_L9C40/FunctionObject_FunctionExpression_3F80BDEB_L9C41>(!!0, float64, string, bool, bool)
 		IL_009c: stloc.s 6
 		IL_009e: ldloc.s 5
 		IL_00a0: ldstr "decode"
@@ -374,220 +588,6 @@
 	} // end of method Require_StringDecoder_MemoryStreamStyle::__js_module_init__
 
 } // end of class Modules.Require_StringDecoder_MemoryStreamStyle
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Require_StringDecoder_MemoryStreamStyle_ED7DB06F.FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x22a6
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22ae
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22b1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22b4
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Require_StringDecoder_MemoryStreamStyle/MemoryWritableStream::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22c0
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Require_StringDecoder_MemoryStreamStyle/MemoryWritableStream::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22c8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream::ConstructCore
-
-} // end of class FunctionObjects.Require_StringDecoder_MemoryStreamStyle_ED7DB06F.FunctionObject_FunctionDeclaration_CC5BA3C1_MemoryWritableStream
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Require_StringDecoder_MemoryStreamStyle_ED7DB06F.FunctionObject_FunctionExpression_3F80BDEB_L9C41
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Require_StringDecoder_MemoryStreamStyle/Scope _environment0_Require_StringDecoder_MemoryStreamStyle
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Require_StringDecoder_MemoryStreamStyle/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x22d7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Require_StringDecoder_MemoryStreamStyle/Scope FunctionObjects.Require_StringDecoder_MemoryStreamStyle_ED7DB06F.FunctionObject_FunctionExpression_3F80BDEB_L9C41::_environment0_Require_StringDecoder_MemoryStreamStyle
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3F80BDEB_L9C41::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22e6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3F80BDEB_L9C41::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22e9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3F80BDEB_L9C41::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22ec
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Require_StringDecoder_MemoryStreamStyle/Scope FunctionObjects.Require_StringDecoder_MemoryStreamStyle_ED7DB06F.FunctionObject_FunctionExpression_3F80BDEB_L9C41::_environment0_Require_StringDecoder_MemoryStreamStyle
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Require_StringDecoder_MemoryStreamStyle/FunctionExpression_L9C40::__js_call__(class Modules.Require_StringDecoder_MemoryStreamStyle/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionExpression_3F80BDEB_L9C41::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x230c
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Require_StringDecoder_MemoryStreamStyle/Scope FunctionObjects.Require_StringDecoder_MemoryStreamStyle_ED7DB06F.FunctionObject_FunctionExpression_3F80BDEB_L9C41::_environment0_Require_StringDecoder_MemoryStreamStyle
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Require_StringDecoder_MemoryStreamStyle/FunctionExpression_L9C40::__js_call__(class Modules.Require_StringDecoder_MemoryStreamStyle/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionExpression_3F80BDEB_L9C41::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2328
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3F80BDEB_L9C41::ConstructCore
-
-} // end of class FunctionObjects.Require_StringDecoder_MemoryStreamStyle_ED7DB06F.FunctionObject_FunctionExpression_3F80BDEB_L9C41
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Timers/Snapshots/GeneratorTests.GlobalTimers_AsValues_WindowLikeAssignment.verified.txt
+++ b/tests/Jroc.Tests/Node/Timers/Snapshots/GeneratorTests.GlobalTimers_AsValues_WindowLikeAssignment.verified.txt
@@ -31,6 +31,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A9D7FBF9_L19C30
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x221c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_A9D7FBF9_L19C30::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2224
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A9D7FBF9_L19C30::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2227
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A9D7FBF9_L19C30::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x222a
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.GlobalTimers_AsValues_WindowLikeAssignment/FunctionExpression_id::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_A9D7FBF9_L19C30::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2236
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.GlobalTimers_AsValues_WindowLikeAssignment/FunctionExpression_id::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_A9D7FBF9_L19C30::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x223e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_A9D7FBF9_L19C30::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_A9D7FBF9_L19C30
+
 
 		// Methods
 		.method public hidebysig static 
@@ -95,7 +190,7 @@
 			[4] object,
 			[5] string,
 			[6] object[],
-			[7] class FunctionObjects.GlobalTimers_AsValues_WindowLikeAssignment_652F9BF6.FunctionObject_FunctionExpression_A9D7FBF9_L19C30
+			[7] class Modules.GlobalTimers_AsValues_WindowLikeAssignment/FunctionExpression_id/FunctionObject_FunctionExpression_A9D7FBF9_L19C30
 		)
 
 		IL_0000: newobj instance void Modules.GlobalTimers_AsValues_WindowLikeAssignment/Scope::.ctor()
@@ -210,13 +305,13 @@
 		IL_0149: ldloc.0
 		IL_014a: stelem.ref
 		IL_014b: stloc.s 6
-		IL_014d: newobj instance void FunctionObjects.GlobalTimers_AsValues_WindowLikeAssignment_652F9BF6.FunctionObject_FunctionExpression_A9D7FBF9_L19C30::.ctor()
+		IL_014d: newobj instance void Modules.GlobalTimers_AsValues_WindowLikeAssignment/FunctionExpression_id/FunctionObject_FunctionExpression_A9D7FBF9_L19C30::.ctor()
 		IL_0152: ldc.i4.0
 		IL_0153: conv.r8
 		IL_0154: ldstr ""
 		IL_0159: ldc.i4.0
 		IL_015a: ldc.i4.1
-		IL_015b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.GlobalTimers_AsValues_WindowLikeAssignment_652F9BF6.FunctionObject_FunctionExpression_A9D7FBF9_L19C30>(!!0, float64, string, bool, bool)
+		IL_015b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.GlobalTimers_AsValues_WindowLikeAssignment/FunctionExpression_id/FunctionObject_FunctionExpression_A9D7FBF9_L19C30>(!!0, float64, string, bool, bool)
 		IL_0160: stloc.s 7
 		IL_0162: ldloc.1
 		IL_0163: ldstr "setTimeout"
@@ -241,101 +336,6 @@
 	} // end of method GlobalTimers_AsValues_WindowLikeAssignment::__js_module_init__
 
 } // end of class Modules.GlobalTimers_AsValues_WindowLikeAssignment
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.GlobalTimers_AsValues_WindowLikeAssignment_652F9BF6.FunctionObject_FunctionExpression_A9D7FBF9_L19C30
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x221c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_A9D7FBF9_L19C30::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2224
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A9D7FBF9_L19C30::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2227
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A9D7FBF9_L19C30::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x222a
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.GlobalTimers_AsValues_WindowLikeAssignment/FunctionExpression_id::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_A9D7FBF9_L19C30::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2236
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.GlobalTimers_AsValues_WindowLikeAssignment/FunctionExpression_id::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_A9D7FBF9_L19C30::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x223e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A9D7FBF9_L19C30::ConstructCore
-
-} // end of class FunctionObjects.GlobalTimers_AsValues_WindowLikeAssignment_652F9BF6.FunctionObject_FunctionExpression_A9D7FBF9_L19C30
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Timers/Snapshots/GeneratorTests.SetImmediate_WithArgs_PassesCorrectly.verified.txt
+++ b/tests/Jroc.Tests/Node/Timers/Snapshots/GeneratorTests.SetImmediate_WithArgs_PassesCorrectly.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E226DE30_logNameAge
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x211d
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_E226DE30_logNameAge::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2125
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E226DE30_logNameAge::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2128
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E226DE30_logNameAge::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x212b
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.SetImmediate_WithArgs_PassesCorrectly/logNameAge::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_E226DE30_logNameAge::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2145
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.SetImmediate_WithArgs_PassesCorrectly/logNameAge::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_E226DE30_logNameAge::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x215b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E226DE30_logNameAge::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E226DE30_logNameAge
+
 
 		// Methods
 		.method public hidebysig static 
@@ -120,7 +227,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.SetImmediate_WithArgs_PassesCorrectly/Scope,
-			[1] class FunctionObjects.SetImmediate_WithArgs_PassesCorrectly_525E37C5.FunctionObject_FunctionDeclaration_E226DE30_logNameAge,
+			[1] class Modules.SetImmediate_WithArgs_PassesCorrectly/logNameAge/FunctionObject_FunctionDeclaration_E226DE30_logNameAge,
 			[2] object[]
 		)
 
@@ -133,13 +240,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.SetImmediate_WithArgs_PassesCorrectly_525E37C5.FunctionObject_FunctionDeclaration_E226DE30_logNameAge::.ctor()
+		IL_0011: newobj instance void Modules.SetImmediate_WithArgs_PassesCorrectly/logNameAge/FunctionObject_FunctionDeclaration_E226DE30_logNameAge::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "logNameAge"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.SetImmediate_WithArgs_PassesCorrectly_525E37C5.FunctionObject_FunctionDeclaration_E226DE30_logNameAge>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.SetImmediate_WithArgs_PassesCorrectly/logNameAge/FunctionObject_FunctionDeclaration_E226DE30_logNameAge>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -168,113 +275,6 @@
 	} // end of method SetImmediate_WithArgs_PassesCorrectly::__js_module_init__
 
 } // end of class Modules.SetImmediate_WithArgs_PassesCorrectly
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.SetImmediate_WithArgs_PassesCorrectly_525E37C5.FunctionObject_FunctionDeclaration_E226DE30_logNameAge
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x211d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_E226DE30_logNameAge::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2125
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E226DE30_logNameAge::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2128
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E226DE30_logNameAge::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x212b
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.SetImmediate_WithArgs_PassesCorrectly/logNameAge::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_E226DE30_logNameAge::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2145
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.SetImmediate_WithArgs_PassesCorrectly/logNameAge::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_E226DE30_logNameAge::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x215b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E226DE30_logNameAge::ConstructCore
-
-} // end of class FunctionObjects.SetImmediate_WithArgs_PassesCorrectly_525E37C5.FunctionObject_FunctionDeclaration_E226DE30_logNameAge
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_GetterErrors_SurfaceCorrectly.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_GetterErrors_SurfaceCorrectly.verified.txt
@@ -31,6 +31,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0AB671BF_L7C8
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x248f
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_0AB671BF_L7C8::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2497
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_0AB671BF_L7C8::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x249a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_0AB671BF_L7C8::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x249d
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L7C7::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_0AB671BF_L7C8::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24a9
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L7C7::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_0AB671BF_L7C8::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24b1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_0AB671BF_L7C8::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_0AB671BF_L7C8
+
 
 		// Methods
 		.method public hidebysig static 
@@ -94,6 +189,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E62F123B_L17C9
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x24c0
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_E62F123B_L17C9::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24c8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E62F123B_L17C9::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24cb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E62F123B_L17C9::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24ce
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L17C8::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_E62F123B_L17C9::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24da
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L17C8::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_E62F123B_L17C9::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24e2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E62F123B_L17C9::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_E62F123B_L17C9
+
 
 		// Methods
 		.method public hidebysig static 
@@ -145,6 +335,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D519D947_L20C10
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x24f1
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_D519D947_L20C10::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24f9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D519D947_L20C10::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24fc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D519D947_L20C10::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24ff
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L20C9::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_D519D947_L20C10::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2512
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L20C9::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_D519D947_L20C10::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2521
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_D519D947_L20C10::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_D519D947_L20C10
 
 
 		// Methods
@@ -226,6 +517,101 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7DA2C414_L26C25
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2574
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_7DA2C414_L26C25::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x257c
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_7DA2C414_L26C25::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x257f
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_7DA2C414_L26C25::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2582
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_signal::__js_call__(object)
+					IL_000a: ret
+				} // end of method FunctionObject_FunctionExpression_7DA2C414_L26C25::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x258e
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_signal::__js_call__(object)
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_7DA2C414_L26C25::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2596
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_7DA2C414_L26C25::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_7DA2C414_L26C25
+
 
 			// Methods
 			.method public hidebysig static 
@@ -270,6 +656,101 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_68F621F1_L29C12
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x25a5
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_68F621F1_L29C12::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x25ad
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_68F621F1_L29C12::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x25b0
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_68F621F1_L29C12::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x25b3
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_L29C11::__js_call__(object)
+					IL_000a: ret
+				} // end of method FunctionObject_FunctionExpression_68F621F1_L29C12::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x25bf
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_L29C11::__js_call__(object)
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_68F621F1_L29C12::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x25c7
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_68F621F1_L29C12::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_68F621F1_L29C12
 
 
 			// Methods
@@ -372,6 +853,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_20FF4171_L24C9
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope _environment0_TimersPromises_Abort_GetterErrors_SurfaceCorrectly
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2530
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionObject_FunctionExpression_20FF4171_L24C9::_environment0_TimersPromises_Abort_GetterErrors_SurfaceCorrectly
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_20FF4171_L24C9::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x253f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_20FF4171_L24C9::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2542
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_20FF4171_L24C9::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2545
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionObject_FunctionExpression_20FF4171_L24C9::_environment0_TimersPromises_Abort_GetterErrors_SurfaceCorrectly
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8::__js_call__(class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_20FF4171_L24C9::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2557
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionObject_FunctionExpression_20FF4171_L24C9::_environment0_TimersPromises_Abort_GetterErrors_SurfaceCorrectly
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8::__js_call__(class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_20FF4171_L24C9::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2565
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_20FF4171_L24C9::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_20FF4171_L24C9
+
 
 		// Methods
 		.method public hidebysig static 
@@ -397,8 +985,8 @@
 				[4] object,
 				[5] object,
 				[6] object[],
-				[7] class FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_7DA2C414_L26C25,
-				[8] class FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_68F621F1_L29C12,
+				[7] class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_signal/FunctionObject_FunctionExpression_7DA2C414_L26C25,
+				[8] class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_L29C11/FunctionObject_FunctionExpression_68F621F1_L29C12,
 				[9] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[10] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule,
 				[11] object,
@@ -414,13 +1002,13 @@
 			IL_000e: ldarg.0
 			IL_000f: stelem.ref
 			IL_0010: stloc.s 6
-			IL_0012: newobj instance void FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_7DA2C414_L26C25::.ctor()
+			IL_0012: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_signal/FunctionObject_FunctionExpression_7DA2C414_L26C25::.ctor()
 			IL_0017: ldc.i4.0
 			IL_0018: conv.r8
 			IL_0019: ldstr ""
 			IL_001e: ldc.i4.0
 			IL_001f: ldc.i4.1
-			IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_7DA2C414_L26C25>(!!0, float64, string, bool, bool)
+			IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_signal/FunctionObject_FunctionExpression_7DA2C414_L26C25>(!!0, float64, string, bool, bool)
 			IL_0025: stloc.s 7
 			IL_0027: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_002c: dup
@@ -435,13 +1023,13 @@
 			IL_0042: ldarg.0
 			IL_0043: stelem.ref
 			IL_0044: stloc.s 6
-			IL_0046: newobj instance void FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_68F621F1_L29C12::.ctor()
+			IL_0046: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_L29C11/FunctionObject_FunctionExpression_68F621F1_L29C12::.ctor()
 			IL_004b: ldc.i4.0
 			IL_004c: conv.r8
 			IL_004d: ldstr ""
 			IL_0052: ldc.i4.0
 			IL_0053: ldc.i4.1
-			IL_0054: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_68F621F1_L29C12>(!!0, float64, string, bool, bool)
+			IL_0054: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_L29C11/FunctionObject_FunctionExpression_68F621F1_L29C12>(!!0, float64, string, bool, bool)
 			IL_0059: stloc.s 8
 			IL_005b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0060: dup
@@ -593,14 +1181,14 @@
 			[2] object,
 			[3] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule,
 			[4] object[],
-			[5] class FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_0AB671BF_L7C8,
+			[5] class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L7C7/FunctionObject_FunctionExpression_0AB671BF_L7C8,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[7] object,
 			[8] object,
 			[9] string,
-			[10] class FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_E62F123B_L17C9,
-			[11] class FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_D519D947_L20C10,
-			[12] class FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_20FF4171_L24C9
+			[10] class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L17C8/FunctionObject_FunctionExpression_E62F123B_L17C9,
+			[11] class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L20C9/FunctionObject_FunctionExpression_D519D947_L20C10,
+			[12] class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionObject_FunctionExpression_20FF4171_L24C9
 		)
 
 		IL_0000: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope::.ctor()
@@ -622,13 +1210,13 @@
 		IL_0028: ldloc.0
 		IL_0029: stelem.ref
 		IL_002a: stloc.s 4
-		IL_002c: newobj instance void FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_0AB671BF_L7C8::.ctor()
+		IL_002c: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L7C7/FunctionObject_FunctionExpression_0AB671BF_L7C8::.ctor()
 		IL_0031: ldc.i4.0
 		IL_0032: conv.r8
 		IL_0033: ldstr ""
 		IL_0038: ldc.i4.0
 		IL_0039: ldc.i4.1
-		IL_003a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_0AB671BF_L7C8>(!!0, float64, string, bool, bool)
+		IL_003a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L7C7/FunctionObject_FunctionExpression_0AB671BF_L7C8>(!!0, float64, string, bool, bool)
 		IL_003f: stloc.s 5
 		IL_0041: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0046: dup
@@ -677,13 +1265,13 @@
 		IL_00cb: ldloc.0
 		IL_00cc: stelem.ref
 		IL_00cd: stloc.s 4
-		IL_00cf: newobj instance void FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_E62F123B_L17C9::.ctor()
+		IL_00cf: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L17C8/FunctionObject_FunctionExpression_E62F123B_L17C9::.ctor()
 		IL_00d4: ldc.i4.0
 		IL_00d5: conv.r8
 		IL_00d6: ldstr ""
 		IL_00db: ldc.i4.0
 		IL_00dc: ldc.i4.1
-		IL_00dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_E62F123B_L17C9>(!!0, float64, string, bool, bool)
+		IL_00dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L17C8/FunctionObject_FunctionExpression_E62F123B_L17C9>(!!0, float64, string, bool, bool)
 		IL_00e2: stloc.s 10
 		IL_00e4: ldloc.s 7
 		IL_00e6: ldstr "then"
@@ -700,13 +1288,13 @@
 		IL_0105: ldloc.0
 		IL_0106: stelem.ref
 		IL_0107: stloc.s 4
-		IL_0109: newobj instance void FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_D519D947_L20C10::.ctor()
+		IL_0109: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L20C9/FunctionObject_FunctionExpression_D519D947_L20C10::.ctor()
 		IL_010e: ldc.i4.1
 		IL_010f: conv.r8
 		IL_0110: ldstr ""
 		IL_0115: ldc.i4.0
 		IL_0116: ldc.i4.1
-		IL_0117: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_D519D947_L20C10>(!!0, float64, string, bool, bool)
+		IL_0117: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L20C9/FunctionObject_FunctionExpression_D519D947_L20C10>(!!0, float64, string, bool, bool)
 		IL_011c: stloc.s 11
 		IL_011e: ldloc.s 7
 		IL_0120: ldstr "catch"
@@ -727,13 +1315,13 @@
 		IL_0145: ldc.i4.0
 		IL_0146: ldelem.ref
 		IL_0147: castclass Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope
-		IL_014c: newobj instance void FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_20FF4171_L24C9::.ctor(class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope)
+		IL_014c: newobj instance void Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionObject_FunctionExpression_20FF4171_L24C9::.ctor(class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope)
 		IL_0151: ldc.i4.0
 		IL_0152: conv.r8
 		IL_0153: ldstr ""
 		IL_0158: ldc.i4.0
 		IL_0159: ldc.i4.1
-		IL_015a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_20FF4171_L24C9>(!!0, float64, string, bool, bool)
+		IL_015a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionObject_FunctionExpression_20FF4171_L24C9>(!!0, float64, string, bool, bool)
 		IL_015f: stloc.s 12
 		IL_0161: ldloc.s 7
 		IL_0163: ldstr "then"
@@ -744,594 +1332,6 @@
 	} // end of method TimersPromises_Abort_GetterErrors_SurfaceCorrectly::__js_module_init__
 
 } // end of class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_0AB671BF_L7C8
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x248f
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_0AB671BF_L7C8::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2497
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_0AB671BF_L7C8::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x249a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_0AB671BF_L7C8::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x249d
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L7C7::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_0AB671BF_L7C8::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24a9
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L7C7::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_0AB671BF_L7C8::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24b1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_0AB671BF_L7C8::ConstructCore
-
-} // end of class FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_0AB671BF_L7C8
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_E62F123B_L17C9
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x24c0
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_E62F123B_L17C9::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24c8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E62F123B_L17C9::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24cb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E62F123B_L17C9::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24ce
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L17C8::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_E62F123B_L17C9::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24da
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L17C8::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_E62F123B_L17C9::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24e2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E62F123B_L17C9::ConstructCore
-
-} // end of class FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_E62F123B_L17C9
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_D519D947_L20C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x24f1
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_D519D947_L20C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24f9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D519D947_L20C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24fc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D519D947_L20C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24ff
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L20C9::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_D519D947_L20C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2512
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L20C9::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D519D947_L20C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2521
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D519D947_L20C10::ConstructCore
-
-} // end of class FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_D519D947_L20C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_20FF4171_L24C9
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope _environment0_TimersPromises_Abort_GetterErrors_SurfaceCorrectly
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2530
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_20FF4171_L24C9::_environment0_TimersPromises_Abort_GetterErrors_SurfaceCorrectly
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_20FF4171_L24C9::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x253f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_20FF4171_L24C9::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2542
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_20FF4171_L24C9::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2545
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_20FF4171_L24C9::_environment0_TimersPromises_Abort_GetterErrors_SurfaceCorrectly
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8::__js_call__(class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_20FF4171_L24C9::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2557
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_20FF4171_L24C9::_environment0_TimersPromises_Abort_GetterErrors_SurfaceCorrectly
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8::__js_call__(class Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_20FF4171_L24C9::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2565
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_20FF4171_L24C9::ConstructCore
-
-} // end of class FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_20FF4171_L24C9
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_7DA2C414_L26C25
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2574
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_7DA2C414_L26C25::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x257c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7DA2C414_L26C25::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x257f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7DA2C414_L26C25::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2582
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_signal::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_7DA2C414_L26C25::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x258e
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_signal::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_7DA2C414_L26C25::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2596
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7DA2C414_L26C25::ConstructCore
-
-} // end of class FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_7DA2C414_L26C25
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_68F621F1_L29C12
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x25a5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_68F621F1_L29C12::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x25ad
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_68F621F1_L29C12::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x25b0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_68F621F1_L29C12::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x25b3
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_L29C11::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_68F621F1_L29C12::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25bf
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.TimersPromises_Abort_GetterErrors_SurfaceCorrectly/FunctionExpression_L24C8/FunctionExpression_L29C11::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_68F621F1_L29C12::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25c7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_68F621F1_L29C12::ConstructCore
-
-} // end of class FunctionObjects.TimersPromises_Abort_GetterErrors_SurfaceCorrectly_7C54DE0E.FunctionObject_FunctionExpression_68F621F1_L29C12
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_RejectsSupportedOneShotApis.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Abort_RejectsSupportedOneShotApis.verified.txt
@@ -57,6 +57,113 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8F2862D0_L8C23
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x26ea
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_8F2862D0_L8C23::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x26f2
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_8F2862D0_L8C23::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x26f5
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_8F2862D0_L8C23::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x26f8
+					// Header size: 1
+					// Code size: 25 (0x19)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: ldarg.2
+					IL_0006: ldc.i4.0
+					IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000c: ldarg.2
+					IL_000d: ldc.i4.1
+					IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0013: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal::__js_call__(object, object, object)
+					IL_0018: ret
+				} // end of method FunctionObject_FunctionExpression_8F2862D0_L8C23::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2712
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: ldarg.2
+					IL_0002: ldc.i4.0
+					IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0008: ldarg.2
+					IL_0009: ldc.i4.1
+					IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000f: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal::__js_call__(object, object, object)
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionExpression_8F2862D0_L8C23::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2728
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_8F2862D0_L8C23::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_8F2862D0_L8C23
+
 
 			// Methods
 			.method public hidebysig static 
@@ -143,6 +250,113 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C2488DF7_L13C26
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2737
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_C2488DF7_L13C26::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x273f
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_C2488DF7_L13C26::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2742
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_C2488DF7_L13C26::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2745
+					// Header size: 1
+					// Code size: 25 (0x19)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: ldarg.2
+					IL_0006: ldc.i4.0
+					IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000c: ldarg.2
+					IL_000d: ldc.i4.1
+					IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0013: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal_L13C25::__js_call__(object, object, object)
+					IL_0018: ret
+				} // end of method FunctionObject_FunctionExpression_C2488DF7_L13C26::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x275f
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: ldarg.2
+					IL_0002: ldc.i4.0
+					IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0008: ldarg.2
+					IL_0009: ldc.i4.1
+					IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000f: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal_L13C25::__js_call__(object, object, object)
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionExpression_C2488DF7_L13C26::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2775
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_C2488DF7_L13C26::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_C2488DF7_L13C26
 
 
 			// Methods
@@ -268,6 +482,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3A0BD2BC_L22C12
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope _environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
+				.field private initonly class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope _environment1_createController
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope capture0,
+						class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2784
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/FunctionObject_FunctionExpression_3A0BD2BC_L22C12::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/FunctionObject_FunctionExpression_3A0BD2BC_L22C12::_environment1_createController
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/FunctionObject_FunctionExpression_3A0BD2BC_L22C12::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_3A0BD2BC_L22C12::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x27a1
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_3A0BD2BC_L22C12::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x27a4
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_3A0BD2BC_L22C12::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x27a7
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/FunctionObject_FunctionExpression_3A0BD2BC_L22C12::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_3A0BD2BC_L22C12::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x27b9
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/FunctionObject_FunctionExpression_3A0BD2BC_L22C12::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_3A0BD2BC_L22C12::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x27c7
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_3A0BD2BC_L22C12::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_3A0BD2BC_L22C12
+
 
 			// Methods
 			.method public hidebysig static 
@@ -358,6 +689,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_552FE78F_createController
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope _environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x26a6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionObject_FunctionDeclaration_552FE78F_createController::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_552FE78F_createController::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x26b5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_552FE78F_createController::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x26b8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_552FE78F_createController::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x26bb
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionObject_FunctionDeclaration_552FE78F_createController::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_552FE78F_createController::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26cd
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionObject_FunctionDeclaration_552FE78F_createController::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_552FE78F_createController::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26db
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_552FE78F_createController::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_552FE78F_createController
+
 
 		// Methods
 		.method public hidebysig static 
@@ -378,11 +816,11 @@
 			.locals init (
 				[0] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope,
 				[1] object[],
-				[2] class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_8F2862D0_L8C23,
-				[3] class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_C2488DF7_L13C26,
+				[2] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal/FunctionObject_FunctionExpression_8F2862D0_L8C23,
+				[3] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal_L13C25/FunctionObject_FunctionExpression_C2488DF7_L13C26,
 				[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[5] object,
-				[6] class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_3A0BD2BC_L22C12
+				[6] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/FunctionObject_FunctionExpression_3A0BD2BC_L22C12
 			)
 
 			IL_0000: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope::.ctor()
@@ -394,13 +832,13 @@
 			IL_000e: ldarg.0
 			IL_000f: stelem.ref
 			IL_0010: stloc.1
-			IL_0011: newobj instance void FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_8F2862D0_L8C23::.ctor()
+			IL_0011: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal/FunctionObject_FunctionExpression_8F2862D0_L8C23::.ctor()
 			IL_0016: ldc.i4.2
 			IL_0017: conv.r8
 			IL_0018: ldstr ""
 			IL_001d: ldc.i4.1
 			IL_001e: ldc.i4.1
-			IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_8F2862D0_L8C23>(!!0, float64, string, bool, bool)
+			IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal/FunctionObject_FunctionExpression_8F2862D0_L8C23>(!!0, float64, string, bool, bool)
 			IL_0024: stloc.2
 			IL_0025: ldc.i4.1
 			IL_0026: newarr [System.Runtime]System.Object
@@ -409,13 +847,13 @@
 			IL_002d: ldarg.0
 			IL_002e: stelem.ref
 			IL_002f: stloc.1
-			IL_0030: newobj instance void FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_C2488DF7_L13C26::.ctor()
+			IL_0030: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal_L13C25/FunctionObject_FunctionExpression_C2488DF7_L13C26::.ctor()
 			IL_0035: ldc.i4.2
 			IL_0036: conv.r8
 			IL_0037: ldstr ""
 			IL_003c: ldc.i4.1
 			IL_003d: ldc.i4.1
-			IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_C2488DF7_L13C26>(!!0, float64, string, bool, bool)
+			IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal_L13C25/FunctionObject_FunctionExpression_C2488DF7_L13C26>(!!0, float64, string, bool, bool)
 			IL_0043: stloc.3
 			IL_0044: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0049: dup
@@ -457,13 +895,13 @@
 			IL_0098: ldelem.ref
 			IL_0099: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope
 			IL_009e: ldloc.1
-			IL_009f: newobj instance void FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_3A0BD2BC_L22C12::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope, object[])
+			IL_009f: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/FunctionObject_FunctionExpression_3A0BD2BC_L22C12::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope, object[])
 			IL_00a4: ldc.i4.0
 			IL_00a5: conv.r8
 			IL_00a6: ldstr ""
 			IL_00ab: ldc.i4.0
 			IL_00ac: ldc.i4.1
-			IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_3A0BD2BC_L22C12>(!!0, float64, string, bool, bool)
+			IL_00ad: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11/FunctionObject_FunctionExpression_3A0BD2BC_L22C12>(!!0, float64, string, bool, bool)
 			IL_00b2: stloc.s 6
 			IL_00b4: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_00b9: dup
@@ -504,6 +942,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_44BD824F_logAbort
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x27d6
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_44BD824F_logAbort::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x27de
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_44BD824F_logAbort::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x27e1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_44BD824F_logAbort::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x27e4
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/logAbort::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_44BD824F_logAbort::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x27f7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/logAbort::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_44BD824F_logAbort::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2806
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_44BD824F_logAbort::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_44BD824F_logAbort
 
 
 		// Methods
@@ -594,6 +1133,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E4BF264B_L42C9
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2815
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_E4BF264B_L42C9::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x281d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E4BF264B_L42C9::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2820
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E4BF264B_L42C9::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2823
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L42C8::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_E4BF264B_L42C9::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x282f
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L42C8::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_E4BF264B_L42C9::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2837
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E4BF264B_L42C9::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_E4BF264B_L42C9
+
 
 		// Methods
 		.method public hidebysig static 
@@ -645,6 +1279,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_86CA2372_L45C10
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope _environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2846
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9/FunctionObject_FunctionExpression_86CA2372_L45C10::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_86CA2372_L45C10::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2855
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_86CA2372_L45C10::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2858
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_86CA2372_L45C10::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x285b
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9/FunctionObject_FunctionExpression_86CA2372_L45C10::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_86CA2372_L45C10::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2874
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9/FunctionObject_FunctionExpression_86CA2372_L45C10::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_86CA2372_L45C10::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2889
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_86CA2372_L45C10::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_86CA2372_L45C10
 
 
 		// Methods
@@ -718,6 +1465,101 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F1462999_L53C13
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x28dc
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_F1462999_L53C13::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x28e4
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_F1462999_L53C13::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x28e7
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_F1462999_L53C13::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x28ea
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12::__js_call__(object)
+					IL_000a: ret
+				} // end of method FunctionObject_FunctionExpression_F1462999_L53C13::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x28f6
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12::__js_call__(object)
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_F1462999_L53C13::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x28fe
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_F1462999_L53C13::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_F1462999_L53C13
+
 
 			// Methods
 			.method public hidebysig static 
@@ -769,6 +1611,124 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_00CA7359_L56C14
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope _environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x290d
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject_FunctionExpression_00CA7359_L56C14::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject_FunctionExpression_00CA7359_L56C14::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionExpression_00CA7359_L56C14::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2923
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_00CA7359_L56C14::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2926
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_00CA7359_L56C14::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2929
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject_FunctionExpression_00CA7359_L56C14::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_00CA7359_L56C14::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2942
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject_FunctionExpression_00CA7359_L56C14::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_00CA7359_L56C14::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2957
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_00CA7359_L56C14::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_00CA7359_L56C14
 
 
 			// Methods
@@ -843,6 +1803,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B08E779D_L48C9
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope _environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2898
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionObject_FunctionExpression_B08E779D_L48C9::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_B08E779D_L48C9::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x28a7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_B08E779D_L48C9::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x28aa
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_B08E779D_L48C9::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x28ad
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionObject_FunctionExpression_B08E779D_L48C9::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_B08E779D_L48C9::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x28bf
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionObject_FunctionExpression_B08E779D_L48C9::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_B08E779D_L48C9::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x28cd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_B08E779D_L48C9::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_B08E779D_L48C9
+
 
 		// Methods
 		.method public hidebysig static 
@@ -867,8 +1934,8 @@
 				[3] object,
 				[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[5] object[],
-				[6] class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_F1462999_L53C13,
-				[7] class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_00CA7359_L56C14
+				[6] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12/FunctionObject_FunctionExpression_F1462999_L53C13,
+				[7] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject_FunctionExpression_00CA7359_L56C14
 			)
 
 			IL_0000: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/Scope::.ctor()
@@ -916,13 +1983,13 @@
 			IL_0070: ldarg.0
 			IL_0071: stelem.ref
 			IL_0072: stloc.s 5
-			IL_0074: newobj instance void FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_F1462999_L53C13::.ctor()
+			IL_0074: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12/FunctionObject_FunctionExpression_F1462999_L53C13::.ctor()
 			IL_0079: ldc.i4.0
 			IL_007a: conv.r8
 			IL_007b: ldstr ""
 			IL_0080: ldc.i4.0
 			IL_0081: ldc.i4.1
-			IL_0082: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_F1462999_L53C13>(!!0, float64, string, bool, bool)
+			IL_0082: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12/FunctionObject_FunctionExpression_F1462999_L53C13>(!!0, float64, string, bool, bool)
 			IL_0087: stloc.s 6
 			IL_0089: ldloc.3
 			IL_008a: ldstr "then"
@@ -948,13 +2015,13 @@
 			IL_00b1: ldelem.ref
 			IL_00b2: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
 			IL_00b7: ldloc.s 5
-			IL_00b9: newobj instance void FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_00CA7359_L56C14::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object[])
+			IL_00b9: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject_FunctionExpression_00CA7359_L56C14::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object[])
 			IL_00be: ldc.i4.1
 			IL_00bf: conv.r8
 			IL_00c0: ldstr ""
 			IL_00c5: ldc.i4.0
 			IL_00c6: ldc.i4.1
-			IL_00c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_00CA7359_L56C14>(!!0, float64, string, bool, bool)
+			IL_00c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13/FunctionObject_FunctionExpression_00CA7359_L56C14>(!!0, float64, string, bool, bool)
 			IL_00cc: stloc.s 7
 			IL_00ce: ldloc.3
 			IL_00cf: ldstr "catch"
@@ -1021,14 +2088,14 @@
 			[1] object,
 			[2] object,
 			[3] object[],
-			[4] class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionDeclaration_552FE78F_createController,
-			[5] class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionDeclaration_44BD824F_logAbort,
+			[4] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionObject_FunctionDeclaration_552FE78F_createController,
+			[5] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/logAbort/FunctionObject_FunctionDeclaration_44BD824F_logAbort,
 			[6] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule,
 			[7] object,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[9] class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_E4BF264B_L42C9,
-			[10] class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_86CA2372_L45C10,
-			[11] class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_B08E779D_L48C9
+			[9] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L42C8/FunctionObject_FunctionExpression_E4BF264B_L42C9,
+			[10] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9/FunctionObject_FunctionExpression_86CA2372_L45C10,
+			[11] class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionObject_FunctionExpression_B08E779D_L48C9
 		)
 
 		IL_0000: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope::.ctor()
@@ -1044,13 +2111,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
-		IL_0019: newobj instance void FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionDeclaration_552FE78F_createController::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope)
+		IL_0019: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionObject_FunctionDeclaration_552FE78F_createController::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "createController"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionDeclaration_552FE78F_createController>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionObject_FunctionDeclaration_552FE78F_createController>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.s 4
 		IL_002e: ldloc.0
 		IL_002f: ldloc.s 4
@@ -1062,13 +2129,13 @@
 		IL_003e: ldloc.0
 		IL_003f: stelem.ref
 		IL_0040: stloc.3
-		IL_0041: newobj instance void FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionDeclaration_44BD824F_logAbort::.ctor()
+		IL_0041: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/logAbort/FunctionObject_FunctionDeclaration_44BD824F_logAbort::.ctor()
 		IL_0046: ldc.i4.1
 		IL_0047: conv.r8
 		IL_0048: ldstr "logAbort"
 		IL_004d: ldc.i4.0
 		IL_004e: ldc.i4.1
-		IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionDeclaration_44BD824F_logAbort>(!!0, float64, string, bool, bool)
+		IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/logAbort/FunctionObject_FunctionDeclaration_44BD824F_logAbort>(!!0, float64, string, bool, bool)
 		IL_0054: stloc.s 5
 		IL_0056: ldloc.0
 		IL_0057: ldloc.s 5
@@ -1123,13 +2190,13 @@
 		IL_00ee: ldloc.0
 		IL_00ef: stelem.ref
 		IL_00f0: stloc.3
-		IL_00f1: newobj instance void FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_E4BF264B_L42C9::.ctor()
+		IL_00f1: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L42C8/FunctionObject_FunctionExpression_E4BF264B_L42C9::.ctor()
 		IL_00f6: ldc.i4.0
 		IL_00f7: conv.r8
 		IL_00f8: ldstr ""
 		IL_00fd: ldc.i4.0
 		IL_00fe: ldc.i4.1
-		IL_00ff: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_E4BF264B_L42C9>(!!0, float64, string, bool, bool)
+		IL_00ff: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L42C8/FunctionObject_FunctionExpression_E4BF264B_L42C9>(!!0, float64, string, bool, bool)
 		IL_0104: stloc.s 9
 		IL_0106: ldloc.s 7
 		IL_0108: ldstr "then"
@@ -1150,13 +2217,13 @@
 		IL_012b: ldc.i4.0
 		IL_012c: ldelem.ref
 		IL_012d: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
-		IL_0132: newobj instance void FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_86CA2372_L45C10::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope)
+		IL_0132: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9/FunctionObject_FunctionExpression_86CA2372_L45C10::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope)
 		IL_0137: ldc.i4.1
 		IL_0138: conv.r8
 		IL_0139: ldstr ""
 		IL_013e: ldc.i4.0
 		IL_013f: ldc.i4.1
-		IL_0140: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_86CA2372_L45C10>(!!0, float64, string, bool, bool)
+		IL_0140: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9/FunctionObject_FunctionExpression_86CA2372_L45C10>(!!0, float64, string, bool, bool)
 		IL_0145: stloc.s 10
 		IL_0147: ldloc.s 7
 		IL_0149: ldstr "catch"
@@ -1177,13 +2244,13 @@
 		IL_016c: ldc.i4.0
 		IL_016d: ldelem.ref
 		IL_016e: castclass Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope
-		IL_0173: newobj instance void FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_B08E779D_L48C9::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope)
+		IL_0173: newobj instance void Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionObject_FunctionExpression_B08E779D_L48C9::.ctor(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope)
 		IL_0178: ldc.i4.0
 		IL_0179: conv.r8
 		IL_017a: ldstr ""
 		IL_017f: ldc.i4.0
 		IL_0180: ldc.i4.1
-		IL_0181: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_B08E779D_L48C9>(!!0, float64, string, bool, bool)
+		IL_0181: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionObject_FunctionExpression_B08E779D_L48C9>(!!0, float64, string, bool, bool)
 		IL_0186: stloc.s 11
 		IL_0188: ldloc.s 7
 		IL_018a: ldstr "then"
@@ -1194,1073 +2261,6 @@
 	} // end of method TimersPromises_Abort_RejectsSupportedOneShotApis::__js_module_init__
 
 } // end of class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionDeclaration_552FE78F_createController
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope _environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x26a6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionDeclaration_552FE78F_createController::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_552FE78F_createController::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x26b5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_552FE78F_createController::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x26b8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_552FE78F_createController::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x26bb
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionDeclaration_552FE78F_createController::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_552FE78F_createController::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26cd
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionDeclaration_552FE78F_createController::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_552FE78F_createController::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26db
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_552FE78F_createController::ConstructCore
-
-} // end of class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionDeclaration_552FE78F_createController
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_8F2862D0_L8C23
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x26ea
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_8F2862D0_L8C23::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x26f2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_8F2862D0_L8C23::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x26f5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_8F2862D0_L8C23::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x26f8
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_8F2862D0_L8C23::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2712
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_8F2862D0_L8C23::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2728
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_8F2862D0_L8C23::ConstructCore
-
-} // end of class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_8F2862D0_L8C23
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_C2488DF7_L13C26
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2737
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_C2488DF7_L13C26::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x273f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C2488DF7_L13C26::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2742
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C2488DF7_L13C26::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2745
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal_L13C25::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_C2488DF7_L13C26::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x275f
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_signal_L13C25::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_C2488DF7_L13C26::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2775
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C2488DF7_L13C26::ConstructCore
-
-} // end of class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_C2488DF7_L13C26
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_3A0BD2BC_L22C12
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope _environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
-	.field private initonly class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope _environment1_createController
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope capture0,
-			class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2784
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_3A0BD2BC_L22C12::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/Scope FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_3A0BD2BC_L22C12::_environment1_createController
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_3A0BD2BC_L22C12::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_3A0BD2BC_L22C12::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x27a1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3A0BD2BC_L22C12::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x27a4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3A0BD2BC_L22C12::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x27a7
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_3A0BD2BC_L22C12::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_3A0BD2BC_L22C12::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27b9
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_3A0BD2BC_L22C12::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/createController/FunctionExpression_L22C11::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_3A0BD2BC_L22C12::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27c7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3A0BD2BC_L22C12::ConstructCore
-
-} // end of class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_3A0BD2BC_L22C12
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionDeclaration_44BD824F_logAbort
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x27d6
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_44BD824F_logAbort::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x27de
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_44BD824F_logAbort::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x27e1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_44BD824F_logAbort::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x27e4
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/logAbort::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_44BD824F_logAbort::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27f7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/logAbort::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_44BD824F_logAbort::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2806
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_44BD824F_logAbort::ConstructCore
-
-} // end of class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionDeclaration_44BD824F_logAbort
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_E4BF264B_L42C9
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2815
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_E4BF264B_L42C9::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x281d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E4BF264B_L42C9::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2820
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E4BF264B_L42C9::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2823
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L42C8::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_E4BF264B_L42C9::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x282f
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L42C8::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_E4BF264B_L42C9::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2837
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E4BF264B_L42C9::ConstructCore
-
-} // end of class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_E4BF264B_L42C9
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_86CA2372_L45C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope _environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2846
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_86CA2372_L45C10::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_86CA2372_L45C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2855
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_86CA2372_L45C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2858
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_86CA2372_L45C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x285b
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_86CA2372_L45C10::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_86CA2372_L45C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2874
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_86CA2372_L45C10::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L45C9::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_86CA2372_L45C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2889
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_86CA2372_L45C10::ConstructCore
-
-} // end of class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_86CA2372_L45C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_B08E779D_L48C9
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope _environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2898
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_B08E779D_L48C9::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_B08E779D_L48C9::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x28a7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_B08E779D_L48C9::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x28aa
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_B08E779D_L48C9::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x28ad
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_B08E779D_L48C9::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_B08E779D_L48C9::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28bf
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_B08E779D_L48C9::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8::__js_call__(class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_B08E779D_L48C9::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28cd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_B08E779D_L48C9::ConstructCore
-
-} // end of class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_B08E779D_L48C9
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_F1462999_L53C13
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x28dc
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_F1462999_L53C13::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x28e4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F1462999_L53C13::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x28e7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F1462999_L53C13::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x28ea
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_F1462999_L53C13::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28f6
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L53C12::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_F1462999_L53C13::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28fe
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F1462999_L53C13::ConstructCore
-
-} // end of class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_F1462999_L53C13
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_00CA7359_L56C14
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope _environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x290d
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/Scope FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_00CA7359_L56C14::_environment0_TimersPromises_Abort_RejectsSupportedOneShotApis
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_00CA7359_L56C14::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_00CA7359_L56C14::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2923
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_00CA7359_L56C14::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2926
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_00CA7359_L56C14::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2929
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_00CA7359_L56C14::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_00CA7359_L56C14::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2942
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_00CA7359_L56C14::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.TimersPromises_Abort_RejectsSupportedOneShotApis/FunctionExpression_L48C8/FunctionExpression_L56C13::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_00CA7359_L56C14::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2957
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_00CA7359_L56C14::ConstructCore
-
-} // end of class FunctionObjects.TimersPromises_Abort_RejectsSupportedOneShotApis_9F4EE5EC.FunctionObject_FunctionExpression_00CA7359_L56C14
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B088FFC5_L8C18
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope _environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2344
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L8C17/FunctionObject_FunctionExpression_B088FFC5_L8C18::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_B088FFC5_L8C18::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2353
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_B088FFC5_L8C18::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2356
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_B088FFC5_L8C18::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2359
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L8C17/FunctionObject_FunctionExpression_B088FFC5_L8C18::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L8C17::__js_call__(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_B088FFC5_L8C18::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x236b
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L8C17/FunctionObject_FunctionExpression_B088FFC5_L8C18::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L8C17::__js_call__(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_B088FFC5_L8C18::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2379
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_B088FFC5_L8C18::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_B088FFC5_L8C18
+
 
 		// Methods
 		.method public hidebysig static 
@@ -88,6 +195,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_62CA5352_L12C25
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope _environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2388
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24/FunctionObject_FunctionExpression_62CA5352_L12C25::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_62CA5352_L12C25::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2397
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_62CA5352_L12C25::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x239a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_62CA5352_L12C25::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x239d
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24/FunctionObject_FunctionExpression_62CA5352_L12C25::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24::__js_call__(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_62CA5352_L12C25::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23af
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24/FunctionObject_FunctionExpression_62CA5352_L12C25::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24::__js_call__(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_62CA5352_L12C25::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23bd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_62CA5352_L12C25::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_62CA5352_L12C25
 
 
 		// Methods
@@ -150,6 +364,124 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_33286A9C_L19C55
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope _environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x241e
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54/FunctionObject_FunctionExpression_33286A9C_L19C55::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54/FunctionObject_FunctionExpression_33286A9C_L19C55::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionExpression_33286A9C_L19C55::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2434
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_33286A9C_L19C55::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2437
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_33286A9C_L19C55::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x243a
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54/FunctionObject_FunctionExpression_33286A9C_L19C55::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_33286A9C_L19C55::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2453
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54/FunctionObject_FunctionExpression_33286A9C_L19C55::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_33286A9C_L19C55::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2468
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_33286A9C_L19C55::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_33286A9C_L19C55
 
 
 			// Methods
@@ -264,6 +596,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_85A874E2_L16C47
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope _environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x23cc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionObject_FunctionExpression_85A874E2_L16C47::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_85A874E2_L16C47::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x23db
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_85A874E2_L16C47::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x23de
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_85A874E2_L16C47::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x23e1
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionObject_FunctionExpression_85A874E2_L16C47::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46::__js_call__(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_85A874E2_L16C47::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23fa
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionObject_FunctionExpression_85A874E2_L16C47::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46::__js_call__(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_85A874E2_L16C47::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x240f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_85A874E2_L16C47::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_85A874E2_L16C47
+
 
 		// Methods
 		.method public hidebysig static 
@@ -288,7 +733,7 @@
 				[2] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule,
 				[3] object,
 				[4] object[],
-				[5] class FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_33286A9C_L19C55
+				[5] class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54/FunctionObject_FunctionExpression_33286A9C_L19C55
 			)
 
 			IL_0000: newobj instance void Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/Scope::.ctor()
@@ -328,13 +773,13 @@
 			IL_0050: ldelem.ref
 			IL_0051: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
 			IL_0056: ldloc.s 4
-			IL_0058: newobj instance void FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_33286A9C_L19C55::.ctor(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object[])
+			IL_0058: newobj instance void Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54/FunctionObject_FunctionExpression_33286A9C_L19C55::.ctor(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object[])
 			IL_005d: ldc.i4.1
 			IL_005e: conv.r8
 			IL_005f: ldstr ""
 			IL_0064: ldc.i4.0
 			IL_0065: ldc.i4.1
-			IL_0066: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_33286A9C_L19C55>(!!0, float64, string, bool, bool)
+			IL_0066: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54/FunctionObject_FunctionExpression_33286A9C_L19C55>(!!0, float64, string, bool, bool)
 			IL_006b: stloc.s 5
 			IL_006d: ldloc.3
 			IL_006e: ldstr "then"
@@ -398,9 +843,9 @@
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] object,
 			[4] object[],
-			[5] class FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_B088FFC5_L8C18,
-			[6] class FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_62CA5352_L12C25,
-			[7] class FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_85A874E2_L16C47
+			[5] class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L8C17/FunctionObject_FunctionExpression_B088FFC5_L8C18,
+			[6] class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24/FunctionObject_FunctionExpression_62CA5352_L12C25,
+			[7] class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionObject_FunctionExpression_85A874E2_L16C47
 		)
 
 		IL_0000: newobj instance void Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope::.ctor()
@@ -441,13 +886,13 @@
 		IL_0059: ldc.i4.0
 		IL_005a: ldelem.ref
 		IL_005b: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
-		IL_0060: newobj instance void FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_B088FFC5_L8C18::.ctor(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope)
+		IL_0060: newobj instance void Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L8C17/FunctionObject_FunctionExpression_B088FFC5_L8C18::.ctor(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope)
 		IL_0065: ldc.i4.0
 		IL_0066: conv.r8
 		IL_0067: ldstr ""
 		IL_006c: ldc.i4.0
 		IL_006d: ldc.i4.1
-		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_B088FFC5_L8C18>(!!0, float64, string, bool, bool)
+		IL_006e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L8C17/FunctionObject_FunctionExpression_B088FFC5_L8C18>(!!0, float64, string, bool, bool)
 		IL_0073: stloc.s 5
 		IL_0075: ldloc.3
 		IL_0076: ldstr "nextTick"
@@ -470,13 +915,13 @@
 		IL_00aa: ldc.i4.0
 		IL_00ab: ldelem.ref
 		IL_00ac: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
-		IL_00b1: newobj instance void FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_62CA5352_L12C25::.ctor(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope)
+		IL_00b1: newobj instance void Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24/FunctionObject_FunctionExpression_62CA5352_L12C25::.ctor(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope)
 		IL_00b6: ldc.i4.0
 		IL_00b7: conv.r8
 		IL_00b8: ldstr ""
 		IL_00bd: ldc.i4.0
 		IL_00be: ldc.i4.1
-		IL_00bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_62CA5352_L12C25>(!!0, float64, string, bool, bool)
+		IL_00bf: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24/FunctionObject_FunctionExpression_62CA5352_L12C25>(!!0, float64, string, bool, bool)
 		IL_00c4: stloc.s 6
 		IL_00c6: ldloc.3
 		IL_00c7: ldstr "then"
@@ -504,13 +949,13 @@
 		IL_00fc: ldc.i4.0
 		IL_00fd: ldelem.ref
 		IL_00fe: castclass Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope
-		IL_0103: newobj instance void FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_85A874E2_L16C47::.ctor(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope)
+		IL_0103: newobj instance void Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionObject_FunctionExpression_85A874E2_L16C47::.ctor(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope)
 		IL_0108: ldc.i4.1
 		IL_0109: conv.r8
 		IL_010a: ldstr ""
 		IL_010f: ldc.i4.0
 		IL_0110: ldc.i4.1
-		IL_0111: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_85A874E2_L16C47>(!!0, float64, string, bool, bool)
+		IL_0111: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionObject_FunctionExpression_85A874E2_L16C47>(!!0, float64, string, bool, bool)
 		IL_0116: stloc.s 7
 		IL_0118: ldloc.3
 		IL_0119: ldstr "then"
@@ -521,451 +966,6 @@
 	} // end of method TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks::__js_module_init__
 
 } // end of class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_B088FFC5_L8C18
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope _environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2344
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_B088FFC5_L8C18::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_B088FFC5_L8C18::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2353
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_B088FFC5_L8C18::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2356
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_B088FFC5_L8C18::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2359
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_B088FFC5_L8C18::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L8C17::__js_call__(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_B088FFC5_L8C18::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x236b
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_B088FFC5_L8C18::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L8C17::__js_call__(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_B088FFC5_L8C18::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2379
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_B088FFC5_L8C18::ConstructCore
-
-} // end of class FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_B088FFC5_L8C18
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_62CA5352_L12C25
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope _environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2388
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_62CA5352_L12C25::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_62CA5352_L12C25::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2397
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_62CA5352_L12C25::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x239a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_62CA5352_L12C25::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x239d
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_62CA5352_L12C25::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24::__js_call__(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_62CA5352_L12C25::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23af
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_62CA5352_L12C25::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L12C24::__js_call__(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_62CA5352_L12C25::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23bd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_62CA5352_L12C25::ConstructCore
-
-} // end of class FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_62CA5352_L12C25
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_85A874E2_L16C47
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope _environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x23cc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_85A874E2_L16C47::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_85A874E2_L16C47::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23db
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_85A874E2_L16C47::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23de
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_85A874E2_L16C47::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23e1
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_85A874E2_L16C47::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46::__js_call__(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_85A874E2_L16C47::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23fa
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_85A874E2_L16C47::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46::__js_call__(class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_85A874E2_L16C47::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x240f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_85A874E2_L16C47::ConstructCore
-
-} // end of class FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_85A874E2_L16C47
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_33286A9C_L19C55
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope _environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x241e
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/Scope FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_33286A9C_L19C55::_environment0_TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_33286A9C_L19C55::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_33286A9C_L19C55::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2434
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_33286A9C_L19C55::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2437
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_33286A9C_L19C55::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x243a
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_33286A9C_L19C55::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_33286A9C_L19C55::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2453
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_33286A9C_L19C55::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks/FunctionExpression_L16C46/FunctionExpression_L19C54::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_33286A9C_L19C55::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2468
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_33286A9C_L19C55::ConstructCore
-
-} // end of class FunctionObjects.TimersPromises_Ordering_WithNextTick_AndPromiseMicrotasks_C835BB94.FunctionObject_FunctionExpression_33286A9C_L19C55
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetImmediate_AwaitsValue.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetImmediate_AwaitsValue.verified.txt
@@ -41,6 +41,100 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_28C8AC9A_main
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21ef
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.TimersPromises_SetImmediate_AwaitsValue/main/FunctionObject_FunctionDeclaration_28C8AC9A_main::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_28C8AC9A_main::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21fe
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_28C8AC9A_main::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2201
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_28C8AC9A_main::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2204
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.TimersPromises_SetImmediate_AwaitsValue/main/FunctionObject_FunctionDeclaration_28C8AC9A_main::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.TimersPromises_SetImmediate_AwaitsValue/main::__js_call__(object[], object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_28C8AC9A_main::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x221d
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.TimersPromises_SetImmediate_AwaitsValue/main/FunctionObject_FunctionDeclaration_28C8AC9A_main::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.TimersPromises_SetImmediate_AwaitsValue/main::__js_call__(object[], object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_28C8AC9A_main::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_28C8AC9A_main
+
 
 		// Methods
 		.method public hidebysig static 
@@ -277,100 +371,6 @@
 	} // end of method TimersPromises_SetImmediate_AwaitsValue::__js_module_init__
 
 } // end of class Modules.TimersPromises_SetImmediate_AwaitsValue
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_SetImmediate_AwaitsValue_04A160A4.FunctionObject_FunctionDeclaration_28C8AC9A_main
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ef
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.TimersPromises_SetImmediate_AwaitsValue_04A160A4.FunctionObject_FunctionDeclaration_28C8AC9A_main::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_28C8AC9A_main::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21fe
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_28C8AC9A_main::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2201
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_28C8AC9A_main::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2204
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.TimersPromises_SetImmediate_AwaitsValue_04A160A4.FunctionObject_FunctionDeclaration_28C8AC9A_main::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.TimersPromises_SetImmediate_AwaitsValue/main::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_28C8AC9A_main::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x221d
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.TimersPromises_SetImmediate_AwaitsValue_04A160A4.FunctionObject_FunctionDeclaration_28C8AC9A_main::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.TimersPromises_SetImmediate_AwaitsValue/main::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_28C8AC9A_main::ConstructBodyCore
-
-} // end of class FunctionObjects.TimersPromises_SetImmediate_AwaitsValue_04A160A4.FunctionObject_FunctionDeclaration_28C8AC9A_main
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Abort_RejectsActiveIterator.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Abort_RejectsActiveIterator.verified.txt
@@ -57,6 +57,113 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DA4E8BE8_L9C23
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x2882
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_DA4E8BE8_L9C23::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x288a
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_DA4E8BE8_L9C23::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x288d
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_DA4E8BE8_L9C23::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2890
+					// Header size: 1
+					// Code size: 25 (0x19)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: ldarg.2
+					IL_0006: ldc.i4.0
+					IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000c: ldarg.2
+					IL_000d: ldc.i4.1
+					IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0013: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal::__js_call__(object, object, object)
+					IL_0018: ret
+				} // end of method FunctionObject_FunctionExpression_DA4E8BE8_L9C23::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x28aa
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: ldarg.2
+					IL_0002: ldc.i4.0
+					IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0008: ldarg.2
+					IL_0009: ldc.i4.1
+					IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000f: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal::__js_call__(object, object, object)
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionExpression_DA4E8BE8_L9C23::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x28c0
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_DA4E8BE8_L9C23::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_DA4E8BE8_L9C23
+
 
 			// Methods
 			.method public hidebysig static 
@@ -143,6 +250,113 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_CF26639F_L14C26
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x28cf
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_CF26639F_L14C26::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x28d7
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_CF26639F_L14C26::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x28da
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_CF26639F_L14C26::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x28dd
+					// Header size: 1
+					// Code size: 25 (0x19)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: ldarg.2
+					IL_0006: ldc.i4.0
+					IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000c: ldarg.2
+					IL_000d: ldc.i4.1
+					IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0013: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal_L14C25::__js_call__(object, object, object)
+					IL_0018: ret
+				} // end of method FunctionObject_FunctionExpression_CF26639F_L14C26::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x28f7
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: ldarg.2
+					IL_0002: ldc.i4.0
+					IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0008: ldarg.2
+					IL_0009: ldc.i4.1
+					IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000f: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal_L14C25::__js_call__(object, object, object)
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionExpression_CF26639F_L14C26::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x290d
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_CF26639F_L14C26::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_CF26639F_L14C26
 
 
 			// Methods
@@ -268,6 +482,129 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C092881A_L23C12
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope _environment0_TimersPromises_SetInterval_Abort_RejectsActiveIterator
+				.field private initonly class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope _environment1_createController
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope capture0,
+						class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x291c
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/FunctionObject_FunctionExpression_C092881A_L23C12::_environment0_TimersPromises_SetInterval_Abort_RejectsActiveIterator
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/FunctionObject_FunctionExpression_C092881A_L23C12::_environment1_createController
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/FunctionObject_FunctionExpression_C092881A_L23C12::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_C092881A_L23C12::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2939
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_C092881A_L23C12::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x293c
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_C092881A_L23C12::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x293f
+					// Header size: 1
+					// Code size: 24 (0x18)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/FunctionObject_FunctionExpression_C092881A_L23C12::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11::__js_call__(object[], object, object)
+					IL_0017: ret
+				} // end of method FunctionObject_FunctionExpression_C092881A_L23C12::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2958
+					// Header size: 1
+					// Code size: 20 (0x14)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/FunctionObject_FunctionExpression_C092881A_L23C12::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11::__js_call__(object[], object, object)
+					IL_0013: ret
+				} // end of method FunctionObject_FunctionExpression_C092881A_L23C12::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x296d
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_C092881A_L23C12::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_C092881A_L23C12
+
 
 			// Methods
 			.method public hidebysig static 
@@ -371,6 +708,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_12B63234_createController
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope _environment0_TimersPromises_SetInterval_Abort_RejectsActiveIterator
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x283e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionObject_FunctionDeclaration_12B63234_createController::_environment0_TimersPromises_SetInterval_Abort_RejectsActiveIterator
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_12B63234_createController::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x284d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_12B63234_createController::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2850
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_12B63234_createController::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2853
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionObject_FunctionDeclaration_12B63234_createController::_environment0_TimersPromises_SetInterval_Abort_RejectsActiveIterator
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController::__js_call__(class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_12B63234_createController::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2865
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionObject_FunctionDeclaration_12B63234_createController::_environment0_TimersPromises_SetInterval_Abort_RejectsActiveIterator
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController::__js_call__(class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_12B63234_createController::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2873
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_12B63234_createController::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_12B63234_createController
+
 
 		// Methods
 		.method public hidebysig static 
@@ -391,11 +835,11 @@
 			.locals init (
 				[0] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope,
 				[1] object[],
-				[2] class FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_DA4E8BE8_L9C23,
-				[3] class FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_CF26639F_L14C26,
+				[2] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal/FunctionObject_FunctionExpression_DA4E8BE8_L9C23,
+				[3] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal_L14C25/FunctionObject_FunctionExpression_CF26639F_L14C26,
 				[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[5] object,
-				[6] class FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_C092881A_L23C12
+				[6] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/FunctionObject_FunctionExpression_C092881A_L23C12
 			)
 
 			IL_0000: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope::.ctor()
@@ -407,13 +851,13 @@
 			IL_000e: ldarg.0
 			IL_000f: stelem.ref
 			IL_0010: stloc.1
-			IL_0011: newobj instance void FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_DA4E8BE8_L9C23::.ctor()
+			IL_0011: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal/FunctionObject_FunctionExpression_DA4E8BE8_L9C23::.ctor()
 			IL_0016: ldc.i4.2
 			IL_0017: conv.r8
 			IL_0018: ldstr ""
 			IL_001d: ldc.i4.1
 			IL_001e: ldc.i4.1
-			IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_DA4E8BE8_L9C23>(!!0, float64, string, bool, bool)
+			IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal/FunctionObject_FunctionExpression_DA4E8BE8_L9C23>(!!0, float64, string, bool, bool)
 			IL_0024: stloc.2
 			IL_0025: ldc.i4.1
 			IL_0026: newarr [System.Runtime]System.Object
@@ -422,13 +866,13 @@
 			IL_002d: ldarg.0
 			IL_002e: stelem.ref
 			IL_002f: stloc.1
-			IL_0030: newobj instance void FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_CF26639F_L14C26::.ctor()
+			IL_0030: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal_L14C25/FunctionObject_FunctionExpression_CF26639F_L14C26::.ctor()
 			IL_0035: ldc.i4.2
 			IL_0036: conv.r8
 			IL_0037: ldstr ""
 			IL_003c: ldc.i4.1
 			IL_003d: ldc.i4.1
-			IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_CF26639F_L14C26>(!!0, float64, string, bool, bool)
+			IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal_L14C25/FunctionObject_FunctionExpression_CF26639F_L14C26>(!!0, float64, string, bool, bool)
 			IL_0043: stloc.3
 			IL_0044: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_0049: dup
@@ -475,13 +919,13 @@
 			IL_00a9: ldelem.ref
 			IL_00aa: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope
 			IL_00af: ldloc.1
-			IL_00b0: newobj instance void FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_C092881A_L23C12::.ctor(class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope, class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope, object[])
+			IL_00b0: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/FunctionObject_FunctionExpression_C092881A_L23C12::.ctor(class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope, class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope, object[])
 			IL_00b5: ldc.i4.1
 			IL_00b6: conv.r8
 			IL_00b7: ldstr ""
 			IL_00bc: ldc.i4.0
 			IL_00bd: ldc.i4.1
-			IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_C092881A_L23C12>(!!0, float64, string, bool, bool)
+			IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11/FunctionObject_FunctionExpression_C092881A_L23C12>(!!0, float64, string, bool, bool)
 			IL_00c3: stloc.s 6
 			IL_00c5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 			IL_00ca: dup
@@ -526,6 +970,101 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8CB3E255_L46C11
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x29b8
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_8CB3E255_L46C11::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x29c0
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_8CB3E255_L46C11::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x29c3
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_8CB3E255_L46C11::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x29c6
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10::__js_call__(object)
+					IL_000a: ret
+				} // end of method FunctionObject_FunctionExpression_8CB3E255_L46C11::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x29d2
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10::__js_call__(object)
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_8CB3E255_L46C11::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x29da
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_8CB3E255_L46C11::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_8CB3E255_L46C11
 
 
 			// Methods
@@ -578,6 +1117,107 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_6820A98B_L49C12
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x29e9
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_6820A98B_L49C12::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x29f1
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_6820A98B_L49C12::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x29f4
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_6820A98B_L49C12::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x29f7
+					// Header size: 1
+					// Code size: 18 (0x12)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: ldarg.2
+					IL_0006: ldc.i4.0
+					IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000c: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11::__js_call__(object, object)
+					IL_0011: ret
+				} // end of method FunctionObject_FunctionExpression_6820A98B_L49C12::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2a0a
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: ldarg.2
+					IL_0002: ldc.i4.0
+					IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0008: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11::__js_call__(object, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_6820A98B_L49C12::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2a19
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_6820A98B_L49C12::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_6820A98B_L49C12
 
 
 			// Methods
@@ -713,6 +1353,99 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_AF64659D_main
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope _environment0_TimersPromises_SetInterval_Abort_RejectsActiveIterator
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x297c
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionObject_FunctionDeclaration_AF64659D_main::_environment0_TimersPromises_SetInterval_Abort_RejectsActiveIterator
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionObject_FunctionDeclaration_AF64659D_main::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_AF64659D_main::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2992
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_AF64659D_main::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2995
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_AF64659D_main::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2998
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionObject_FunctionDeclaration_AF64659D_main::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_AF64659D_main::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x29aa
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionObject_FunctionDeclaration_AF64659D_main::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_AF64659D_main::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_AF64659D_main
+
 
 		// Methods
 		.method public hidebysig static 
@@ -740,8 +1473,8 @@
 				[8] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 				[9] object,
 				[10] class [JavaScriptRuntime]JavaScriptRuntime.Error,
-				[11] class FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_8CB3E255_L46C11,
-				[12] class FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_6820A98B_L49C12
+				[11] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10/FunctionObject_FunctionExpression_8CB3E255_L46C11,
+				[12] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11/FunctionObject_FunctionExpression_6820A98B_L49C12
 			)
 
 			IL_0000: ldarg.0
@@ -832,12 +1565,12 @@
 			IL_00aa: dup
 			IL_00ab: ldc.i4.s 10
 			IL_00ad: ldelem.ref
-			IL_00ae: castclass FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_8CB3E255_L46C11
+			IL_00ae: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10/FunctionObject_FunctionExpression_8CB3E255_L46C11
 			IL_00b3: stloc.s 11
 			IL_00b5: dup
 			IL_00b6: ldc.i4.s 11
 			IL_00b8: ldelem.ref
-			IL_00b9: castclass FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_6820A98B_L49C12
+			IL_00b9: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11/FunctionObject_FunctionExpression_6820A98B_L49C12
 			IL_00be: stloc.s 12
 			IL_00c0: pop
 
@@ -1097,13 +1830,13 @@
 			IL_02fe: ldelem.ref
 			IL_02ff: stelem.ref
 			IL_0300: stloc.s 5
-			IL_0302: newobj instance void FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_8CB3E255_L46C11::.ctor()
+			IL_0302: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10/FunctionObject_FunctionExpression_8CB3E255_L46C11::.ctor()
 			IL_0307: ldc.i4.0
 			IL_0308: conv.r8
 			IL_0309: ldstr ""
 			IL_030e: ldc.i4.0
 			IL_030f: ldc.i4.1
-			IL_0310: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_8CB3E255_L46C11>(!!0, float64, string, bool, bool)
+			IL_0310: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10/FunctionObject_FunctionExpression_8CB3E255_L46C11>(!!0, float64, string, bool, bool)
 			IL_0315: stloc.s 11
 			IL_0317: ldloc.s 7
 			IL_0319: ldstr "then"
@@ -1122,13 +1855,13 @@
 			IL_033a: ldelem.ref
 			IL_033b: stelem.ref
 			IL_033c: stloc.s 5
-			IL_033e: newobj instance void FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_6820A98B_L49C12::.ctor()
+			IL_033e: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11/FunctionObject_FunctionExpression_6820A98B_L49C12::.ctor()
 			IL_0343: ldc.i4.1
 			IL_0344: conv.r8
 			IL_0345: ldstr ""
 			IL_034a: ldc.i4.0
 			IL_034b: ldc.i4.1
-			IL_034c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_6820A98B_L49C12>(!!0, float64, string, bool, bool)
+			IL_034c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11/FunctionObject_FunctionExpression_6820A98B_L49C12>(!!0, float64, string, bool, bool)
 			IL_0351: stloc.s 12
 			IL_0353: ldloc.s 7
 			IL_0355: ldstr "catch"
@@ -1210,7 +1943,7 @@
 			[0] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
 			[2] object[],
-			[3] class FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionDeclaration_12B63234_createController,
+			[3] class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionObject_FunctionDeclaration_12B63234_createController,
 			[4] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.ITimersPromisesModule
 		)
 
@@ -1227,13 +1960,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope
-		IL_0019: newobj instance void FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionDeclaration_12B63234_createController::.ctor(class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope)
+		IL_0019: newobj instance void Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionObject_FunctionDeclaration_12B63234_createController::.ctor(class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "createController"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionDeclaration_12B63234_createController>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionObject_FunctionDeclaration_12B63234_createController>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.3
 		IL_002d: ldloc.0
 		IL_002e: ldloc.3
@@ -1274,739 +2007,6 @@
 	} // end of method TimersPromises_SetInterval_Abort_RejectsActiveIterator::__js_module_init__
 
 } // end of class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionDeclaration_12B63234_createController
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope _environment0_TimersPromises_SetInterval_Abort_RejectsActiveIterator
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x283e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionDeclaration_12B63234_createController::_environment0_TimersPromises_SetInterval_Abort_RejectsActiveIterator
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_12B63234_createController::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x284d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_12B63234_createController::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2850
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_12B63234_createController::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2853
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionDeclaration_12B63234_createController::_environment0_TimersPromises_SetInterval_Abort_RejectsActiveIterator
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController::__js_call__(class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_12B63234_createController::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2865
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionDeclaration_12B63234_createController::_environment0_TimersPromises_SetInterval_Abort_RejectsActiveIterator
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController::__js_call__(class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_12B63234_createController::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2873
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_12B63234_createController::ConstructCore
-
-} // end of class FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionDeclaration_12B63234_createController
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_DA4E8BE8_L9C23
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2882
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_DA4E8BE8_L9C23::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x288a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DA4E8BE8_L9C23::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x288d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DA4E8BE8_L9C23::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2890
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_DA4E8BE8_L9C23::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28aa
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_DA4E8BE8_L9C23::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28c0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DA4E8BE8_L9C23::ConstructCore
-
-} // end of class FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_DA4E8BE8_L9C23
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_CF26639F_L14C26
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x28cf
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_CF26639F_L14C26::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x28d7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_CF26639F_L14C26::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x28da
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_CF26639F_L14C26::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x28dd
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal_L14C25::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_CF26639F_L14C26::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28f7
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_signal_L14C25::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_CF26639F_L14C26::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x290d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_CF26639F_L14C26::ConstructCore
-
-} // end of class FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_CF26639F_L14C26
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_C092881A_L23C12
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope _environment0_TimersPromises_SetInterval_Abort_RejectsActiveIterator
-	.field private initonly class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope _environment1_createController
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope capture0,
-			class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x291c
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_C092881A_L23C12::_environment0_TimersPromises_SetInterval_Abort_RejectsActiveIterator
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/Scope FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_C092881A_L23C12::_environment1_createController
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_C092881A_L23C12::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_C092881A_L23C12::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2939
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C092881A_L23C12::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x293c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C092881A_L23C12::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x293f
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_C092881A_L23C12::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_C092881A_L23C12::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2958
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_C092881A_L23C12::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/createController/FunctionExpression_L23C11::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_C092881A_L23C12::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x296d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C092881A_L23C12::ConstructCore
-
-} // end of class FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_C092881A_L23C12
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionDeclaration_AF64659D_main
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope _environment0_TimersPromises_SetInterval_Abort_RejectsActiveIterator
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x297c
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/Scope FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionDeclaration_AF64659D_main::_environment0_TimersPromises_SetInterval_Abort_RejectsActiveIterator
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionDeclaration_AF64659D_main::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_AF64659D_main::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2992
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_AF64659D_main::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2995
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_AF64659D_main::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2998
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionDeclaration_AF64659D_main::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_AF64659D_main::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29aa
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionDeclaration_AF64659D_main::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_AF64659D_main::ConstructBodyCore
-
-} // end of class FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionDeclaration_AF64659D_main
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_8CB3E255_L46C11
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x29b8
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_8CB3E255_L46C11::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x29c0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_8CB3E255_L46C11::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x29c3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_8CB3E255_L46C11::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x29c6
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_8CB3E255_L46C11::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29d2
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L46C10::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_8CB3E255_L46C11::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29da
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_8CB3E255_L46C11::ConstructCore
-
-} // end of class FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_8CB3E255_L46C11
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_6820A98B_L49C12
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x29e9
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_6820A98B_L49C12::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x29f1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6820A98B_L49C12::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x29f4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_6820A98B_L49C12::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x29f7
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_6820A98B_L49C12::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a0a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.TimersPromises_SetInterval_Abort_RejectsActiveIterator/main/FunctionExpression_L49C11::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_6820A98B_L49C12::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a19
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_6820A98B_L49C12::ConstructCore
-
-} // end of class FunctionObjects.TimersPromises_SetInterval_Abort_RejectsActiveIterator_1793448D.FunctionObject_FunctionExpression_6820A98B_L49C12
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Backpressure_And_Return.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_Backpressure_And_Return.verified.txt
@@ -62,6 +62,99 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8247CAD9_main
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope _environment0_TimersPromises_SetInterval_Backpressure_And_Return
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x26aa
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/FunctionObject_FunctionDeclaration_8247CAD9_main::_environment0_TimersPromises_SetInterval_Backpressure_And_Return
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/FunctionObject_FunctionDeclaration_8247CAD9_main::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_8247CAD9_main::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x26c0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8247CAD9_main::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x26c3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8247CAD9_main::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x26c6
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/FunctionObject_FunctionDeclaration_8247CAD9_main::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_8247CAD9_main::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26d8
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.TimersPromises_SetInterval_Backpressure_And_Return/main/FunctionObject_FunctionDeclaration_8247CAD9_main::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_8247CAD9_main::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_8247CAD9_main
+
 
 		// Methods
 		.method public hidebysig static 
@@ -870,99 +963,6 @@
 	} // end of method TimersPromises_SetInterval_Backpressure_And_Return::__js_module_init__
 
 } // end of class Modules.TimersPromises_SetInterval_Backpressure_And_Return
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_SetInterval_Backpressure_And_Return_A22FE5A9.FunctionObject_FunctionDeclaration_8247CAD9_main
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope _environment0_TimersPromises_SetInterval_Backpressure_And_Return
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x26aa
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.TimersPromises_SetInterval_Backpressure_And_Return/Scope FunctionObjects.TimersPromises_SetInterval_Backpressure_And_Return_A22FE5A9.FunctionObject_FunctionDeclaration_8247CAD9_main::_environment0_TimersPromises_SetInterval_Backpressure_And_Return
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.TimersPromises_SetInterval_Backpressure_And_Return_A22FE5A9.FunctionObject_FunctionDeclaration_8247CAD9_main::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_8247CAD9_main::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x26c0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8247CAD9_main::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x26c3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8247CAD9_main::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x26c6
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.TimersPromises_SetInterval_Backpressure_And_Return_A22FE5A9.FunctionObject_FunctionDeclaration_8247CAD9_main::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_8247CAD9_main::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26d8
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.TimersPromises_SetInterval_Backpressure_And_Return_A22FE5A9.FunctionObject_FunctionDeclaration_8247CAD9_main::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.TimersPromises_SetInterval_Backpressure_And_Return/main::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_8247CAD9_main::ConstructBodyCore
-
-} // end of class FunctionObjects.TimersPromises_SetInterval_Backpressure_And_Return_A22FE5A9.FunctionObject_FunctionDeclaration_8247CAD9_main
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown.verified.txt
@@ -105,6 +105,99 @@
 
 		} // end of class Scope_ForOf_L8C13
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8194F888_main
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/Scope _environment0_TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x24fe
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/Scope Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/FunctionObject_FunctionDeclaration_8194F888_main::_environment0_TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/FunctionObject_FunctionDeclaration_8194F888_main::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_8194F888_main::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2514
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8194F888_main::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2517
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8194F888_main::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x251a
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/FunctionObject_FunctionDeclaration_8194F888_main::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_8194F888_main::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x252c
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main/FunctionObject_FunctionDeclaration_8194F888_main::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_8194F888_main::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_8194F888_main
+
 
 		// Methods
 		.method public hidebysig static 
@@ -672,99 +765,6 @@
 	} // end of method TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown::__js_module_init__
 
 } // end of class Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown_CE4AA196.FunctionObject_FunctionDeclaration_8194F888_main
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/Scope _environment0_TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x24fe
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/Scope FunctionObjects.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown_CE4AA196.FunctionObject_FunctionDeclaration_8194F888_main::_environment0_TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown_CE4AA196.FunctionObject_FunctionDeclaration_8194F888_main::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_8194F888_main::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2514
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8194F888_main::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2517
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8194F888_main::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x251a
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown_CE4AA196.FunctionObject_FunctionDeclaration_8194F888_main::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_8194F888_main::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x252c
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown_CE4AA196.FunctionObject_FunctionDeclaration_8194F888_main::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown/main::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_8194F888_main::ConstructBodyCore
-
-} // end of class FunctionObjects.TimersPromises_SetInterval_ForAwait_BreaksAndTearsDown_CE4AA196.FunctionObject_FunctionDeclaration_8194F888_main
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_InfinityDelay_ClampsToTick.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetInterval_InfinityDelay_ClampsToTick.verified.txt
@@ -46,6 +46,99 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_88CCDF06_main
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/Scope _environment0_TimersPromises_SetInterval_InfinityDelay_ClampsToTick
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/Scope capture0,
+					object[] capture1
+				) cil managed 
+			{
+				// Method begins at RVA 0x2325
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/Scope Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/FunctionObject_FunctionDeclaration_88CCDF06_main::_environment0_TimersPromises_SetInterval_InfinityDelay_ClampsToTick
+				IL_000d: ldarg.0
+				IL_000e: ldarg.2
+				IL_000f: stfld object[] Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/FunctionObject_FunctionDeclaration_88CCDF06_main::_transitionalScopes
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_88CCDF06_main::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x233b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_88CCDF06_main::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x233e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_88CCDF06_main::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2341
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/FunctionObject_FunctionDeclaration_88CCDF06_main::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_88CCDF06_main::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2353
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main/FunctionObject_FunctionDeclaration_88CCDF06_main::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_88CCDF06_main::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_88CCDF06_main
+
 
 		// Methods
 		.method public hidebysig static 
@@ -418,99 +511,6 @@
 	} // end of method TimersPromises_SetInterval_InfinityDelay_ClampsToTick::__js_module_init__
 
 } // end of class Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_SetInterval_InfinityDelay_ClampsToTick_A6EE70E0.FunctionObject_FunctionDeclaration_88CCDF06_main
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/Scope _environment0_TimersPromises_SetInterval_InfinityDelay_ClampsToTick
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x2325
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/Scope FunctionObjects.TimersPromises_SetInterval_InfinityDelay_ClampsToTick_A6EE70E0.FunctionObject_FunctionDeclaration_88CCDF06_main::_environment0_TimersPromises_SetInterval_InfinityDelay_ClampsToTick
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.TimersPromises_SetInterval_InfinityDelay_ClampsToTick_A6EE70E0.FunctionObject_FunctionDeclaration_88CCDF06_main::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_88CCDF06_main::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x233b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_88CCDF06_main::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x233e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_88CCDF06_main::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2341
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.TimersPromises_SetInterval_InfinityDelay_ClampsToTick_A6EE70E0.FunctionObject_FunctionDeclaration_88CCDF06_main::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_88CCDF06_main::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2353
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.TimersPromises_SetInterval_InfinityDelay_ClampsToTick_A6EE70E0.FunctionObject_FunctionDeclaration_88CCDF06_main::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.TimersPromises_SetInterval_InfinityDelay_ClampsToTick/main::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_88CCDF06_main::ConstructBodyCore
-
-} // end of class FunctionObjects.TimersPromises_SetInterval_InfinityDelay_ClampsToTick_A6EE70E0.FunctionObject_FunctionDeclaration_88CCDF06_main
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetTimeout_AwaitsValue.verified.txt
+++ b/tests/Jroc.Tests/Node/TimersPromises/Snapshots/GeneratorTests.TimersPromises_SetTimeout_AwaitsValue.verified.txt
@@ -41,6 +41,100 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5AC71590_main
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21fd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.TimersPromises_SetTimeout_AwaitsValue/main/FunctionObject_FunctionDeclaration_5AC71590_main::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5AC71590_main::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x220c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5AC71590_main::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x220f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5AC71590_main::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2212
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.TimersPromises_SetTimeout_AwaitsValue/main/FunctionObject_FunctionDeclaration_5AC71590_main::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.TimersPromises_SetTimeout_AwaitsValue/main::__js_call__(object[], object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_5AC71590_main::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x222b
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.TimersPromises_SetTimeout_AwaitsValue/main/FunctionObject_FunctionDeclaration_5AC71590_main::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.TimersPromises_SetTimeout_AwaitsValue/main::__js_call__(object[], object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_5AC71590_main::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionDeclaration_5AC71590_main
+
 
 		// Methods
 		.method public hidebysig static 
@@ -279,100 +373,6 @@
 	} // end of method TimersPromises_SetTimeout_AwaitsValue::__js_module_init__
 
 } // end of class Modules.TimersPromises_SetTimeout_AwaitsValue
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TimersPromises_SetTimeout_AwaitsValue_F3EA045E.FunctionObject_FunctionDeclaration_5AC71590_main
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21fd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.TimersPromises_SetTimeout_AwaitsValue_F3EA045E.FunctionObject_FunctionDeclaration_5AC71590_main::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5AC71590_main::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x220c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5AC71590_main::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x220f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5AC71590_main::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2212
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.TimersPromises_SetTimeout_AwaitsValue_F3EA045E.FunctionObject_FunctionDeclaration_5AC71590_main::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.TimersPromises_SetTimeout_AwaitsValue/main::__js_call__(object[], object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_5AC71590_main::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x222b
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.TimersPromises_SetTimeout_AwaitsValue_F3EA045E.FunctionObject_FunctionDeclaration_5AC71590_main::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.TimersPromises_SetTimeout_AwaitsValue/main::__js_call__(object[], object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_5AC71590_main::ConstructBodyCore
-
-} // end of class FunctionObjects.TimersPromises_SetTimeout_AwaitsValue_F3EA045E.FunctionObject_FunctionDeclaration_5AC71590_main
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Url/Snapshots/GeneratorTests.Require_Url_SearchParams_Mutate.verified.txt
+++ b/tests/Jroc.Tests/Node/Url/Snapshots/GeneratorTests.Require_Url_SearchParams_Mutate.verified.txt
@@ -196,6 +196,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7B874945_L19C29
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2654
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_7B874945_L19C29::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x265c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7B874945_L19C29::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x265f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7B874945_L19C29::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2662
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Require_Url_SearchParams_Mutate/FunctionExpression_L19C28::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionExpression_7B874945_L19C29::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x267c
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Require_Url_SearchParams_Mutate/FunctionExpression_L19C28::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionExpression_7B874945_L19C29::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2692
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_7B874945_L19C29::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_7B874945_L19C29
+
 
 		// Methods
 		.method public hidebysig static 
@@ -495,7 +602,7 @@
 			[7] object,
 			[8] object[],
 			[9] class Modules.Require_Url_SearchParams_Mutate/ArrowFunction_L14C29/FunctionObject,
-			[10] class FunctionObjects.Require_Url_SearchParams_Mutate_C429D800.FunctionObject_FunctionExpression_7B874945_L19C29,
+			[10] class Modules.Require_Url_SearchParams_Mutate/FunctionExpression_L19C28/FunctionObject_FunctionExpression_7B874945_L19C29,
 			[11] class Modules.Require_Url_SearchParams_Mutate/ArrowFunction_L33C18/FunctionObject
 		)
 
@@ -665,13 +772,13 @@
 		IL_0221: ldloc.0
 		IL_0222: stelem.ref
 		IL_0223: stloc.s 8
-		IL_0225: newobj instance void FunctionObjects.Require_Url_SearchParams_Mutate_C429D800.FunctionObject_FunctionExpression_7B874945_L19C29::.ctor()
+		IL_0225: newobj instance void Modules.Require_Url_SearchParams_Mutate/FunctionExpression_L19C28/FunctionObject_FunctionExpression_7B874945_L19C29::.ctor()
 		IL_022a: ldc.i4.2
 		IL_022b: conv.r8
 		IL_022c: ldstr ""
 		IL_0231: ldc.i4.1
 		IL_0232: ldc.i4.1
-		IL_0233: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Require_Url_SearchParams_Mutate_C429D800.FunctionObject_FunctionExpression_7B874945_L19C29>(!!0, float64, string, bool, bool)
+		IL_0233: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Url_SearchParams_Mutate/FunctionExpression_L19C28/FunctionObject_FunctionExpression_7B874945_L19C29>(!!0, float64, string, bool, bool)
 		IL_0238: stloc.s 10
 		IL_023a: ldloc.s 7
 		IL_023c: ldstr "forEach"
@@ -858,113 +965,6 @@
 	} // end of method Require_Url_SearchParams_Mutate::__js_module_init__
 
 } // end of class Modules.Require_Url_SearchParams_Mutate
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Require_Url_SearchParams_Mutate_C429D800.FunctionObject_FunctionExpression_7B874945_L19C29
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2654
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_7B874945_L19C29::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x265c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7B874945_L19C29::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x265f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7B874945_L19C29::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2662
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Require_Url_SearchParams_Mutate/FunctionExpression_L19C28::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_7B874945_L19C29::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x267c
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Require_Url_SearchParams_Mutate/FunctionExpression_L19C28::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_7B874945_L19C29::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2692
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7B874945_L19C29::ConstructCore
-
-} // end of class FunctionObjects.Require_Url_SearchParams_Mutate_C429D800.FunctionObject_FunctionExpression_7B874945_L19C29
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Inherits_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Inherits_Basic.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_01CA746E_Animal
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2278
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_01CA746E_Animal::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2280
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_01CA746E_Animal::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2283
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_01CA746E_Animal::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2286
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Require_Util_Inherits_Basic/Animal::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_01CA746E_Animal::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2299
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Require_Util_Inherits_Basic/Animal::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_01CA746E_Animal::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22a8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_01CA746E_Animal::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_01CA746E_Animal
+
 
 		// Methods
 		.method public hidebysig static 
@@ -83,6 +184,101 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9DFEAE32_L10C26
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x22b7
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_9DFEAE32_L10C26::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22bf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_9DFEAE32_L10C26::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22c2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_9DFEAE32_L10C26::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22c5
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Require_Util_Inherits_Basic/FunctionExpression_L10C25::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_9DFEAE32_L10C26::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22d1
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Require_Util_Inherits_Basic/FunctionExpression_L10C25::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_9DFEAE32_L10C26::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22d9
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_9DFEAE32_L10C26::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_9DFEAE32_L10C26
 
 
 		// Methods
@@ -141,6 +337,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E77D98A8_Dog
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x22e8
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_E77D98A8_Dog::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22f0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E77D98A8_Dog::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22f3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E77D98A8_Dog::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22f6
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Require_Util_Inherits_Basic/Dog::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_E77D98A8_Dog::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2310
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Require_Util_Inherits_Basic/Dog::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_E77D98A8_Dog::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2326
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E77D98A8_Dog::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E77D98A8_Dog
 
 
 		// Methods
@@ -225,13 +528,13 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Util_Inherits_Basic/Scope,
-			[1] class FunctionObjects.Require_Util_Inherits_Basic_2188D247.FunctionObject_FunctionDeclaration_01CA746E_Animal,
-			[2] class FunctionObjects.Require_Util_Inherits_Basic_2188D247.FunctionObject_FunctionDeclaration_E77D98A8_Dog,
+			[1] class Modules.Require_Util_Inherits_Basic/Animal/FunctionObject_FunctionDeclaration_01CA746E_Animal,
+			[2] class Modules.Require_Util_Inherits_Basic/Dog/FunctionObject_FunctionDeclaration_E77D98A8_Dog,
 			[3] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule,
 			[4] object,
 			[5] object[],
 			[6] object,
-			[7] class FunctionObjects.Require_Util_Inherits_Basic_2188D247.FunctionObject_FunctionExpression_9DFEAE32_L10C26,
+			[7] class Modules.Require_Util_Inherits_Basic/FunctionExpression_L10C25/FunctionObject_FunctionExpression_9DFEAE32_L10C26,
 			[8] object,
 			[9] bool,
 			[10] object
@@ -246,13 +549,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 5
-		IL_0012: newobj instance void FunctionObjects.Require_Util_Inherits_Basic_2188D247.FunctionObject_FunctionDeclaration_01CA746E_Animal::.ctor()
+		IL_0012: newobj instance void Modules.Require_Util_Inherits_Basic/Animal/FunctionObject_FunctionDeclaration_01CA746E_Animal::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "Animal"
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Require_Util_Inherits_Basic_2188D247.FunctionObject_FunctionDeclaration_01CA746E_Animal>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Inherits_Basic/Animal/FunctionObject_FunctionDeclaration_01CA746E_Animal>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -261,13 +564,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 5
-		IL_0032: newobj instance void FunctionObjects.Require_Util_Inherits_Basic_2188D247.FunctionObject_FunctionDeclaration_E77D98A8_Dog::.ctor()
+		IL_0032: newobj instance void Modules.Require_Util_Inherits_Basic/Dog/FunctionObject_FunctionDeclaration_E77D98A8_Dog::.ctor()
 		IL_0037: ldc.i4.2
 		IL_0038: conv.r8
 		IL_0039: ldstr "Dog"
 		IL_003e: ldc.i4.1
 		IL_003f: ldc.i4.1
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Require_Util_Inherits_Basic_2188D247.FunctionObject_FunctionDeclaration_E77D98A8_Dog>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Inherits_Basic/Dog/FunctionObject_FunctionDeclaration_E77D98A8_Dog>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: nop
 		IL_0047: ldarg.1
@@ -286,13 +589,13 @@
 		IL_0069: ldloc.0
 		IL_006a: stelem.ref
 		IL_006b: stloc.s 5
-		IL_006d: newobj instance void FunctionObjects.Require_Util_Inherits_Basic_2188D247.FunctionObject_FunctionExpression_9DFEAE32_L10C26::.ctor()
+		IL_006d: newobj instance void Modules.Require_Util_Inherits_Basic/FunctionExpression_L10C25/FunctionObject_FunctionExpression_9DFEAE32_L10C26::.ctor()
 		IL_0072: ldc.i4.0
 		IL_0073: conv.r8
 		IL_0074: ldstr ""
 		IL_0079: ldc.i4.1
 		IL_007a: ldc.i4.1
-		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Require_Util_Inherits_Basic_2188D247.FunctionObject_FunctionExpression_9DFEAE32_L10C26>(!!0, float64, string, bool, bool)
+		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Inherits_Basic/FunctionExpression_L10C25/FunctionObject_FunctionExpression_9DFEAE32_L10C26>(!!0, float64, string, bool, bool)
 		IL_0080: stloc.s 7
 		IL_0082: ldloc.s 6
 		IL_0084: ldstr "speak"
@@ -377,309 +680,6 @@
 	} // end of method Require_Util_Inherits_Basic::__js_module_init__
 
 } // end of class Modules.Require_Util_Inherits_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Require_Util_Inherits_Basic_2188D247.FunctionObject_FunctionDeclaration_01CA746E_Animal
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2278
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_01CA746E_Animal::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2280
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_01CA746E_Animal::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2283
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_01CA746E_Animal::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2286
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Require_Util_Inherits_Basic/Animal::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_01CA746E_Animal::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2299
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Require_Util_Inherits_Basic/Animal::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_01CA746E_Animal::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22a8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_01CA746E_Animal::ConstructCore
-
-} // end of class FunctionObjects.Require_Util_Inherits_Basic_2188D247.FunctionObject_FunctionDeclaration_01CA746E_Animal
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Require_Util_Inherits_Basic_2188D247.FunctionObject_FunctionExpression_9DFEAE32_L10C26
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x22b7
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_9DFEAE32_L10C26::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22bf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9DFEAE32_L10C26::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22c2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9DFEAE32_L10C26::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22c5
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Require_Util_Inherits_Basic/FunctionExpression_L10C25::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_9DFEAE32_L10C26::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22d1
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Require_Util_Inherits_Basic/FunctionExpression_L10C25::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_9DFEAE32_L10C26::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22d9
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_9DFEAE32_L10C26::ConstructCore
-
-} // end of class FunctionObjects.Require_Util_Inherits_Basic_2188D247.FunctionObject_FunctionExpression_9DFEAE32_L10C26
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Require_Util_Inherits_Basic_2188D247.FunctionObject_FunctionDeclaration_E77D98A8_Dog
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x22e8
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_E77D98A8_Dog::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22f0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E77D98A8_Dog::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22f3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E77D98A8_Dog::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22f6
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Require_Util_Inherits_Basic/Dog::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_E77D98A8_Dog::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2310
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Require_Util_Inherits_Basic/Dog::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_E77D98A8_Dog::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2326
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E77D98A8_Dog::ConstructCore
-
-} // end of class FunctionObjects.Require_Util_Inherits_Basic_2188D247.FunctionObject_FunctionDeclaration_E77D98A8_Dog
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Inspect_Custom.verified.txt
+++ b/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Inspect_Custom.verified.txt
@@ -31,6 +31,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5DD29BEB_L9C15
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21f1
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_5DD29BEB_L9C15::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21f9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5DD29BEB_L9C15::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21fc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5DD29BEB_L9C15::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21ff
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.2
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.Require_Util_Inspect_Custom/FunctionExpression_L9C14::__js_call__(object, object, object, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionExpression_5DD29BEB_L9C15::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2220
+				// Header size: 1
+				// Code size: 28 (0x1c)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: ldarg.2
+				IL_0010: ldc.i4.2
+				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0016: call object Modules.Require_Util_Inspect_Custom/FunctionExpression_L9C14::__js_call__(object, object, object, object)
+				IL_001b: ret
+			} // end of method FunctionObject_FunctionExpression_5DD29BEB_L9C15::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x223d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_5DD29BEB_L9C15::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_5DD29BEB_L9C15
+
 
 		// Methods
 		.method public hidebysig static 
@@ -141,7 +254,7 @@
 			[6] bool,
 			[7] object,
 			[8] object[],
-			[9] class FunctionObjects.Require_Util_Inspect_Custom_EE576CEC.FunctionObject_FunctionExpression_5DD29BEB_L9C15,
+			[9] class Modules.Require_Util_Inspect_Custom/FunctionExpression_L9C14/FunctionObject_FunctionExpression_5DD29BEB_L9C15,
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
 
@@ -192,13 +305,13 @@
 		IL_008e: ldloc.0
 		IL_008f: stelem.ref
 		IL_0090: stloc.s 8
-		IL_0092: newobj instance void FunctionObjects.Require_Util_Inspect_Custom_EE576CEC.FunctionObject_FunctionExpression_5DD29BEB_L9C15::.ctor()
+		IL_0092: newobj instance void Modules.Require_Util_Inspect_Custom/FunctionExpression_L9C14/FunctionObject_FunctionExpression_5DD29BEB_L9C15::.ctor()
 		IL_0097: ldc.i4.3
 		IL_0098: conv.r8
 		IL_0099: ldstr ""
 		IL_009e: ldc.i4.1
 		IL_009f: ldc.i4.1
-		IL_00a0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Require_Util_Inspect_Custom_EE576CEC.FunctionObject_FunctionExpression_5DD29BEB_L9C15>(!!0, float64, string, bool, bool)
+		IL_00a0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Inspect_Custom/FunctionExpression_L9C14/FunctionObject_FunctionExpression_5DD29BEB_L9C15>(!!0, float64, string, bool, bool)
 		IL_00a5: stloc.s 9
 		IL_00a7: ldloc.3
 		IL_00a8: ldloc.2
@@ -230,119 +343,6 @@
 	} // end of method Require_Util_Inspect_Custom::__js_module_init__
 
 } // end of class Modules.Require_Util_Inspect_Custom
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Require_Util_Inspect_Custom_EE576CEC.FunctionObject_FunctionExpression_5DD29BEB_L9C15
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21f1
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_5DD29BEB_L9C15::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21f9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5DD29BEB_L9C15::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21fc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5DD29BEB_L9C15::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ff
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.2
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.Require_Util_Inspect_Custom/FunctionExpression_L9C14::__js_call__(object, object, object, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionExpression_5DD29BEB_L9C15::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2220
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: ldarg.2
-		IL_0010: ldc.i4.2
-		IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0016: call object Modules.Require_Util_Inspect_Custom/FunctionExpression_L9C14::__js_call__(object, object, object, object)
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_5DD29BEB_L9C15::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x223d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5DD29BEB_L9C15::ConstructCore
-
-} // end of class FunctionObjects.Require_Util_Inspect_Custom_EE576CEC.FunctionObject_FunctionExpression_5DD29BEB_L9C15
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Promisify_Basic.verified.txt
+++ b/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Promisify_Basic.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5D339815_callbackFn
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2170
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_5D339815_callbackFn::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2178
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5D339815_callbackFn::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x217b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5D339815_callbackFn::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x217e
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Require_Util_Promisify_Basic/callbackFn::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_5D339815_callbackFn::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2198
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Require_Util_Promisify_Basic/callbackFn::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_5D339815_callbackFn::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21ae
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5D339815_callbackFn::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_5D339815_callbackFn
+
 
 		// Methods
 		.method public hidebysig static 
@@ -243,7 +350,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Util_Promisify_Basic/Scope,
-			[1] class FunctionObjects.Require_Util_Promisify_Basic_4BC2C8DF.FunctionObject_FunctionDeclaration_5D339815_callbackFn,
+			[1] class Modules.Require_Util_Promisify_Basic/callbackFn/FunctionObject_FunctionDeclaration_5D339815_callbackFn,
 			[2] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule,
 			[3] object,
 			[4] object[],
@@ -260,13 +367,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 4
-		IL_0012: newobj instance void FunctionObjects.Require_Util_Promisify_Basic_4BC2C8DF.FunctionObject_FunctionDeclaration_5D339815_callbackFn::.ctor()
+		IL_0012: newobj instance void Modules.Require_Util_Promisify_Basic/callbackFn/FunctionObject_FunctionDeclaration_5D339815_callbackFn::.ctor()
 		IL_0017: ldc.i4.2
 		IL_0018: conv.r8
 		IL_0019: ldstr "callbackFn"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Require_Util_Promisify_Basic_4BC2C8DF.FunctionObject_FunctionDeclaration_5D339815_callbackFn>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Promisify_Basic/callbackFn/FunctionObject_FunctionDeclaration_5D339815_callbackFn>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: ldarg.1
@@ -315,113 +422,6 @@
 	} // end of method Require_Util_Promisify_Basic::__js_module_init__
 
 } // end of class Modules.Require_Util_Promisify_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Require_Util_Promisify_Basic_4BC2C8DF.FunctionObject_FunctionDeclaration_5D339815_callbackFn
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2170
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_5D339815_callbackFn::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2178
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5D339815_callbackFn::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x217b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5D339815_callbackFn::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x217e
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Require_Util_Promisify_Basic/callbackFn::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_5D339815_callbackFn::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2198
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Require_Util_Promisify_Basic/callbackFn::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_5D339815_callbackFn::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ae
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5D339815_callbackFn::ConstructCore
-
-} // end of class FunctionObjects.Require_Util_Promisify_Basic_4BC2C8DF.FunctionObject_FunctionDeclaration_5D339815_callbackFn
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Promisify_ErrorHandling.verified.txt
+++ b/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Promisify_ErrorHandling.verified.txt
@@ -73,6 +73,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2324
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x232c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x232f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2332
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Require_Util_Promisify_ErrorHandling/callbackFn::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x234c
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Require_Util_Promisify_ErrorHandling/callbackFn::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2362
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn
+
 
 		// Methods
 		.method public hidebysig static 
@@ -686,7 +793,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Util_Promisify_ErrorHandling/Scope,
-			[1] class FunctionObjects.Require_Util_Promisify_ErrorHandling_62E7CD4A.FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn,
+			[1] class Modules.Require_Util_Promisify_ErrorHandling/callbackFn/FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn,
 			[2] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule,
 			[3] object,
 			[4] object[],
@@ -706,13 +813,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 4
-		IL_0012: newobj instance void FunctionObjects.Require_Util_Promisify_ErrorHandling_62E7CD4A.FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn::.ctor()
+		IL_0012: newobj instance void Modules.Require_Util_Promisify_ErrorHandling/callbackFn/FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn::.ctor()
 		IL_0017: ldc.i4.2
 		IL_0018: conv.r8
 		IL_0019: ldstr "callbackFn"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Require_Util_Promisify_ErrorHandling_62E7CD4A.FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Promisify_ErrorHandling/callbackFn/FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: ldarg.1
@@ -841,113 +948,6 @@
 	} // end of method Require_Util_Promisify_ErrorHandling::__js_module_init__
 
 } // end of class Modules.Require_Util_Promisify_ErrorHandling
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Require_Util_Promisify_ErrorHandling_62E7CD4A.FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2324
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x232c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x232f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2332
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Require_Util_Promisify_ErrorHandling/callbackFn::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x234c
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Require_Util_Promisify_ErrorHandling/callbackFn::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2362
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn::ConstructCore
-
-} // end of class FunctionObjects.Require_Util_Promisify_ErrorHandling_62E7CD4A.FunctionObject_FunctionDeclaration_27AFCB2E_callbackFn
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Types_IsFunction.verified.txt
+++ b/tests/Jroc.Tests/Node/Util/Snapshots/GeneratorTests.Require_Util_Types_IsFunction.verified.txt
@@ -31,6 +31,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A71E7C01_regularFn
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21f2
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_A71E7C01_regularFn::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21fa
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A71E7C01_regularFn::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21fd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A71E7C01_regularFn::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2200
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Require_Util_Types_IsFunction/regularFn::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_A71E7C01_regularFn::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x220c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Require_Util_Types_IsFunction/regularFn::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_A71E7C01_regularFn::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2214
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A71E7C01_regularFn::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_A71E7C01_regularFn
+
 
 		// Methods
 		.method public hidebysig static 
@@ -200,7 +295,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Util_Types_IsFunction/Scope,
-			[1] class FunctionObjects.Require_Util_Types_IsFunction_69CFA0F0.FunctionObject_FunctionDeclaration_A71E7C01_regularFn,
+			[1] class Modules.Require_Util_Types_IsFunction/regularFn/FunctionObject_FunctionDeclaration_A71E7C01_regularFn,
 			[2] class [JavaScriptRuntime]Jroc.Runtime.Node.Contracts.IUtilModule,
 			[3] object,
 			[4] float64,
@@ -221,13 +316,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 6
-		IL_0012: newobj instance void FunctionObjects.Require_Util_Types_IsFunction_69CFA0F0.FunctionObject_FunctionDeclaration_A71E7C01_regularFn::.ctor()
+		IL_0012: newobj instance void Modules.Require_Util_Types_IsFunction/regularFn/FunctionObject_FunctionDeclaration_A71E7C01_regularFn::.ctor()
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "regularFn"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Require_Util_Types_IsFunction_69CFA0F0.FunctionObject_FunctionDeclaration_A71E7C01_regularFn>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Util_Types_IsFunction/regularFn/FunctionObject_FunctionDeclaration_A71E7C01_regularFn>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: ldarg.1
@@ -338,101 +433,6 @@
 	} // end of method Require_Util_Types_IsFunction::__js_module_init__
 
 } // end of class Modules.Require_Util_Types_IsFunction
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Require_Util_Types_IsFunction_69CFA0F0.FunctionObject_FunctionDeclaration_A71E7C01_regularFn
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21f2
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_A71E7C01_regularFn::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21fa
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A71E7C01_regularFn::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21fd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A71E7C01_regularFn::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2200
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Require_Util_Types_IsFunction/regularFn::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_A71E7C01_regularFn::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x220c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Require_Util_Types_IsFunction/regularFn::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_A71E7C01_regularFn::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2214
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A71E7C01_regularFn::ConstructCore
-
-} // end of class FunctionObjects.Require_Util_Types_IsFunction_69CFA0F0.FunctionObject_FunctionDeclaration_A71E7C01_regularFn
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_ErrorPaths.verified.txt
+++ b/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_ErrorPaths.verified.txt
@@ -73,6 +73,115 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E70B6C52_logError
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2773
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_E70B6C52_logError::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x277b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E70B6C52_logError::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x277e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E70B6C52_logError::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2781
+				// Header size: 1
+				// Code size: 30 (0x1e)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: call object Modules.Require_Zlib_ErrorPaths/logError::__js_call__(object, string, object)
+				IL_001d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E70B6C52_logError::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x27a0
+				// Header size: 1
+				// Code size: 26 (0x1a)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call object Modules.Require_Zlib_ErrorPaths/logError::__js_call__(object, string, object)
+				IL_0019: ret
+			} // end of method FunctionObject_FunctionDeclaration_E70B6C52_logError::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x27bb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E70B6C52_logError::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E70B6C52_logError
+
 
 		// Methods
 		.method public hidebysig static 
@@ -982,7 +1091,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Require_Zlib_ErrorPaths/Scope,
-			[1] class FunctionObjects.Require_Zlib_ErrorPaths_D7B42E0B.FunctionObject_FunctionDeclaration_E70B6C52_logError,
+			[1] class Modules.Require_Zlib_ErrorPaths/logError/FunctionObject_FunctionDeclaration_E70B6C52_logError,
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
@@ -1017,13 +1126,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 6
-		IL_0012: newobj instance void FunctionObjects.Require_Zlib_ErrorPaths_D7B42E0B.FunctionObject_FunctionDeclaration_E70B6C52_logError::.ctor()
+		IL_0012: newobj instance void Modules.Require_Zlib_ErrorPaths/logError/FunctionObject_FunctionDeclaration_E70B6C52_logError::.ctor()
 		IL_0017: ldc.i4.2
 		IL_0018: conv.r8
 		IL_0019: ldstr "logError"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Require_Zlib_ErrorPaths_D7B42E0B.FunctionObject_FunctionDeclaration_E70B6C52_logError>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_ErrorPaths/logError/FunctionObject_FunctionDeclaration_E70B6C52_logError>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: ldarg.1
@@ -1383,115 +1492,6 @@
 	} // end of method Require_Zlib_ErrorPaths::__js_module_init__
 
 } // end of class Modules.Require_Zlib_ErrorPaths
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Require_Zlib_ErrorPaths_D7B42E0B.FunctionObject_FunctionDeclaration_E70B6C52_logError
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2773
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_E70B6C52_logError::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x277b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E70B6C52_logError::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x277e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E70B6C52_logError::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2781
-		// Header size: 1
-		// Code size: 30 (0x1e)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: call object Modules.Require_Zlib_ErrorPaths/logError::__js_call__(object, string, object)
-		IL_001d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E70B6C52_logError::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27a0
-		// Header size: 1
-		// Code size: 26 (0x1a)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call object Modules.Require_Zlib_ErrorPaths/logError::__js_call__(object, string, object)
-		IL_0019: ret
-	} // end of method FunctionObject_FunctionDeclaration_E70B6C52_logError::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27bb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E70B6C52_logError::ConstructCore
-
-} // end of class FunctionObjects.Require_Zlib_ErrorPaths_D7B42E0B.FunctionObject_FunctionDeclaration_E70B6C52_logError
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_Stream_RoundTrip.verified.txt
+++ b/tests/Jroc.Tests/Node/Zlib/Snapshots/GeneratorTests.Require_Zlib_Stream_RoundTrip.verified.txt
@@ -535,6 +535,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_721B6487_L19C19
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Require_Zlib_Stream_RoundTrip/Scope _environment0_Require_Zlib_Stream_RoundTrip
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Require_Zlib_Stream_RoundTrip/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x255e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Require_Zlib_Stream_RoundTrip/Scope Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L19C18/FunctionObject_FunctionExpression_721B6487_L19C19::_environment0_Require_Zlib_Stream_RoundTrip
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_721B6487_L19C19::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x256d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_721B6487_L19C19::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2570
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_721B6487_L19C19::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2573
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Require_Zlib_Stream_RoundTrip/Scope Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L19C18/FunctionObject_FunctionExpression_721B6487_L19C19::_environment0_Require_Zlib_Stream_RoundTrip
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L19C18::__js_call__(class Modules.Require_Zlib_Stream_RoundTrip/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_721B6487_L19C19::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x258c
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Require_Zlib_Stream_RoundTrip/Scope Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L19C18/FunctionObject_FunctionExpression_721B6487_L19C19::_environment0_Require_Zlib_Stream_RoundTrip
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L19C18::__js_call__(class Modules.Require_Zlib_Stream_RoundTrip/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_721B6487_L19C19::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25a1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_721B6487_L19C19::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_721B6487_L19C19
+
 
 		// Methods
 		.method public hidebysig static 
@@ -593,6 +706,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3356B439_L23C23
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Require_Zlib_Stream_RoundTrip/Scope _environment0_Require_Zlib_Stream_RoundTrip
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Require_Zlib_Stream_RoundTrip/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x25b0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Require_Zlib_Stream_RoundTrip/Scope Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L23C22/FunctionObject_FunctionExpression_3356B439_L23C23::_environment0_Require_Zlib_Stream_RoundTrip
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_3356B439_L23C23::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x25bf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_3356B439_L23C23::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x25c2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_3356B439_L23C23::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x25c5
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Require_Zlib_Stream_RoundTrip/Scope Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L23C22/FunctionObject_FunctionExpression_3356B439_L23C23::_environment0_Require_Zlib_Stream_RoundTrip
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L23C22::__js_call__(class Modules.Require_Zlib_Stream_RoundTrip/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_3356B439_L23C23::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25d7
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Require_Zlib_Stream_RoundTrip/Scope Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L23C22/FunctionObject_FunctionExpression_3356B439_L23C23::_environment0_Require_Zlib_Stream_RoundTrip
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L23C22::__js_call__(class Modules.Require_Zlib_Stream_RoundTrip/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_3356B439_L23C23::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25e5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_3356B439_L23C23::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_3356B439_L23C23
 
 
 		// Methods
@@ -736,8 +956,8 @@
 			[12] class Modules.Require_Zlib_Stream_RoundTrip/ArrowFunction_L15C16/FunctionObject,
 			[13] class Modules.Require_Zlib_Stream_RoundTrip/ArrowFunction_L16C21/FunctionObject,
 			[14] class Modules.Require_Zlib_Stream_RoundTrip/ArrowFunction_L17C18/FunctionObject,
-			[15] class FunctionObjects.Require_Zlib_Stream_RoundTrip_37505BFD.FunctionObject_FunctionExpression_721B6487_L19C19,
-			[16] class FunctionObjects.Require_Zlib_Stream_RoundTrip_37505BFD.FunctionObject_FunctionExpression_3356B439_L23C23,
+			[15] class Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L19C18/FunctionObject_FunctionExpression_721B6487_L19C19,
+			[16] class Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L23C22/FunctionObject_FunctionExpression_3356B439_L23C23,
 			[17] class [JavaScriptRuntime]JavaScriptRuntime.Node.Buffer
 		)
 
@@ -921,13 +1141,13 @@
 		IL_01d8: ldc.i4.0
 		IL_01d9: ldelem.ref
 		IL_01da: castclass Modules.Require_Zlib_Stream_RoundTrip/Scope
-		IL_01df: newobj instance void FunctionObjects.Require_Zlib_Stream_RoundTrip_37505BFD.FunctionObject_FunctionExpression_721B6487_L19C19::.ctor(class Modules.Require_Zlib_Stream_RoundTrip/Scope)
+		IL_01df: newobj instance void Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L19C18/FunctionObject_FunctionExpression_721B6487_L19C19::.ctor(class Modules.Require_Zlib_Stream_RoundTrip/Scope)
 		IL_01e4: ldc.i4.1
 		IL_01e5: conv.r8
 		IL_01e6: ldstr ""
 		IL_01eb: ldc.i4.0
 		IL_01ec: ldc.i4.1
-		IL_01ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Require_Zlib_Stream_RoundTrip_37505BFD.FunctionObject_FunctionExpression_721B6487_L19C19>(!!0, float64, string, bool, bool)
+		IL_01ed: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L19C18/FunctionObject_FunctionExpression_721B6487_L19C19>(!!0, float64, string, bool, bool)
 		IL_01f2: stloc.s 15
 		IL_01f4: ldloc.s 6
 		IL_01f6: ldstr "_write"
@@ -949,13 +1169,13 @@
 		IL_021b: ldc.i4.0
 		IL_021c: ldelem.ref
 		IL_021d: castclass Modules.Require_Zlib_Stream_RoundTrip/Scope
-		IL_0222: newobj instance void FunctionObjects.Require_Zlib_Stream_RoundTrip_37505BFD.FunctionObject_FunctionExpression_3356B439_L23C23::.ctor(class Modules.Require_Zlib_Stream_RoundTrip/Scope)
+		IL_0222: newobj instance void Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L23C22/FunctionObject_FunctionExpression_3356B439_L23C23::.ctor(class Modules.Require_Zlib_Stream_RoundTrip/Scope)
 		IL_0227: ldc.i4.0
 		IL_0228: conv.r8
 		IL_0229: ldstr ""
 		IL_022e: ldc.i4.0
 		IL_022f: ldc.i4.1
-		IL_0230: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Require_Zlib_Stream_RoundTrip_37505BFD.FunctionObject_FunctionExpression_3356B439_L23C23>(!!0, float64, string, bool, bool)
+		IL_0230: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L23C22/FunctionObject_FunctionExpression_3356B439_L23C23>(!!0, float64, string, bool, bool)
 		IL_0235: stloc.s 16
 		IL_0237: ldloc.s 7
 		IL_0239: ldstr "on"
@@ -1010,226 +1230,6 @@
 	} // end of method Require_Zlib_Stream_RoundTrip::__js_module_init__
 
 } // end of class Modules.Require_Zlib_Stream_RoundTrip
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Require_Zlib_Stream_RoundTrip_37505BFD.FunctionObject_FunctionExpression_721B6487_L19C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Require_Zlib_Stream_RoundTrip/Scope _environment0_Require_Zlib_Stream_RoundTrip
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Require_Zlib_Stream_RoundTrip/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x255e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Require_Zlib_Stream_RoundTrip/Scope FunctionObjects.Require_Zlib_Stream_RoundTrip_37505BFD.FunctionObject_FunctionExpression_721B6487_L19C19::_environment0_Require_Zlib_Stream_RoundTrip
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_721B6487_L19C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x256d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_721B6487_L19C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2570
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_721B6487_L19C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2573
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Require_Zlib_Stream_RoundTrip/Scope FunctionObjects.Require_Zlib_Stream_RoundTrip_37505BFD.FunctionObject_FunctionExpression_721B6487_L19C19::_environment0_Require_Zlib_Stream_RoundTrip
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L19C18::__js_call__(class Modules.Require_Zlib_Stream_RoundTrip/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_721B6487_L19C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x258c
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Require_Zlib_Stream_RoundTrip/Scope FunctionObjects.Require_Zlib_Stream_RoundTrip_37505BFD.FunctionObject_FunctionExpression_721B6487_L19C19::_environment0_Require_Zlib_Stream_RoundTrip
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L19C18::__js_call__(class Modules.Require_Zlib_Stream_RoundTrip/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_721B6487_L19C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25a1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_721B6487_L19C19::ConstructCore
-
-} // end of class FunctionObjects.Require_Zlib_Stream_RoundTrip_37505BFD.FunctionObject_FunctionExpression_721B6487_L19C19
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Require_Zlib_Stream_RoundTrip_37505BFD.FunctionObject_FunctionExpression_3356B439_L23C23
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Require_Zlib_Stream_RoundTrip/Scope _environment0_Require_Zlib_Stream_RoundTrip
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Require_Zlib_Stream_RoundTrip/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x25b0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Require_Zlib_Stream_RoundTrip/Scope FunctionObjects.Require_Zlib_Stream_RoundTrip_37505BFD.FunctionObject_FunctionExpression_3356B439_L23C23::_environment0_Require_Zlib_Stream_RoundTrip
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3356B439_L23C23::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x25bf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3356B439_L23C23::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x25c2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3356B439_L23C23::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x25c5
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Require_Zlib_Stream_RoundTrip/Scope FunctionObjects.Require_Zlib_Stream_RoundTrip_37505BFD.FunctionObject_FunctionExpression_3356B439_L23C23::_environment0_Require_Zlib_Stream_RoundTrip
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L23C22::__js_call__(class Modules.Require_Zlib_Stream_RoundTrip/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_3356B439_L23C23::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25d7
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Require_Zlib_Stream_RoundTrip/Scope FunctionObjects.Require_Zlib_Stream_RoundTrip_37505BFD.FunctionObject_FunctionExpression_3356B439_L23C23::_environment0_Require_Zlib_Stream_RoundTrip
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Require_Zlib_Stream_RoundTrip/FunctionExpression_L23C22::__js_call__(class Modules.Require_Zlib_Stream_RoundTrip/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_3356B439_L23C23::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25e5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3356B439_L23C23::ConstructCore
-
-} // end of class FunctionObjects.Require_Zlib_Stream_RoundTrip_37505BFD.FunctionObject_FunctionExpression_3356B439_L23C23
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectDefineProperty_Accessor.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectDefineProperty_Accessor.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_477C5B43_L7C8
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.ObjectDefineProperty_Accessor/Scope _environment0_ObjectDefineProperty_Accessor
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.ObjectDefineProperty_Accessor/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2205
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.ObjectDefineProperty_Accessor/Scope Modules.ObjectDefineProperty_Accessor/FunctionExpression_L7C7/FunctionObject_FunctionExpression_477C5B43_L7C8::_environment0_ObjectDefineProperty_Accessor
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_477C5B43_L7C8::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2214
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_477C5B43_L7C8::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2217
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_477C5B43_L7C8::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x221a
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectDefineProperty_Accessor/Scope Modules.ObjectDefineProperty_Accessor/FunctionExpression_L7C7/FunctionObject_FunctionExpression_477C5B43_L7C8::_environment0_ObjectDefineProperty_Accessor
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.ObjectDefineProperty_Accessor/FunctionExpression_L7C7::__js_call__(class Modules.ObjectDefineProperty_Accessor/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_477C5B43_L7C8::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x222c
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectDefineProperty_Accessor/Scope Modules.ObjectDefineProperty_Accessor/FunctionExpression_L7C7/FunctionObject_FunctionExpression_477C5B43_L7C8::_environment0_ObjectDefineProperty_Accessor
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.ObjectDefineProperty_Accessor/FunctionExpression_L7C7::__js_call__(class Modules.ObjectDefineProperty_Accessor/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_477C5B43_L7C8::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x223a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_477C5B43_L7C8::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_477C5B43_L7C8
+
 
 		// Methods
 		.method public hidebysig static 
@@ -86,6 +193,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_AAFBE7D6_L8C8
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.ObjectDefineProperty_Accessor/Scope _environment0_ObjectDefineProperty_Accessor
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.ObjectDefineProperty_Accessor/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2249
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.ObjectDefineProperty_Accessor/Scope Modules.ObjectDefineProperty_Accessor/FunctionExpression_L8C7/FunctionObject_FunctionExpression_AAFBE7D6_L8C8::_environment0_ObjectDefineProperty_Accessor
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_AAFBE7D6_L8C8::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2258
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_AAFBE7D6_L8C8::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x225b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_AAFBE7D6_L8C8::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x225e
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectDefineProperty_Accessor/Scope Modules.ObjectDefineProperty_Accessor/FunctionExpression_L8C7/FunctionObject_FunctionExpression_AAFBE7D6_L8C8::_environment0_ObjectDefineProperty_Accessor
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.ObjectDefineProperty_Accessor/FunctionExpression_L8C7::__js_call__(class Modules.ObjectDefineProperty_Accessor/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_AAFBE7D6_L8C8::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2277
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectDefineProperty_Accessor/Scope Modules.ObjectDefineProperty_Accessor/FunctionExpression_L8C7/FunctionObject_FunctionExpression_AAFBE7D6_L8C8::_environment0_ObjectDefineProperty_Accessor
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.ObjectDefineProperty_Accessor/FunctionExpression_L8C7::__js_call__(class Modules.ObjectDefineProperty_Accessor/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_AAFBE7D6_L8C8::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x228c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_AAFBE7D6_L8C8::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_AAFBE7D6_L8C8
 
 
 		// Methods
@@ -178,8 +398,8 @@
 			[0] class Modules.ObjectDefineProperty_Accessor/Scope,
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[2] object[],
-			[3] class FunctionObjects.ObjectDefineProperty_Accessor_4A4BD6DA.FunctionObject_FunctionExpression_477C5B43_L7C8,
-			[4] class FunctionObjects.ObjectDefineProperty_Accessor_4A4BD6DA.FunctionObject_FunctionExpression_AAFBE7D6_L8C8,
+			[3] class Modules.ObjectDefineProperty_Accessor/FunctionExpression_L7C7/FunctionObject_FunctionExpression_477C5B43_L7C8,
+			[4] class Modules.ObjectDefineProperty_Accessor/FunctionExpression_L8C7/FunctionObject_FunctionExpression_AAFBE7D6_L8C8,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[6] object,
 			[7] object
@@ -205,13 +425,13 @@
 		IL_002d: ldc.i4.0
 		IL_002e: ldelem.ref
 		IL_002f: castclass Modules.ObjectDefineProperty_Accessor/Scope
-		IL_0034: newobj instance void FunctionObjects.ObjectDefineProperty_Accessor_4A4BD6DA.FunctionObject_FunctionExpression_477C5B43_L7C8::.ctor(class Modules.ObjectDefineProperty_Accessor/Scope)
+		IL_0034: newobj instance void Modules.ObjectDefineProperty_Accessor/FunctionExpression_L7C7/FunctionObject_FunctionExpression_477C5B43_L7C8::.ctor(class Modules.ObjectDefineProperty_Accessor/Scope)
 		IL_0039: ldc.i4.0
 		IL_003a: conv.r8
 		IL_003b: ldstr ""
 		IL_0040: ldc.i4.0
 		IL_0041: ldc.i4.1
-		IL_0042: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectDefineProperty_Accessor_4A4BD6DA.FunctionObject_FunctionExpression_477C5B43_L7C8>(!!0, float64, string, bool, bool)
+		IL_0042: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectDefineProperty_Accessor/FunctionExpression_L7C7/FunctionObject_FunctionExpression_477C5B43_L7C8>(!!0, float64, string, bool, bool)
 		IL_0047: stloc.3
 		IL_0048: ldc.i4.1
 		IL_0049: newarr [System.Runtime]System.Object
@@ -224,13 +444,13 @@
 		IL_0054: ldc.i4.0
 		IL_0055: ldelem.ref
 		IL_0056: castclass Modules.ObjectDefineProperty_Accessor/Scope
-		IL_005b: newobj instance void FunctionObjects.ObjectDefineProperty_Accessor_4A4BD6DA.FunctionObject_FunctionExpression_AAFBE7D6_L8C8::.ctor(class Modules.ObjectDefineProperty_Accessor/Scope)
+		IL_005b: newobj instance void Modules.ObjectDefineProperty_Accessor/FunctionExpression_L8C7/FunctionObject_FunctionExpression_AAFBE7D6_L8C8::.ctor(class Modules.ObjectDefineProperty_Accessor/Scope)
 		IL_0060: ldc.i4.1
 		IL_0061: conv.r8
 		IL_0062: ldstr ""
 		IL_0067: ldc.i4.0
 		IL_0068: ldc.i4.1
-		IL_0069: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectDefineProperty_Accessor_4A4BD6DA.FunctionObject_FunctionExpression_AAFBE7D6_L8C8>(!!0, float64, string, bool, bool)
+		IL_0069: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectDefineProperty_Accessor/FunctionExpression_L8C7/FunctionObject_FunctionExpression_AAFBE7D6_L8C8>(!!0, float64, string, bool, bool)
 		IL_006e: stloc.s 4
 		IL_0070: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0075: dup
@@ -291,226 +511,6 @@
 	} // end of method ObjectDefineProperty_Accessor::__js_module_init__
 
 } // end of class Modules.ObjectDefineProperty_Accessor
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectDefineProperty_Accessor_4A4BD6DA.FunctionObject_FunctionExpression_477C5B43_L7C8
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ObjectDefineProperty_Accessor/Scope _environment0_ObjectDefineProperty_Accessor
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ObjectDefineProperty_Accessor/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2205
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ObjectDefineProperty_Accessor/Scope FunctionObjects.ObjectDefineProperty_Accessor_4A4BD6DA.FunctionObject_FunctionExpression_477C5B43_L7C8::_environment0_ObjectDefineProperty_Accessor
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_477C5B43_L7C8::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2214
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_477C5B43_L7C8::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2217
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_477C5B43_L7C8::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x221a
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectDefineProperty_Accessor/Scope FunctionObjects.ObjectDefineProperty_Accessor_4A4BD6DA.FunctionObject_FunctionExpression_477C5B43_L7C8::_environment0_ObjectDefineProperty_Accessor
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.ObjectDefineProperty_Accessor/FunctionExpression_L7C7::__js_call__(class Modules.ObjectDefineProperty_Accessor/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_477C5B43_L7C8::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x222c
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectDefineProperty_Accessor/Scope FunctionObjects.ObjectDefineProperty_Accessor_4A4BD6DA.FunctionObject_FunctionExpression_477C5B43_L7C8::_environment0_ObjectDefineProperty_Accessor
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.ObjectDefineProperty_Accessor/FunctionExpression_L7C7::__js_call__(class Modules.ObjectDefineProperty_Accessor/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_477C5B43_L7C8::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x223a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_477C5B43_L7C8::ConstructCore
-
-} // end of class FunctionObjects.ObjectDefineProperty_Accessor_4A4BD6DA.FunctionObject_FunctionExpression_477C5B43_L7C8
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectDefineProperty_Accessor_4A4BD6DA.FunctionObject_FunctionExpression_AAFBE7D6_L8C8
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ObjectDefineProperty_Accessor/Scope _environment0_ObjectDefineProperty_Accessor
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ObjectDefineProperty_Accessor/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2249
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ObjectDefineProperty_Accessor/Scope FunctionObjects.ObjectDefineProperty_Accessor_4A4BD6DA.FunctionObject_FunctionExpression_AAFBE7D6_L8C8::_environment0_ObjectDefineProperty_Accessor
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_AAFBE7D6_L8C8::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2258
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_AAFBE7D6_L8C8::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x225b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_AAFBE7D6_L8C8::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x225e
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectDefineProperty_Accessor/Scope FunctionObjects.ObjectDefineProperty_Accessor_4A4BD6DA.FunctionObject_FunctionExpression_AAFBE7D6_L8C8::_environment0_ObjectDefineProperty_Accessor
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.ObjectDefineProperty_Accessor/FunctionExpression_L8C7::__js_call__(class Modules.ObjectDefineProperty_Accessor/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_AAFBE7D6_L8C8::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2277
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectDefineProperty_Accessor/Scope FunctionObjects.ObjectDefineProperty_Accessor_4A4BD6DA.FunctionObject_FunctionExpression_AAFBE7D6_L8C8::_environment0_ObjectDefineProperty_Accessor
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.ObjectDefineProperty_Accessor/FunctionExpression_L8C7::__js_call__(class Modules.ObjectDefineProperty_Accessor/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_AAFBE7D6_L8C8::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x228c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_AAFBE7D6_L8C8::ConstructCore
-
-} // end of class FunctionObjects.ObjectDefineProperty_Accessor_4A4BD6DA.FunctionObject_FunctionExpression_AAFBE7D6_L8C8
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_AccessorDefinitions.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_AccessorDefinitions.verified.txt
@@ -31,6 +31,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_131FC9A5_L5C12
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x251b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_131FC9A5_L5C12::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2523
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_131FC9A5_L5C12::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2526
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_131FC9A5_L5C12::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2529
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_131FC9A5_L5C12::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2535
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_131FC9A5_L5C12::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x253d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_131FC9A5_L5C12::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_131FC9A5_L5C12
+
 
 		// Methods
 		.method public hidebysig static 
@@ -88,6 +183,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A0C76C5C_L8C12
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x254c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_A0C76C5C_L8C12::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2554
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A0C76C5C_L8C12::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2557
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A0C76C5C_L8C12::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x255a
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_A0C76C5C_L8C12::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x256d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_A0C76C5C_L8C12::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x257c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_A0C76C5C_L8C12::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_A0C76C5C_L8C12
 
 
 		// Methods
@@ -150,6 +346,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_61B490A1_L11C17
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x258b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_61B490A1_L11C17::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2593
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_61B490A1_L11C17::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2596
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_61B490A1_L11C17::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2599
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_61B490A1_L11C17::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25a5
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_61B490A1_L11C17::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25ad
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_61B490A1_L11C17::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_61B490A1_L11C17
+
 
 		// Methods
 		.method public hidebysig static 
@@ -207,6 +498,103 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_CB10A8EE_L30C8
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x25bc
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_CB10A8EE_L30C8::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x25c4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_CB10A8EE_L30C8::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x25c7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_CB10A8EE_L30C8::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x25ca
+				// Header size: 1
+				// Code size: 16 (0x10)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call float64 Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten::__js_call__(object)
+				IL_000a: box [System.Runtime]System.Double
+				IL_000f: ret
+			} // end of method FunctionObject_FunctionExpression_CB10A8EE_L30C8::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25db
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call float64 Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten::__js_call__(object)
+				IL_0006: box [System.Runtime]System.Double
+				IL_000b: ret
+			} // end of method FunctionObject_FunctionExpression_CB10A8EE_L30C8::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25e8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_CB10A8EE_L30C8::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_CB10A8EE_L30C8
+
 
 		// Methods
 		.method public hidebysig static 
@@ -251,6 +639,103 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_B2462A16_L38C8
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x25f7
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_B2462A16_L38C8::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x25ff
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_B2462A16_L38C8::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2602
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_B2462A16_L38C8::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2605
+				// Header size: 1
+				// Code size: 16 (0x10)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call float64 Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite::__js_call__(object)
+				IL_000a: box [System.Runtime]System.Double
+				IL_000f: ret
+			} // end of method FunctionObject_FunctionExpression_B2462A16_L38C8::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2616
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call float64 Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite::__js_call__(object)
+				IL_0006: box [System.Runtime]System.Double
+				IL_000b: ret
+			} // end of method FunctionObject_FunctionExpression_B2462A16_L38C8::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2623
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_B2462A16_L38C8::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_B2462A16_L38C8
 
 
 		// Methods
@@ -316,14 +801,14 @@
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[6] object[],
-			[7] class FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_131FC9A5_L5C12,
-			[8] class FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_A0C76C5C_L8C12,
-			[9] class FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_61B490A1_L11C17,
+			[7] class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj/FunctionObject_FunctionExpression_131FC9A5_L5C12,
+			[8] class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11/FunctionObject_FunctionExpression_A0C76C5C_L8C12,
+			[9] class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject_FunctionExpression_61B490A1_L11C17,
 			[10] object,
 			[11] object,
 			[12] string,
-			[13] class FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_CB10A8EE_L30C8,
-			[14] class FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_B2462A16_L38C8,
+			[13] class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject_FunctionExpression_CB10A8EE_L30C8,
+			[14] class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject_FunctionExpression_B2462A16_L38C8,
 			[15] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
 
@@ -344,16 +829,16 @@
 		IL_002c: ldloc.0
 		IL_002d: stelem.ref
 		IL_002e: stloc.s 6
-		IL_0030: newobj instance void FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_131FC9A5_L5C12::.ctor()
+		IL_0030: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj/FunctionObject_FunctionExpression_131FC9A5_L5C12::.ctor()
 		IL_0035: ldc.i4.0
 		IL_0036: conv.r8
 		IL_0037: ldstr ""
 		IL_003c: ldc.i4.1
 		IL_003d: ldc.i4.1
-		IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_131FC9A5_L5C12>(!!0, float64, string, bool, bool)
+		IL_003e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj/FunctionObject_FunctionExpression_131FC9A5_L5C12>(!!0, float64, string, bool, bool)
 		IL_0043: stloc.s 7
 		IL_0045: ldloc.s 7
-		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_131FC9A5_L5C12>(!!0)
+		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj/FunctionObject_FunctionExpression_131FC9A5_L5C12>(!!0)
 		IL_004c: stloc.s 7
 		IL_004e: ldloc.s 5
 		IL_0050: ldstr "value"
@@ -368,16 +853,16 @@
 		IL_0066: ldloc.0
 		IL_0067: stelem.ref
 		IL_0068: stloc.s 6
-		IL_006a: newobj instance void FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_A0C76C5C_L8C12::.ctor()
+		IL_006a: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11/FunctionObject_FunctionExpression_A0C76C5C_L8C12::.ctor()
 		IL_006f: ldc.i4.1
 		IL_0070: conv.r8
 		IL_0071: ldstr ""
 		IL_0076: ldc.i4.1
 		IL_0077: ldc.i4.1
-		IL_0078: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_A0C76C5C_L8C12>(!!0, float64, string, bool, bool)
+		IL_0078: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11/FunctionObject_FunctionExpression_A0C76C5C_L8C12>(!!0, float64, string, bool, bool)
 		IL_007d: stloc.s 8
 		IL_007f: ldloc.s 8
-		IL_0081: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_A0C76C5C_L8C12>(!!0)
+		IL_0081: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11/FunctionObject_FunctionExpression_A0C76C5C_L8C12>(!!0)
 		IL_0086: stloc.s 8
 		IL_0088: ldloc.s 5
 		IL_008a: ldstr "value"
@@ -392,16 +877,16 @@
 		IL_00a0: ldloc.0
 		IL_00a1: stelem.ref
 		IL_00a2: stloc.s 6
-		IL_00a4: newobj instance void FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_61B490A1_L11C17::.ctor()
+		IL_00a4: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject_FunctionExpression_61B490A1_L11C17::.ctor()
 		IL_00a9: ldc.i4.0
 		IL_00aa: conv.r8
 		IL_00ab: ldstr ""
 		IL_00b0: ldc.i4.1
 		IL_00b1: ldc.i4.1
-		IL_00b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_61B490A1_L11C17>(!!0, float64, string, bool, bool)
+		IL_00b2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject_FunctionExpression_61B490A1_L11C17>(!!0, float64, string, bool, bool)
 		IL_00b7: stloc.s 9
 		IL_00b9: ldloc.s 9
-		IL_00bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_61B490A1_L11C17>(!!0)
+		IL_00bb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16/FunctionObject_FunctionExpression_61B490A1_L11C17>(!!0)
 		IL_00c0: stloc.s 9
 		IL_00c2: ldloc.s 5
 		IL_00c4: ldstr "double"
@@ -556,16 +1041,16 @@
 		IL_02bc: ldloc.0
 		IL_02bd: stelem.ref
 		IL_02be: stloc.s 6
-		IL_02c0: newobj instance void FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_CB10A8EE_L30C8::.ctor()
+		IL_02c0: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject_FunctionExpression_CB10A8EE_L30C8::.ctor()
 		IL_02c5: ldc.i4.0
 		IL_02c6: conv.r8
 		IL_02c7: ldstr ""
 		IL_02cc: ldc.i4.0
 		IL_02cd: ldc.i4.1
-		IL_02ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_CB10A8EE_L30C8>(!!0, float64, string, bool, bool)
+		IL_02ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject_FunctionExpression_CB10A8EE_L30C8>(!!0, float64, string, bool, bool)
 		IL_02d3: stloc.s 13
 		IL_02d5: ldloc.s 13
-		IL_02d7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_CB10A8EE_L30C8>(!!0)
+		IL_02d7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten/FunctionObject_FunctionExpression_CB10A8EE_L30C8>(!!0)
 		IL_02dc: stloc.s 13
 		IL_02de: ldloc.s 5
 		IL_02e0: ldstr "x"
@@ -602,16 +1087,16 @@
 		IL_0343: ldloc.0
 		IL_0344: stelem.ref
 		IL_0345: stloc.s 6
-		IL_0347: newobj instance void FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_B2462A16_L38C8::.ctor()
+		IL_0347: newobj instance void Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject_FunctionExpression_B2462A16_L38C8::.ctor()
 		IL_034c: ldc.i4.0
 		IL_034d: conv.r8
 		IL_034e: ldstr ""
 		IL_0353: ldc.i4.0
 		IL_0354: ldc.i4.1
-		IL_0355: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_B2462A16_L38C8>(!!0, float64, string, bool, bool)
+		IL_0355: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject_FunctionExpression_B2462A16_L38C8>(!!0, float64, string, bool, bool)
 		IL_035a: stloc.s 14
 		IL_035c: ldloc.s 14
-		IL_035e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_B2462A16_L38C8>(!!0)
+		IL_035e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::MarkUndefinedPrototype<class Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite/FunctionObject_FunctionExpression_B2462A16_L38C8>(!!0)
 		IL_0363: stloc.s 14
 		IL_0365: ldloc.s 5
 		IL_0367: ldstr "x"
@@ -648,491 +1133,6 @@
 	} // end of method ObjectLiteral_AccessorDefinitions::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_AccessorDefinitions
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_131FC9A5_L5C12
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x251b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_131FC9A5_L5C12::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2523
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_131FC9A5_L5C12::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2526
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_131FC9A5_L5C12::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2529
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_131FC9A5_L5C12::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2535
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_131FC9A5_L5C12::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x253d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_131FC9A5_L5C12::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_131FC9A5_L5C12
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_A0C76C5C_L8C12
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x254c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_A0C76C5C_L8C12::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2554
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A0C76C5C_L8C12::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2557
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A0C76C5C_L8C12::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x255a
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_A0C76C5C_L8C12::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x256d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L8C11::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A0C76C5C_L8C12::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x257c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A0C76C5C_L8C12::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_A0C76C5C_L8C12
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_61B490A1_L11C17
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x258b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_61B490A1_L11C17::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2593
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_61B490A1_L11C17::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2596
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_61B490A1_L11C17::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2599
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_61B490A1_L11C17::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25a5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_obj_L11C16::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_61B490A1_L11C17::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25ad
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_61B490A1_L11C17::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_61B490A1_L11C17
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_CB10A8EE_L30C8
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x25bc
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_CB10A8EE_L30C8::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x25c4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_CB10A8EE_L30C8::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x25c7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_CB10A8EE_L30C8::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x25ca
-		// Header size: 1
-		// Code size: 16 (0x10)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call float64 Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten::__js_call__(object)
-		IL_000a: box [System.Runtime]System.Double
-		IL_000f: ret
-	} // end of method FunctionObject_FunctionExpression_CB10A8EE_L30C8::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25db
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call float64 Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_overwritten::__js_call__(object)
-		IL_0006: box [System.Runtime]System.Double
-		IL_000b: ret
-	} // end of method FunctionObject_FunctionExpression_CB10A8EE_L30C8::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25e8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_CB10A8EE_L30C8::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_CB10A8EE_L30C8
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_B2462A16_L38C8
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x25f7
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_B2462A16_L38C8::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x25ff
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_B2462A16_L38C8::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2602
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_B2462A16_L38C8::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2605
-		// Header size: 1
-		// Code size: 16 (0x10)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call float64 Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite::__js_call__(object)
-		IL_000a: box [System.Runtime]System.Double
-		IL_000f: ret
-	} // end of method FunctionObject_FunctionExpression_B2462A16_L38C8::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2616
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call float64 Modules.ObjectLiteral_AccessorDefinitions/FunctionExpression_spreadOverwrite::__js_call__(object)
-		IL_0006: box [System.Runtime]System.Double
-		IL_000b: ret
-	} // end of method FunctionObject_FunctionExpression_B2462A16_L38C8::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2623
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_B2462A16_L38C8::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_AccessorDefinitions_59A9C4CD.FunctionObject_FunctionExpression_B2462A16_L38C8
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_ComputedKey_EvaluationOrder.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_ComputedKey_EvaluationOrder.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B3D1F03E_f
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope _environment0_ObjectLiteral_ComputedKey_EvaluationOrder
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2284
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope Modules.ObjectLiteral_ComputedKey_EvaluationOrder/f/FunctionObject_FunctionDeclaration_B3D1F03E_f::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B3D1F03E_f::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2293
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B3D1F03E_f::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2296
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B3D1F03E_f::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2299
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope Modules.ObjectLiteral_ComputedKey_EvaluationOrder/f/FunctionObject_FunctionDeclaration_B3D1F03E_f::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/f::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_B3D1F03E_f::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22ab
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope Modules.ObjectLiteral_ComputedKey_EvaluationOrder/f/FunctionObject_FunctionDeclaration_B3D1F03E_f::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/f::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_B3D1F03E_f::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22b9
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B3D1F03E_f::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_B3D1F03E_f
+
 
 		// Methods
 		.method public hidebysig static 
@@ -92,6 +199,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B4D1F1D1_g
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope _environment0_ObjectLiteral_ComputedKey_EvaluationOrder
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x22c8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope Modules.ObjectLiteral_ComputedKey_EvaluationOrder/g/FunctionObject_FunctionDeclaration_B4D1F1D1_g::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B4D1F1D1_g::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22d7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B4D1F1D1_g::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22da
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B4D1F1D1_g::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22dd
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope Modules.ObjectLiteral_ComputedKey_EvaluationOrder/g/FunctionObject_FunctionDeclaration_B4D1F1D1_g::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/g::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_B4D1F1D1_g::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22ef
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope Modules.ObjectLiteral_ComputedKey_EvaluationOrder/g/FunctionObject_FunctionDeclaration_B4D1F1D1_g::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/g::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_B4D1F1D1_g::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22fd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B4D1F1D1_g::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_B4D1F1D1_g
 
 
 		// Methods
@@ -155,6 +369,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_ADD1E6CC_h
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope _environment0_ObjectLiteral_ComputedKey_EvaluationOrder
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x230c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope Modules.ObjectLiteral_ComputedKey_EvaluationOrder/h/FunctionObject_FunctionDeclaration_ADD1E6CC_h::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_ADD1E6CC_h::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x231b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_ADD1E6CC_h::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x231e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_ADD1E6CC_h::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2321
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope Modules.ObjectLiteral_ComputedKey_EvaluationOrder/h/FunctionObject_FunctionDeclaration_ADD1E6CC_h::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/h::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_ADD1E6CC_h::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2333
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope Modules.ObjectLiteral_ComputedKey_EvaluationOrder/h/FunctionObject_FunctionDeclaration_ADD1E6CC_h::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/h::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_ADD1E6CC_h::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2341
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_ADD1E6CC_h::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_ADD1E6CC_h
 
 
 		// Methods
@@ -246,9 +567,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope,
-			[1] class FunctionObjects.ObjectLiteral_ComputedKey_EvaluationOrder_0A21D269.FunctionObject_FunctionDeclaration_B3D1F03E_f,
-			[2] class FunctionObjects.ObjectLiteral_ComputedKey_EvaluationOrder_0A21D269.FunctionObject_FunctionDeclaration_B4D1F1D1_g,
-			[3] class FunctionObjects.ObjectLiteral_ComputedKey_EvaluationOrder_0A21D269.FunctionObject_FunctionDeclaration_ADD1E6CC_h,
+			[1] class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/f/FunctionObject_FunctionDeclaration_B3D1F03E_f,
+			[2] class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/g/FunctionObject_FunctionDeclaration_B4D1F1D1_g,
+			[3] class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/h/FunctionObject_FunctionDeclaration_ADD1E6CC_h,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[5] object[],
 			[6] object,
@@ -269,13 +590,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope
-		IL_001b: newobj instance void FunctionObjects.ObjectLiteral_ComputedKey_EvaluationOrder_0A21D269.FunctionObject_FunctionDeclaration_B3D1F03E_f::.ctor(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope)
+		IL_001b: newobj instance void Modules.ObjectLiteral_ComputedKey_EvaluationOrder/f/FunctionObject_FunctionDeclaration_B3D1F03E_f::.ctor(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope)
 		IL_0020: ldc.i4.0
 		IL_0021: conv.r8
 		IL_0022: ldstr "f"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_ComputedKey_EvaluationOrder_0A21D269.FunctionObject_FunctionDeclaration_B3D1F03E_f>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/f/FunctionObject_FunctionDeclaration_B3D1F03E_f>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: ldc.i4.1
 		IL_0030: newarr [System.Runtime]System.Object
@@ -288,13 +609,13 @@
 		IL_003d: ldc.i4.0
 		IL_003e: ldelem.ref
 		IL_003f: castclass Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope
-		IL_0044: newobj instance void FunctionObjects.ObjectLiteral_ComputedKey_EvaluationOrder_0A21D269.FunctionObject_FunctionDeclaration_B4D1F1D1_g::.ctor(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope)
+		IL_0044: newobj instance void Modules.ObjectLiteral_ComputedKey_EvaluationOrder/g/FunctionObject_FunctionDeclaration_B4D1F1D1_g::.ctor(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope)
 		IL_0049: ldc.i4.0
 		IL_004a: conv.r8
 		IL_004b: ldstr "g"
 		IL_0050: ldc.i4.0
 		IL_0051: ldc.i4.1
-		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_ComputedKey_EvaluationOrder_0A21D269.FunctionObject_FunctionDeclaration_B4D1F1D1_g>(!!0, float64, string, bool, bool)
+		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/g/FunctionObject_FunctionDeclaration_B4D1F1D1_g>(!!0, float64, string, bool, bool)
 		IL_0057: stloc.2
 		IL_0058: ldc.i4.1
 		IL_0059: newarr [System.Runtime]System.Object
@@ -307,13 +628,13 @@
 		IL_0066: ldc.i4.0
 		IL_0067: ldelem.ref
 		IL_0068: castclass Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope
-		IL_006d: newobj instance void FunctionObjects.ObjectLiteral_ComputedKey_EvaluationOrder_0A21D269.FunctionObject_FunctionDeclaration_ADD1E6CC_h::.ctor(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope)
+		IL_006d: newobj instance void Modules.ObjectLiteral_ComputedKey_EvaluationOrder/h/FunctionObject_FunctionDeclaration_ADD1E6CC_h::.ctor(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope)
 		IL_0072: ldc.i4.0
 		IL_0073: conv.r8
 		IL_0074: ldstr "h"
 		IL_0079: ldc.i4.0
 		IL_007a: ldc.i4.1
-		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_ComputedKey_EvaluationOrder_0A21D269.FunctionObject_FunctionDeclaration_ADD1E6CC_h>(!!0, float64, string, bool, bool)
+		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/h/FunctionObject_FunctionDeclaration_ADD1E6CC_h>(!!0, float64, string, bool, bool)
 		IL_0080: stloc.3
 		IL_0081: nop
 		IL_0082: ldloc.0
@@ -389,327 +710,6 @@
 	} // end of method ObjectLiteral_ComputedKey_EvaluationOrder::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_ComputedKey_EvaluationOrder
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_ComputedKey_EvaluationOrder_0A21D269.FunctionObject_FunctionDeclaration_B3D1F03E_f
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope _environment0_ObjectLiteral_ComputedKey_EvaluationOrder
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2284
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope FunctionObjects.ObjectLiteral_ComputedKey_EvaluationOrder_0A21D269.FunctionObject_FunctionDeclaration_B3D1F03E_f::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B3D1F03E_f::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2293
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B3D1F03E_f::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2296
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B3D1F03E_f::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2299
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope FunctionObjects.ObjectLiteral_ComputedKey_EvaluationOrder_0A21D269.FunctionObject_FunctionDeclaration_B3D1F03E_f::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/f::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_B3D1F03E_f::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22ab
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope FunctionObjects.ObjectLiteral_ComputedKey_EvaluationOrder_0A21D269.FunctionObject_FunctionDeclaration_B3D1F03E_f::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/f::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_B3D1F03E_f::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22b9
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B3D1F03E_f::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_ComputedKey_EvaluationOrder_0A21D269.FunctionObject_FunctionDeclaration_B3D1F03E_f
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_ComputedKey_EvaluationOrder_0A21D269.FunctionObject_FunctionDeclaration_B4D1F1D1_g
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope _environment0_ObjectLiteral_ComputedKey_EvaluationOrder
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x22c8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope FunctionObjects.ObjectLiteral_ComputedKey_EvaluationOrder_0A21D269.FunctionObject_FunctionDeclaration_B4D1F1D1_g::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B4D1F1D1_g::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22d7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B4D1F1D1_g::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22da
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B4D1F1D1_g::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22dd
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope FunctionObjects.ObjectLiteral_ComputedKey_EvaluationOrder_0A21D269.FunctionObject_FunctionDeclaration_B4D1F1D1_g::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/g::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_B4D1F1D1_g::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22ef
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope FunctionObjects.ObjectLiteral_ComputedKey_EvaluationOrder_0A21D269.FunctionObject_FunctionDeclaration_B4D1F1D1_g::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/g::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_B4D1F1D1_g::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22fd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B4D1F1D1_g::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_ComputedKey_EvaluationOrder_0A21D269.FunctionObject_FunctionDeclaration_B4D1F1D1_g
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_ComputedKey_EvaluationOrder_0A21D269.FunctionObject_FunctionDeclaration_ADD1E6CC_h
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope _environment0_ObjectLiteral_ComputedKey_EvaluationOrder
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x230c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope FunctionObjects.ObjectLiteral_ComputedKey_EvaluationOrder_0A21D269.FunctionObject_FunctionDeclaration_ADD1E6CC_h::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_ADD1E6CC_h::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x231b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_ADD1E6CC_h::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x231e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_ADD1E6CC_h::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2321
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope FunctionObjects.ObjectLiteral_ComputedKey_EvaluationOrder_0A21D269.FunctionObject_FunctionDeclaration_ADD1E6CC_h::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/h::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_ADD1E6CC_h::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2333
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope FunctionObjects.ObjectLiteral_ComputedKey_EvaluationOrder_0A21D269.FunctionObject_FunctionDeclaration_ADD1E6CC_h::_environment0_ObjectLiteral_ComputedKey_EvaluationOrder
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.ObjectLiteral_ComputedKey_EvaluationOrder/h::__js_call__(class Modules.ObjectLiteral_ComputedKey_EvaluationOrder/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_ADD1E6CC_h::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2341
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_ADD1E6CC_h::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_ComputedKey_EvaluationOrder_0A21D269.FunctionObject_FunctionDeclaration_ADD1E6CC_h
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_EarlyBoundAccess_Parity.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_EarlyBoundAccess_Parity.verified.txt
@@ -135,6 +135,122 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_722B85FE_inspect
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x29fd
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_722B85FE_inspect::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2a05
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_722B85FE_inspect::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2a08
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_722B85FE_inspect::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a0b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_722B85FE_inspect::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a13
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.ObjectLiteral_EarlyBoundAccess_Parity/inspect::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_722B85FE_inspect::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a26
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.ObjectLiteral_EarlyBoundAccess_Parity/inspect::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_722B85FE_inspect::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a35
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_722B85FE_inspect::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_722B85FE_inspect
+
 
 		// Methods
 		.method public hidebysig static 
@@ -624,7 +740,7 @@
 		.maxstack 12
 		.locals init (
 			[0] class Modules.ObjectLiteral_EarlyBoundAccess_Parity/Scope,
-			[1] class FunctionObjects.ObjectLiteral_EarlyBoundAccess_Parity_F13F1317.FunctionObject_FunctionDeclaration_722B85FE_inspect,
+			[1] class Modules.ObjectLiteral_EarlyBoundAccess_Parity/inspect/FunctionObject_FunctionDeclaration_722B85FE_inspect,
 			[2] class Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L2C18_eligible,
 			[3] class Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L22C17_counter,
 			[4] class Modules.ObjectLiteral_EarlyBoundAccess_Parity/ObjectLiterals/L30C18_nullable,
@@ -661,13 +777,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 14
-		IL_0012: newobj instance void FunctionObjects.ObjectLiteral_EarlyBoundAccess_Parity_F13F1317.FunctionObject_FunctionDeclaration_722B85FE_inspect::.ctor()
+		IL_0012: newobj instance void Modules.ObjectLiteral_EarlyBoundAccess_Parity/inspect/FunctionObject_FunctionDeclaration_722B85FE_inspect::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "inspect"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.0
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_EarlyBoundAccess_Parity_F13F1317.FunctionObject_FunctionDeclaration_722B85FE_inspect>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_EarlyBoundAccess_Parity/inspect/FunctionObject_FunctionDeclaration_722B85FE_inspect>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -1298,122 +1414,6 @@
 	} // end of method ObjectLiteral_EarlyBoundAccess_Parity::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_EarlyBoundAccess_Parity
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_EarlyBoundAccess_Parity_F13F1317.FunctionObject_FunctionDeclaration_722B85FE_inspect
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x29fd
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_722B85FE_inspect::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a05
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_722B85FE_inspect::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a08
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_722B85FE_inspect::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a0b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_722B85FE_inspect::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a13
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.ObjectLiteral_EarlyBoundAccess_Parity/inspect::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_722B85FE_inspect::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a26
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.ObjectLiteral_EarlyBoundAccess_Parity/inspect::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_722B85FE_inspect::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a35
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_722B85FE_inspect::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_EarlyBoundAccess_Parity_F13F1317.FunctionObject_FunctionDeclaration_722B85FE_inspect
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_EarlyBoundCapturedVarFunctionCall.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_EarlyBoundCapturedVarFunctionCall.verified.txt
@@ -31,6 +31,134 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_BE9889E4_L2C8
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21b3
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_BE9889E4_L2C8::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21bb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_BE9889E4_L2C8::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21be
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_BE9889E4_L2C8::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x21c1
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_BE9889E4_L2C8::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21c9
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.2
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/FunctionExpression_callable::__js_call__(object, object, object, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionExpression_BE9889E4_L2C8::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21ea
+				// Header size: 1
+				// Code size: 28 (0x1c)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: ldarg.2
+				IL_0010: ldc.i4.2
+				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0016: call object Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/FunctionExpression_callable::__js_call__(object, object, object, object)
+				IL_001b: ret
+			} // end of method FunctionObject_FunctionExpression_BE9889E4_L2C8::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2207
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_BE9889E4_L2C8::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_BE9889E4_L2C8
+
 
 		// Methods
 		.method public hidebysig static 
@@ -89,6 +217,128 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_939DC655_invokeCallable
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope _environment0_ObjectLiteral_EarlyBoundCapturedVarFunctionCall
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2216
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/invokeCallable/FunctionObject_FunctionDeclaration_939DC655_invokeCallable::_environment0_ObjectLiteral_EarlyBoundCapturedVarFunctionCall
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_939DC655_invokeCallable::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2225
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_939DC655_invokeCallable::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2228
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_939DC655_invokeCallable::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x222b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_939DC655_invokeCallable::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2233
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/invokeCallable/FunctionObject_FunctionDeclaration_939DC655_invokeCallable::_environment0_ObjectLiteral_EarlyBoundCapturedVarFunctionCall
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/invokeCallable::__js_call__(class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_939DC655_invokeCallable::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2245
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/invokeCallable/FunctionObject_FunctionDeclaration_939DC655_invokeCallable::_environment0_ObjectLiteral_EarlyBoundCapturedVarFunctionCall
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/invokeCallable::__js_call__(class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_939DC655_invokeCallable::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2253
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_939DC655_invokeCallable::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_939DC655_invokeCallable
 
 
 		// Methods
@@ -253,9 +503,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope,
-			[1] class FunctionObjects.ObjectLiteral_EarlyBoundCapturedVarFunctionCall_E3980D8A.FunctionObject_FunctionDeclaration_939DC655_invokeCallable,
+			[1] class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/invokeCallable/FunctionObject_FunctionDeclaration_939DC655_invokeCallable,
 			[2] object[],
-			[3] class FunctionObjects.ObjectLiteral_EarlyBoundCapturedVarFunctionCall_E3980D8A.FunctionObject_FunctionExpression_BE9889E4_L2C8,
+			[3] class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/FunctionExpression_callable/FunctionObject_FunctionExpression_BE9889E4_L2C8,
 			[4] class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/ObjectLiterals/L1C16_callable,
 			[5] object,
 			[6] object
@@ -274,13 +524,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope
-		IL_0019: newobj instance void FunctionObjects.ObjectLiteral_EarlyBoundCapturedVarFunctionCall_E3980D8A.FunctionObject_FunctionDeclaration_939DC655_invokeCallable::.ctor(class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope)
+		IL_0019: newobj instance void Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/invokeCallable/FunctionObject_FunctionDeclaration_939DC655_invokeCallable::.ctor(class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "invokeCallable"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.0
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_EarlyBoundCapturedVarFunctionCall_E3980D8A.FunctionObject_FunctionDeclaration_939DC655_invokeCallable>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/invokeCallable/FunctionObject_FunctionDeclaration_939DC655_invokeCallable>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: ldc.i4.1
 		IL_002e: newarr [System.Runtime]System.Object
@@ -289,13 +539,13 @@
 		IL_0035: ldloc.0
 		IL_0036: stelem.ref
 		IL_0037: stloc.2
-		IL_0038: newobj instance void FunctionObjects.ObjectLiteral_EarlyBoundCapturedVarFunctionCall_E3980D8A.FunctionObject_FunctionExpression_BE9889E4_L2C8::.ctor()
+		IL_0038: newobj instance void Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/FunctionExpression_callable/FunctionObject_FunctionExpression_BE9889E4_L2C8::.ctor()
 		IL_003d: ldc.i4.3
 		IL_003e: conv.r8
 		IL_003f: ldstr ""
 		IL_0044: ldc.i4.0
 		IL_0045: ldc.i4.0
-		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_EarlyBoundCapturedVarFunctionCall_E3980D8A.FunctionObject_FunctionExpression_BE9889E4_L2C8>(!!0, float64, string, bool, bool)
+		IL_0046: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/FunctionExpression_callable/FunctionObject_FunctionExpression_BE9889E4_L2C8>(!!0, float64, string, bool, bool)
 		IL_004b: stloc.3
 		IL_004c: newobj instance void Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/ObjectLiterals/L1C16_callable::.ctor()
 		IL_0051: stloc.s 4
@@ -324,256 +574,6 @@
 	} // end of method ObjectLiteral_EarlyBoundCapturedVarFunctionCall::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_EarlyBoundCapturedVarFunctionCall_E3980D8A.FunctionObject_FunctionExpression_BE9889E4_L2C8
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21b3
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_BE9889E4_L2C8::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21bb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_BE9889E4_L2C8::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21be
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_BE9889E4_L2C8::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x21c1
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_BE9889E4_L2C8::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21c9
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.2
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/FunctionExpression_callable::__js_call__(object, object, object, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionExpression_BE9889E4_L2C8::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ea
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: ldarg.2
-		IL_0010: ldc.i4.2
-		IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0016: call object Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/FunctionExpression_callable::__js_call__(object, object, object, object)
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_BE9889E4_L2C8::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2207
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_BE9889E4_L2C8::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_EarlyBoundCapturedVarFunctionCall_E3980D8A.FunctionObject_FunctionExpression_BE9889E4_L2C8
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_EarlyBoundCapturedVarFunctionCall_E3980D8A.FunctionObject_FunctionDeclaration_939DC655_invokeCallable
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope _environment0_ObjectLiteral_EarlyBoundCapturedVarFunctionCall
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2216
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope FunctionObjects.ObjectLiteral_EarlyBoundCapturedVarFunctionCall_E3980D8A.FunctionObject_FunctionDeclaration_939DC655_invokeCallable::_environment0_ObjectLiteral_EarlyBoundCapturedVarFunctionCall
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_939DC655_invokeCallable::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2225
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_939DC655_invokeCallable::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2228
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_939DC655_invokeCallable::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x222b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_939DC655_invokeCallable::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2233
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope FunctionObjects.ObjectLiteral_EarlyBoundCapturedVarFunctionCall_E3980D8A.FunctionObject_FunctionDeclaration_939DC655_invokeCallable::_environment0_ObjectLiteral_EarlyBoundCapturedVarFunctionCall
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/invokeCallable::__js_call__(class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_939DC655_invokeCallable::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2245
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope FunctionObjects.ObjectLiteral_EarlyBoundCapturedVarFunctionCall_E3980D8A.FunctionObject_FunctionDeclaration_939DC655_invokeCallable::_environment0_ObjectLiteral_EarlyBoundCapturedVarFunctionCall
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/invokeCallable::__js_call__(class Modules.ObjectLiteral_EarlyBoundCapturedVarFunctionCall/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_939DC655_invokeCallable::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2253
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_939DC655_invokeCallable::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_EarlyBoundCapturedVarFunctionCall_E3980D8A.FunctionObject_FunctionDeclaration_939DC655_invokeCallable
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_Inference_ClosureAndAliasing_Parity.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_Inference_ClosureAndAliasing_Parity.verified.txt
@@ -31,6 +31,122 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_25BCDD16_addFive
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2699
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_25BCDD16_addFive::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x26a1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_25BCDD16_addFive::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x26a4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_25BCDD16_addFive::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x26a7
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_25BCDD16_addFive::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x26af
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/addFive::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_25BCDD16_addFive::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26c2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/addFive::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_25BCDD16_addFive::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26d1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_25BCDD16_addFive::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_25BCDD16_addFive
+
 
 		// Methods
 		.method public hidebysig static 
@@ -94,6 +210,128 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3385C3D7_bump
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope _environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x26e0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/bump/FunctionObject_FunctionDeclaration_3385C3D7_bump::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3385C3D7_bump::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x26ef
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3385C3D7_bump::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x26f2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3385C3D7_bump::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x26f5
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_3385C3D7_bump::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x26fd
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/bump/FunctionObject_FunctionDeclaration_3385C3D7_bump::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/bump::__js_call__(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_3385C3D7_bump::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x270f
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/bump/FunctionObject_FunctionDeclaration_3385C3D7_bump::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/bump::__js_call__(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_3385C3D7_bump::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x271d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3385C3D7_bump::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_3385C3D7_bump
 
 
 		// Methods
@@ -170,6 +408,128 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D67744E0_L32C18
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope _environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x272c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_getValue/FunctionObject_FunctionExpression_D67744E0_L32C18::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_D67744E0_L32C18::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x273b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D67744E0_L32C18::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x273e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D67744E0_L32C18::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2741
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_D67744E0_L32C18::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2749
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_getValue/FunctionObject_FunctionExpression_D67744E0_L32C18::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_getValue::__js_call__(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_D67744E0_L32C18::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x275b
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_getValue/FunctionObject_FunctionExpression_D67744E0_L32C18::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_getValue::__js_call__(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_D67744E0_L32C18::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2769
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_D67744E0_L32C18::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_D67744E0_L32C18
+
 
 		// Methods
 		.method public hidebysig static 
@@ -227,6 +587,134 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_09405E31_L33C18
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope _environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2778
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_setValue/FunctionObject_FunctionExpression_09405E31_L33C18::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_09405E31_L33C18::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2787
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_09405E31_L33C18::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x278a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_09405E31_L33C18::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x278d
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_09405E31_L33C18::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2795
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_setValue/FunctionObject_FunctionExpression_09405E31_L33C18::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_setValue::__js_call__(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_09405E31_L33C18::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x27ae
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_setValue/FunctionObject_FunctionExpression_09405E31_L33C18::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_setValue::__js_call__(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_09405E31_L33C18::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x27c3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_09405E31_L33C18::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_09405E31_L33C18
 
 
 		// Methods
@@ -286,6 +774,128 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_442D5AC0_flip
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope _environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x27d2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/flip/FunctionObject_FunctionDeclaration_442D5AC0_flip::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_442D5AC0_flip::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x27e1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_442D5AC0_flip::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x27e4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_442D5AC0_flip::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x27e7
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_442D5AC0_flip::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x27ef
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/flip/FunctionObject_FunctionDeclaration_442D5AC0_flip::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/flip::__js_call__(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_442D5AC0_flip::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2801
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/flip/FunctionObject_FunctionDeclaration_442D5AC0_flip::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/flip::__js_call__(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_442D5AC0_flip::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x280f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_442D5AC0_flip::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_442D5AC0_flip
 
 
 		// Methods
@@ -646,9 +1256,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope,
-			[1] class FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionDeclaration_25BCDD16_addFive,
-			[2] class FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionDeclaration_3385C3D7_bump,
-			[3] class FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionDeclaration_442D5AC0_flip,
+			[1] class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/addFive/FunctionObject_FunctionDeclaration_25BCDD16_addFive,
+			[2] class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/bump/FunctionObject_FunctionDeclaration_3385C3D7_bump,
+			[3] class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/flip/FunctionObject_FunctionDeclaration_442D5AC0_flip,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -665,8 +1275,8 @@
 			[17] object,
 			[18] string,
 			[19] class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/ObjectLiterals/L31C13_box,
-			[20] class FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionExpression_D67744E0_L32C18,
-			[21] class FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionExpression_09405E31_L33C18,
+			[20] class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_getValue/FunctionObject_FunctionExpression_D67744E0_L32C18,
+			[21] class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_setValue/FunctionObject_FunctionExpression_09405E31_L33C18,
 			[22] float64,
 			[23] object,
 			[24] class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/ObjectLiterals/L38C19_toggleState
@@ -681,13 +1291,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 9
-		IL_0012: newobj instance void FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionDeclaration_25BCDD16_addFive::.ctor()
+		IL_0012: newobj instance void Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/addFive/FunctionObject_FunctionDeclaration_25BCDD16_addFive::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "addFive"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.0
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionDeclaration_25BCDD16_addFive>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/addFive/FunctionObject_FunctionDeclaration_25BCDD16_addFive>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -700,13 +1310,13 @@
 		IL_0034: ldc.i4.0
 		IL_0035: ldelem.ref
 		IL_0036: castclass Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope
-		IL_003b: newobj instance void FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionDeclaration_3385C3D7_bump::.ctor(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope)
+		IL_003b: newobj instance void Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/bump/FunctionObject_FunctionDeclaration_3385C3D7_bump::.ctor(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope)
 		IL_0040: ldc.i4.0
 		IL_0041: conv.r8
 		IL_0042: ldstr "bump"
 		IL_0047: ldc.i4.0
 		IL_0048: ldc.i4.0
-		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionDeclaration_3385C3D7_bump>(!!0, float64, string, bool, bool)
+		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/bump/FunctionObject_FunctionDeclaration_3385C3D7_bump>(!!0, float64, string, bool, bool)
 		IL_004e: stloc.2
 		IL_004f: ldc.i4.1
 		IL_0050: newarr [System.Runtime]System.Object
@@ -719,13 +1329,13 @@
 		IL_005d: ldc.i4.0
 		IL_005e: ldelem.ref
 		IL_005f: castclass Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope
-		IL_0064: newobj instance void FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionDeclaration_442D5AC0_flip::.ctor(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope)
+		IL_0064: newobj instance void Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/flip/FunctionObject_FunctionDeclaration_442D5AC0_flip::.ctor(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope)
 		IL_0069: ldc.i4.0
 		IL_006a: conv.r8
 		IL_006b: ldstr "flip"
 		IL_0070: ldc.i4.0
 		IL_0071: ldc.i4.0
-		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionDeclaration_442D5AC0_flip>(!!0, float64, string, bool, bool)
+		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/flip/FunctionObject_FunctionDeclaration_442D5AC0_flip>(!!0, float64, string, bool, bool)
 		IL_0077: stloc.3
 		IL_0078: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_007d: dup
@@ -884,13 +1494,13 @@
 		IL_025b: ldc.i4.0
 		IL_025c: ldelem.ref
 		IL_025d: castclass Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope
-		IL_0262: newobj instance void FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionExpression_D67744E0_L32C18::.ctor(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope)
+		IL_0262: newobj instance void Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_getValue/FunctionObject_FunctionExpression_D67744E0_L32C18::.ctor(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope)
 		IL_0267: ldc.i4.0
 		IL_0268: conv.r8
 		IL_0269: ldstr ""
 		IL_026e: ldc.i4.0
 		IL_026f: ldc.i4.0
-		IL_0270: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionExpression_D67744E0_L32C18>(!!0, float64, string, bool, bool)
+		IL_0270: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_getValue/FunctionObject_FunctionExpression_D67744E0_L32C18>(!!0, float64, string, bool, bool)
 		IL_0275: stloc.s 20
 		IL_0277: ldloc.s 20
 		IL_0279: ldstr "getValue"
@@ -907,13 +1517,13 @@
 		IL_0293: ldc.i4.0
 		IL_0294: ldelem.ref
 		IL_0295: castclass Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope
-		IL_029a: newobj instance void FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionExpression_09405E31_L33C18::.ctor(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope)
+		IL_029a: newobj instance void Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_setValue/FunctionObject_FunctionExpression_09405E31_L33C18::.ctor(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope)
 		IL_029f: ldc.i4.1
 		IL_02a0: conv.r8
 		IL_02a1: ldstr ""
 		IL_02a6: ldc.i4.0
 		IL_02a7: ldc.i4.0
-		IL_02a8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionExpression_09405E31_L33C18>(!!0, float64, string, bool, bool)
+		IL_02a8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_setValue/FunctionObject_FunctionExpression_09405E31_L33C18>(!!0, float64, string, bool, bool)
 		IL_02ad: stloc.s 21
 		IL_02af: ldloc.s 21
 		IL_02b1: ldstr "setValue"
@@ -1030,616 +1640,6 @@
 	} // end of method ObjectLiteral_Inference_ClosureAndAliasing_Parity::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionDeclaration_25BCDD16_addFive
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2699
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_25BCDD16_addFive::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x26a1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_25BCDD16_addFive::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x26a4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_25BCDD16_addFive::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x26a7
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_25BCDD16_addFive::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x26af
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/addFive::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_25BCDD16_addFive::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26c2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/addFive::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_25BCDD16_addFive::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26d1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_25BCDD16_addFive::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionDeclaration_25BCDD16_addFive
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionDeclaration_3385C3D7_bump
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope _environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x26e0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionDeclaration_3385C3D7_bump::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3385C3D7_bump::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x26ef
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3385C3D7_bump::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x26f2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3385C3D7_bump::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x26f5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_3385C3D7_bump::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x26fd
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionDeclaration_3385C3D7_bump::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/bump::__js_call__(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_3385C3D7_bump::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x270f
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionDeclaration_3385C3D7_bump::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/bump::__js_call__(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_3385C3D7_bump::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x271d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3385C3D7_bump::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionDeclaration_3385C3D7_bump
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionExpression_D67744E0_L32C18
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope _environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x272c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionExpression_D67744E0_L32C18::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D67744E0_L32C18::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x273b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D67744E0_L32C18::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x273e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D67744E0_L32C18::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2741
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_D67744E0_L32C18::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2749
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionExpression_D67744E0_L32C18::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_getValue::__js_call__(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_D67744E0_L32C18::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x275b
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionExpression_D67744E0_L32C18::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_getValue::__js_call__(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_D67744E0_L32C18::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2769
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D67744E0_L32C18::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionExpression_D67744E0_L32C18
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionExpression_09405E31_L33C18
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope _environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2778
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionExpression_09405E31_L33C18::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_09405E31_L33C18::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2787
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_09405E31_L33C18::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x278a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_09405E31_L33C18::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x278d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_09405E31_L33C18::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2795
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionExpression_09405E31_L33C18::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_setValue::__js_call__(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_09405E31_L33C18::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27ae
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionExpression_09405E31_L33C18::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/FunctionExpression_setValue::__js_call__(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_09405E31_L33C18::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27c3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_09405E31_L33C18::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionExpression_09405E31_L33C18
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionDeclaration_442D5AC0_flip
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope _environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x27d2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionDeclaration_442D5AC0_flip::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_442D5AC0_flip::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x27e1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_442D5AC0_flip::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x27e4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_442D5AC0_flip::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x27e7
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_442D5AC0_flip::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x27ef
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionDeclaration_442D5AC0_flip::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/flip::__js_call__(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_442D5AC0_flip::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2801
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionDeclaration_442D5AC0_flip::_environment0_ObjectLiteral_Inference_ClosureAndAliasing_Parity
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/flip::__js_call__(class Modules.ObjectLiteral_Inference_ClosureAndAliasing_Parity/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_442D5AC0_flip::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x280f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_442D5AC0_flip::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_Inference_ClosureAndAliasing_Parity_0D57C72C.FunctionObject_FunctionDeclaration_442D5AC0_flip
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_Inference_EnumerationAndJson_Parity.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_Inference_EnumerationAndJson_Parity.verified.txt
@@ -31,6 +31,122 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F0AB7575_L17C41
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x26f5
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_F0AB7575_L17C41::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x26fd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F0AB7575_L17C41::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2700
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F0AB7575_L17C41::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2703
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_F0AB7575_L17C41::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x270b
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_L17C40::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_F0AB7575_L17C41::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x271e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_L17C40::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_F0AB7575_L17C41::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x272d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_F0AB7575_L17C41::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_F0AB7575_L17C41
+
 
 		// Methods
 		.method public hidebysig static 
@@ -96,6 +212,118 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_094B7E6B_L31C7
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x273c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_094B7E6B_L31C7::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2744
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_094B7E6B_L31C7::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2747
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_094B7E6B_L31C7::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x274a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_094B7E6B_L31C7::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2752
+				// Header size: 1
+				// Code size: 16 (0x10)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call float64 Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_jsonObj::__js_call__(object)
+				IL_000a: box [System.Runtime]System.Double
+				IL_000f: ret
+			} // end of method FunctionObject_FunctionExpression_094B7E6B_L31C7::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2763
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call float64 Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_jsonObj::__js_call__(object)
+				IL_0006: box [System.Runtime]System.Double
+				IL_000b: ret
+			} // end of method FunctionObject_FunctionExpression_094B7E6B_L31C7::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2770
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_094B7E6B_L31C7::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_094B7E6B_L31C7
 
 
 		// Methods
@@ -342,9 +570,9 @@
 			[13] string,
 			[14] object,
 			[15] object[],
-			[16] class FunctionObjects.ObjectLiteral_Inference_EnumerationAndJson_Parity_1F7C3B1C.FunctionObject_FunctionExpression_F0AB7575_L17C41,
+			[16] class Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_L17C40/FunctionObject_FunctionExpression_F0AB7575_L17C41,
 			[17] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[18] class FunctionObjects.ObjectLiteral_Inference_EnumerationAndJson_Parity_1F7C3B1C.FunctionObject_FunctionExpression_094B7E6B_L31C7,
+			[18] class Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_jsonObj/FunctionObject_FunctionExpression_094B7E6B_L31C7,
 			[19] object,
 			[20] float64,
 			[21] object,
@@ -485,13 +713,13 @@
 		IL_01cb: ldloc.0
 		IL_01cc: stelem.ref
 		IL_01cd: stloc.s 15
-		IL_01cf: newobj instance void FunctionObjects.ObjectLiteral_Inference_EnumerationAndJson_Parity_1F7C3B1C.FunctionObject_FunctionExpression_F0AB7575_L17C41::.ctor()
+		IL_01cf: newobj instance void Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_L17C40/FunctionObject_FunctionExpression_F0AB7575_L17C41::.ctor()
 		IL_01d4: ldc.i4.1
 		IL_01d5: conv.r8
 		IL_01d6: ldstr ""
 		IL_01db: ldc.i4.0
 		IL_01dc: ldc.i4.0
-		IL_01dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_Inference_EnumerationAndJson_Parity_1F7C3B1C.FunctionObject_FunctionExpression_F0AB7575_L17C41>(!!0, float64, string, bool, bool)
+		IL_01dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_L17C40/FunctionObject_FunctionExpression_F0AB7575_L17C41>(!!0, float64, string, bool, bool)
 		IL_01e2: stloc.s 16
 		IL_01e4: ldloc.s 14
 		IL_01e6: ldstr "map"
@@ -574,13 +802,13 @@
 		IL_0307: ldloc.0
 		IL_0308: stelem.ref
 		IL_0309: stloc.s 15
-		IL_030b: newobj instance void FunctionObjects.ObjectLiteral_Inference_EnumerationAndJson_Parity_1F7C3B1C.FunctionObject_FunctionExpression_094B7E6B_L31C7::.ctor()
+		IL_030b: newobj instance void Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_jsonObj/FunctionObject_FunctionExpression_094B7E6B_L31C7::.ctor()
 		IL_0310: ldc.i4.0
 		IL_0311: conv.r8
 		IL_0312: ldstr ""
 		IL_0317: ldc.i4.0
 		IL_0318: ldc.i4.0
-		IL_0319: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_Inference_EnumerationAndJson_Parity_1F7C3B1C.FunctionObject_FunctionExpression_094B7E6B_L31C7>(!!0, float64, string, bool, bool)
+		IL_0319: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_jsonObj/FunctionObject_FunctionExpression_094B7E6B_L31C7>(!!0, float64, string, bool, bool)
 		IL_031e: stloc.s 18
 		IL_0320: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0325: dup
@@ -776,234 +1004,6 @@
 	} // end of method ObjectLiteral_Inference_EnumerationAndJson_Parity::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_Inference_EnumerationAndJson_Parity_1F7C3B1C.FunctionObject_FunctionExpression_F0AB7575_L17C41
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x26f5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_F0AB7575_L17C41::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x26fd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F0AB7575_L17C41::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2700
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F0AB7575_L17C41::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2703
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_F0AB7575_L17C41::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x270b
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_L17C40::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_F0AB7575_L17C41::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x271e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_L17C40::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F0AB7575_L17C41::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x272d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F0AB7575_L17C41::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_Inference_EnumerationAndJson_Parity_1F7C3B1C.FunctionObject_FunctionExpression_F0AB7575_L17C41
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_Inference_EnumerationAndJson_Parity_1F7C3B1C.FunctionObject_FunctionExpression_094B7E6B_L31C7
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x273c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_094B7E6B_L31C7::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2744
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_094B7E6B_L31C7::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2747
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_094B7E6B_L31C7::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x274a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_094B7E6B_L31C7::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2752
-		// Header size: 1
-		// Code size: 16 (0x10)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call float64 Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_jsonObj::__js_call__(object)
-		IL_000a: box [System.Runtime]System.Double
-		IL_000f: ret
-	} // end of method FunctionObject_FunctionExpression_094B7E6B_L31C7::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2763
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call float64 Modules.ObjectLiteral_Inference_EnumerationAndJson_Parity/FunctionExpression_jsonObj::__js_call__(object)
-		IL_0006: box [System.Runtime]System.Double
-		IL_000b: ret
-	} // end of method FunctionObject_FunctionExpression_094B7E6B_L31C7::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2770
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_094B7E6B_L31C7::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_Inference_EnumerationAndJson_Parity_1F7C3B1C.FunctionObject_FunctionExpression_094B7E6B_L31C7
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_InferredConstruction_Parity.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_InferredConstruction_Parity.verified.txt
@@ -31,6 +31,116 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_076C2543_L6C7
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x24f7
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_076C2543_L6C7::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24ff
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_076C2543_L6C7::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2502
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_076C2543_L6C7::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2505
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_076C2543_L6C7::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x250d
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_eligible::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_076C2543_L6C7::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2519
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_eligible::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_076C2543_L6C7::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2521
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_076C2543_L6C7::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_076C2543_L6C7
+
 
 		// Methods
 		.method public hidebysig static 
@@ -76,6 +186,116 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E0AC30F6_L18C7
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2530
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_E0AC30F6_L18C7::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2538
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E0AC30F6_L18C7::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x253b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E0AC30F6_L18C7::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x253e
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_E0AC30F6_L18C7::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2546
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_a::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_E0AC30F6_L18C7::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2552
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_a::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_E0AC30F6_L18C7::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x255a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E0AC30F6_L18C7::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_E0AC30F6_L18C7
+
 
 		// Methods
 		.method public hidebysig static 
@@ -120,6 +340,122 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3622E258_leak
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2569
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_3622E258_leak::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2571
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3622E258_leak::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2574
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3622E258_leak::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2577
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_3622E258_leak::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x257f
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.ObjectLiteral_InferredConstruction_Parity/leak::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_3622E258_leak::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2592
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.ObjectLiteral_InferredConstruction_Parity/leak::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3622E258_leak::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25a1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3622E258_leak::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_3622E258_leak
 
 
 		// Methods
@@ -405,13 +741,13 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_InferredConstruction_Parity/Scope,
-			[1] class FunctionObjects.ObjectLiteral_InferredConstruction_Parity_568091E4.FunctionObject_FunctionDeclaration_3622E258_leak,
+			[1] class Modules.ObjectLiteral_InferredConstruction_Parity/leak/FunctionObject_FunctionDeclaration_3622E258_leak,
 			[2] class Modules.ObjectLiteral_InferredConstruction_Parity/ObjectLiterals/L1C18_eligible,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[4] object,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[6] object[],
-			[7] class FunctionObjects.ObjectLiteral_InferredConstruction_Parity_568091E4.FunctionObject_FunctionExpression_076C2543_L6C7,
+			[7] class Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_eligible/FunctionObject_FunctionExpression_076C2543_L6C7,
 			[8] object,
 			[9] string,
 			[10] float64,
@@ -422,7 +758,7 @@
 			[15] object,
 			[16] class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject,
 			[17] string,
-			[18] class FunctionObjects.ObjectLiteral_InferredConstruction_Parity_568091E4.FunctionObject_FunctionExpression_E0AC30F6_L18C7,
+			[18] class Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_a/FunctionObject_FunctionExpression_E0AC30F6_L18C7,
 			[19] object,
 			[20] object,
 			[21] object
@@ -437,13 +773,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 6
-		IL_0012: newobj instance void FunctionObjects.ObjectLiteral_InferredConstruction_Parity_568091E4.FunctionObject_FunctionDeclaration_3622E258_leak::.ctor()
+		IL_0012: newobj instance void Modules.ObjectLiteral_InferredConstruction_Parity/leak/FunctionObject_FunctionDeclaration_3622E258_leak::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "leak"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.0
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_InferredConstruction_Parity_568091E4.FunctionObject_FunctionDeclaration_3622E258_leak>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InferredConstruction_Parity/leak/FunctionObject_FunctionDeclaration_3622E258_leak>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -452,13 +788,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 6
-		IL_0032: newobj instance void FunctionObjects.ObjectLiteral_InferredConstruction_Parity_568091E4.FunctionObject_FunctionExpression_076C2543_L6C7::.ctor()
+		IL_0032: newobj instance void Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_eligible/FunctionObject_FunctionExpression_076C2543_L6C7::.ctor()
 		IL_0037: ldc.i4.0
 		IL_0038: conv.r8
 		IL_0039: ldstr ""
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.0
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_InferredConstruction_Parity_568091E4.FunctionObject_FunctionExpression_076C2543_L6C7>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_eligible/FunctionObject_FunctionExpression_076C2543_L6C7>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.s 7
 		IL_0047: newobj instance void Modules.ObjectLiteral_InferredConstruction_Parity/ObjectLiterals/L1C18_eligible::.ctor()
 		IL_004c: stloc.2
@@ -552,13 +888,13 @@
 		IL_013b: ldloc.0
 		IL_013c: stelem.ref
 		IL_013d: stloc.s 6
-		IL_013f: newobj instance void FunctionObjects.ObjectLiteral_InferredConstruction_Parity_568091E4.FunctionObject_FunctionExpression_E0AC30F6_L18C7::.ctor()
+		IL_013f: newobj instance void Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_a/FunctionObject_FunctionExpression_E0AC30F6_L18C7::.ctor()
 		IL_0144: ldc.i4.0
 		IL_0145: conv.r8
 		IL_0146: ldstr ""
 		IL_014b: ldc.i4.0
 		IL_014c: ldc.i4.0
-		IL_014d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_InferredConstruction_Parity_568091E4.FunctionObject_FunctionExpression_E0AC30F6_L18C7>(!!0, float64, string, bool, bool)
+		IL_014d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_a/FunctionObject_FunctionExpression_E0AC30F6_L18C7>(!!0, float64, string, bool, bool)
 		IL_0152: stloc.s 18
 		IL_0154: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0159: dup
@@ -745,342 +1081,6 @@
 	} // end of method ObjectLiteral_InferredConstruction_Parity::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_InferredConstruction_Parity
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_InferredConstruction_Parity_568091E4.FunctionObject_FunctionExpression_076C2543_L6C7
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x24f7
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_076C2543_L6C7::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24ff
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_076C2543_L6C7::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2502
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_076C2543_L6C7::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2505
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_076C2543_L6C7::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x250d
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_eligible::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_076C2543_L6C7::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2519
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_eligible::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_076C2543_L6C7::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2521
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_076C2543_L6C7::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_InferredConstruction_Parity_568091E4.FunctionObject_FunctionExpression_076C2543_L6C7
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_InferredConstruction_Parity_568091E4.FunctionObject_FunctionExpression_E0AC30F6_L18C7
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2530
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_E0AC30F6_L18C7::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2538
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E0AC30F6_L18C7::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x253b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E0AC30F6_L18C7::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x253e
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_E0AC30F6_L18C7::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2546
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_a::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_E0AC30F6_L18C7::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2552
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.ObjectLiteral_InferredConstruction_Parity/FunctionExpression_a::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_E0AC30F6_L18C7::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x255a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E0AC30F6_L18C7::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_InferredConstruction_Parity_568091E4.FunctionObject_FunctionExpression_E0AC30F6_L18C7
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_InferredConstruction_Parity_568091E4.FunctionObject_FunctionDeclaration_3622E258_leak
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2569
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_3622E258_leak::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2571
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3622E258_leak::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2574
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3622E258_leak::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2577
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_3622E258_leak::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x257f
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.ObjectLiteral_InferredConstruction_Parity/leak::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_3622E258_leak::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2592
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.ObjectLiteral_InferredConstruction_Parity/leak::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3622E258_leak::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25a1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3622E258_leak::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_InferredConstruction_Parity_568091E4.FunctionObject_FunctionDeclaration_3622E258_leak
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_InlinePropertyInit.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_InlinePropertyInit.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6E078FF7_getX
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.ObjectLiteral_InlinePropertyInit/Scope _environment0_ObjectLiteral_InlinePropertyInit
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.ObjectLiteral_InlinePropertyInit/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21ca
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.ObjectLiteral_InlinePropertyInit/Scope Modules.ObjectLiteral_InlinePropertyInit/getX/FunctionObject_FunctionDeclaration_6E078FF7_getX::_environment0_ObjectLiteral_InlinePropertyInit
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6E078FF7_getX::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21d9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6E078FF7_getX::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21dc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6E078FF7_getX::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21df
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectLiteral_InlinePropertyInit/Scope Modules.ObjectLiteral_InlinePropertyInit/getX/FunctionObject_FunctionDeclaration_6E078FF7_getX::_environment0_ObjectLiteral_InlinePropertyInit
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.ObjectLiteral_InlinePropertyInit/getX::__js_call__(class Modules.ObjectLiteral_InlinePropertyInit/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_6E078FF7_getX::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f1
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectLiteral_InlinePropertyInit/Scope Modules.ObjectLiteral_InlinePropertyInit/getX/FunctionObject_FunctionDeclaration_6E078FF7_getX::_environment0_ObjectLiteral_InlinePropertyInit
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.ObjectLiteral_InlinePropertyInit/getX::__js_call__(class Modules.ObjectLiteral_InlinePropertyInit/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_6E078FF7_getX::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21ff
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6E078FF7_getX::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_6E078FF7_getX
+
 
 		// Methods
 		.method public hidebysig static 
@@ -117,7 +224,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_InlinePropertyInit/Scope,
-			[1] class FunctionObjects.ObjectLiteral_InlinePropertyInit_61D2DC24.FunctionObject_FunctionDeclaration_6E078FF7_getX,
+			[1] class Modules.ObjectLiteral_InlinePropertyInit/getX/FunctionObject_FunctionDeclaration_6E078FF7_getX,
 			[2] object[],
 			[3] object,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -137,13 +244,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.ObjectLiteral_InlinePropertyInit/Scope
-		IL_0019: newobj instance void FunctionObjects.ObjectLiteral_InlinePropertyInit_61D2DC24.FunctionObject_FunctionDeclaration_6E078FF7_getX::.ctor(class Modules.ObjectLiteral_InlinePropertyInit/Scope)
+		IL_0019: newobj instance void Modules.ObjectLiteral_InlinePropertyInit/getX/FunctionObject_FunctionDeclaration_6E078FF7_getX::.ctor(class Modules.ObjectLiteral_InlinePropertyInit/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "getX"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_InlinePropertyInit_61D2DC24.FunctionObject_FunctionDeclaration_6E078FF7_getX>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InlinePropertyInit/getX/FunctionObject_FunctionDeclaration_6E078FF7_getX>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldstr "console"
@@ -210,113 +317,6 @@
 	} // end of method ObjectLiteral_InlinePropertyInit::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_InlinePropertyInit
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_InlinePropertyInit_61D2DC24.FunctionObject_FunctionDeclaration_6E078FF7_getX
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ObjectLiteral_InlinePropertyInit/Scope _environment0_ObjectLiteral_InlinePropertyInit
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ObjectLiteral_InlinePropertyInit/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ca
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ObjectLiteral_InlinePropertyInit/Scope FunctionObjects.ObjectLiteral_InlinePropertyInit_61D2DC24.FunctionObject_FunctionDeclaration_6E078FF7_getX::_environment0_ObjectLiteral_InlinePropertyInit
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6E078FF7_getX::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21d9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6E078FF7_getX::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21dc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6E078FF7_getX::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21df
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectLiteral_InlinePropertyInit/Scope FunctionObjects.ObjectLiteral_InlinePropertyInit_61D2DC24.FunctionObject_FunctionDeclaration_6E078FF7_getX::_environment0_ObjectLiteral_InlinePropertyInit
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.ObjectLiteral_InlinePropertyInit/getX::__js_call__(class Modules.ObjectLiteral_InlinePropertyInit/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_6E078FF7_getX::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f1
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectLiteral_InlinePropertyInit/Scope FunctionObjects.ObjectLiteral_InlinePropertyInit_61D2DC24.FunctionObject_FunctionDeclaration_6E078FF7_getX::_environment0_ObjectLiteral_InlinePropertyInit
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.ObjectLiteral_InlinePropertyInit/getX::__js_call__(class Modules.ObjectLiteral_InlinePropertyInit/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_6E078FF7_getX::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ff
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6E078FF7_getX::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_InlinePropertyInit_61D2DC24.FunctionObject_FunctionDeclaration_6E078FF7_getX
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_InterproceduralInference_Parity.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_InterproceduralInference_Parity.verified.txt
@@ -31,6 +31,122 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8C67F5E2_c
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2899
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_8C67F5E2_c::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x28a1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8C67F5E2_c::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x28a4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8C67F5E2_c::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x28a7
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_8C67F5E2_c::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x28af
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.ObjectLiteral_InterproceduralInference_Parity/c::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_8C67F5E2_c::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x28c2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.ObjectLiteral_InterproceduralInference_Parity/c::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8C67F5E2_c::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x28d1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8C67F5E2_c::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_8C67F5E2_c
+
 
 		// Methods
 		.method public hidebysig static 
@@ -93,6 +209,122 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DDB94903_h6
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x28e0
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_DDB94903_h6::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x28e8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DDB94903_h6::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x28eb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DDB94903_h6::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x28ee
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_DDB94903_h6::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x28f6
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h6::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_DDB94903_h6::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2909
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h6::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DDB94903_h6::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2918
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DDB94903_h6::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_DDB94903_h6
 
 
 		// Methods
@@ -161,6 +393,134 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DEB94A96_h5
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope _environment0_ObjectLiteral_InterproceduralInference_Parity
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2927
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h5/FunctionObject_FunctionDeclaration_DEB94A96_h5::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DEB94A96_h5::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2936
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DEB94A96_h5::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2939
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DEB94A96_h5::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x293c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_DEB94A96_h5::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2944
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h5/FunctionObject_FunctionDeclaration_DEB94A96_h5::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h5::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_DEB94A96_h5::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x295d
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h5/FunctionObject_FunctionDeclaration_DEB94A96_h5::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h5::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_DEB94A96_h5::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2972
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DEB94A96_h5::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_DEB94A96_h5
+
 
 		// Methods
 		.method public hidebysig static 
@@ -213,6 +573,134 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DFB94C29_h4
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope _environment0_ObjectLiteral_InterproceduralInference_Parity
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2981
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h4/FunctionObject_FunctionDeclaration_DFB94C29_h4::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DFB94C29_h4::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2990
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DFB94C29_h4::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2993
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DFB94C29_h4::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2996
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_DFB94C29_h4::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x299e
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h4/FunctionObject_FunctionDeclaration_DFB94C29_h4::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h4::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_DFB94C29_h4::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x29b7
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h4/FunctionObject_FunctionDeclaration_DFB94C29_h4::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h4::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_DFB94C29_h4::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x29cc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DFB94C29_h4::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_DFB94C29_h4
 
 
 		// Methods
@@ -269,6 +757,134 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E0B94DBC_h3
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope _environment0_ObjectLiteral_InterproceduralInference_Parity
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x29db
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h3/FunctionObject_FunctionDeclaration_E0B94DBC_h3::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E0B94DBC_h3::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x29ea
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E0B94DBC_h3::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x29ed
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E0B94DBC_h3::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x29f0
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_E0B94DBC_h3::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x29f8
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h3/FunctionObject_FunctionDeclaration_E0B94DBC_h3::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h3::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_E0B94DBC_h3::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a11
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h3/FunctionObject_FunctionDeclaration_E0B94DBC_h3::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h3::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_E0B94DBC_h3::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a26
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E0B94DBC_h3::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E0B94DBC_h3
+
 
 		// Methods
 		.method public hidebysig static 
@@ -323,6 +939,134 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E1B94F4F_h2
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope _environment0_ObjectLiteral_InterproceduralInference_Parity
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a35
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h2/FunctionObject_FunctionDeclaration_E1B94F4F_h2::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E1B94F4F_h2::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2a44
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E1B94F4F_h2::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2a47
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E1B94F4F_h2::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a4a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_E1B94F4F_h2::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a52
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h2/FunctionObject_FunctionDeclaration_E1B94F4F_h2::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h2::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_E1B94F4F_h2::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a6b
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h2/FunctionObject_FunctionDeclaration_E1B94F4F_h2::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h2::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_E1B94F4F_h2::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a80
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E1B94F4F_h2::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E1B94F4F_h2
 
 
 		// Methods
@@ -379,6 +1123,134 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E2B950E2_h1
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope _environment0_ObjectLiteral_InterproceduralInference_Parity
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a8f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h1/FunctionObject_FunctionDeclaration_E2B950E2_h1::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E2B950E2_h1::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2a9e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E2B950E2_h1::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2aa1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E2B950E2_h1::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2aa4
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_E2B950E2_h1::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2aac
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h1/FunctionObject_FunctionDeclaration_E2B950E2_h1::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h1::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_E2B950E2_h1::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ac5
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope Modules.ObjectLiteral_InterproceduralInference_Parity/h1/FunctionObject_FunctionDeclaration_E2B950E2_h1::_environment0_ObjectLiteral_InterproceduralInference_Parity
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h1::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_E2B950E2_h1::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ada
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E2B950E2_h1::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E2B950E2_h1
+
 
 		// Methods
 		.method public hidebysig static 
@@ -433,6 +1305,122 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4A6A76F7_readX
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2ae9
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_4A6A76F7_readX::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2af1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4A6A76F7_readX::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2af4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4A6A76F7_readX::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2af7
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_4A6A76F7_readX::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2aff
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.ObjectLiteral_InterproceduralInference_Parity/readX::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_4A6A76F7_readX::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b12
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.ObjectLiteral_InterproceduralInference_Parity/readX::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4A6A76F7_readX::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b21
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4A6A76F7_readX::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_4A6A76F7_readX
 
 
 		// Methods
@@ -501,6 +1489,122 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_556A8848_readM
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2b30
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_556A8848_readM::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2b38
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_556A8848_readM::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2b3b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_556A8848_readM::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b3e
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_556A8848_readM::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b46
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.ObjectLiteral_InterproceduralInference_Parity/readM::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_556A8848_readM::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b59
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.ObjectLiteral_InterproceduralInference_Parity/readM::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_556A8848_readM::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b68
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_556A8848_readM::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_556A8848_readM
+
 
 		// Methods
 		.method public hidebysig static 
@@ -563,6 +1667,122 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_AF71EA98_keep
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2b77
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_AF71EA98_keep::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2b7f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_AF71EA98_keep::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2b82
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_AF71EA98_keep::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b85
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_AF71EA98_keep::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b8d
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.ObjectLiteral_InterproceduralInference_Parity/keep::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_AF71EA98_keep::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ba0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.ObjectLiteral_InterproceduralInference_Parity/keep::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_AF71EA98_keep::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2baf
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_AF71EA98_keep::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_AF71EA98_keep
 
 
 		// Methods
@@ -629,6 +1849,122 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D398D3EA_readXY
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2bbe
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_D398D3EA_readXY::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2bc6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D398D3EA_readXY::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2bc9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D398D3EA_readXY::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bcc
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_D398D3EA_readXY::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bd4
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.ObjectLiteral_InterproceduralInference_Parity/readXY::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_D398D3EA_readXY::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2be7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.ObjectLiteral_InterproceduralInference_Parity/readXY::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D398D3EA_readXY::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bf6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D398D3EA_readXY::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_D398D3EA_readXY
 
 
 		// Methods
@@ -706,6 +2042,122 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8838F9A5_bump
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2c05
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_8838F9A5_bump::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2c0d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8838F9A5_bump::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2c10
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8838F9A5_bump::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c13
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_8838F9A5_bump::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c1b
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.ObjectLiteral_InterproceduralInference_Parity/bump::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_8838F9A5_bump::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c2e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.ObjectLiteral_InterproceduralInference_Parity/bump::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8838F9A5_bump::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c3d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8838F9A5_bump::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_8838F9A5_bump
 
 
 		// Methods
@@ -789,6 +2241,134 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_53EB1517_shift
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2c4c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_53EB1517_shift::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2c54
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_53EB1517_shift::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2c57
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_53EB1517_shift::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c5a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_53EB1517_shift::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c62
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.2
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.ObjectLiteral_InterproceduralInference_Parity/shift::__js_call__(object, object, object, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionDeclaration_53EB1517_shift::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c83
+				// Header size: 1
+				// Code size: 28 (0x1c)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: ldarg.2
+				IL_0010: ldc.i4.2
+				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0016: call object Modules.ObjectLiteral_InterproceduralInference_Parity/shift::__js_call__(object, object, object, object)
+				IL_001b: ret
+			} // end of method FunctionObject_FunctionDeclaration_53EB1517_shift::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ca0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_53EB1517_shift::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_53EB1517_shift
 
 
 		// Methods
@@ -1334,14 +2914,14 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope,
-			[1] class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_8C67F5E2_c,
-			[2] class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_E2B950E2_h1,
-			[3] class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_4A6A76F7_readX,
-			[4] class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_556A8848_readM,
-			[5] class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_AF71EA98_keep,
-			[6] class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_D398D3EA_readXY,
-			[7] class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_8838F9A5_bump,
-			[8] class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_53EB1517_shift,
+			[1] class Modules.ObjectLiteral_InterproceduralInference_Parity/c/FunctionObject_FunctionDeclaration_8C67F5E2_c,
+			[2] class Modules.ObjectLiteral_InterproceduralInference_Parity/h1/FunctionObject_FunctionDeclaration_E2B950E2_h1,
+			[3] class Modules.ObjectLiteral_InterproceduralInference_Parity/readX/FunctionObject_FunctionDeclaration_4A6A76F7_readX,
+			[4] class Modules.ObjectLiteral_InterproceduralInference_Parity/readM/FunctionObject_FunctionDeclaration_556A8848_readM,
+			[5] class Modules.ObjectLiteral_InterproceduralInference_Parity/keep/FunctionObject_FunctionDeclaration_AF71EA98_keep,
+			[6] class Modules.ObjectLiteral_InterproceduralInference_Parity/readXY/FunctionObject_FunctionDeclaration_D398D3EA_readXY,
+			[7] class Modules.ObjectLiteral_InterproceduralInference_Parity/bump/FunctionObject_FunctionDeclaration_8838F9A5_bump,
+			[8] class Modules.ObjectLiteral_InterproceduralInference_Parity/shift/FunctionObject_FunctionDeclaration_53EB1517_shift,
 			[9] class Modules.ObjectLiteral_InterproceduralInference_Parity/ObjectLiterals/L2C11_a,
 			[10] class Modules.ObjectLiteral_InterproceduralInference_Parity/ObjectLiterals/L9C11_p,
 			[11] class Modules.ObjectLiteral_InterproceduralInference_Parity/ObjectLiterals/L19C12_s1,
@@ -1355,11 +2935,11 @@
 			[19] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[20] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[21] object[],
-			[22] class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_DDB94903_h6,
-			[23] class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_DEB94A96_h5,
-			[24] class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_DFB94C29_h4,
-			[25] class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_E0B94DBC_h3,
-			[26] class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_E1B94F4F_h2,
+			[22] class Modules.ObjectLiteral_InterproceduralInference_Parity/h6/FunctionObject_FunctionDeclaration_DDB94903_h6,
+			[23] class Modules.ObjectLiteral_InterproceduralInference_Parity/h5/FunctionObject_FunctionDeclaration_DEB94A96_h5,
+			[24] class Modules.ObjectLiteral_InterproceduralInference_Parity/h4/FunctionObject_FunctionDeclaration_DFB94C29_h4,
+			[25] class Modules.ObjectLiteral_InterproceduralInference_Parity/h3/FunctionObject_FunctionDeclaration_E0B94DBC_h3,
+			[26] class Modules.ObjectLiteral_InterproceduralInference_Parity/h2/FunctionObject_FunctionDeclaration_E1B94F4F_h2,
 			[27] class [JavaScriptRuntime]JavaScriptRuntime.Array
 		)
 
@@ -1372,13 +2952,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 21
-		IL_0012: newobj instance void FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_8C67F5E2_c::.ctor()
+		IL_0012: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/c/FunctionObject_FunctionDeclaration_8C67F5E2_c::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "c"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.0
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_8C67F5E2_c>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/c/FunctionObject_FunctionDeclaration_8C67F5E2_c>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -1387,13 +2967,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 21
-		IL_0032: newobj instance void FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_DDB94903_h6::.ctor()
+		IL_0032: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/h6/FunctionObject_FunctionDeclaration_DDB94903_h6::.ctor()
 		IL_0037: ldc.i4.1
 		IL_0038: conv.r8
 		IL_0039: ldstr "h6"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.0
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_DDB94903_h6>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/h6/FunctionObject_FunctionDeclaration_DDB94903_h6>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.s 22
 		IL_0047: ldloc.0
 		IL_0048: ldloc.s 22
@@ -1409,13 +2989,13 @@
 		IL_005d: ldc.i4.0
 		IL_005e: ldelem.ref
 		IL_005f: castclass Modules.ObjectLiteral_InterproceduralInference_Parity/Scope
-		IL_0064: newobj instance void FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_DEB94A96_h5::.ctor(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope)
+		IL_0064: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/h5/FunctionObject_FunctionDeclaration_DEB94A96_h5::.ctor(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope)
 		IL_0069: ldc.i4.1
 		IL_006a: conv.r8
 		IL_006b: ldstr "h5"
 		IL_0070: ldc.i4.0
 		IL_0071: ldc.i4.0
-		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_DEB94A96_h5>(!!0, float64, string, bool, bool)
+		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/h5/FunctionObject_FunctionDeclaration_DEB94A96_h5>(!!0, float64, string, bool, bool)
 		IL_0077: stloc.s 23
 		IL_0079: ldloc.0
 		IL_007a: ldloc.s 23
@@ -1431,13 +3011,13 @@
 		IL_008f: ldc.i4.0
 		IL_0090: ldelem.ref
 		IL_0091: castclass Modules.ObjectLiteral_InterproceduralInference_Parity/Scope
-		IL_0096: newobj instance void FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_DFB94C29_h4::.ctor(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope)
+		IL_0096: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/h4/FunctionObject_FunctionDeclaration_DFB94C29_h4::.ctor(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope)
 		IL_009b: ldc.i4.1
 		IL_009c: conv.r8
 		IL_009d: ldstr "h4"
 		IL_00a2: ldc.i4.0
 		IL_00a3: ldc.i4.0
-		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_DFB94C29_h4>(!!0, float64, string, bool, bool)
+		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/h4/FunctionObject_FunctionDeclaration_DFB94C29_h4>(!!0, float64, string, bool, bool)
 		IL_00a9: stloc.s 24
 		IL_00ab: ldloc.0
 		IL_00ac: ldloc.s 24
@@ -1453,13 +3033,13 @@
 		IL_00c1: ldc.i4.0
 		IL_00c2: ldelem.ref
 		IL_00c3: castclass Modules.ObjectLiteral_InterproceduralInference_Parity/Scope
-		IL_00c8: newobj instance void FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_E0B94DBC_h3::.ctor(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope)
+		IL_00c8: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/h3/FunctionObject_FunctionDeclaration_E0B94DBC_h3::.ctor(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope)
 		IL_00cd: ldc.i4.1
 		IL_00ce: conv.r8
 		IL_00cf: ldstr "h3"
 		IL_00d4: ldc.i4.0
 		IL_00d5: ldc.i4.0
-		IL_00d6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_E0B94DBC_h3>(!!0, float64, string, bool, bool)
+		IL_00d6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/h3/FunctionObject_FunctionDeclaration_E0B94DBC_h3>(!!0, float64, string, bool, bool)
 		IL_00db: stloc.s 25
 		IL_00dd: ldloc.0
 		IL_00de: ldloc.s 25
@@ -1475,13 +3055,13 @@
 		IL_00f3: ldc.i4.0
 		IL_00f4: ldelem.ref
 		IL_00f5: castclass Modules.ObjectLiteral_InterproceduralInference_Parity/Scope
-		IL_00fa: newobj instance void FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_E1B94F4F_h2::.ctor(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope)
+		IL_00fa: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/h2/FunctionObject_FunctionDeclaration_E1B94F4F_h2::.ctor(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope)
 		IL_00ff: ldc.i4.1
 		IL_0100: conv.r8
 		IL_0101: ldstr "h2"
 		IL_0106: ldc.i4.0
 		IL_0107: ldc.i4.0
-		IL_0108: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_E1B94F4F_h2>(!!0, float64, string, bool, bool)
+		IL_0108: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/h2/FunctionObject_FunctionDeclaration_E1B94F4F_h2>(!!0, float64, string, bool, bool)
 		IL_010d: stloc.s 26
 		IL_010f: ldloc.0
 		IL_0110: ldloc.s 26
@@ -1497,13 +3077,13 @@
 		IL_0125: ldc.i4.0
 		IL_0126: ldelem.ref
 		IL_0127: castclass Modules.ObjectLiteral_InterproceduralInference_Parity/Scope
-		IL_012c: newobj instance void FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_E2B950E2_h1::.ctor(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope)
+		IL_012c: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/h1/FunctionObject_FunctionDeclaration_E2B950E2_h1::.ctor(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope)
 		IL_0131: ldc.i4.1
 		IL_0132: conv.r8
 		IL_0133: ldstr "h1"
 		IL_0138: ldc.i4.0
 		IL_0139: ldc.i4.0
-		IL_013a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_E2B950E2_h1>(!!0, float64, string, bool, bool)
+		IL_013a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/h1/FunctionObject_FunctionDeclaration_E2B950E2_h1>(!!0, float64, string, bool, bool)
 		IL_013f: stloc.2
 		IL_0140: ldc.i4.1
 		IL_0141: newarr [System.Runtime]System.Object
@@ -1512,13 +3092,13 @@
 		IL_0148: ldloc.0
 		IL_0149: stelem.ref
 		IL_014a: stloc.s 21
-		IL_014c: newobj instance void FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_4A6A76F7_readX::.ctor()
+		IL_014c: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/readX/FunctionObject_FunctionDeclaration_4A6A76F7_readX::.ctor()
 		IL_0151: ldc.i4.1
 		IL_0152: conv.r8
 		IL_0153: ldstr "readX"
 		IL_0158: ldc.i4.0
 		IL_0159: ldc.i4.0
-		IL_015a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_4A6A76F7_readX>(!!0, float64, string, bool, bool)
+		IL_015a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/readX/FunctionObject_FunctionDeclaration_4A6A76F7_readX>(!!0, float64, string, bool, bool)
 		IL_015f: stloc.3
 		IL_0160: ldc.i4.1
 		IL_0161: newarr [System.Runtime]System.Object
@@ -1527,13 +3107,13 @@
 		IL_0168: ldloc.0
 		IL_0169: stelem.ref
 		IL_016a: stloc.s 21
-		IL_016c: newobj instance void FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_556A8848_readM::.ctor()
+		IL_016c: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/readM/FunctionObject_FunctionDeclaration_556A8848_readM::.ctor()
 		IL_0171: ldc.i4.1
 		IL_0172: conv.r8
 		IL_0173: ldstr "readM"
 		IL_0178: ldc.i4.0
 		IL_0179: ldc.i4.0
-		IL_017a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_556A8848_readM>(!!0, float64, string, bool, bool)
+		IL_017a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/readM/FunctionObject_FunctionDeclaration_556A8848_readM>(!!0, float64, string, bool, bool)
 		IL_017f: stloc.s 4
 		IL_0181: ldc.i4.1
 		IL_0182: newarr [System.Runtime]System.Object
@@ -1542,13 +3122,13 @@
 		IL_0189: ldloc.0
 		IL_018a: stelem.ref
 		IL_018b: stloc.s 21
-		IL_018d: newobj instance void FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_AF71EA98_keep::.ctor()
+		IL_018d: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/keep/FunctionObject_FunctionDeclaration_AF71EA98_keep::.ctor()
 		IL_0192: ldc.i4.1
 		IL_0193: conv.r8
 		IL_0194: ldstr "keep"
 		IL_0199: ldc.i4.0
 		IL_019a: ldc.i4.0
-		IL_019b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_AF71EA98_keep>(!!0, float64, string, bool, bool)
+		IL_019b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/keep/FunctionObject_FunctionDeclaration_AF71EA98_keep>(!!0, float64, string, bool, bool)
 		IL_01a0: stloc.s 5
 		IL_01a2: ldc.i4.1
 		IL_01a3: newarr [System.Runtime]System.Object
@@ -1557,13 +3137,13 @@
 		IL_01aa: ldloc.0
 		IL_01ab: stelem.ref
 		IL_01ac: stloc.s 21
-		IL_01ae: newobj instance void FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_D398D3EA_readXY::.ctor()
+		IL_01ae: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/readXY/FunctionObject_FunctionDeclaration_D398D3EA_readXY::.ctor()
 		IL_01b3: ldc.i4.1
 		IL_01b4: conv.r8
 		IL_01b5: ldstr "readXY"
 		IL_01ba: ldc.i4.0
 		IL_01bb: ldc.i4.0
-		IL_01bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_D398D3EA_readXY>(!!0, float64, string, bool, bool)
+		IL_01bc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/readXY/FunctionObject_FunctionDeclaration_D398D3EA_readXY>(!!0, float64, string, bool, bool)
 		IL_01c1: stloc.s 6
 		IL_01c3: ldc.i4.1
 		IL_01c4: newarr [System.Runtime]System.Object
@@ -1572,13 +3152,13 @@
 		IL_01cb: ldloc.0
 		IL_01cc: stelem.ref
 		IL_01cd: stloc.s 21
-		IL_01cf: newobj instance void FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_8838F9A5_bump::.ctor()
+		IL_01cf: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/bump/FunctionObject_FunctionDeclaration_8838F9A5_bump::.ctor()
 		IL_01d4: ldc.i4.1
 		IL_01d5: conv.r8
 		IL_01d6: ldstr "bump"
 		IL_01db: ldc.i4.0
 		IL_01dc: ldc.i4.0
-		IL_01dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_8838F9A5_bump>(!!0, float64, string, bool, bool)
+		IL_01dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/bump/FunctionObject_FunctionDeclaration_8838F9A5_bump>(!!0, float64, string, bool, bool)
 		IL_01e2: stloc.s 7
 		IL_01e4: ldc.i4.1
 		IL_01e5: newarr [System.Runtime]System.Object
@@ -1587,13 +3167,13 @@
 		IL_01ec: ldloc.0
 		IL_01ed: stelem.ref
 		IL_01ee: stloc.s 21
-		IL_01f0: newobj instance void FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_53EB1517_shift::.ctor()
+		IL_01f0: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/shift/FunctionObject_FunctionDeclaration_53EB1517_shift::.ctor()
 		IL_01f5: ldc.i4.3
 		IL_01f6: conv.r8
 		IL_01f7: ldstr "shift"
 		IL_01fc: ldc.i4.0
 		IL_01fd: ldc.i4.0
-		IL_01fe: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_53EB1517_shift>(!!0, float64, string, bool, bool)
+		IL_01fe: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ObjectLiteral_InterproceduralInference_Parity/shift/FunctionObject_FunctionDeclaration_53EB1517_shift>(!!0, float64, string, bool, bool)
 		IL_0203: stloc.s 8
 		IL_0205: newobj instance void Modules.ObjectLiteral_InterproceduralInference_Parity/ObjectLiterals/L2C11_a::.ctor()
 		IL_020a: stloc.s 9
@@ -1750,1586 +3330,6 @@
 	} // end of method ObjectLiteral_InterproceduralInference_Parity::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_InterproceduralInference_Parity
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_8C67F5E2_c
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2899
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_8C67F5E2_c::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x28a1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8C67F5E2_c::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x28a4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8C67F5E2_c::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x28a7
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_8C67F5E2_c::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x28af
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.ObjectLiteral_InterproceduralInference_Parity/c::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_8C67F5E2_c::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28c2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.ObjectLiteral_InterproceduralInference_Parity/c::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8C67F5E2_c::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28d1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8C67F5E2_c::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_8C67F5E2_c
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_DDB94903_h6
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x28e0
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_DDB94903_h6::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x28e8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DDB94903_h6::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x28eb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DDB94903_h6::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x28ee
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_DDB94903_h6::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x28f6
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h6::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_DDB94903_h6::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2909
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h6::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DDB94903_h6::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2918
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DDB94903_h6::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_DDB94903_h6
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_DEB94A96_h5
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope _environment0_ObjectLiteral_InterproceduralInference_Parity
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2927
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_DEB94A96_h5::_environment0_ObjectLiteral_InterproceduralInference_Parity
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DEB94A96_h5::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2936
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DEB94A96_h5::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2939
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DEB94A96_h5::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x293c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_DEB94A96_h5::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2944
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_DEB94A96_h5::_environment0_ObjectLiteral_InterproceduralInference_Parity
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h5::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_DEB94A96_h5::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x295d
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_DEB94A96_h5::_environment0_ObjectLiteral_InterproceduralInference_Parity
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h5::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_DEB94A96_h5::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2972
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DEB94A96_h5::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_DEB94A96_h5
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_DFB94C29_h4
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope _environment0_ObjectLiteral_InterproceduralInference_Parity
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2981
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_DFB94C29_h4::_environment0_ObjectLiteral_InterproceduralInference_Parity
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DFB94C29_h4::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2990
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DFB94C29_h4::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2993
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DFB94C29_h4::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2996
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_DFB94C29_h4::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x299e
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_DFB94C29_h4::_environment0_ObjectLiteral_InterproceduralInference_Parity
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h4::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_DFB94C29_h4::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29b7
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_DFB94C29_h4::_environment0_ObjectLiteral_InterproceduralInference_Parity
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h4::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_DFB94C29_h4::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29cc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DFB94C29_h4::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_DFB94C29_h4
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_E0B94DBC_h3
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope _environment0_ObjectLiteral_InterproceduralInference_Parity
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x29db
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_E0B94DBC_h3::_environment0_ObjectLiteral_InterproceduralInference_Parity
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E0B94DBC_h3::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x29ea
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E0B94DBC_h3::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x29ed
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E0B94DBC_h3::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x29f0
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_E0B94DBC_h3::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x29f8
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_E0B94DBC_h3::_environment0_ObjectLiteral_InterproceduralInference_Parity
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h3::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_E0B94DBC_h3::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a11
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_E0B94DBC_h3::_environment0_ObjectLiteral_InterproceduralInference_Parity
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h3::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_E0B94DBC_h3::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a26
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E0B94DBC_h3::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_E0B94DBC_h3
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_E1B94F4F_h2
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope _environment0_ObjectLiteral_InterproceduralInference_Parity
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a35
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_E1B94F4F_h2::_environment0_ObjectLiteral_InterproceduralInference_Parity
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E1B94F4F_h2::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a44
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E1B94F4F_h2::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a47
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E1B94F4F_h2::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a4a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_E1B94F4F_h2::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a52
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_E1B94F4F_h2::_environment0_ObjectLiteral_InterproceduralInference_Parity
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h2::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_E1B94F4F_h2::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a6b
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_E1B94F4F_h2::_environment0_ObjectLiteral_InterproceduralInference_Parity
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h2::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_E1B94F4F_h2::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a80
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E1B94F4F_h2::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_E1B94F4F_h2
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_E2B950E2_h1
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope _environment0_ObjectLiteral_InterproceduralInference_Parity
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a8f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_E2B950E2_h1::_environment0_ObjectLiteral_InterproceduralInference_Parity
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E2B950E2_h1::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a9e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E2B950E2_h1::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2aa1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E2B950E2_h1::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2aa4
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_E2B950E2_h1::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2aac
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_E2B950E2_h1::_environment0_ObjectLiteral_InterproceduralInference_Parity
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h1::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_E2B950E2_h1::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ac5
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_E2B950E2_h1::_environment0_ObjectLiteral_InterproceduralInference_Parity
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.ObjectLiteral_InterproceduralInference_Parity/h1::__js_call__(class Modules.ObjectLiteral_InterproceduralInference_Parity/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_E2B950E2_h1::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ada
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E2B950E2_h1::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_E2B950E2_h1
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_4A6A76F7_readX
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2ae9
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_4A6A76F7_readX::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2af1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4A6A76F7_readX::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2af4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4A6A76F7_readX::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2af7
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_4A6A76F7_readX::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2aff
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.ObjectLiteral_InterproceduralInference_Parity/readX::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_4A6A76F7_readX::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b12
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.ObjectLiteral_InterproceduralInference_Parity/readX::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4A6A76F7_readX::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b21
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4A6A76F7_readX::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_4A6A76F7_readX
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_556A8848_readM
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2b30
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_556A8848_readM::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2b38
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_556A8848_readM::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2b3b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_556A8848_readM::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b3e
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_556A8848_readM::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b46
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.ObjectLiteral_InterproceduralInference_Parity/readM::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_556A8848_readM::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b59
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.ObjectLiteral_InterproceduralInference_Parity/readM::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_556A8848_readM::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b68
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_556A8848_readM::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_556A8848_readM
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_AF71EA98_keep
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2b77
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_AF71EA98_keep::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2b7f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_AF71EA98_keep::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2b82
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_AF71EA98_keep::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b85
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_AF71EA98_keep::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b8d
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.ObjectLiteral_InterproceduralInference_Parity/keep::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_AF71EA98_keep::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ba0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.ObjectLiteral_InterproceduralInference_Parity/keep::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_AF71EA98_keep::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2baf
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_AF71EA98_keep::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_AF71EA98_keep
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_D398D3EA_readXY
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2bbe
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_D398D3EA_readXY::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2bc6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D398D3EA_readXY::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2bc9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D398D3EA_readXY::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bcc
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_D398D3EA_readXY::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bd4
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.ObjectLiteral_InterproceduralInference_Parity/readXY::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_D398D3EA_readXY::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2be7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.ObjectLiteral_InterproceduralInference_Parity/readXY::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D398D3EA_readXY::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bf6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D398D3EA_readXY::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_D398D3EA_readXY
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_8838F9A5_bump
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2c05
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_8838F9A5_bump::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2c0d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8838F9A5_bump::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2c10
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8838F9A5_bump::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c13
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_8838F9A5_bump::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c1b
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.ObjectLiteral_InterproceduralInference_Parity/bump::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_8838F9A5_bump::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c2e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.ObjectLiteral_InterproceduralInference_Parity/bump::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8838F9A5_bump::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c3d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8838F9A5_bump::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_8838F9A5_bump
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_53EB1517_shift
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2c4c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_53EB1517_shift::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2c54
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_53EB1517_shift::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2c57
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_53EB1517_shift::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c5a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_53EB1517_shift::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c62
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.2
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.ObjectLiteral_InterproceduralInference_Parity/shift::__js_call__(object, object, object, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionDeclaration_53EB1517_shift::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c83
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: ldarg.2
-		IL_0010: ldc.i4.2
-		IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0016: call object Modules.ObjectLiteral_InterproceduralInference_Parity/shift::__js_call__(object, object, object, object)
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionDeclaration_53EB1517_shift::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ca0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_53EB1517_shift::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_InterproceduralInference_Parity_545DB486.FunctionObject_FunctionDeclaration_53EB1517_shift
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_ShorthandAndMethod.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.ObjectLiteral_ShorthandAndMethod.verified.txt
@@ -31,6 +31,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_95740A33_L8C20
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2175
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_95740A33_L8C20::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x217d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_95740A33_L8C20::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2180
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_95740A33_L8C20::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2183
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.ObjectLiteral_ShorthandAndMethod/FunctionExpression_o::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_95740A33_L8C20::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x218f
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.ObjectLiteral_ShorthandAndMethod/FunctionExpression_o::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_95740A33_L8C20::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2197
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_95740A33_L8C20::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_95740A33_L8C20
+
 
 		// Methods
 		.method public hidebysig static 
@@ -181,101 +276,6 @@
 	} // end of method ObjectLiteral_ShorthandAndMethod::__js_module_init__
 
 } // end of class Modules.ObjectLiteral_ShorthandAndMethod
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ObjectLiteral_ShorthandAndMethod_27B0FA3B.FunctionObject_FunctionExpression_95740A33_L8C20
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2175
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_95740A33_L8C20::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x217d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_95740A33_L8C20::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2180
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_95740A33_L8C20::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2183
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.ObjectLiteral_ShorthandAndMethod/FunctionExpression_o::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_95740A33_L8C20::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x218f
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.ObjectLiteral_ShorthandAndMethod/FunctionExpression_o::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_95740A33_L8C20::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2197
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_95740A33_L8C20::ConstructCore
-
-} // end of class FunctionObjects.ObjectLiteral_ShorthandAndMethod_27B0FA3B.FunctionObject_FunctionExpression_95740A33_L8C20
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_DefineProperty_AccessorTransitions_And_Invariants.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_DefineProperty_AccessorTransitions_And_Invariants.verified.txt
@@ -31,6 +31,103 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_652775DD_getter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x290b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_652775DD_getter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2913
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_652775DD_getter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2916
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_652775DD_getter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2919
+				// Header size: 1
+				// Code size: 16 (0x10)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call float64 Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/getter::__js_call__(object)
+				IL_000a: box [System.Runtime]System.Double
+				IL_000f: ret
+			} // end of method FunctionObject_FunctionDeclaration_652775DD_getter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x292a
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call float64 Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/getter::__js_call__(object)
+				IL_0006: box [System.Runtime]System.Double
+				IL_000b: ret
+			} // end of method FunctionObject_FunctionDeclaration_652775DD_getter::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2937
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_652775DD_getter::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_652775DD_getter
+
 
 		// Methods
 		.method public hidebysig static 
@@ -75,6 +172,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_EE8F74E0_setter1
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope _environment0_Object_DefineProperty_AccessorTransitions_And_Invariants
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2946
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter1/FunctionObject_FunctionDeclaration_EE8F74E0_setter1::_environment0_Object_DefineProperty_AccessorTransitions_And_Invariants
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_EE8F74E0_setter1::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2955
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_EE8F74E0_setter1::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2958
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_EE8F74E0_setter1::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x295b
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter1/FunctionObject_FunctionDeclaration_EE8F74E0_setter1::_environment0_Object_DefineProperty_AccessorTransitions_And_Invariants
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter1::__js_call__(class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_EE8F74E0_setter1::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2974
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter1/FunctionObject_FunctionDeclaration_EE8F74E0_setter1::_environment0_Object_DefineProperty_AccessorTransitions_And_Invariants
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter1::__js_call__(class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_EE8F74E0_setter1::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2989
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_EE8F74E0_setter1::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_EE8F74E0_setter1
 
 
 		// Methods
@@ -141,6 +351,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F18F7999_setter2
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope _environment0_Object_DefineProperty_AccessorTransitions_And_Invariants
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2998
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter2/FunctionObject_FunctionDeclaration_F18F7999_setter2::_environment0_Object_DefineProperty_AccessorTransitions_And_Invariants
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F18F7999_setter2::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x29a7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F18F7999_setter2::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x29aa
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F18F7999_setter2::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x29ad
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter2/FunctionObject_FunctionDeclaration_F18F7999_setter2::_environment0_Object_DefineProperty_AccessorTransitions_And_Invariants
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter2::__js_call__(class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_F18F7999_setter2::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x29c6
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter2/FunctionObject_FunctionDeclaration_F18F7999_setter2::_environment0_Object_DefineProperty_AccessorTransitions_And_Invariants
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter2::__js_call__(class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_F18F7999_setter2::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x29db
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F18F7999_setter2::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_F18F7999_setter2
 
 
 		// Methods
@@ -396,9 +719,9 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope,
-			[1] class FunctionObjects.Object_DefineProperty_AccessorTransitions_And_Invariants_1E58EA6B.FunctionObject_FunctionDeclaration_652775DD_getter,
-			[2] class FunctionObjects.Object_DefineProperty_AccessorTransitions_And_Invariants_1E58EA6B.FunctionObject_FunctionDeclaration_EE8F74E0_setter1,
-			[3] class FunctionObjects.Object_DefineProperty_AccessorTransitions_And_Invariants_1E58EA6B.FunctionObject_FunctionDeclaration_F18F7999_setter2,
+			[1] class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/getter/FunctionObject_FunctionDeclaration_652775DD_getter,
+			[2] class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter1/FunctionObject_FunctionDeclaration_EE8F74E0_setter1,
+			[3] class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter2/FunctionObject_FunctionDeclaration_F18F7999_setter2,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[5] object,
 			[6] class [System.Runtime]System.Exception,
@@ -437,13 +760,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 24
-		IL_0012: newobj instance void FunctionObjects.Object_DefineProperty_AccessorTransitions_And_Invariants_1E58EA6B.FunctionObject_FunctionDeclaration_652775DD_getter::.ctor()
+		IL_0012: newobj instance void Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/getter/FunctionObject_FunctionDeclaration_652775DD_getter::.ctor()
 		IL_0017: ldc.i4.0
 		IL_0018: conv.r8
 		IL_0019: ldstr "getter"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Object_DefineProperty_AccessorTransitions_And_Invariants_1E58EA6B.FunctionObject_FunctionDeclaration_652775DD_getter>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/getter/FunctionObject_FunctionDeclaration_652775DD_getter>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -456,13 +779,13 @@
 		IL_0034: ldc.i4.0
 		IL_0035: ldelem.ref
 		IL_0036: castclass Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope
-		IL_003b: newobj instance void FunctionObjects.Object_DefineProperty_AccessorTransitions_And_Invariants_1E58EA6B.FunctionObject_FunctionDeclaration_EE8F74E0_setter1::.ctor(class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope)
+		IL_003b: newobj instance void Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter1/FunctionObject_FunctionDeclaration_EE8F74E0_setter1::.ctor(class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope)
 		IL_0040: ldc.i4.1
 		IL_0041: conv.r8
 		IL_0042: ldstr "setter1"
 		IL_0047: ldc.i4.0
 		IL_0048: ldc.i4.1
-		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Object_DefineProperty_AccessorTransitions_And_Invariants_1E58EA6B.FunctionObject_FunctionDeclaration_EE8F74E0_setter1>(!!0, float64, string, bool, bool)
+		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter1/FunctionObject_FunctionDeclaration_EE8F74E0_setter1>(!!0, float64, string, bool, bool)
 		IL_004e: stloc.2
 		IL_004f: ldc.i4.1
 		IL_0050: newarr [System.Runtime]System.Object
@@ -475,13 +798,13 @@
 		IL_005d: ldc.i4.0
 		IL_005e: ldelem.ref
 		IL_005f: castclass Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope
-		IL_0064: newobj instance void FunctionObjects.Object_DefineProperty_AccessorTransitions_And_Invariants_1E58EA6B.FunctionObject_FunctionDeclaration_F18F7999_setter2::.ctor(class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope)
+		IL_0064: newobj instance void Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter2/FunctionObject_FunctionDeclaration_F18F7999_setter2::.ctor(class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope)
 		IL_0069: ldc.i4.1
 		IL_006a: conv.r8
 		IL_006b: ldstr "setter2"
 		IL_0070: ldc.i4.0
 		IL_0071: ldc.i4.1
-		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Object_DefineProperty_AccessorTransitions_And_Invariants_1E58EA6B.FunctionObject_FunctionDeclaration_F18F7999_setter2>(!!0, float64, string, bool, bool)
+		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter2/FunctionObject_FunctionDeclaration_F18F7999_setter2>(!!0, float64, string, bool, bool)
 		IL_0077: stloc.3
 		IL_0078: nop
 		IL_0079: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -1068,329 +1391,6 @@
 	} // end of method Object_DefineProperty_AccessorTransitions_And_Invariants::__js_module_init__
 
 } // end of class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Object_DefineProperty_AccessorTransitions_And_Invariants_1E58EA6B.FunctionObject_FunctionDeclaration_652775DD_getter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x290b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_652775DD_getter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2913
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_652775DD_getter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2916
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_652775DD_getter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2919
-		// Header size: 1
-		// Code size: 16 (0x10)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call float64 Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/getter::__js_call__(object)
-		IL_000a: box [System.Runtime]System.Double
-		IL_000f: ret
-	} // end of method FunctionObject_FunctionDeclaration_652775DD_getter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x292a
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call float64 Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/getter::__js_call__(object)
-		IL_0006: box [System.Runtime]System.Double
-		IL_000b: ret
-	} // end of method FunctionObject_FunctionDeclaration_652775DD_getter::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2937
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_652775DD_getter::ConstructCore
-
-} // end of class FunctionObjects.Object_DefineProperty_AccessorTransitions_And_Invariants_1E58EA6B.FunctionObject_FunctionDeclaration_652775DD_getter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Object_DefineProperty_AccessorTransitions_And_Invariants_1E58EA6B.FunctionObject_FunctionDeclaration_EE8F74E0_setter1
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope _environment0_Object_DefineProperty_AccessorTransitions_And_Invariants
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2946
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope FunctionObjects.Object_DefineProperty_AccessorTransitions_And_Invariants_1E58EA6B.FunctionObject_FunctionDeclaration_EE8F74E0_setter1::_environment0_Object_DefineProperty_AccessorTransitions_And_Invariants
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_EE8F74E0_setter1::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2955
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_EE8F74E0_setter1::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2958
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_EE8F74E0_setter1::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x295b
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope FunctionObjects.Object_DefineProperty_AccessorTransitions_And_Invariants_1E58EA6B.FunctionObject_FunctionDeclaration_EE8F74E0_setter1::_environment0_Object_DefineProperty_AccessorTransitions_And_Invariants
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter1::__js_call__(class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_EE8F74E0_setter1::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2974
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope FunctionObjects.Object_DefineProperty_AccessorTransitions_And_Invariants_1E58EA6B.FunctionObject_FunctionDeclaration_EE8F74E0_setter1::_environment0_Object_DefineProperty_AccessorTransitions_And_Invariants
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter1::__js_call__(class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_EE8F74E0_setter1::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2989
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_EE8F74E0_setter1::ConstructCore
-
-} // end of class FunctionObjects.Object_DefineProperty_AccessorTransitions_And_Invariants_1E58EA6B.FunctionObject_FunctionDeclaration_EE8F74E0_setter1
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Object_DefineProperty_AccessorTransitions_And_Invariants_1E58EA6B.FunctionObject_FunctionDeclaration_F18F7999_setter2
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope _environment0_Object_DefineProperty_AccessorTransitions_And_Invariants
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2998
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope FunctionObjects.Object_DefineProperty_AccessorTransitions_And_Invariants_1E58EA6B.FunctionObject_FunctionDeclaration_F18F7999_setter2::_environment0_Object_DefineProperty_AccessorTransitions_And_Invariants
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F18F7999_setter2::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x29a7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F18F7999_setter2::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x29aa
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F18F7999_setter2::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x29ad
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope FunctionObjects.Object_DefineProperty_AccessorTransitions_And_Invariants_1E58EA6B.FunctionObject_FunctionDeclaration_F18F7999_setter2::_environment0_Object_DefineProperty_AccessorTransitions_And_Invariants
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter2::__js_call__(class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_F18F7999_setter2::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29c6
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope FunctionObjects.Object_DefineProperty_AccessorTransitions_And_Invariants_1E58EA6B.FunctionObject_FunctionDeclaration_F18F7999_setter2::_environment0_Object_DefineProperty_AccessorTransitions_And_Invariants
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/setter2::__js_call__(class Modules.Object_DefineProperty_AccessorTransitions_And_Invariants/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_F18F7999_setter2::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29db
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F18F7999_setter2::ConstructCore
-
-} // end of class FunctionObjects.Object_DefineProperty_AccessorTransitions_And_Invariants_1E58EA6B.FunctionObject_FunctionDeclaration_F18F7999_setter2
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_GroupBy_Basic.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_GroupBy_Basic.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7AE9A538_L3C47
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2362
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_7AE9A538_L3C47::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x236a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7AE9A538_L3C47::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x236d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7AE9A538_L3C47::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2370
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Object_GroupBy_Basic/FunctionExpression_grouped::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_7AE9A538_L3C47::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2383
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Object_GroupBy_Basic/FunctionExpression_grouped::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_7AE9A538_L3C47::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2392
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_7AE9A538_L3C47::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_7AE9A538_L3C47
+
 
 		// Methods
 		.method public hidebysig static 
@@ -104,7 +205,7 @@
 			[1] object,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] object[],
-			[4] class FunctionObjects.Object_GroupBy_Basic_BC275246.FunctionObject_FunctionExpression_7AE9A538_L3C47,
+			[4] class Modules.Object_GroupBy_Basic/FunctionExpression_grouped/FunctionObject_FunctionExpression_7AE9A538_L3C47,
 			[5] object,
 			[6] object,
 			[7] bool,
@@ -144,13 +245,13 @@
 		IL_0061: ldloc.0
 		IL_0062: stelem.ref
 		IL_0063: stloc.3
-		IL_0064: newobj instance void FunctionObjects.Object_GroupBy_Basic_BC275246.FunctionObject_FunctionExpression_7AE9A538_L3C47::.ctor()
+		IL_0064: newobj instance void Modules.Object_GroupBy_Basic/FunctionExpression_grouped/FunctionObject_FunctionExpression_7AE9A538_L3C47::.ctor()
 		IL_0069: ldc.i4.1
 		IL_006a: conv.r8
 		IL_006b: ldstr ""
 		IL_0070: ldc.i4.0
 		IL_0071: ldc.i4.1
-		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Object_GroupBy_Basic_BC275246.FunctionObject_FunctionExpression_7AE9A538_L3C47>(!!0, float64, string, bool, bool)
+		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_GroupBy_Basic/FunctionExpression_grouped/FunctionObject_FunctionExpression_7AE9A538_L3C47>(!!0, float64, string, bool, bool)
 		IL_0077: stloc.s 4
 		IL_0079: ldloc.2
 		IL_007a: ldloc.s 4
@@ -328,107 +429,6 @@
 	} // end of method Object_GroupBy_Basic::__js_module_init__
 
 } // end of class Modules.Object_GroupBy_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Object_GroupBy_Basic_BC275246.FunctionObject_FunctionExpression_7AE9A538_L3C47
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2362
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_7AE9A538_L3C47::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x236a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7AE9A538_L3C47::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x236d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7AE9A538_L3C47::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2370
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Object_GroupBy_Basic/FunctionExpression_grouped::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_7AE9A538_L3C47::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2383
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Object_GroupBy_Basic/FunctionExpression_grouped::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7AE9A538_L3C47::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2392
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7AE9A538_L3C47::ConstructCore
-
-} // end of class FunctionObjects.Object_GroupBy_Basic_BC275246.FunctionObject_FunctionExpression_7AE9A538_L3C47
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_Integrity_DefineProperty_And_StrictWrites.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_Integrity_DefineProperty_And_StrictWrites.verified.txt
@@ -31,6 +31,103 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_268A99E2_L49C8
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x26ff
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_268A99E2_L49C8::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2707
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_268A99E2_L49C8::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x270a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_268A99E2_L49C8::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x270d
+				// Header size: 1
+				// Code size: 16 (0x10)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call float64 Modules.Object_Integrity_DefineProperty_And_StrictWrites/FunctionExpression_L49C7::__js_call__(object)
+				IL_000a: box [System.Runtime]System.Double
+				IL_000f: ret
+			} // end of method FunctionObject_FunctionExpression_268A99E2_L49C8::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x271e
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call float64 Modules.Object_Integrity_DefineProperty_And_StrictWrites/FunctionExpression_L49C7::__js_call__(object)
+				IL_0006: box [System.Runtime]System.Double
+				IL_000b: ret
+			} // end of method FunctionObject_FunctionExpression_268A99E2_L49C8::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x272b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_268A99E2_L49C8::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_268A99E2_L49C8
+
 
 		// Methods
 		.method public hidebysig static 
@@ -317,7 +414,7 @@
 			[24] object,
 			[25] object,
 			[26] object[],
-			[27] class FunctionObjects.Object_Integrity_DefineProperty_And_StrictWrites_69414EF1.FunctionObject_FunctionExpression_268A99E2_L49C8,
+			[27] class Modules.Object_Integrity_DefineProperty_And_StrictWrites/FunctionExpression_L49C7/FunctionObject_FunctionExpression_268A99E2_L49C8,
 			[28] class [JavaScriptRuntime]JavaScriptRuntime.JsObject
 		)
 
@@ -715,13 +812,13 @@
 		IL_04a6: ldloc.0
 		IL_04a7: stelem.ref
 		IL_04a8: stloc.s 26
-		IL_04aa: newobj instance void FunctionObjects.Object_Integrity_DefineProperty_And_StrictWrites_69414EF1.FunctionObject_FunctionExpression_268A99E2_L49C8::.ctor()
+		IL_04aa: newobj instance void Modules.Object_Integrity_DefineProperty_And_StrictWrites/FunctionExpression_L49C7/FunctionObject_FunctionExpression_268A99E2_L49C8::.ctor()
 		IL_04af: ldc.i4.0
 		IL_04b0: conv.r8
 		IL_04b1: ldstr ""
 		IL_04b6: ldc.i4.0
 		IL_04b7: ldc.i4.1
-		IL_04b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Object_Integrity_DefineProperty_And_StrictWrites_69414EF1.FunctionObject_FunctionExpression_268A99E2_L49C8>(!!0, float64, string, bool, bool)
+		IL_04b8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_Integrity_DefineProperty_And_StrictWrites/FunctionExpression_L49C7/FunctionObject_FunctionExpression_268A99E2_L49C8>(!!0, float64, string, bool, bool)
 		IL_04bd: stloc.s 27
 		IL_04bf: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_04c4: dup
@@ -828,103 +925,6 @@
 	} // end of method Object_Integrity_DefineProperty_And_StrictWrites::__js_module_init__
 
 } // end of class Modules.Object_Integrity_DefineProperty_And_StrictWrites
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Object_Integrity_DefineProperty_And_StrictWrites_69414EF1.FunctionObject_FunctionExpression_268A99E2_L49C8
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x26ff
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_268A99E2_L49C8::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2707
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_268A99E2_L49C8::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x270a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_268A99E2_L49C8::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x270d
-		// Header size: 1
-		// Code size: 16 (0x10)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call float64 Modules.Object_Integrity_DefineProperty_And_StrictWrites/FunctionExpression_L49C7::__js_call__(object)
-		IL_000a: box [System.Runtime]System.Double
-		IL_000f: ret
-	} // end of method FunctionObject_FunctionExpression_268A99E2_L49C8::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x271e
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call float64 Modules.Object_Integrity_DefineProperty_And_StrictWrites/FunctionExpression_L49C7::__js_call__(object)
-		IL_0006: box [System.Runtime]System.Double
-		IL_000b: ret
-	} // end of method FunctionObject_FunctionExpression_268A99E2_L49C8::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x272b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_268A99E2_L49C8::ConstructCore
-
-} // end of class FunctionObjects.Object_Integrity_DefineProperty_And_StrictWrites_69414EF1.FunctionObject_FunctionExpression_268A99E2_L49C8
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_Prototype_LegacyAccessors.verified.txt
+++ b/tests/Jroc.Tests/Object/Snapshots/GeneratorTests.Object_Prototype_LegacyAccessors.verified.txt
@@ -31,6 +31,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_25CE272F_L4C48
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x22c8
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_25CE272F_L4C48::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22d0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_25CE272F_L4C48::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22d3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_25CE272F_L4C48::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22d6
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L4C47::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_25CE272F_L4C48::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22e2
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L4C47::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_25CE272F_L4C48::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22ea
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_25CE272F_L4C48::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_25CE272F_L4C48
+
 
 		// Methods
 		.method public hidebysig static 
@@ -83,6 +178,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_33787FB6_L5C48
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x22f9
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_33787FB6_L5C48::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2301
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_33787FB6_L5C48::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2304
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_33787FB6_L5C48::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2307
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L5C47::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_33787FB6_L5C48::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x231a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L5C47::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_33787FB6_L5C48::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2329
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_33787FB6_L5C48::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_33787FB6_L5C48
 
 
 		// Methods
@@ -153,8 +349,8 @@
 			[1] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[2] object,
 			[3] object[],
-			[4] class FunctionObjects.Object_Prototype_LegacyAccessors_4FE74741.FunctionObject_FunctionExpression_25CE272F_L4C48,
-			[5] class FunctionObjects.Object_Prototype_LegacyAccessors_4FE74741.FunctionObject_FunctionExpression_33787FB6_L5C48,
+			[4] class Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L4C47/FunctionObject_FunctionExpression_25CE272F_L4C48,
+			[5] class Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L5C47/FunctionObject_FunctionExpression_33787FB6_L5C48,
 			[6] object,
 			[7] string,
 			[8] bool,
@@ -189,13 +385,13 @@
 		IL_0051: ldloc.0
 		IL_0052: stelem.ref
 		IL_0053: stloc.3
-		IL_0054: newobj instance void FunctionObjects.Object_Prototype_LegacyAccessors_4FE74741.FunctionObject_FunctionExpression_25CE272F_L4C48::.ctor()
+		IL_0054: newobj instance void Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L4C47/FunctionObject_FunctionExpression_25CE272F_L4C48::.ctor()
 		IL_0059: ldc.i4.0
 		IL_005a: conv.r8
 		IL_005b: ldstr ""
 		IL_0060: ldc.i4.1
 		IL_0061: ldc.i4.1
-		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Object_Prototype_LegacyAccessors_4FE74741.FunctionObject_FunctionExpression_25CE272F_L4C48>(!!0, float64, string, bool, bool)
+		IL_0062: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L4C47/FunctionObject_FunctionExpression_25CE272F_L4C48>(!!0, float64, string, bool, bool)
 		IL_0067: stloc.s 4
 		IL_0069: ldloc.2
 		IL_006a: ldstr "call"
@@ -223,13 +419,13 @@
 		IL_00ad: ldloc.0
 		IL_00ae: stelem.ref
 		IL_00af: stloc.3
-		IL_00b0: newobj instance void FunctionObjects.Object_Prototype_LegacyAccessors_4FE74741.FunctionObject_FunctionExpression_33787FB6_L5C48::.ctor()
+		IL_00b0: newobj instance void Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L5C47/FunctionObject_FunctionExpression_33787FB6_L5C48::.ctor()
 		IL_00b5: ldc.i4.1
 		IL_00b6: conv.r8
 		IL_00b7: ldstr ""
 		IL_00bc: ldc.i4.1
 		IL_00bd: ldc.i4.1
-		IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Object_Prototype_LegacyAccessors_4FE74741.FunctionObject_FunctionExpression_33787FB6_L5C48>(!!0, float64, string, bool, bool)
+		IL_00be: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L5C47/FunctionObject_FunctionExpression_33787FB6_L5C48>(!!0, float64, string, bool, bool)
 		IL_00c3: stloc.s 5
 		IL_00c5: ldloc.2
 		IL_00c6: ldstr "call"
@@ -331,202 +527,6 @@
 	} // end of method Object_Prototype_LegacyAccessors::__js_module_init__
 
 } // end of class Modules.Object_Prototype_LegacyAccessors
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Object_Prototype_LegacyAccessors_4FE74741.FunctionObject_FunctionExpression_25CE272F_L4C48
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x22c8
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_25CE272F_L4C48::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22d0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_25CE272F_L4C48::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22d3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_25CE272F_L4C48::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22d6
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L4C47::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_25CE272F_L4C48::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22e2
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L4C47::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_25CE272F_L4C48::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22ea
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_25CE272F_L4C48::ConstructCore
-
-} // end of class FunctionObjects.Object_Prototype_LegacyAccessors_4FE74741.FunctionObject_FunctionExpression_25CE272F_L4C48
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Object_Prototype_LegacyAccessors_4FE74741.FunctionObject_FunctionExpression_33787FB6_L5C48
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x22f9
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_33787FB6_L5C48::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2301
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_33787FB6_L5C48::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2304
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_33787FB6_L5C48::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2307
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L5C47::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_33787FB6_L5C48::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x231a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Object_Prototype_LegacyAccessors/FunctionExpression_L5C47::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_33787FB6_L5C48::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2329
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_33787FB6_L5C48::ConstructCore
-
-} // end of class FunctionObjects.Object_Prototype_LegacyAccessors_4FE74741.FunctionObject_FunctionExpression_33787FB6_L5C48
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21b5
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21bd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21c0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21c3
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/thenImpl::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21dd
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/thenImpl::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl
+
 
 		// Methods
 		.method public hidebysig static 
@@ -354,7 +461,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/Scope,
-			[1] class FunctionObjects.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled_1C30AE78.FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl,
+			[1] class Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/thenImpl/FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[4] object,
@@ -371,13 +478,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled_1C30AE78.FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl::.ctor()
+		IL_0011: newobj instance void Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/thenImpl/FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "thenImpl"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled_1C30AE78.FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/thenImpl/FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -448,113 +555,6 @@
 	} // end of method Promise_Finally_ReturnsThenable_PassThrough_Fulfilled::__js_module_init__
 
 } // end of class Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled_1C30AE78.FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21b5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21bd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21c0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21c3
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/thenImpl::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21dd
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled/thenImpl::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl::ConstructCore
-
-} // end of class FunctionObjects.Promise_Finally_ReturnsThenable_PassThrough_Fulfilled_1C30AE78.FunctionObject_FunctionDeclaration_EF2AA2FA_thenImpl
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsThenable_PassThrough_Rejected.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Finally_ReturnsThenable_PassThrough_Rejected.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21a9
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21b1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21b4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21b7
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/thenImpl::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21d1
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/thenImpl::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21e7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl
+
 
 		// Methods
 		.method public hidebysig static 
@@ -354,7 +461,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/Scope,
-			[1] class FunctionObjects.Promise_Finally_ReturnsThenable_PassThrough_Rejected_FA0699BF.FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl,
+			[1] class Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/thenImpl/FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[4] object,
@@ -371,13 +478,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.Promise_Finally_ReturnsThenable_PassThrough_Rejected_FA0699BF.FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl::.ctor()
+		IL_0011: newobj instance void Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/thenImpl/FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "thenImpl"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Promise_Finally_ReturnsThenable_PassThrough_Rejected_FA0699BF.FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/thenImpl/FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -447,113 +554,6 @@
 	} // end of method Promise_Finally_ReturnsThenable_PassThrough_Rejected::__js_module_init__
 
 } // end of class Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Promise_Finally_ReturnsThenable_PassThrough_Rejected_FA0699BF.FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21a9
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21b1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21b4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21b7
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/thenImpl::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21d1
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Promise_Finally_ReturnsThenable_PassThrough_Rejected/thenImpl::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21e7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl::ConstructCore
-
-} // end of class FunctionObjects.Promise_Finally_ReturnsThenable_PassThrough_Rejected_FA0699BF.FunctionObject_FunctionDeclaration_DCE6C9CF_thenImpl
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Nested.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Nested.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_33DE5924_innerThen
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21c5
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_33DE5924_innerThen::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21cd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_33DE5924_innerThen::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21d0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_33DE5924_innerThen::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21d3
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Promise_Thenable_Nested/innerThen::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_33DE5924_innerThen::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21ed
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Promise_Thenable_Nested/innerThen::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_33DE5924_innerThen::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2203
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_33DE5924_innerThen::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_33DE5924_innerThen
+
 
 		// Methods
 		.method public hidebysig static 
@@ -88,6 +195,125 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Promise_Thenable_Nested/Scope _environment0_Promise_Thenable_Nested
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Promise_Thenable_Nested/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2212
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Promise_Thenable_Nested/Scope Modules.Promise_Thenable_Nested/outerThen/FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::_environment0_Promise_Thenable_Nested
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2221
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2224
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2227
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Promise_Thenable_Nested/Scope Modules.Promise_Thenable_Nested/outerThen/FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::_environment0_Promise_Thenable_Nested
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Promise_Thenable_Nested/outerThen::__js_call__(class Modules.Promise_Thenable_Nested/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2247
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Promise_Thenable_Nested/Scope Modules.Promise_Thenable_Nested/outerThen/FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::_environment0_Promise_Thenable_Nested
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Promise_Thenable_Nested/outerThen::__js_call__(class Modules.Promise_Thenable_Nested/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2263
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen
 
 
 		// Methods
@@ -309,8 +535,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Thenable_Nested/Scope,
-			[1] class FunctionObjects.Promise_Thenable_Nested_42CD2BD6.FunctionObject_FunctionDeclaration_33DE5924_innerThen,
-			[2] class FunctionObjects.Promise_Thenable_Nested_42CD2BD6.FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen,
+			[1] class Modules.Promise_Thenable_Nested/innerThen/FunctionObject_FunctionDeclaration_33DE5924_innerThen,
+			[2] class Modules.Promise_Thenable_Nested/outerThen/FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[4] object[],
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
@@ -327,13 +553,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 4
-		IL_0012: newobj instance void FunctionObjects.Promise_Thenable_Nested_42CD2BD6.FunctionObject_FunctionDeclaration_33DE5924_innerThen::.ctor()
+		IL_0012: newobj instance void Modules.Promise_Thenable_Nested/innerThen/FunctionObject_FunctionDeclaration_33DE5924_innerThen::.ctor()
 		IL_0017: ldc.i4.2
 		IL_0018: conv.r8
 		IL_0019: ldstr "innerThen"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Promise_Thenable_Nested_42CD2BD6.FunctionObject_FunctionDeclaration_33DE5924_innerThen>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_Nested/innerThen/FunctionObject_FunctionDeclaration_33DE5924_innerThen>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -346,13 +572,13 @@
 		IL_0034: ldc.i4.0
 		IL_0035: ldelem.ref
 		IL_0036: castclass Modules.Promise_Thenable_Nested/Scope
-		IL_003b: newobj instance void FunctionObjects.Promise_Thenable_Nested_42CD2BD6.FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::.ctor(class Modules.Promise_Thenable_Nested/Scope)
+		IL_003b: newobj instance void Modules.Promise_Thenable_Nested/outerThen/FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::.ctor(class Modules.Promise_Thenable_Nested/Scope)
 		IL_0040: ldc.i4.2
 		IL_0041: conv.r8
 		IL_0042: ldstr "outerThen"
 		IL_0047: ldc.i4.0
 		IL_0048: ldc.i4.1
-		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Promise_Thenable_Nested_42CD2BD6.FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen>(!!0, float64, string, bool, bool)
+		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_Nested/outerThen/FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen>(!!0, float64, string, bool, bool)
 		IL_004e: stloc.2
 		IL_004f: nop
 		IL_0050: nop
@@ -401,232 +627,6 @@
 	} // end of method Promise_Thenable_Nested::__js_module_init__
 
 } // end of class Modules.Promise_Thenable_Nested
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Promise_Thenable_Nested_42CD2BD6.FunctionObject_FunctionDeclaration_33DE5924_innerThen
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21c5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_33DE5924_innerThen::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21cd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_33DE5924_innerThen::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21d0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_33DE5924_innerThen::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21d3
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Promise_Thenable_Nested/innerThen::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_33DE5924_innerThen::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ed
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Promise_Thenable_Nested/innerThen::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_33DE5924_innerThen::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2203
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_33DE5924_innerThen::ConstructCore
-
-} // end of class FunctionObjects.Promise_Thenable_Nested_42CD2BD6.FunctionObject_FunctionDeclaration_33DE5924_innerThen
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Promise_Thenable_Nested_42CD2BD6.FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Promise_Thenable_Nested/Scope _environment0_Promise_Thenable_Nested
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Promise_Thenable_Nested/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2212
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Promise_Thenable_Nested/Scope FunctionObjects.Promise_Thenable_Nested_42CD2BD6.FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::_environment0_Promise_Thenable_Nested
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2221
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2224
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2227
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Promise_Thenable_Nested/Scope FunctionObjects.Promise_Thenable_Nested_42CD2BD6.FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::_environment0_Promise_Thenable_Nested
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Promise_Thenable_Nested/outerThen::__js_call__(class Modules.Promise_Thenable_Nested/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2247
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Promise_Thenable_Nested/Scope FunctionObjects.Promise_Thenable_Nested_42CD2BD6.FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::_environment0_Promise_Thenable_Nested
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Promise_Thenable_Nested/outerThen::__js_call__(class Modules.Promise_Thenable_Nested/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2263
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen::ConstructCore
-
-} // end of class FunctionObjects.Promise_Thenable_Nested_42CD2BD6.FunctionObject_FunctionDeclaration_2BE6CB4B_outerThen
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Reject.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Reject.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2140
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2148
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x214b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x214e
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Promise_Thenable_Reject/thenImpl::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2168
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Promise_Thenable_Reject/thenImpl::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x217e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl
+
 
 		// Methods
 		.method public hidebysig static 
@@ -233,7 +340,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Thenable_Reject/Scope,
-			[1] class FunctionObjects.Promise_Thenable_Reject_D2CEC712.FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl,
+			[1] class Modules.Promise_Thenable_Reject/thenImpl/FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object[],
 			[4] object,
@@ -249,13 +356,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.Promise_Thenable_Reject_D2CEC712.FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl::.ctor()
+		IL_0011: newobj instance void Modules.Promise_Thenable_Reject/thenImpl/FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "thenImpl"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Promise_Thenable_Reject_D2CEC712.FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_Reject/thenImpl/FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -294,113 +401,6 @@
 	} // end of method Promise_Thenable_Reject::__js_module_init__
 
 } // end of class Modules.Promise_Thenable_Reject
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Promise_Thenable_Reject_D2CEC712.FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2140
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2148
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x214b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x214e
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Promise_Thenable_Reject/thenImpl::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2168
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Promise_Thenable_Reject/thenImpl::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x217e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl::ConstructCore
-
-} // end of class FunctionObjects.Promise_Thenable_Reject_D2CEC712.FunctionObject_FunctionDeclaration_41FAAFD8_thenImpl
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Resolve_Delayed.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Resolve_Delayed.verified.txt
@@ -35,6 +35,118 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A1F718B1_later
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Promise_Thenable_Resolve_Delayed/thenImpl/Scope _environment1_thenImpl
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Promise_Thenable_Resolve_Delayed/thenImpl/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x2239
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Promise_Thenable_Resolve_Delayed/thenImpl/Scope Modules.Promise_Thenable_Resolve_Delayed/thenImpl/later/FunctionObject_FunctionDeclaration_A1F718B1_later::_environment1_thenImpl
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Promise_Thenable_Resolve_Delayed/thenImpl/later/FunctionObject_FunctionDeclaration_A1F718B1_later::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionDeclaration_A1F718B1_later::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x224f
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_A1F718B1_later::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2252
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_A1F718B1_later::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2255
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Promise_Thenable_Resolve_Delayed/thenImpl/later/FunctionObject_FunctionDeclaration_A1F718B1_later::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Promise_Thenable_Resolve_Delayed/thenImpl/later::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionDeclaration_A1F718B1_later::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2267
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Promise_Thenable_Resolve_Delayed/thenImpl/later/FunctionObject_FunctionDeclaration_A1F718B1_later::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Promise_Thenable_Resolve_Delayed/thenImpl/later::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionDeclaration_A1F718B1_later::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2275
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionDeclaration_A1F718B1_later::ConstructCore
+
+			} // end of class FunctionObject_FunctionDeclaration_A1F718B1_later
+
 
 			// Methods
 			.method public hidebysig static 
@@ -117,6 +229,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_86EAAB54_thenImpl
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Promise_Thenable_Resolve_Delayed/Scope _environment0_Promise_Thenable_Resolve_Delayed
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Promise_Thenable_Resolve_Delayed/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21d9
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Promise_Thenable_Resolve_Delayed/Scope Modules.Promise_Thenable_Resolve_Delayed/thenImpl/FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::_environment0_Promise_Thenable_Resolve_Delayed
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21e8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21eb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21ee
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Promise_Thenable_Resolve_Delayed/Scope Modules.Promise_Thenable_Resolve_Delayed/thenImpl/FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::_environment0_Promise_Thenable_Resolve_Delayed
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Promise_Thenable_Resolve_Delayed/thenImpl::__js_call__(class Modules.Promise_Thenable_Resolve_Delayed/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x220e
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Promise_Thenable_Resolve_Delayed/Scope Modules.Promise_Thenable_Resolve_Delayed/thenImpl/FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::_environment0_Promise_Thenable_Resolve_Delayed
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Promise_Thenable_Resolve_Delayed/thenImpl::__js_call__(class Modules.Promise_Thenable_Resolve_Delayed/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x222a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_86EAAB54_thenImpl
+
 
 		// Methods
 		.method public hidebysig static 
@@ -138,7 +369,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Promise_Thenable_Resolve_Delayed/thenImpl/Scope,
-				[1] class FunctionObjects.Promise_Thenable_Resolve_Delayed_A5DDD276.FunctionObject_FunctionDeclaration_A1F718B1_later,
+				[1] class Modules.Promise_Thenable_Resolve_Delayed/thenImpl/later/FunctionObject_FunctionDeclaration_A1F718B1_later,
 				[2] object[]
 			)
 
@@ -163,13 +394,13 @@
 			IL_001e: ldelem.ref
 			IL_001f: castclass Modules.Promise_Thenable_Resolve_Delayed/thenImpl/Scope
 			IL_0024: ldloc.2
-			IL_0025: newobj instance void FunctionObjects.Promise_Thenable_Resolve_Delayed_A5DDD276.FunctionObject_FunctionDeclaration_A1F718B1_later::.ctor(class Modules.Promise_Thenable_Resolve_Delayed/thenImpl/Scope, object[])
+			IL_0025: newobj instance void Modules.Promise_Thenable_Resolve_Delayed/thenImpl/later/FunctionObject_FunctionDeclaration_A1F718B1_later::.ctor(class Modules.Promise_Thenable_Resolve_Delayed/thenImpl/Scope, object[])
 			IL_002a: ldc.i4.0
 			IL_002b: conv.r8
 			IL_002c: ldstr "later"
 			IL_0031: ldc.i4.0
 			IL_0032: ldc.i4.1
-			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Promise_Thenable_Resolve_Delayed_A5DDD276.FunctionObject_FunctionDeclaration_A1F718B1_later>(!!0, float64, string, bool, bool)
+			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_Resolve_Delayed/thenImpl/later/FunctionObject_FunctionDeclaration_A1F718B1_later>(!!0, float64, string, bool, bool)
 			IL_0038: stloc.1
 			IL_0039: nop
 			IL_003a: ldloc.1
@@ -354,7 +585,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Thenable_Resolve_Delayed/Scope,
-			[1] class FunctionObjects.Promise_Thenable_Resolve_Delayed_A5DDD276.FunctionObject_FunctionDeclaration_86EAAB54_thenImpl,
+			[1] class Modules.Promise_Thenable_Resolve_Delayed/thenImpl/FunctionObject_FunctionDeclaration_86EAAB54_thenImpl,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object[],
 			[4] object,
@@ -374,13 +605,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Promise_Thenable_Resolve_Delayed/Scope
-		IL_0019: newobj instance void FunctionObjects.Promise_Thenable_Resolve_Delayed_A5DDD276.FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::.ctor(class Modules.Promise_Thenable_Resolve_Delayed/Scope)
+		IL_0019: newobj instance void Modules.Promise_Thenable_Resolve_Delayed/thenImpl/FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::.ctor(class Modules.Promise_Thenable_Resolve_Delayed/Scope)
 		IL_001e: ldc.i4.2
 		IL_001f: conv.r8
 		IL_0020: ldstr "thenImpl"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Promise_Thenable_Resolve_Delayed_A5DDD276.FunctionObject_FunctionDeclaration_86EAAB54_thenImpl>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_Resolve_Delayed/thenImpl/FunctionObject_FunctionDeclaration_86EAAB54_thenImpl>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
@@ -419,237 +650,6 @@
 	} // end of method Promise_Thenable_Resolve_Delayed::__js_module_init__
 
 } // end of class Modules.Promise_Thenable_Resolve_Delayed
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Promise_Thenable_Resolve_Delayed_A5DDD276.FunctionObject_FunctionDeclaration_86EAAB54_thenImpl
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Promise_Thenable_Resolve_Delayed/Scope _environment0_Promise_Thenable_Resolve_Delayed
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Promise_Thenable_Resolve_Delayed/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21d9
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Promise_Thenable_Resolve_Delayed/Scope FunctionObjects.Promise_Thenable_Resolve_Delayed_A5DDD276.FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::_environment0_Promise_Thenable_Resolve_Delayed
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21e8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21eb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ee
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Promise_Thenable_Resolve_Delayed/Scope FunctionObjects.Promise_Thenable_Resolve_Delayed_A5DDD276.FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::_environment0_Promise_Thenable_Resolve_Delayed
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Promise_Thenable_Resolve_Delayed/thenImpl::__js_call__(class Modules.Promise_Thenable_Resolve_Delayed/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x220e
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Promise_Thenable_Resolve_Delayed/Scope FunctionObjects.Promise_Thenable_Resolve_Delayed_A5DDD276.FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::_environment0_Promise_Thenable_Resolve_Delayed
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Promise_Thenable_Resolve_Delayed/thenImpl::__js_call__(class Modules.Promise_Thenable_Resolve_Delayed/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x222a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_86EAAB54_thenImpl::ConstructCore
-
-} // end of class FunctionObjects.Promise_Thenable_Resolve_Delayed_A5DDD276.FunctionObject_FunctionDeclaration_86EAAB54_thenImpl
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Promise_Thenable_Resolve_Delayed_A5DDD276.FunctionObject_FunctionDeclaration_A1F718B1_later
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Promise_Thenable_Resolve_Delayed/thenImpl/Scope _environment1_thenImpl
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Promise_Thenable_Resolve_Delayed/thenImpl/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x2239
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Promise_Thenable_Resolve_Delayed/thenImpl/Scope FunctionObjects.Promise_Thenable_Resolve_Delayed_A5DDD276.FunctionObject_FunctionDeclaration_A1F718B1_later::_environment1_thenImpl
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Promise_Thenable_Resolve_Delayed_A5DDD276.FunctionObject_FunctionDeclaration_A1F718B1_later::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_A1F718B1_later::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x224f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A1F718B1_later::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2252
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A1F718B1_later::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2255
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Promise_Thenable_Resolve_Delayed_A5DDD276.FunctionObject_FunctionDeclaration_A1F718B1_later::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Promise_Thenable_Resolve_Delayed/thenImpl/later::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_A1F718B1_later::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2267
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Promise_Thenable_Resolve_Delayed_A5DDD276.FunctionObject_FunctionDeclaration_A1F718B1_later::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Promise_Thenable_Resolve_Delayed/thenImpl/later::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_A1F718B1_later::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2275
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A1F718B1_later::ConstructCore
-
-} // end of class FunctionObjects.Promise_Thenable_Resolve_Delayed_A5DDD276.FunctionObject_FunctionDeclaration_A1F718B1_later
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Resolve_Immediate.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Resolve_Immediate.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_97B71571_thenImpl
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2148
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_97B71571_thenImpl::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2150
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_97B71571_thenImpl::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2153
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_97B71571_thenImpl::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2156
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Promise_Thenable_Resolve_Immediate/thenImpl::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_97B71571_thenImpl::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2170
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Promise_Thenable_Resolve_Immediate/thenImpl::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_97B71571_thenImpl::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2186
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_97B71571_thenImpl::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_97B71571_thenImpl
+
 
 		// Methods
 		.method public hidebysig static 
@@ -234,7 +341,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Thenable_Resolve_Immediate/Scope,
-			[1] class FunctionObjects.Promise_Thenable_Resolve_Immediate_C224F77D.FunctionObject_FunctionDeclaration_97B71571_thenImpl,
+			[1] class Modules.Promise_Thenable_Resolve_Immediate/thenImpl/FunctionObject_FunctionDeclaration_97B71571_thenImpl,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object[],
 			[4] object,
@@ -250,13 +357,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.Promise_Thenable_Resolve_Immediate_C224F77D.FunctionObject_FunctionDeclaration_97B71571_thenImpl::.ctor()
+		IL_0011: newobj instance void Modules.Promise_Thenable_Resolve_Immediate/thenImpl/FunctionObject_FunctionDeclaration_97B71571_thenImpl::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "thenImpl"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Promise_Thenable_Resolve_Immediate_C224F77D.FunctionObject_FunctionDeclaration_97B71571_thenImpl>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_Resolve_Immediate/thenImpl/FunctionObject_FunctionDeclaration_97B71571_thenImpl>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -295,113 +402,6 @@
 	} // end of method Promise_Thenable_Resolve_Immediate::__js_module_init__
 
 } // end of class Modules.Promise_Thenable_Resolve_Immediate
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Promise_Thenable_Resolve_Immediate_C224F77D.FunctionObject_FunctionDeclaration_97B71571_thenImpl
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2148
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_97B71571_thenImpl::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2150
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_97B71571_thenImpl::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2153
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_97B71571_thenImpl::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2156
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Promise_Thenable_Resolve_Immediate/thenImpl::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_97B71571_thenImpl::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2170
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Promise_Thenable_Resolve_Immediate/thenImpl::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_97B71571_thenImpl::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2186
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_97B71571_thenImpl::ConstructCore
-
-} // end of class FunctionObjects.Promise_Thenable_Resolve_Immediate_C224F77D.FunctionObject_FunctionDeclaration_97B71571_thenImpl
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Returned_FromHandler.verified.txt
+++ b/tests/Jroc.Tests/Promise/Snapshots/GeneratorTests.Promise_Thenable_Returned_FromHandler.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6F5A0281_thenImpl
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21b5
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_6F5A0281_thenImpl::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21bd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6F5A0281_thenImpl::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21c0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6F5A0281_thenImpl::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21c3
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Promise_Thenable_Returned_FromHandler/thenImpl::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_6F5A0281_thenImpl::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21dd
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Promise_Thenable_Returned_FromHandler/thenImpl::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_6F5A0281_thenImpl::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6F5A0281_thenImpl::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_6F5A0281_thenImpl
+
 
 		// Methods
 		.method public hidebysig static 
@@ -355,7 +462,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Promise_Thenable_Returned_FromHandler/Scope,
-			[1] class FunctionObjects.Promise_Thenable_Returned_FromHandler_DD0814CD.FunctionObject_FunctionDeclaration_6F5A0281_thenImpl,
+			[1] class Modules.Promise_Thenable_Returned_FromHandler/thenImpl/FunctionObject_FunctionDeclaration_6F5A0281_thenImpl,
 			[2] object[],
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[4] object,
@@ -372,13 +479,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.Promise_Thenable_Returned_FromHandler_DD0814CD.FunctionObject_FunctionDeclaration_6F5A0281_thenImpl::.ctor()
+		IL_0011: newobj instance void Modules.Promise_Thenable_Returned_FromHandler/thenImpl/FunctionObject_FunctionDeclaration_6F5A0281_thenImpl::.ctor()
 		IL_0016: ldc.i4.2
 		IL_0017: conv.r8
 		IL_0018: ldstr "thenImpl"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Promise_Thenable_Returned_FromHandler_DD0814CD.FunctionObject_FunctionDeclaration_6F5A0281_thenImpl>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Promise_Thenable_Returned_FromHandler/thenImpl/FunctionObject_FunctionDeclaration_6F5A0281_thenImpl>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -449,113 +556,6 @@
 	} // end of method Promise_Thenable_Returned_FromHandler::__js_module_init__
 
 } // end of class Modules.Promise_Thenable_Returned_FromHandler
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Promise_Thenable_Returned_FromHandler_DD0814CD.FunctionObject_FunctionDeclaration_6F5A0281_thenImpl
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21b5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_6F5A0281_thenImpl::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21bd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6F5A0281_thenImpl::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21c0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6F5A0281_thenImpl::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21c3
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Promise_Thenable_Returned_FromHandler/thenImpl::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_6F5A0281_thenImpl::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21dd
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Promise_Thenable_Returned_FromHandler/thenImpl::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_6F5A0281_thenImpl::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6F5A0281_thenImpl::ConstructCore
-
-} // end of class FunctionObjects.Promise_Thenable_Returned_FromHandler_DD0814CD.FunctionObject_FunctionDeclaration_6F5A0281_thenImpl
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_ApplyAndConstructTraps_WithFallback.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_ApplyAndConstructTraps_WithFallback.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_91358973_add
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x249a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_91358973_add::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24a2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_91358973_add::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24a5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_91358973_add::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24a8
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Proxy_ApplyAndConstructTraps_WithFallback/'add'::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_91358973_add::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24c2
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Proxy_ApplyAndConstructTraps_WithFallback/'add'::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionDeclaration_91358973_add::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24d8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_91358973_add::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_91358973_add
+
 
 		// Methods
 		.method public hidebysig static 
@@ -84,6 +191,131 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_CCAF019B_L9C10
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope _environment0_Proxy_ApplyAndConstructTraps_WithFallback
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x24e7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_applyProxy/FunctionObject_FunctionExpression_CCAF019B_L9C10::_environment0_Proxy_ApplyAndConstructTraps_WithFallback
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_CCAF019B_L9C10::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24f6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_CCAF019B_L9C10::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24f9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_CCAF019B_L9C10::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24fc
+				// Header size: 1
+				// Code size: 38 (0x26)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_applyProxy/FunctionObject_FunctionExpression_CCAF019B_L9C10::_environment0_Proxy_ApplyAndConstructTraps_WithFallback
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: call object Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_applyProxy::__js_call__(class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope, object, object, object, object)
+				IL_0025: ret
+			} // end of method FunctionObject_FunctionExpression_CCAF019B_L9C10::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2523
+				// Header size: 1
+				// Code size: 34 (0x22)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_applyProxy/FunctionObject_FunctionExpression_CCAF019B_L9C10::_environment0_Proxy_ApplyAndConstructTraps_WithFallback
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: ldarg.2
+				IL_0016: ldc.i4.2
+				IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001c: call object Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_applyProxy::__js_call__(class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope, object, object, object, object)
+				IL_0021: ret
+			} // end of method FunctionObject_FunctionExpression_CCAF019B_L9C10::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2546
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_CCAF019B_L9C10::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_CCAF019B_L9C10
 
 
 		// Methods
@@ -173,6 +405,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_78A503F9_Box
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2555
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_78A503F9_Box::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x255d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_78A503F9_Box::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2560
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_78A503F9_Box::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2563
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Proxy_ApplyAndConstructTraps_WithFallback/Box::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_78A503F9_Box::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2576
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Proxy_ApplyAndConstructTraps_WithFallback/Box::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_78A503F9_Box::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2585
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_78A503F9_Box::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_78A503F9_Box
+
 
 		// Methods
 		.method public hidebysig static 
@@ -225,6 +558,131 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1C0769A5_L25C14
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope _environment0_Proxy_ApplyAndConstructTraps_WithFallback
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2594
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_L25C13/FunctionObject_FunctionExpression_1C0769A5_L25C14::_environment0_Proxy_ApplyAndConstructTraps_WithFallback
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_1C0769A5_L25C14::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x25a3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_1C0769A5_L25C14::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x25a6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_1C0769A5_L25C14::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x25a9
+				// Header size: 1
+				// Code size: 38 (0x26)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_L25C13/FunctionObject_FunctionExpression_1C0769A5_L25C14::_environment0_Proxy_ApplyAndConstructTraps_WithFallback
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: call object Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_L25C13::__js_call__(class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope, object, object, object, object)
+				IL_0025: ret
+			} // end of method FunctionObject_FunctionExpression_1C0769A5_L25C14::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25d0
+				// Header size: 1
+				// Code size: 34 (0x22)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_L25C13/FunctionObject_FunctionExpression_1C0769A5_L25C14::_environment0_Proxy_ApplyAndConstructTraps_WithFallback
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: ldarg.2
+				IL_0016: ldc.i4.2
+				IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001c: call object Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_L25C13::__js_call__(class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope, object, object, object, object)
+				IL_0021: ret
+			} // end of method FunctionObject_FunctionExpression_1C0769A5_L25C14::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25f3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_1C0769A5_L25C14::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_1C0769A5_L25C14
 
 
 		// Methods
@@ -332,8 +790,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope,
-			[1] class FunctionObjects.Proxy_ApplyAndConstructTraps_WithFallback_15DFB54D.FunctionObject_FunctionDeclaration_91358973_add,
-			[2] class FunctionObjects.Proxy_ApplyAndConstructTraps_WithFallback_15DFB54D.FunctionObject_FunctionDeclaration_78A503F9_Box,
+			[1] class Modules.Proxy_ApplyAndConstructTraps_WithFallback/'add'/FunctionObject_FunctionDeclaration_91358973_add,
+			[2] class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Box/FunctionObject_FunctionDeclaration_78A503F9_Box,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
 			[4] object,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
@@ -341,12 +799,12 @@
 			[7] object,
 			[8] object[],
 			[9] class [JavaScriptRuntime]JavaScriptRuntime.Array,
-			[10] class FunctionObjects.Proxy_ApplyAndConstructTraps_WithFallback_15DFB54D.FunctionObject_FunctionExpression_CCAF019B_L9C10,
+			[10] class Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_applyProxy/FunctionObject_FunctionExpression_CCAF019B_L9C10,
 			[11] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[12] object,
 			[13] object,
 			[14] string,
-			[15] class FunctionObjects.Proxy_ApplyAndConstructTraps_WithFallback_15DFB54D.FunctionObject_FunctionExpression_1C0769A5_L25C14,
+			[15] class Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_L25C13/FunctionObject_FunctionExpression_1C0769A5_L25C14,
 			[16] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
 			[17] object,
 			[18] bool,
@@ -363,13 +821,13 @@
 		IL_0013: ldloc.0
 		IL_0014: stelem.ref
 		IL_0015: stloc.s 8
-		IL_0017: newobj instance void FunctionObjects.Proxy_ApplyAndConstructTraps_WithFallback_15DFB54D.FunctionObject_FunctionDeclaration_91358973_add::.ctor()
+		IL_0017: newobj instance void Modules.Proxy_ApplyAndConstructTraps_WithFallback/'add'/FunctionObject_FunctionDeclaration_91358973_add::.ctor()
 		IL_001c: ldc.i4.2
 		IL_001d: conv.r8
 		IL_001e: ldstr "add"
 		IL_0023: ldc.i4.0
 		IL_0024: ldc.i4.1
-		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_ApplyAndConstructTraps_WithFallback_15DFB54D.FunctionObject_FunctionDeclaration_91358973_add>(!!0, float64, string, bool, bool)
+		IL_0025: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_ApplyAndConstructTraps_WithFallback/'add'/FunctionObject_FunctionDeclaration_91358973_add>(!!0, float64, string, bool, bool)
 		IL_002a: stloc.1
 		IL_002b: ldc.i4.1
 		IL_002c: newarr [System.Runtime]System.Object
@@ -378,13 +836,13 @@
 		IL_0033: ldloc.0
 		IL_0034: stelem.ref
 		IL_0035: stloc.s 8
-		IL_0037: newobj instance void FunctionObjects.Proxy_ApplyAndConstructTraps_WithFallback_15DFB54D.FunctionObject_FunctionDeclaration_78A503F9_Box::.ctor()
+		IL_0037: newobj instance void Modules.Proxy_ApplyAndConstructTraps_WithFallback/Box/FunctionObject_FunctionDeclaration_78A503F9_Box::.ctor()
 		IL_003c: ldc.i4.1
 		IL_003d: conv.r8
 		IL_003e: ldstr "Box"
 		IL_0043: ldc.i4.1
 		IL_0044: ldc.i4.1
-		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_ApplyAndConstructTraps_WithFallback_15DFB54D.FunctionObject_FunctionDeclaration_78A503F9_Box>(!!0, float64, string, bool, bool)
+		IL_0045: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Box/FunctionObject_FunctionDeclaration_78A503F9_Box>(!!0, float64, string, bool, bool)
 		IL_004a: stloc.2
 		IL_004b: nop
 		IL_004c: nop
@@ -405,13 +863,13 @@
 		IL_006b: ldc.i4.0
 		IL_006c: ldelem.ref
 		IL_006d: castclass Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope
-		IL_0072: newobj instance void FunctionObjects.Proxy_ApplyAndConstructTraps_WithFallback_15DFB54D.FunctionObject_FunctionExpression_CCAF019B_L9C10::.ctor(class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope)
+		IL_0072: newobj instance void Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_applyProxy/FunctionObject_FunctionExpression_CCAF019B_L9C10::.ctor(class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope)
 		IL_0077: ldc.i4.3
 		IL_0078: conv.r8
 		IL_0079: ldstr ""
 		IL_007e: ldc.i4.0
 		IL_007f: ldc.i4.1
-		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_ApplyAndConstructTraps_WithFallback_15DFB54D.FunctionObject_FunctionExpression_CCAF019B_L9C10>(!!0, float64, string, bool, bool)
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_applyProxy/FunctionObject_FunctionExpression_CCAF019B_L9C10>(!!0, float64, string, bool, bool)
 		IL_0085: stloc.s 10
 		IL_0087: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_008c: dup
@@ -476,13 +934,13 @@
 		IL_0142: ldc.i4.0
 		IL_0143: ldelem.ref
 		IL_0144: castclass Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope
-		IL_0149: newobj instance void FunctionObjects.Proxy_ApplyAndConstructTraps_WithFallback_15DFB54D.FunctionObject_FunctionExpression_1C0769A5_L25C14::.ctor(class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope)
+		IL_0149: newobj instance void Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_L25C13/FunctionObject_FunctionExpression_1C0769A5_L25C14::.ctor(class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope)
 		IL_014e: ldc.i4.3
 		IL_014f: conv.r8
 		IL_0150: ldstr ""
 		IL_0155: ldc.i4.0
 		IL_0156: ldc.i4.1
-		IL_0157: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_ApplyAndConstructTraps_WithFallback_15DFB54D.FunctionObject_FunctionExpression_1C0769A5_L25C14>(!!0, float64, string, bool, bool)
+		IL_0157: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_L25C13/FunctionObject_FunctionExpression_1C0769A5_L25C14>(!!0, float64, string, bool, bool)
 		IL_015c: stloc.s 15
 		IL_015e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0163: dup
@@ -618,464 +1076,6 @@
 	} // end of method Proxy_ApplyAndConstructTraps_WithFallback::__js_module_init__
 
 } // end of class Modules.Proxy_ApplyAndConstructTraps_WithFallback
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_ApplyAndConstructTraps_WithFallback_15DFB54D.FunctionObject_FunctionDeclaration_91358973_add
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x249a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_91358973_add::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24a2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_91358973_add::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24a5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_91358973_add::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24a8
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Proxy_ApplyAndConstructTraps_WithFallback/'add'::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_91358973_add::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24c2
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Proxy_ApplyAndConstructTraps_WithFallback/'add'::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_91358973_add::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24d8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_91358973_add::ConstructCore
-
-} // end of class FunctionObjects.Proxy_ApplyAndConstructTraps_WithFallback_15DFB54D.FunctionObject_FunctionDeclaration_91358973_add
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_ApplyAndConstructTraps_WithFallback_15DFB54D.FunctionObject_FunctionExpression_CCAF019B_L9C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope _environment0_Proxy_ApplyAndConstructTraps_WithFallback
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x24e7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope FunctionObjects.Proxy_ApplyAndConstructTraps_WithFallback_15DFB54D.FunctionObject_FunctionExpression_CCAF019B_L9C10::_environment0_Proxy_ApplyAndConstructTraps_WithFallback
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_CCAF019B_L9C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24f6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_CCAF019B_L9C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24f9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_CCAF019B_L9C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24fc
-		// Header size: 1
-		// Code size: 38 (0x26)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope FunctionObjects.Proxy_ApplyAndConstructTraps_WithFallback_15DFB54D.FunctionObject_FunctionExpression_CCAF019B_L9C10::_environment0_Proxy_ApplyAndConstructTraps_WithFallback
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: call object Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_applyProxy::__js_call__(class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope, object, object, object, object)
-		IL_0025: ret
-	} // end of method FunctionObject_FunctionExpression_CCAF019B_L9C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2523
-		// Header size: 1
-		// Code size: 34 (0x22)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope FunctionObjects.Proxy_ApplyAndConstructTraps_WithFallback_15DFB54D.FunctionObject_FunctionExpression_CCAF019B_L9C10::_environment0_Proxy_ApplyAndConstructTraps_WithFallback
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: ldarg.2
-		IL_0016: ldc.i4.2
-		IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001c: call object Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_applyProxy::__js_call__(class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope, object, object, object, object)
-		IL_0021: ret
-	} // end of method FunctionObject_FunctionExpression_CCAF019B_L9C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2546
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_CCAF019B_L9C10::ConstructCore
-
-} // end of class FunctionObjects.Proxy_ApplyAndConstructTraps_WithFallback_15DFB54D.FunctionObject_FunctionExpression_CCAF019B_L9C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_ApplyAndConstructTraps_WithFallback_15DFB54D.FunctionObject_FunctionDeclaration_78A503F9_Box
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2555
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_78A503F9_Box::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x255d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_78A503F9_Box::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2560
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_78A503F9_Box::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2563
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Proxy_ApplyAndConstructTraps_WithFallback/Box::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_78A503F9_Box::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2576
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Proxy_ApplyAndConstructTraps_WithFallback/Box::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_78A503F9_Box::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2585
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_78A503F9_Box::ConstructCore
-
-} // end of class FunctionObjects.Proxy_ApplyAndConstructTraps_WithFallback_15DFB54D.FunctionObject_FunctionDeclaration_78A503F9_Box
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_ApplyAndConstructTraps_WithFallback_15DFB54D.FunctionObject_FunctionExpression_1C0769A5_L25C14
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope _environment0_Proxy_ApplyAndConstructTraps_WithFallback
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2594
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope FunctionObjects.Proxy_ApplyAndConstructTraps_WithFallback_15DFB54D.FunctionObject_FunctionExpression_1C0769A5_L25C14::_environment0_Proxy_ApplyAndConstructTraps_WithFallback
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1C0769A5_L25C14::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x25a3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1C0769A5_L25C14::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x25a6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1C0769A5_L25C14::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x25a9
-		// Header size: 1
-		// Code size: 38 (0x26)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope FunctionObjects.Proxy_ApplyAndConstructTraps_WithFallback_15DFB54D.FunctionObject_FunctionExpression_1C0769A5_L25C14::_environment0_Proxy_ApplyAndConstructTraps_WithFallback
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: call object Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_L25C13::__js_call__(class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope, object, object, object, object)
-		IL_0025: ret
-	} // end of method FunctionObject_FunctionExpression_1C0769A5_L25C14::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25d0
-		// Header size: 1
-		// Code size: 34 (0x22)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope FunctionObjects.Proxy_ApplyAndConstructTraps_WithFallback_15DFB54D.FunctionObject_FunctionExpression_1C0769A5_L25C14::_environment0_Proxy_ApplyAndConstructTraps_WithFallback
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: ldarg.2
-		IL_0016: ldc.i4.2
-		IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001c: call object Modules.Proxy_ApplyAndConstructTraps_WithFallback/FunctionExpression_L25C13::__js_call__(class Modules.Proxy_ApplyAndConstructTraps_WithFallback/Scope, object, object, object, object)
-		IL_0021: ret
-	} // end of method FunctionObject_FunctionExpression_1C0769A5_L25C14::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25f3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1C0769A5_L25C14::ConstructCore
-
-} // end of class FunctionObjects.Proxy_ApplyAndConstructTraps_WithFallback_15DFB54D.FunctionObject_FunctionExpression_1C0769A5_L25C14
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_DeletePropertyTrap_And_Fallback.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_DeletePropertyTrap_And_Fallback.verified.txt
@@ -53,6 +53,125 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_66D771F7_L7C19
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope _environment0_Proxy_DeletePropertyTrap_And_Fallback
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2306
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy/FunctionObject_FunctionExpression_66D771F7_L7C19::_environment0_Proxy_DeletePropertyTrap_And_Fallback
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_66D771F7_L7C19::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2315
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_66D771F7_L7C19::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2318
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_66D771F7_L7C19::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x231b
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy/FunctionObject_FunctionExpression_66D771F7_L7C19::_environment0_Proxy_DeletePropertyTrap_And_Fallback
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy::__js_call__(class Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionExpression_66D771F7_L7C19::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x233b
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy/FunctionObject_FunctionExpression_66D771F7_L7C19::_environment0_Proxy_DeletePropertyTrap_And_Fallback
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy::__js_call__(class Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionExpression_66D771F7_L7C19::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2357
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_66D771F7_L7C19::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_66D771F7_L7C19
+
 
 		// Methods
 		.method public hidebysig static 
@@ -156,7 +275,7 @@
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[6] object[],
-			[7] class FunctionObjects.Proxy_DeletePropertyTrap_And_Fallback_DAE0A83E.FunctionObject_FunctionExpression_66D771F7_L7C19,
+			[7] class Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy/FunctionObject_FunctionExpression_66D771F7_L7C19,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[9] object,
 			[10] bool,
@@ -198,13 +317,13 @@
 		IL_0067: ldc.i4.0
 		IL_0068: ldelem.ref
 		IL_0069: castclass Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope
-		IL_006e: newobj instance void FunctionObjects.Proxy_DeletePropertyTrap_And_Fallback_DAE0A83E.FunctionObject_FunctionExpression_66D771F7_L7C19::.ctor(class Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope)
+		IL_006e: newobj instance void Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy/FunctionObject_FunctionExpression_66D771F7_L7C19::.ctor(class Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope)
 		IL_0073: ldc.i4.2
 		IL_0074: conv.r8
 		IL_0075: ldstr ""
 		IL_007a: ldc.i4.0
 		IL_007b: ldc.i4.1
-		IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_DeletePropertyTrap_And_Fallback_DAE0A83E.FunctionObject_FunctionExpression_66D771F7_L7C19>(!!0, float64, string, bool, bool)
+		IL_007c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy/FunctionObject_FunctionExpression_66D771F7_L7C19>(!!0, float64, string, bool, bool)
 		IL_0081: stloc.s 7
 		IL_0083: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0088: dup
@@ -347,125 +466,6 @@
 	} // end of method Proxy_DeletePropertyTrap_And_Fallback::__js_module_init__
 
 } // end of class Modules.Proxy_DeletePropertyTrap_And_Fallback
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_DeletePropertyTrap_And_Fallback_DAE0A83E.FunctionObject_FunctionExpression_66D771F7_L7C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope _environment0_Proxy_DeletePropertyTrap_And_Fallback
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2306
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope FunctionObjects.Proxy_DeletePropertyTrap_And_Fallback_DAE0A83E.FunctionObject_FunctionExpression_66D771F7_L7C19::_environment0_Proxy_DeletePropertyTrap_And_Fallback
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_66D771F7_L7C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2315
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_66D771F7_L7C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2318
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_66D771F7_L7C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x231b
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope FunctionObjects.Proxy_DeletePropertyTrap_And_Fallback_DAE0A83E.FunctionObject_FunctionExpression_66D771F7_L7C19::_environment0_Proxy_DeletePropertyTrap_And_Fallback
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy::__js_call__(class Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionExpression_66D771F7_L7C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x233b
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope FunctionObjects.Proxy_DeletePropertyTrap_And_Fallback_DAE0A83E.FunctionObject_FunctionExpression_66D771F7_L7C19::_environment0_Proxy_DeletePropertyTrap_And_Fallback
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.Proxy_DeletePropertyTrap_And_Fallback/FunctionExpression_trappedProxy::__js_call__(class Modules.Proxy_DeletePropertyTrap_And_Fallback/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionExpression_66D771F7_L7C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2357
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_66D771F7_L7C19::ConstructCore
-
-} // end of class FunctionObjects.Proxy_DeletePropertyTrap_And_Fallback_DAE0A83E.FunctionObject_FunctionExpression_66D771F7_L7C19
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_GetTrap_OverridesProperty.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_GetTrap_OverridesProperty.verified.txt
@@ -31,6 +31,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_18B12A89_L7C8
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2171
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_18B12A89_L7C8::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2179
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_18B12A89_L7C8::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x217c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_18B12A89_L7C8::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x217f
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.2
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.Proxy_GetTrap_OverridesProperty/FunctionExpression_handler::__js_call__(object, object, object, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionExpression_18B12A89_L7C8::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21a0
+				// Header size: 1
+				// Code size: 28 (0x1c)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: ldarg.2
+				IL_0010: ldc.i4.2
+				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0016: call object Modules.Proxy_GetTrap_OverridesProperty/FunctionExpression_handler::__js_call__(object, object, object, object)
+				IL_001b: ret
+			} // end of method FunctionObject_FunctionExpression_18B12A89_L7C8::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21bd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_18B12A89_L7C8::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_18B12A89_L7C8
+
 
 		// Methods
 		.method public hidebysig static 
@@ -115,7 +228,7 @@
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
 			[4] object[],
-			[5] class FunctionObjects.Proxy_GetTrap_OverridesProperty_71D8FAD8.FunctionObject_FunctionExpression_18B12A89_L7C8,
+			[5] class Modules.Proxy_GetTrap_OverridesProperty/FunctionExpression_handler/FunctionObject_FunctionExpression_18B12A89_L7C8,
 			[6] object,
 			[7] object
 		)
@@ -140,13 +253,13 @@
 		IL_003d: ldloc.0
 		IL_003e: stelem.ref
 		IL_003f: stloc.s 4
-		IL_0041: newobj instance void FunctionObjects.Proxy_GetTrap_OverridesProperty_71D8FAD8.FunctionObject_FunctionExpression_18B12A89_L7C8::.ctor()
+		IL_0041: newobj instance void Modules.Proxy_GetTrap_OverridesProperty/FunctionExpression_handler/FunctionObject_FunctionExpression_18B12A89_L7C8::.ctor()
 		IL_0046: ldc.i4.3
 		IL_0047: conv.r8
 		IL_0048: ldstr ""
 		IL_004d: ldc.i4.0
 		IL_004e: ldc.i4.1
-		IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_GetTrap_OverridesProperty_71D8FAD8.FunctionObject_FunctionExpression_18B12A89_L7C8>(!!0, float64, string, bool, bool)
+		IL_004f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_GetTrap_OverridesProperty/FunctionExpression_handler/FunctionObject_FunctionExpression_18B12A89_L7C8>(!!0, float64, string, bool, bool)
 		IL_0054: stloc.s 5
 		IL_0056: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_005b: dup
@@ -188,119 +301,6 @@
 	} // end of method Proxy_GetTrap_OverridesProperty::__js_module_init__
 
 } // end of class Modules.Proxy_GetTrap_OverridesProperty
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_GetTrap_OverridesProperty_71D8FAD8.FunctionObject_FunctionExpression_18B12A89_L7C8
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2171
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_18B12A89_L7C8::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2179
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_18B12A89_L7C8::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x217c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_18B12A89_L7C8::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x217f
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.2
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.Proxy_GetTrap_OverridesProperty/FunctionExpression_handler::__js_call__(object, object, object, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionExpression_18B12A89_L7C8::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21a0
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: ldarg.2
-		IL_0010: ldc.i4.2
-		IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0016: call object Modules.Proxy_GetTrap_OverridesProperty/FunctionExpression_handler::__js_call__(object, object, object, object)
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_18B12A89_L7C8::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21bd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_18B12A89_L7C8::ConstructCore
-
-} // end of class FunctionObjects.Proxy_GetTrap_OverridesProperty_71D8FAD8.FunctionObject_FunctionExpression_18B12A89_L7C8
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_HasTrap_AffectsInOperator.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_HasTrap_AffectsInOperator.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C3F4D568_L7C8
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21a2
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_C3F4D568_L7C8::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21aa
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C3F4D568_L7C8::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21ad
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C3F4D568_L7C8::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21b0
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Proxy_HasTrap_AffectsInOperator/FunctionExpression_handler::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionExpression_C3F4D568_L7C8::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21ca
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Proxy_HasTrap_AffectsInOperator/FunctionExpression_handler::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionExpression_C3F4D568_L7C8::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21e0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_C3F4D568_L7C8::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_C3F4D568_L7C8
+
 
 		// Methods
 		.method public hidebysig static 
@@ -114,7 +221,7 @@
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
 			[4] object[],
-			[5] class FunctionObjects.Proxy_HasTrap_AffectsInOperator_F7961A65.FunctionObject_FunctionExpression_C3F4D568_L7C8,
+			[5] class Modules.Proxy_HasTrap_AffectsInOperator/FunctionExpression_handler/FunctionObject_FunctionExpression_C3F4D568_L7C8,
 			[6] object,
 			[7] bool,
 			[8] object
@@ -136,13 +243,13 @@
 		IL_0029: ldloc.0
 		IL_002a: stelem.ref
 		IL_002b: stloc.s 4
-		IL_002d: newobj instance void FunctionObjects.Proxy_HasTrap_AffectsInOperator_F7961A65.FunctionObject_FunctionExpression_C3F4D568_L7C8::.ctor()
+		IL_002d: newobj instance void Modules.Proxy_HasTrap_AffectsInOperator/FunctionExpression_handler/FunctionObject_FunctionExpression_C3F4D568_L7C8::.ctor()
 		IL_0032: ldc.i4.2
 		IL_0033: conv.r8
 		IL_0034: ldstr ""
 		IL_0039: ldc.i4.0
 		IL_003a: ldc.i4.1
-		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_HasTrap_AffectsInOperator_F7961A65.FunctionObject_FunctionExpression_C3F4D568_L7C8>(!!0, float64, string, bool, bool)
+		IL_003b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_HasTrap_AffectsInOperator/FunctionExpression_handler/FunctionObject_FunctionExpression_C3F4D568_L7C8>(!!0, float64, string, bool, bool)
 		IL_0040: stloc.s 5
 		IL_0042: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0047: dup
@@ -206,113 +313,6 @@
 	} // end of method Proxy_HasTrap_AffectsInOperator::__js_module_init__
 
 } // end of class Modules.Proxy_HasTrap_AffectsInOperator
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_HasTrap_AffectsInOperator_F7961A65.FunctionObject_FunctionExpression_C3F4D568_L7C8
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21a2
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_C3F4D568_L7C8::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21aa
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C3F4D568_L7C8::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21ad
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C3F4D568_L7C8::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21b0
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Proxy_HasTrap_AffectsInOperator/FunctionExpression_handler::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_C3F4D568_L7C8::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21ca
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Proxy_HasTrap_AffectsInOperator/FunctionExpression_handler::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_C3F4D568_L7C8::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21e0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C3F4D568_L7C8::ConstructCore
-
-} // end of class FunctionObjects.Proxy_HasTrap_AffectsInOperator_F7961A65.FunctionObject_FunctionExpression_C3F4D568_L7C8
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_OwnKeys_And_PrototypeTraps_WithFallback.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_OwnKeys_And_PrototypeTraps_WithFallback.verified.txt
@@ -31,6 +31,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_54FF07F3_L4C12
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x23d9
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_54FF07F3_L4C12::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x23e1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_54FF07F3_L4C12::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x23e4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_54FF07F3_L4C12::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x23e7
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_ownKeysProxy::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_54FF07F3_L4C12::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23f3
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_ownKeysProxy::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_54FF07F3_L4C12::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x23fb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_54FF07F3_L4C12::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_54FF07F3_L4C12
+
 
 		// Methods
 		.method public hidebysig static 
@@ -86,6 +181,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_38BEC47B_L14C19
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope _environment0_Proxy_OwnKeys_And_PrototypeTraps_WithFallback
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x240a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy/FunctionObject_FunctionExpression_38BEC47B_L14C19::_environment0_Proxy_OwnKeys_And_PrototypeTraps_WithFallback
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_38BEC47B_L14C19::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2419
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_38BEC47B_L14C19::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x241c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_38BEC47B_L14C19::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x241f
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy/FunctionObject_FunctionExpression_38BEC47B_L14C19::_environment0_Proxy_OwnKeys_And_PrototypeTraps_WithFallback
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy::__js_call__(class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_38BEC47B_L14C19::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2431
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy/FunctionObject_FunctionExpression_38BEC47B_L14C19::_environment0_Proxy_OwnKeys_And_PrototypeTraps_WithFallback
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy::__js_call__(class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_38BEC47B_L14C19::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x243f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_38BEC47B_L14C19::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_38BEC47B_L14C19
+
 
 		// Methods
 		.method public hidebysig static 
@@ -134,6 +336,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A30F1C44_L17C19
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x244e
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_A30F1C44_L17C19::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2456
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A30F1C44_L17C19::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2459
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A30F1C44_L17C19::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x245c
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy_L17C18::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionExpression_A30F1C44_L17C19::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2476
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy_L17C18::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionExpression_A30F1C44_L17C19::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x248c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_A30F1C44_L17C19::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_A30F1C44_L17C19
 
 
 		// Methods
@@ -225,12 +534,12 @@
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[8] object[],
-			[9] class FunctionObjects.Proxy_OwnKeys_And_PrototypeTraps_WithFallback_1EFA4BEC.FunctionObject_FunctionExpression_54FF07F3_L4C12,
+			[9] class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_ownKeysProxy/FunctionObject_FunctionExpression_54FF07F3_L4C12,
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[11] object,
 			[12] object,
-			[13] class FunctionObjects.Proxy_OwnKeys_And_PrototypeTraps_WithFallback_1EFA4BEC.FunctionObject_FunctionExpression_38BEC47B_L14C19,
-			[14] class FunctionObjects.Proxy_OwnKeys_And_PrototypeTraps_WithFallback_1EFA4BEC.FunctionObject_FunctionExpression_A30F1C44_L17C19,
+			[13] class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy/FunctionObject_FunctionExpression_38BEC47B_L14C19,
+			[14] class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy_L17C18/FunctionObject_FunctionExpression_A30F1C44_L17C19,
 			[15] bool,
 			[16] object
 		)
@@ -252,13 +561,13 @@
 		IL_0027: ldloc.0
 		IL_0028: stelem.ref
 		IL_0029: stloc.s 8
-		IL_002b: newobj instance void FunctionObjects.Proxy_OwnKeys_And_PrototypeTraps_WithFallback_1EFA4BEC.FunctionObject_FunctionExpression_54FF07F3_L4C12::.ctor()
+		IL_002b: newobj instance void Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_ownKeysProxy/FunctionObject_FunctionExpression_54FF07F3_L4C12::.ctor()
 		IL_0030: ldc.i4.0
 		IL_0031: conv.r8
 		IL_0032: ldstr ""
 		IL_0037: ldc.i4.0
 		IL_0038: ldc.i4.1
-		IL_0039: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_OwnKeys_And_PrototypeTraps_WithFallback_1EFA4BEC.FunctionObject_FunctionExpression_54FF07F3_L4C12>(!!0, float64, string, bool, bool)
+		IL_0039: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_ownKeysProxy/FunctionObject_FunctionExpression_54FF07F3_L4C12>(!!0, float64, string, bool, bool)
 		IL_003e: stloc.s 9
 		IL_0040: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0045: dup
@@ -308,13 +617,13 @@
 		IL_00cd: ldc.i4.0
 		IL_00ce: ldelem.ref
 		IL_00cf: castclass Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope
-		IL_00d4: newobj instance void FunctionObjects.Proxy_OwnKeys_And_PrototypeTraps_WithFallback_1EFA4BEC.FunctionObject_FunctionExpression_38BEC47B_L14C19::.ctor(class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope)
+		IL_00d4: newobj instance void Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy/FunctionObject_FunctionExpression_38BEC47B_L14C19::.ctor(class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope)
 		IL_00d9: ldc.i4.0
 		IL_00da: conv.r8
 		IL_00db: ldstr ""
 		IL_00e0: ldc.i4.0
 		IL_00e1: ldc.i4.1
-		IL_00e2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_OwnKeys_And_PrototypeTraps_WithFallback_1EFA4BEC.FunctionObject_FunctionExpression_38BEC47B_L14C19>(!!0, float64, string, bool, bool)
+		IL_00e2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy/FunctionObject_FunctionExpression_38BEC47B_L14C19>(!!0, float64, string, bool, bool)
 		IL_00e7: stloc.s 13
 		IL_00e9: ldc.i4.1
 		IL_00ea: newarr [System.Runtime]System.Object
@@ -323,13 +632,13 @@
 		IL_00f1: ldloc.0
 		IL_00f2: stelem.ref
 		IL_00f3: stloc.s 8
-		IL_00f5: newobj instance void FunctionObjects.Proxy_OwnKeys_And_PrototypeTraps_WithFallback_1EFA4BEC.FunctionObject_FunctionExpression_A30F1C44_L17C19::.ctor()
+		IL_00f5: newobj instance void Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy_L17C18/FunctionObject_FunctionExpression_A30F1C44_L17C19::.ctor()
 		IL_00fa: ldc.i4.2
 		IL_00fb: conv.r8
 		IL_00fc: ldstr ""
 		IL_0101: ldc.i4.0
 		IL_0102: ldc.i4.1
-		IL_0103: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_OwnKeys_And_PrototypeTraps_WithFallback_1EFA4BEC.FunctionObject_FunctionExpression_A30F1C44_L17C19>(!!0, float64, string, bool, bool)
+		IL_0103: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy_L17C18/FunctionObject_FunctionExpression_A30F1C44_L17C19>(!!0, float64, string, bool, bool)
 		IL_0108: stloc.s 14
 		IL_010a: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_010f: dup
@@ -479,315 +788,6 @@
 	} // end of method Proxy_OwnKeys_And_PrototypeTraps_WithFallback::__js_module_init__
 
 } // end of class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_OwnKeys_And_PrototypeTraps_WithFallback_1EFA4BEC.FunctionObject_FunctionExpression_54FF07F3_L4C12
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x23d9
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_54FF07F3_L4C12::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x23e1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_54FF07F3_L4C12::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x23e4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_54FF07F3_L4C12::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x23e7
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_ownKeysProxy::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_54FF07F3_L4C12::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23f3
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_ownKeysProxy::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_54FF07F3_L4C12::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x23fb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_54FF07F3_L4C12::ConstructCore
-
-} // end of class FunctionObjects.Proxy_OwnKeys_And_PrototypeTraps_WithFallback_1EFA4BEC.FunctionObject_FunctionExpression_54FF07F3_L4C12
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_OwnKeys_And_PrototypeTraps_WithFallback_1EFA4BEC.FunctionObject_FunctionExpression_38BEC47B_L14C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope _environment0_Proxy_OwnKeys_And_PrototypeTraps_WithFallback
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x240a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope FunctionObjects.Proxy_OwnKeys_And_PrototypeTraps_WithFallback_1EFA4BEC.FunctionObject_FunctionExpression_38BEC47B_L14C19::_environment0_Proxy_OwnKeys_And_PrototypeTraps_WithFallback
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_38BEC47B_L14C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2419
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_38BEC47B_L14C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x241c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_38BEC47B_L14C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x241f
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope FunctionObjects.Proxy_OwnKeys_And_PrototypeTraps_WithFallback_1EFA4BEC.FunctionObject_FunctionExpression_38BEC47B_L14C19::_environment0_Proxy_OwnKeys_And_PrototypeTraps_WithFallback
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy::__js_call__(class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_38BEC47B_L14C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2431
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope FunctionObjects.Proxy_OwnKeys_And_PrototypeTraps_WithFallback_1EFA4BEC.FunctionObject_FunctionExpression_38BEC47B_L14C19::_environment0_Proxy_OwnKeys_And_PrototypeTraps_WithFallback
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy::__js_call__(class Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_38BEC47B_L14C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x243f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_38BEC47B_L14C19::ConstructCore
-
-} // end of class FunctionObjects.Proxy_OwnKeys_And_PrototypeTraps_WithFallback_1EFA4BEC.FunctionObject_FunctionExpression_38BEC47B_L14C19
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_OwnKeys_And_PrototypeTraps_WithFallback_1EFA4BEC.FunctionObject_FunctionExpression_A30F1C44_L17C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x244e
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_A30F1C44_L17C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2456
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A30F1C44_L17C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2459
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A30F1C44_L17C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x245c
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy_L17C18::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_A30F1C44_L17C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2476
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Proxy_OwnKeys_And_PrototypeTraps_WithFallback/FunctionExpression_prototypeProxy_L17C18::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_A30F1C44_L17C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x248c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A30F1C44_L17C19::ConstructCore
-
-} // end of class FunctionObjects.Proxy_OwnKeys_And_PrototypeTraps_WithFallback_1EFA4BEC.FunctionObject_FunctionExpression_A30F1C44_L17C19
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Revocable_ThrowsAfterRevoke.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Revocable_ThrowsAfterRevoke.verified.txt
@@ -73,6 +73,127 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5FAC858C_logThrow
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope _environment0_Proxy_Revocable_ThrowsAfterRevoke
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2862
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow/FunctionObject_FunctionDeclaration_5FAC858C_logThrow::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5FAC858C_logThrow::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2871
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5FAC858C_logThrow::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2874
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5FAC858C_logThrow::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2877
+				// Header size: 1
+				// Code size: 36 (0x24)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow/FunctionObject_FunctionDeclaration_5FAC858C_logThrow::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0017: ldarg.2
+				IL_0018: ldc.i4.1
+				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001e: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, string, object)
+				IL_0023: ret
+			} // end of method FunctionObject_FunctionDeclaration_5FAC858C_logThrow::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x289c
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow/FunctionObject_FunctionDeclaration_5FAC858C_logThrow::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.1
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, string, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionDeclaration_5FAC858C_logThrow::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x28bd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5FAC858C_logThrow::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_5FAC858C_logThrow
+
 
 		// Methods
 		.method public hidebysig static 
@@ -216,6 +337,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3925BBA6_L14C8
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x28cc
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_3925BBA6_L14C8::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x28d4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_3925BBA6_L14C8::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x28d7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_3925BBA6_L14C8::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x28da
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionExpression_3925BBA6_L14C8::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x28f4
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionExpression_3925BBA6_L14C8::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x290a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_3925BBA6_L14C8::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_3925BBA6_L14C8
+
 
 		// Methods
 		.method public hidebysig static 
@@ -269,6 +497,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F9B416A7_L17C8
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2919
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_F9B416A7_L17C8::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2921
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F9B416A7_L17C8::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2924
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F9B416A7_L17C8::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2927
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.2
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable_L17C7::__js_call__(object, object, object, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionExpression_F9B416A7_L17C8::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2948
+				// Header size: 1
+				// Code size: 28 (0x1c)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: ldarg.2
+				IL_0010: ldc.i4.2
+				IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0016: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable_L17C7::__js_call__(object, object, object, object)
+				IL_001b: ret
+			} // end of method FunctionObject_FunctionExpression_F9B416A7_L17C8::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2965
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_F9B416A7_L17C8::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_F9B416A7_L17C8
 
 
 		// Methods
@@ -324,6 +665,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DCCED563_L28C17
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope _environment0_Proxy_Revocable_ThrowsAfterRevoke
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2974
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16/FunctionObject_FunctionExpression_DCCED563_L28C17::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_DCCED563_L28C17::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2983
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_DCCED563_L28C17::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2986
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_DCCED563_L28C17::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2989
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16/FunctionObject_FunctionExpression_DCCED563_L28C17::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_DCCED563_L28C17::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x299b
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16/FunctionObject_FunctionExpression_DCCED563_L28C17::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_DCCED563_L28C17::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x29a9
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_DCCED563_L28C17::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_DCCED563_L28C17
 
 
 		// Methods
@@ -384,6 +832,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_007DCDBA_L29C17
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope _environment0_Proxy_Revocable_ThrowsAfterRevoke
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x29b8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16/FunctionObject_FunctionExpression_007DCDBA_L29C17::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_007DCDBA_L29C17::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x29c7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_007DCDBA_L29C17::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x29ca
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_007DCDBA_L29C17::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x29cd
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16/FunctionObject_FunctionExpression_007DCDBA_L29C17::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_007DCDBA_L29C17::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x29df
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16/FunctionObject_FunctionExpression_007DCDBA_L29C17::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_007DCDBA_L29C17::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x29ed
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_007DCDBA_L29C17::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_007DCDBA_L29C17
 
 
 		// Methods
@@ -447,6 +1002,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7AF52BFC_L30C17
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope _environment0_Proxy_Revocable_ThrowsAfterRevoke
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x29fc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16/FunctionObject_FunctionExpression_7AF52BFC_L30C17::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_7AF52BFC_L30C17::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2a0b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7AF52BFC_L30C17::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2a0e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7AF52BFC_L30C17::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a11
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16/FunctionObject_FunctionExpression_7AF52BFC_L30C17::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_7AF52BFC_L30C17::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a23
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16/FunctionObject_FunctionExpression_7AF52BFC_L30C17::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_7AF52BFC_L30C17::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a31
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_7AF52BFC_L30C17::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_7AF52BFC_L30C17
+
 
 		// Methods
 		.method public hidebysig static 
@@ -509,6 +1171,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3C8D3F03_L31C20
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope _environment0_Proxy_Revocable_ThrowsAfterRevoke
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a40
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19/FunctionObject_FunctionExpression_3C8D3F03_L31C20::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_3C8D3F03_L31C20::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2a4f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_3C8D3F03_L31C20::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2a52
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_3C8D3F03_L31C20::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a55
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19/FunctionObject_FunctionExpression_3C8D3F03_L31C20::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_3C8D3F03_L31C20::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a67
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19/FunctionObject_FunctionExpression_3C8D3F03_L31C20::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_3C8D3F03_L31C20::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a75
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_3C8D3F03_L31C20::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_3C8D3F03_L31C20
+
 
 		// Methods
 		.method public hidebysig static 
@@ -570,6 +1339,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2D98E99F_L32C18
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope _environment0_Proxy_Revocable_ThrowsAfterRevoke
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a84
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17/FunctionObject_FunctionExpression_2D98E99F_L32C18::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_2D98E99F_L32C18::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2a93
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_2D98E99F_L32C18::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2a96
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_2D98E99F_L32C18::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a99
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17/FunctionObject_FunctionExpression_2D98E99F_L32C18::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_2D98E99F_L32C18::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2aab
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17/FunctionObject_FunctionExpression_2D98E99F_L32C18::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_2D98E99F_L32C18::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ab9
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_2D98E99F_L32C18::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_2D98E99F_L32C18
 
 
 		// Methods
@@ -636,6 +1512,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1DE7D22D_L33C28
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope _environment0_Proxy_Revocable_ThrowsAfterRevoke
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ac8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27/FunctionObject_FunctionExpression_1DE7D22D_L33C28::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_1DE7D22D_L33C28::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2ad7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_1DE7D22D_L33C28::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2ada
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_1DE7D22D_L33C28::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2add
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27/FunctionObject_FunctionExpression_1DE7D22D_L33C28::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_1DE7D22D_L33C28::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2aef
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27/FunctionObject_FunctionExpression_1DE7D22D_L33C28::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_1DE7D22D_L33C28::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2afd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_1DE7D22D_L33C28::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_1DE7D22D_L33C28
+
 
 		// Methods
 		.method public hidebysig static 
@@ -692,6 +1675,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_DB63B8EE_L34C28
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope _environment0_Proxy_Revocable_ThrowsAfterRevoke
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b0c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27/FunctionObject_FunctionExpression_DB63B8EE_L34C28::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_DB63B8EE_L34C28::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2b1b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_DB63B8EE_L34C28::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2b1e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_DB63B8EE_L34C28::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b21
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27/FunctionObject_FunctionExpression_DB63B8EE_L34C28::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_DB63B8EE_L34C28::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b33
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27/FunctionObject_FunctionExpression_DB63B8EE_L34C28::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_DB63B8EE_L34C28::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b41
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_DB63B8EE_L34C28::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_DB63B8EE_L34C28
 
 
 		// Methods
@@ -752,6 +1842,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_81EE28F5_L36C34
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2b50
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_81EE28F5_L36C34::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2b58
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_81EE28F5_L36C34::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2b5b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_81EE28F5_L36C34::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b5e
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_callable::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_81EE28F5_L36C34::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b71
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_callable::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_81EE28F5_L36C34::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b80
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_81EE28F5_L36C34::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_81EE28F5_L36C34
+
 
 		// Methods
 		.method public hidebysig static 
@@ -804,6 +1995,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7028F334_L40C18
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope _environment0_Proxy_Revocable_ThrowsAfterRevoke
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b8f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17/FunctionObject_FunctionExpression_7028F334_L40C18::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_7028F334_L40C18::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2b9e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7028F334_L40C18::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2ba1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7028F334_L40C18::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ba4
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17/FunctionObject_FunctionExpression_7028F334_L40C18::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_7028F334_L40C18::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bb6
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17/FunctionObject_FunctionExpression_7028F334_L40C18::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_7028F334_L40C18::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bc4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_7028F334_L40C18::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_7028F334_L40C18
 
 
 		// Methods
@@ -870,6 +2168,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_4A0EDC35_C
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2bd3
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_4A0EDC35_C::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2bdb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_4A0EDC35_C::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2bde
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_4A0EDC35_C::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2be1
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/C::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_4A0EDC35_C::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bf4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/C::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_4A0EDC35_C::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c03
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_4A0EDC35_C::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_4A0EDC35_C
+
 
 		// Methods
 		.method public hidebysig static 
@@ -930,6 +2329,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_35ED904C_L46C23
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope _environment0_Proxy_Revocable_ThrowsAfterRevoke
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c12
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22/FunctionObject_FunctionExpression_35ED904C_L46C23::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_35ED904C_L46C23::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2c21
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_35ED904C_L46C23::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2c24
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_35ED904C_L46C23::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c27
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22/FunctionObject_FunctionExpression_35ED904C_L46C23::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_35ED904C_L46C23::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c39
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22/FunctionObject_FunctionExpression_35ED904C_L46C23::_environment0_Proxy_Revocable_ThrowsAfterRevoke
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_35ED904C_L46C23::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c47
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_35ED904C_L46C23::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_35ED904C_L46C23
 
 
 		// Methods
@@ -1025,26 +2531,26 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope,
-			[1] class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionDeclaration_5FAC858C_logThrow,
+			[1] class Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow/FunctionObject_FunctionDeclaration_5FAC858C_logThrow,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object[],
-			[4] class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_3925BBA6_L14C8,
-			[5] class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_F9B416A7_L17C8,
+			[4] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable/FunctionObject_FunctionExpression_3925BBA6_L14C8,
+			[5] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable_L17C7/FunctionObject_FunctionExpression_F9B416A7_L17C8,
 			[6] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[7] object,
 			[8] object,
 			[9] object[],
-			[10] class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_DCCED563_L28C17,
-			[11] class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_007DCDBA_L29C17,
-			[12] class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_7AF52BFC_L30C17,
-			[13] class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_3C8D3F03_L31C20,
-			[14] class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_2D98E99F_L32C18,
-			[15] class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_1DE7D22D_L33C28,
-			[16] class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_DB63B8EE_L34C28,
-			[17] class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_81EE28F5_L36C34,
-			[18] class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_7028F334_L40C18,
-			[19] class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_4A0EDC35_C,
-			[20] class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_35ED904C_L46C23
+			[10] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16/FunctionObject_FunctionExpression_DCCED563_L28C17,
+			[11] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16/FunctionObject_FunctionExpression_007DCDBA_L29C17,
+			[12] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16/FunctionObject_FunctionExpression_7AF52BFC_L30C17,
+			[13] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19/FunctionObject_FunctionExpression_3C8D3F03_L31C20,
+			[14] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17/FunctionObject_FunctionExpression_2D98E99F_L32C18,
+			[15] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27/FunctionObject_FunctionExpression_1DE7D22D_L33C28,
+			[16] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27/FunctionObject_FunctionExpression_DB63B8EE_L34C28,
+			[17] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_callable/FunctionObject_FunctionExpression_81EE28F5_L36C34,
+			[18] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17/FunctionObject_FunctionExpression_7028F334_L40C18,
+			[19] class Modules.Proxy_Revocable_ThrowsAfterRevoke/C/FunctionObject_FunctionExpression_4A0EDC35_C,
+			[20] class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22/FunctionObject_FunctionExpression_35ED904C_L46C23
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -1061,13 +2567,13 @@
 		IL_0017: ldc.i4.0
 		IL_0018: ldelem.ref
 		IL_0019: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_001e: newobj instance void FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionDeclaration_5FAC858C_logThrow::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_001e: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow/FunctionObject_FunctionDeclaration_5FAC858C_logThrow::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
 		IL_0023: ldc.i4.2
 		IL_0024: conv.r8
 		IL_0025: ldstr "logThrow"
 		IL_002a: ldc.i4.0
 		IL_002b: ldc.i4.1
-		IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionDeclaration_5FAC858C_logThrow>(!!0, float64, string, bool, bool)
+		IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow/FunctionObject_FunctionDeclaration_5FAC858C_logThrow>(!!0, float64, string, bool, bool)
 		IL_0031: stloc.1
 		IL_0032: nop
 		IL_0033: nop
@@ -1084,13 +2590,13 @@
 		IL_0056: ldloc.0
 		IL_0057: stelem.ref
 		IL_0058: stloc.3
-		IL_0059: newobj instance void FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_3925BBA6_L14C8::.ctor()
+		IL_0059: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable/FunctionObject_FunctionExpression_3925BBA6_L14C8::.ctor()
 		IL_005e: ldc.i4.2
 		IL_005f: conv.r8
 		IL_0060: ldstr ""
 		IL_0065: ldc.i4.0
 		IL_0066: ldc.i4.1
-		IL_0067: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_3925BBA6_L14C8>(!!0, float64, string, bool, bool)
+		IL_0067: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable/FunctionObject_FunctionExpression_3925BBA6_L14C8>(!!0, float64, string, bool, bool)
 		IL_006c: stloc.s 4
 		IL_006e: ldc.i4.1
 		IL_006f: newarr [System.Runtime]System.Object
@@ -1099,13 +2605,13 @@
 		IL_0076: ldloc.0
 		IL_0077: stelem.ref
 		IL_0078: stloc.3
-		IL_0079: newobj instance void FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_F9B416A7_L17C8::.ctor()
+		IL_0079: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable_L17C7/FunctionObject_FunctionExpression_F9B416A7_L17C8::.ctor()
 		IL_007e: ldc.i4.3
 		IL_007f: conv.r8
 		IL_0080: ldstr ""
 		IL_0085: ldc.i4.0
 		IL_0086: ldc.i4.1
-		IL_0087: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_F9B416A7_L17C8>(!!0, float64, string, bool, bool)
+		IL_0087: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable_L17C7/FunctionObject_FunctionExpression_F9B416A7_L17C8>(!!0, float64, string, bool, bool)
 		IL_008c: stloc.s 5
 		IL_008e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0093: dup
@@ -1185,13 +2691,13 @@
 		IL_0181: ldc.i4.0
 		IL_0182: ldelem.ref
 		IL_0183: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0188: newobj instance void FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_DCCED563_L28C17::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_0188: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16/FunctionObject_FunctionExpression_DCCED563_L28C17::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
 		IL_018d: ldc.i4.0
 		IL_018e: conv.r8
 		IL_018f: ldstr ""
 		IL_0194: ldc.i4.0
 		IL_0195: ldc.i4.1
-		IL_0196: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_DCCED563_L28C17>(!!0, float64, string, bool, bool)
+		IL_0196: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16/FunctionObject_FunctionExpression_DCCED563_L28C17>(!!0, float64, string, bool, bool)
 		IL_019b: stloc.s 10
 		IL_019d: ldloc.1
 		IL_019e: ldloc.3
@@ -1212,13 +2718,13 @@
 		IL_01c0: ldc.i4.0
 		IL_01c1: ldelem.ref
 		IL_01c2: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_01c7: newobj instance void FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_007DCDBA_L29C17::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_01c7: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16/FunctionObject_FunctionExpression_007DCDBA_L29C17::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
 		IL_01cc: ldc.i4.0
 		IL_01cd: conv.r8
 		IL_01ce: ldstr ""
 		IL_01d3: ldc.i4.0
 		IL_01d4: ldc.i4.1
-		IL_01d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_007DCDBA_L29C17>(!!0, float64, string, bool, bool)
+		IL_01d5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16/FunctionObject_FunctionExpression_007DCDBA_L29C17>(!!0, float64, string, bool, bool)
 		IL_01da: stloc.s 11
 		IL_01dc: ldloc.1
 		IL_01dd: ldloc.3
@@ -1239,13 +2745,13 @@
 		IL_01ff: ldc.i4.0
 		IL_0200: ldelem.ref
 		IL_0201: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0206: newobj instance void FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_7AF52BFC_L30C17::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_0206: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16/FunctionObject_FunctionExpression_7AF52BFC_L30C17::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
 		IL_020b: ldc.i4.0
 		IL_020c: conv.r8
 		IL_020d: ldstr ""
 		IL_0212: ldc.i4.0
 		IL_0213: ldc.i4.1
-		IL_0214: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_7AF52BFC_L30C17>(!!0, float64, string, bool, bool)
+		IL_0214: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16/FunctionObject_FunctionExpression_7AF52BFC_L30C17>(!!0, float64, string, bool, bool)
 		IL_0219: stloc.s 12
 		IL_021b: ldloc.1
 		IL_021c: ldloc.3
@@ -1266,13 +2772,13 @@
 		IL_023e: ldc.i4.0
 		IL_023f: ldelem.ref
 		IL_0240: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0245: newobj instance void FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_3C8D3F03_L31C20::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_0245: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19/FunctionObject_FunctionExpression_3C8D3F03_L31C20::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
 		IL_024a: ldc.i4.0
 		IL_024b: conv.r8
 		IL_024c: ldstr ""
 		IL_0251: ldc.i4.0
 		IL_0252: ldc.i4.1
-		IL_0253: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_3C8D3F03_L31C20>(!!0, float64, string, bool, bool)
+		IL_0253: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19/FunctionObject_FunctionExpression_3C8D3F03_L31C20>(!!0, float64, string, bool, bool)
 		IL_0258: stloc.s 13
 		IL_025a: ldloc.1
 		IL_025b: ldloc.3
@@ -1293,13 +2799,13 @@
 		IL_027d: ldc.i4.0
 		IL_027e: ldelem.ref
 		IL_027f: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0284: newobj instance void FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_2D98E99F_L32C18::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_0284: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17/FunctionObject_FunctionExpression_2D98E99F_L32C18::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
 		IL_0289: ldc.i4.0
 		IL_028a: conv.r8
 		IL_028b: ldstr ""
 		IL_0290: ldc.i4.0
 		IL_0291: ldc.i4.1
-		IL_0292: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_2D98E99F_L32C18>(!!0, float64, string, bool, bool)
+		IL_0292: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17/FunctionObject_FunctionExpression_2D98E99F_L32C18>(!!0, float64, string, bool, bool)
 		IL_0297: stloc.s 14
 		IL_0299: ldloc.1
 		IL_029a: ldloc.3
@@ -1320,13 +2826,13 @@
 		IL_02bc: ldc.i4.0
 		IL_02bd: ldelem.ref
 		IL_02be: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_02c3: newobj instance void FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_1DE7D22D_L33C28::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_02c3: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27/FunctionObject_FunctionExpression_1DE7D22D_L33C28::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
 		IL_02c8: ldc.i4.0
 		IL_02c9: conv.r8
 		IL_02ca: ldstr ""
 		IL_02cf: ldc.i4.0
 		IL_02d0: ldc.i4.1
-		IL_02d1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_1DE7D22D_L33C28>(!!0, float64, string, bool, bool)
+		IL_02d1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27/FunctionObject_FunctionExpression_1DE7D22D_L33C28>(!!0, float64, string, bool, bool)
 		IL_02d6: stloc.s 15
 		IL_02d8: ldloc.1
 		IL_02d9: ldloc.3
@@ -1347,13 +2853,13 @@
 		IL_02fb: ldc.i4.0
 		IL_02fc: ldelem.ref
 		IL_02fd: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0302: newobj instance void FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_DB63B8EE_L34C28::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_0302: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27/FunctionObject_FunctionExpression_DB63B8EE_L34C28::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
 		IL_0307: ldc.i4.0
 		IL_0308: conv.r8
 		IL_0309: ldstr ""
 		IL_030e: ldc.i4.0
 		IL_030f: ldc.i4.1
-		IL_0310: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_DB63B8EE_L34C28>(!!0, float64, string, bool, bool)
+		IL_0310: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27/FunctionObject_FunctionExpression_DB63B8EE_L34C28>(!!0, float64, string, bool, bool)
 		IL_0315: stloc.s 16
 		IL_0317: ldloc.1
 		IL_0318: ldloc.3
@@ -1368,13 +2874,13 @@
 		IL_032e: ldloc.0
 		IL_032f: stelem.ref
 		IL_0330: stloc.3
-		IL_0331: newobj instance void FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_81EE28F5_L36C34::.ctor()
+		IL_0331: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_callable/FunctionObject_FunctionExpression_81EE28F5_L36C34::.ctor()
 		IL_0336: ldc.i4.1
 		IL_0337: conv.r8
 		IL_0338: ldstr ""
 		IL_033d: ldc.i4.0
 		IL_033e: ldc.i4.1
-		IL_033f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_81EE28F5_L36C34>(!!0, float64, string, bool, bool)
+		IL_033f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_callable/FunctionObject_FunctionExpression_81EE28F5_L36C34>(!!0, float64, string, bool, bool)
 		IL_0344: stloc.s 17
 		IL_0346: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_034b: stloc.s 6
@@ -1404,13 +2910,13 @@
 		IL_038a: ldc.i4.0
 		IL_038b: ldelem.ref
 		IL_038c: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0391: newobj instance void FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_7028F334_L40C18::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_0391: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17/FunctionObject_FunctionExpression_7028F334_L40C18::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
 		IL_0396: ldc.i4.0
 		IL_0397: conv.r8
 		IL_0398: ldstr ""
 		IL_039d: ldc.i4.0
 		IL_039e: ldc.i4.1
-		IL_039f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_7028F334_L40C18>(!!0, float64, string, bool, bool)
+		IL_039f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17/FunctionObject_FunctionExpression_7028F334_L40C18>(!!0, float64, string, bool, bool)
 		IL_03a4: stloc.s 18
 		IL_03a6: ldloc.1
 		IL_03a7: ldloc.3
@@ -1425,13 +2931,13 @@
 		IL_03bd: ldloc.0
 		IL_03be: stelem.ref
 		IL_03bf: stloc.3
-		IL_03c0: newobj instance void FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_4A0EDC35_C::.ctor()
+		IL_03c0: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/C/FunctionObject_FunctionExpression_4A0EDC35_C::.ctor()
 		IL_03c5: ldc.i4.1
 		IL_03c6: conv.r8
 		IL_03c7: ldstr "C"
 		IL_03cc: ldc.i4.1
 		IL_03cd: ldc.i4.1
-		IL_03ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_4A0EDC35_C>(!!0, float64, string, bool, bool)
+		IL_03ce: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/C/FunctionObject_FunctionExpression_4A0EDC35_C>(!!0, float64, string, bool, bool)
 		IL_03d3: stloc.s 19
 		IL_03d5: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_03da: stloc.s 6
@@ -1461,13 +2967,13 @@
 		IL_0419: ldc.i4.0
 		IL_041a: ldelem.ref
 		IL_041b: castclass Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope
-		IL_0420: newobj instance void FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_35ED904C_L46C23::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
+		IL_0420: newobj instance void Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22/FunctionObject_FunctionExpression_35ED904C_L46C23::.ctor(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope)
 		IL_0425: ldc.i4.0
 		IL_0426: conv.r8
 		IL_0427: ldstr ""
 		IL_042c: ldc.i4.0
 		IL_042d: ldc.i4.1
-		IL_042e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_35ED904C_L46C23>(!!0, float64, string, bool, bool)
+		IL_042e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22/FunctionObject_FunctionExpression_35ED904C_L46C23>(!!0, float64, string, bool, bool)
 		IL_0433: stloc.s 20
 		IL_0435: ldloc.1
 		IL_0436: ldloc.3
@@ -1479,1512 +2985,6 @@
 	} // end of method Proxy_Revocable_ThrowsAfterRevoke::__js_module_init__
 
 } // end of class Modules.Proxy_Revocable_ThrowsAfterRevoke
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionDeclaration_5FAC858C_logThrow
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope _environment0_Proxy_Revocable_ThrowsAfterRevoke
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2862
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionDeclaration_5FAC858C_logThrow::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5FAC858C_logThrow::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2871
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5FAC858C_logThrow::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2874
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5FAC858C_logThrow::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2877
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionDeclaration_5FAC858C_logThrow::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0017: ldarg.2
-		IL_0018: ldc.i4.1
-		IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001e: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, string, object)
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionDeclaration_5FAC858C_logThrow::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x289c
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionDeclaration_5FAC858C_logThrow::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.1
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/logThrow::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object, string, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionDeclaration_5FAC858C_logThrow::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28bd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5FAC858C_logThrow::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionDeclaration_5FAC858C_logThrow
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_3925BBA6_L14C8
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x28cc
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_3925BBA6_L14C8::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x28d4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3925BBA6_L14C8::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x28d7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3925BBA6_L14C8::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x28da
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_3925BBA6_L14C8::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28f4
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_3925BBA6_L14C8::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x290a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3925BBA6_L14C8::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_3925BBA6_L14C8
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_F9B416A7_L17C8
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2919
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_F9B416A7_L17C8::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2921
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F9B416A7_L17C8::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2924
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F9B416A7_L17C8::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2927
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.2
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable_L17C7::__js_call__(object, object, object, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionExpression_F9B416A7_L17C8::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2948
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: ldarg.2
-		IL_0010: ldc.i4.2
-		IL_0011: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0016: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_revocable_L17C7::__js_call__(object, object, object, object)
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_F9B416A7_L17C8::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2965
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F9B416A7_L17C8::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_F9B416A7_L17C8
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_DCCED563_L28C17
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope _environment0_Proxy_Revocable_ThrowsAfterRevoke
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2974
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_DCCED563_L28C17::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DCCED563_L28C17::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2983
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DCCED563_L28C17::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2986
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DCCED563_L28C17::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2989
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_DCCED563_L28C17::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_DCCED563_L28C17::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x299b
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_DCCED563_L28C17::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L28C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_DCCED563_L28C17::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29a9
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DCCED563_L28C17::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_DCCED563_L28C17
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_007DCDBA_L29C17
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope _environment0_Proxy_Revocable_ThrowsAfterRevoke
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x29b8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_007DCDBA_L29C17::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_007DCDBA_L29C17::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x29c7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_007DCDBA_L29C17::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x29ca
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_007DCDBA_L29C17::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x29cd
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_007DCDBA_L29C17::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_007DCDBA_L29C17::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29df
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_007DCDBA_L29C17::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L29C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_007DCDBA_L29C17::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29ed
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_007DCDBA_L29C17::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_007DCDBA_L29C17
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_7AF52BFC_L30C17
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope _environment0_Proxy_Revocable_ThrowsAfterRevoke
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x29fc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_7AF52BFC_L30C17::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7AF52BFC_L30C17::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a0b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7AF52BFC_L30C17::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a0e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7AF52BFC_L30C17::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a11
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_7AF52BFC_L30C17::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_7AF52BFC_L30C17::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a23
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_7AF52BFC_L30C17::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L30C16::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_7AF52BFC_L30C17::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a31
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7AF52BFC_L30C17::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_7AF52BFC_L30C17
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_3C8D3F03_L31C20
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope _environment0_Proxy_Revocable_ThrowsAfterRevoke
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a40
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_3C8D3F03_L31C20::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3C8D3F03_L31C20::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a4f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3C8D3F03_L31C20::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a52
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3C8D3F03_L31C20::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a55
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_3C8D3F03_L31C20::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_3C8D3F03_L31C20::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a67
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_3C8D3F03_L31C20::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L31C19::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_3C8D3F03_L31C20::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a75
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3C8D3F03_L31C20::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_3C8D3F03_L31C20
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_2D98E99F_L32C18
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope _environment0_Proxy_Revocable_ThrowsAfterRevoke
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a84
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_2D98E99F_L32C18::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2D98E99F_L32C18::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a93
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2D98E99F_L32C18::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a96
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2D98E99F_L32C18::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a99
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_2D98E99F_L32C18::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_2D98E99F_L32C18::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2aab
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_2D98E99F_L32C18::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L32C17::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_2D98E99F_L32C18::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ab9
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2D98E99F_L32C18::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_2D98E99F_L32C18
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_1DE7D22D_L33C28
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope _environment0_Proxy_Revocable_ThrowsAfterRevoke
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ac8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_1DE7D22D_L33C28::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1DE7D22D_L33C28::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2ad7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1DE7D22D_L33C28::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2ada
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1DE7D22D_L33C28::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2add
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_1DE7D22D_L33C28::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_1DE7D22D_L33C28::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2aef
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_1DE7D22D_L33C28::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L33C27::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_1DE7D22D_L33C28::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2afd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1DE7D22D_L33C28::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_1DE7D22D_L33C28
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_DB63B8EE_L34C28
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope _environment0_Proxy_Revocable_ThrowsAfterRevoke
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b0c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_DB63B8EE_L34C28::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DB63B8EE_L34C28::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2b1b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DB63B8EE_L34C28::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2b1e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_DB63B8EE_L34C28::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b21
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_DB63B8EE_L34C28::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_DB63B8EE_L34C28::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b33
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_DB63B8EE_L34C28::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L34C27::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_DB63B8EE_L34C28::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b41
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_DB63B8EE_L34C28::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_DB63B8EE_L34C28
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_81EE28F5_L36C34
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2b50
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_81EE28F5_L36C34::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2b58
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_81EE28F5_L36C34::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2b5b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_81EE28F5_L36C34::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b5e
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_callable::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_81EE28F5_L36C34::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b71
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_callable::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_81EE28F5_L36C34::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b80
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_81EE28F5_L36C34::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_81EE28F5_L36C34
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_7028F334_L40C18
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope _environment0_Proxy_Revocable_ThrowsAfterRevoke
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b8f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_7028F334_L40C18::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7028F334_L40C18::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2b9e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7028F334_L40C18::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2ba1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7028F334_L40C18::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ba4
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_7028F334_L40C18::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_7028F334_L40C18::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bb6
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_7028F334_L40C18::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L40C17::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_7028F334_L40C18::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bc4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7028F334_L40C18::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_7028F334_L40C18
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_4A0EDC35_C
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2bd3
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_4A0EDC35_C::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2bdb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_4A0EDC35_C::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2bde
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_4A0EDC35_C::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2be1
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/C::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_4A0EDC35_C::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bf4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/C::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_4A0EDC35_C::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c03
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_4A0EDC35_C::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_4A0EDC35_C
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_35ED904C_L46C23
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope _environment0_Proxy_Revocable_ThrowsAfterRevoke
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c12
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_35ED904C_L46C23::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_35ED904C_L46C23::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2c21
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_35ED904C_L46C23::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2c24
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_35ED904C_L46C23::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c27
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_35ED904C_L46C23::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_35ED904C_L46C23::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c39
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_35ED904C_L46C23::_environment0_Proxy_Revocable_ThrowsAfterRevoke
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Proxy_Revocable_ThrowsAfterRevoke/FunctionExpression_L46C22::__js_call__(class Modules.Proxy_Revocable_ThrowsAfterRevoke/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_35ED904C_L46C23::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c47
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_35ED904C_L46C23::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Revocable_ThrowsAfterRevoke_F0B36D6B.FunctionObject_FunctionExpression_35ED904C_L46C23
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_SetTrap_InterceptsWrites.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_SetTrap_InterceptsWrites.verified.txt
@@ -31,6 +31,137 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_D555D783_L8C8
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Proxy_SetTrap_InterceptsWrites/Scope _environment0_Proxy_SetTrap_InterceptsWrites
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Proxy_SetTrap_InterceptsWrites/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2195
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Proxy_SetTrap_InterceptsWrites/Scope Modules.Proxy_SetTrap_InterceptsWrites/FunctionExpression_handler/FunctionObject_FunctionExpression_D555D783_L8C8::_environment0_Proxy_SetTrap_InterceptsWrites
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_D555D783_L8C8::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21a4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D555D783_L8C8::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21a7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_D555D783_L8C8::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21aa
+				// Header size: 1
+				// Code size: 45 (0x2d)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_SetTrap_InterceptsWrites/Scope Modules.Proxy_SetTrap_InterceptsWrites/FunctionExpression_handler/FunctionObject_FunctionExpression_D555D783_L8C8::_environment0_Proxy_SetTrap_InterceptsWrites
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: ldarg.2
+				IL_0021: ldc.i4.3
+				IL_0022: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0027: call object Modules.Proxy_SetTrap_InterceptsWrites/FunctionExpression_handler::__js_call__(class Modules.Proxy_SetTrap_InterceptsWrites/Scope, object, object, object, object, object)
+				IL_002c: ret
+			} // end of method FunctionObject_FunctionExpression_D555D783_L8C8::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21d8
+				// Header size: 1
+				// Code size: 41 (0x29)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_SetTrap_InterceptsWrites/Scope Modules.Proxy_SetTrap_InterceptsWrites/FunctionExpression_handler/FunctionObject_FunctionExpression_D555D783_L8C8::_environment0_Proxy_SetTrap_InterceptsWrites
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: ldarg.2
+				IL_0016: ldc.i4.2
+				IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001c: ldarg.2
+				IL_001d: ldc.i4.3
+				IL_001e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0023: call object Modules.Proxy_SetTrap_InterceptsWrites/FunctionExpression_handler::__js_call__(class Modules.Proxy_SetTrap_InterceptsWrites/Scope, object, object, object, object, object)
+				IL_0028: ret
+			} // end of method FunctionObject_FunctionExpression_D555D783_L8C8::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2202
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_D555D783_L8C8::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_D555D783_L8C8
+
 
 		// Methods
 		.method public hidebysig static 
@@ -128,7 +259,7 @@
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[5] object[],
-			[6] class FunctionObjects.Proxy_SetTrap_InterceptsWrites_9D18A06B.FunctionObject_FunctionExpression_D555D783_L8C8,
+			[6] class Modules.Proxy_SetTrap_InterceptsWrites/FunctionExpression_handler/FunctionObject_FunctionExpression_D555D783_L8C8,
 			[7] object,
 			[8] object
 		)
@@ -159,13 +290,13 @@
 		IL_003f: ldc.i4.0
 		IL_0040: ldelem.ref
 		IL_0041: castclass Modules.Proxy_SetTrap_InterceptsWrites/Scope
-		IL_0046: newobj instance void FunctionObjects.Proxy_SetTrap_InterceptsWrites_9D18A06B.FunctionObject_FunctionExpression_D555D783_L8C8::.ctor(class Modules.Proxy_SetTrap_InterceptsWrites/Scope)
+		IL_0046: newobj instance void Modules.Proxy_SetTrap_InterceptsWrites/FunctionExpression_handler/FunctionObject_FunctionExpression_D555D783_L8C8::.ctor(class Modules.Proxy_SetTrap_InterceptsWrites/Scope)
 		IL_004b: ldc.i4.4
 		IL_004c: conv.r8
 		IL_004d: ldstr ""
 		IL_0052: ldc.i4.0
 		IL_0053: ldc.i4.1
-		IL_0054: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_SetTrap_InterceptsWrites_9D18A06B.FunctionObject_FunctionExpression_D555D783_L8C8>(!!0, float64, string, bool, bool)
+		IL_0054: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_SetTrap_InterceptsWrites/FunctionExpression_handler/FunctionObject_FunctionExpression_D555D783_L8C8>(!!0, float64, string, bool, bool)
 		IL_0059: stloc.s 6
 		IL_005b: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0060: dup
@@ -214,137 +345,6 @@
 	} // end of method Proxy_SetTrap_InterceptsWrites::__js_module_init__
 
 } // end of class Modules.Proxy_SetTrap_InterceptsWrites
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_SetTrap_InterceptsWrites_9D18A06B.FunctionObject_FunctionExpression_D555D783_L8C8
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Proxy_SetTrap_InterceptsWrites/Scope _environment0_Proxy_SetTrap_InterceptsWrites
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Proxy_SetTrap_InterceptsWrites/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2195
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Proxy_SetTrap_InterceptsWrites/Scope FunctionObjects.Proxy_SetTrap_InterceptsWrites_9D18A06B.FunctionObject_FunctionExpression_D555D783_L8C8::_environment0_Proxy_SetTrap_InterceptsWrites
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D555D783_L8C8::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21a4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D555D783_L8C8::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21a7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_D555D783_L8C8::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21aa
-		// Header size: 1
-		// Code size: 45 (0x2d)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_SetTrap_InterceptsWrites/Scope FunctionObjects.Proxy_SetTrap_InterceptsWrites_9D18A06B.FunctionObject_FunctionExpression_D555D783_L8C8::_environment0_Proxy_SetTrap_InterceptsWrites
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: ldarg.2
-		IL_0021: ldc.i4.3
-		IL_0022: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0027: call object Modules.Proxy_SetTrap_InterceptsWrites/FunctionExpression_handler::__js_call__(class Modules.Proxy_SetTrap_InterceptsWrites/Scope, object, object, object, object, object)
-		IL_002c: ret
-	} // end of method FunctionObject_FunctionExpression_D555D783_L8C8::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21d8
-		// Header size: 1
-		// Code size: 41 (0x29)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_SetTrap_InterceptsWrites/Scope FunctionObjects.Proxy_SetTrap_InterceptsWrites_9D18A06B.FunctionObject_FunctionExpression_D555D783_L8C8::_environment0_Proxy_SetTrap_InterceptsWrites
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: ldarg.2
-		IL_0016: ldc.i4.2
-		IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001c: ldarg.2
-		IL_001d: ldc.i4.3
-		IL_001e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0023: call object Modules.Proxy_SetTrap_InterceptsWrites/FunctionExpression_handler::__js_call__(class Modules.Proxy_SetTrap_InterceptsWrites/Scope, object, object, object, object, object)
-		IL_0028: ret
-	} // end of method FunctionObject_FunctionExpression_D555D783_L8C8::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2202
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_D555D783_L8C8::ConstructCore
-
-} // end of class FunctionObjects.Proxy_SetTrap_InterceptsWrites_9D18A06B.FunctionObject_FunctionExpression_D555D783_L8C8
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Validation_EdgeCases.verified.txt
+++ b/tests/Jroc.Tests/Proxy/Snapshots/GeneratorTests.Proxy_Validation_EdgeCases.verified.txt
@@ -73,6 +73,127 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_91E97F91_log
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Proxy_Validation_EdgeCases/Scope _environment0_Proxy_Validation_EdgeCases
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Proxy_Validation_EdgeCases/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ad3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/log/FunctionObject_FunctionDeclaration_91E97F91_log::_environment0_Proxy_Validation_EdgeCases
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_91E97F91_log::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2ae2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_91E97F91_log::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2ae5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_91E97F91_log::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ae8
+				// Header size: 1
+				// Code size: 36 (0x24)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/log/FunctionObject_FunctionDeclaration_91E97F91_log::_environment0_Proxy_Validation_EdgeCases
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0017: ldarg.2
+				IL_0018: ldc.i4.1
+				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001e: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, string, object)
+				IL_0023: ret
+			} // end of method FunctionObject_FunctionDeclaration_91E97F91_log::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b0d
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/log/FunctionObject_FunctionDeclaration_91E97F91_log::_environment0_Proxy_Validation_EdgeCases
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.1
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, string, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionDeclaration_91E97F91_log::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b2e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_91E97F91_log::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_91E97F91_log
+
 
 		// Methods
 		.method public hidebysig static 
@@ -216,6 +337,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5445B54C_L12C21
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2b3d
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_5445B54C_L12C21::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2b45
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5445B54C_L12C21::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2b48
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5445B54C_L12C21::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b4b
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L12C20::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_5445B54C_L12C21::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b57
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L12C20::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_5445B54C_L12C21::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b5f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_5445B54C_L12C21::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_5445B54C_L12C21
+
 
 		// Methods
 		.method public hidebysig static 
@@ -271,6 +487,101 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_83DA49A1_L16C22
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2b6e
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_83DA49A1_L16C22::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2b76
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_83DA49A1_L16C22::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2b79
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_83DA49A1_L16C22::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b7c
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L16C21::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_83DA49A1_L16C22::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b88
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L16C21::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_83DA49A1_L16C22::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b90
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_83DA49A1_L16C22::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_83DA49A1_L16C22
 
 
 		// Methods
@@ -328,6 +639,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_284DD4EB_L20C25
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2b9f
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_284DD4EB_L20C25::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2ba7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_284DD4EB_L20C25::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2baa
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_284DD4EB_L20C25::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bad
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L20C24::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_284DD4EB_L20C25::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bb9
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L20C24::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_284DD4EB_L20C25::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bc1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_284DD4EB_L20C25::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_284DD4EB_L20C25
+
 
 		// Methods
 		.method public hidebysig static 
@@ -375,6 +781,101 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_85F7517A_L24C26
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2bd0
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_85F7517A_L24C26::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2bd8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_85F7517A_L24C26::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2bdb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_85F7517A_L24C26::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bde
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L24C25::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_85F7517A_L24C26::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bea
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L24C25::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_85F7517A_L24C26::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bf2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_85F7517A_L24C26::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_85F7517A_L24C26
 
 
 		// Methods
@@ -424,6 +925,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_35ED5A5E_L29C10
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2c01
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_35ED5A5E_L29C10::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2c09
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_35ED5A5E_L29C10::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2c0c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_35ED5A5E_L29C10::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c0f
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_applyProxy::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_35ED5A5E_L29C10::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c1b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_applyProxy::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_35ED5A5E_L29C10::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c23
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_35ED5A5E_L29C10::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_35ED5A5E_L29C10
+
 
 		// Methods
 		.method public hidebysig static 
@@ -468,6 +1064,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_72AF61D9_L34C26
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Proxy_Validation_EdgeCases/Scope _environment0_Proxy_Validation_EdgeCases
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Proxy_Validation_EdgeCases/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c32
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25/FunctionObject_FunctionExpression_72AF61D9_L34C26::_environment0_Proxy_Validation_EdgeCases
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_72AF61D9_L34C26::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2c41
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_72AF61D9_L34C26::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2c44
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_72AF61D9_L34C26::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c47
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25/FunctionObject_FunctionExpression_72AF61D9_L34C26::_environment0_Proxy_Validation_EdgeCases
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_72AF61D9_L34C26::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c59
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25/FunctionObject_FunctionExpression_72AF61D9_L34C26::_environment0_Proxy_Validation_EdgeCases
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_72AF61D9_L34C26::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c67
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_72AF61D9_L34C26::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_72AF61D9_L34C26
 
 
 		// Methods
@@ -531,6 +1234,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_670E5585_L39C14
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Proxy_Validation_EdgeCases/Scope _environment0_Proxy_Validation_EdgeCases
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Proxy_Validation_EdgeCases/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c76
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy/FunctionObject_FunctionExpression_670E5585_L39C14::_environment0_Proxy_Validation_EdgeCases
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_670E5585_L39C14::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2c85
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_670E5585_L39C14::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2c88
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_670E5585_L39C14::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c8b
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy/FunctionObject_FunctionExpression_670E5585_L39C14::_environment0_Proxy_Validation_EdgeCases
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_670E5585_L39C14::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c9d
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy/FunctionObject_FunctionExpression_670E5585_L39C14::_environment0_Proxy_Validation_EdgeCases
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_670E5585_L39C14::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2cab
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_670E5585_L39C14::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_670E5585_L39C14
+
 
 		// Methods
 		.method public hidebysig static 
@@ -582,6 +1392,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1DD156CC_L44C35
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Proxy_Validation_EdgeCases/Scope _environment0_Proxy_Validation_EdgeCases
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Proxy_Validation_EdgeCases/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2cba
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34/FunctionObject_FunctionExpression_1DD156CC_L44C35::_environment0_Proxy_Validation_EdgeCases
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_1DD156CC_L44C35::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2cc9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_1DD156CC_L44C35::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2ccc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_1DD156CC_L44C35::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ccf
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34/FunctionObject_FunctionExpression_1DD156CC_L44C35::_environment0_Proxy_Validation_EdgeCases
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_1DD156CC_L44C35::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ce1
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34/FunctionObject_FunctionExpression_1DD156CC_L44C35::_environment0_Proxy_Validation_EdgeCases
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_1DD156CC_L44C35::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2cef
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_1DD156CC_L44C35::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_1DD156CC_L44C35
 
 
 		// Methods
@@ -651,6 +1568,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_63449D48_Base
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2cfe
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_63449D48_Base::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2d06
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_63449D48_Base::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2d09
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_63449D48_Base::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d0c
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Proxy_Validation_EdgeCases/Base::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_63449D48_Base::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d18
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Proxy_Validation_EdgeCases/Base::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_63449D48_Base::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d20
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_63449D48_Base::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_63449D48_Base
+
 
 		// Methods
 		.method public hidebysig static 
@@ -704,6 +1716,103 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_06B3F2B0_L49C14
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2d2f
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_06B3F2B0_L49C14::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2d37
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_06B3F2B0_L49C14::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2d3a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_06B3F2B0_L49C14::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d3d
+				// Header size: 1
+				// Code size: 16 (0x10)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call float64 Modules.Proxy_Validation_EdgeCases/FunctionExpression_badConstructResultProxy::__js_call__(object)
+				IL_000a: box [System.Runtime]System.Double
+				IL_000f: ret
+			} // end of method FunctionObject_FunctionExpression_06B3F2B0_L49C14::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d4e
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call float64 Modules.Proxy_Validation_EdgeCases/FunctionExpression_badConstructResultProxy::__js_call__(object)
+				IL_0006: box [System.Runtime]System.Double
+				IL_000b: ret
+			} // end of method FunctionObject_FunctionExpression_06B3F2B0_L49C14::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d5b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_06B3F2B0_L49C14::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_06B3F2B0_L49C14
+
 
 		// Methods
 		.method public hidebysig static 
@@ -748,6 +1857,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_F9D274F7_L54C35
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Proxy_Validation_EdgeCases/Scope _environment0_Proxy_Validation_EdgeCases
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Proxy_Validation_EdgeCases/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d6a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34/FunctionObject_FunctionExpression_F9D274F7_L54C35::_environment0_Proxy_Validation_EdgeCases
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_F9D274F7_L54C35::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2d79
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F9D274F7_L54C35::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2d7c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_F9D274F7_L54C35::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d7f
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34/FunctionObject_FunctionExpression_F9D274F7_L54C35::_environment0_Proxy_Validation_EdgeCases
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_F9D274F7_L54C35::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d91
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34/FunctionObject_FunctionExpression_F9D274F7_L54C35::_environment0_Proxy_Validation_EdgeCases
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_F9D274F7_L54C35::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d9f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_F9D274F7_L54C35::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_F9D274F7_L54C35
 
 
 		// Methods
@@ -810,6 +2026,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C27E696C_L59C19
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2dae
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_C27E696C_L59C19::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2db6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C27E696C_L59C19::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2db9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C27E696C_L59C19::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2dbc
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_nullPrototypeProxy::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_C27E696C_L59C19::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2dc8
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_nullPrototypeProxy::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_C27E696C_L59C19::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2dd0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_C27E696C_L59C19::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_C27E696C_L59C19
+
 
 		// Methods
 		.method public hidebysig static 
@@ -856,6 +2167,103 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9F07F033_L67C19
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2ddf
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_9F07F033_L67C19::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2de7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_9F07F033_L67C19::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2dea
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_9F07F033_L67C19::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ded
+				// Header size: 1
+				// Code size: 16 (0x10)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call float64 Modules.Proxy_Validation_EdgeCases/FunctionExpression_badGetPrototypeProxy::__js_call__(object)
+				IL_000a: box [System.Runtime]System.Double
+				IL_000f: ret
+			} // end of method FunctionObject_FunctionExpression_9F07F033_L67C19::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2dfe
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call float64 Modules.Proxy_Validation_EdgeCases/FunctionExpression_badGetPrototypeProxy::__js_call__(object)
+				IL_0006: box [System.Runtime]System.Double
+				IL_000b: ret
+			} // end of method FunctionObject_FunctionExpression_9F07F033_L67C19::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e0b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_9F07F033_L67C19::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_9F07F033_L67C19
+
 
 		// Methods
 		.method public hidebysig static 
@@ -900,6 +2308,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_11D74249_L72C33
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Proxy_Validation_EdgeCases/Scope _environment0_Proxy_Validation_EdgeCases
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Proxy_Validation_EdgeCases/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e1a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32/FunctionObject_FunctionExpression_11D74249_L72C33::_environment0_Proxy_Validation_EdgeCases
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_11D74249_L72C33::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2e29
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_11D74249_L72C33::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2e2c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_11D74249_L72C33::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e2f
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32/FunctionObject_FunctionExpression_11D74249_L72C33::_environment0_Proxy_Validation_EdgeCases
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_11D74249_L72C33::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e41
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32/FunctionObject_FunctionExpression_11D74249_L72C33::_environment0_Proxy_Validation_EdgeCases
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_11D74249_L72C33::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e4f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_11D74249_L72C33::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_11D74249_L72C33
 
 
 		// Methods
@@ -956,6 +2471,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E36E315D_L77C12
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Proxy_Validation_EdgeCases/Scope _environment0_Proxy_Validation_EdgeCases
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Proxy_Validation_EdgeCases/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e5e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy/FunctionObject_FunctionExpression_E36E315D_L77C12::_environment0_Proxy_Validation_EdgeCases
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E36E315D_L77C12::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2e6d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E36E315D_L77C12::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2e70
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E36E315D_L77C12::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e73
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy/FunctionObject_FunctionExpression_E36E315D_L77C12::_environment0_Proxy_Validation_EdgeCases
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_E36E315D_L77C12::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e85
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy/FunctionObject_FunctionExpression_E36E315D_L77C12::_environment0_Proxy_Validation_EdgeCases
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_E36E315D_L77C12::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e93
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E36E315D_L77C12::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_E36E315D_L77C12
 
 
 		// Methods
@@ -1016,6 +2638,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_87888FCA_L85C12
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Proxy_Validation_EdgeCases/Scope _environment0_Proxy_Validation_EdgeCases
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Proxy_Validation_EdgeCases/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ea2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy/FunctionObject_FunctionExpression_87888FCA_L85C12::_environment0_Proxy_Validation_EdgeCases
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_87888FCA_L85C12::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2eb1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_87888FCA_L85C12::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2eb4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_87888FCA_L85C12::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2eb7
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy/FunctionObject_FunctionExpression_87888FCA_L85C12::_environment0_Proxy_Validation_EdgeCases
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_87888FCA_L85C12::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ec9
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy/FunctionObject_FunctionExpression_87888FCA_L85C12::_environment0_Proxy_Validation_EdgeCases
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_87888FCA_L85C12::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ed7
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_87888FCA_L85C12::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_87888FCA_L85C12
 
 
 		// Methods
@@ -1078,6 +2807,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C0FBDA47_L93C12
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2ee6
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_C0FBDA47_L93C12::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2eee
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C0FBDA47_L93C12::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2ef1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C0FBDA47_L93C12::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ef4
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_C0FBDA47_L93C12::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f00
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_C0FBDA47_L93C12::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f08
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_C0FBDA47_L93C12::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_C0FBDA47_L93C12
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1122,6 +2946,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_A2005DA7_L98C26
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Proxy_Validation_EdgeCases/Scope _environment0_Proxy_Validation_EdgeCases
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Proxy_Validation_EdgeCases/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f17
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25/FunctionObject_FunctionExpression_A2005DA7_L98C26::_environment0_Proxy_Validation_EdgeCases
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_A2005DA7_L98C26::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2f26
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A2005DA7_L98C26::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2f29
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_A2005DA7_L98C26::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f2c
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25/FunctionObject_FunctionExpression_A2005DA7_L98C26::_environment0_Proxy_Validation_EdgeCases
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_A2005DA7_L98C26::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f3e
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25/FunctionObject_FunctionExpression_A2005DA7_L98C26::_environment0_Proxy_Validation_EdgeCases
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_A2005DA7_L98C26::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f4c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_A2005DA7_L98C26::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_A2005DA7_L98C26
 
 
 		// Methods
@@ -1188,6 +3119,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5427424B_L103C12
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2f5b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_5427424B_L103C12::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2f63
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5427424B_L103C12::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2f66
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5427424B_L103C12::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f69
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionExpression_5427424B_L103C12::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f75
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_5427424B_L103C12::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f7d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_5427424B_L103C12::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_5427424B_L103C12
+
 
 		// Methods
 		.method public hidebysig static 
@@ -1236,6 +3262,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0EB74DCF_L108C22
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Proxy_Validation_EdgeCases/Scope _environment0_Proxy_Validation_EdgeCases
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Proxy_Validation_EdgeCases/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f8c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21/FunctionObject_FunctionExpression_0EB74DCF_L108C22::_environment0_Proxy_Validation_EdgeCases
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_0EB74DCF_L108C22::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2f9b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_0EB74DCF_L108C22::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2f9e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_0EB74DCF_L108C22::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2fa1
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21/FunctionObject_FunctionExpression_0EB74DCF_L108C22::_environment0_Proxy_Validation_EdgeCases
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_0EB74DCF_L108C22::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2fb3
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21/FunctionObject_FunctionExpression_0EB74DCF_L108C22::_environment0_Proxy_Validation_EdgeCases
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_0EB74DCF_L108C22::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2fc1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_0EB74DCF_L108C22::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_0EB74DCF_L108C22
 
 
 		// Methods
@@ -1342,39 +3475,39 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Proxy_Validation_EdgeCases/Scope,
-			[1] class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionDeclaration_91E97F91_log,
+			[1] class Modules.Proxy_Validation_EdgeCases/log/FunctionObject_FunctionDeclaration_91E97F91_log,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
 			[5] object[],
 			[6] object[],
-			[7] class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_5445B54C_L12C21,
-			[8] class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_83DA49A1_L16C22,
-			[9] class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_284DD4EB_L20C25,
-			[10] class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_85F7517A_L24C26,
+			[7] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L12C20/FunctionObject_FunctionExpression_5445B54C_L12C21,
+			[8] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L16C21/FunctionObject_FunctionExpression_83DA49A1_L16C22,
+			[9] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L20C24/FunctionObject_FunctionExpression_284DD4EB_L20C25,
+			[10] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L24C25/FunctionObject_FunctionExpression_85F7517A_L24C26,
 			[11] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
-			[12] class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_35ED5A5E_L29C10,
+			[12] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_applyProxy/FunctionObject_FunctionExpression_35ED5A5E_L29C10,
 			[13] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[14] class [JavaScriptRuntime]JavaScriptRuntime.Proxy,
-			[15] class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_72AF61D9_L34C26,
-			[16] class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_670E5585_L39C14,
-			[17] class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_1DD156CC_L44C35,
-			[18] class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_63449D48_Base,
-			[19] class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_06B3F2B0_L49C14,
-			[20] class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_F9D274F7_L54C35,
-			[21] class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_C27E696C_L59C19,
+			[15] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25/FunctionObject_FunctionExpression_72AF61D9_L34C26,
+			[16] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy/FunctionObject_FunctionExpression_670E5585_L39C14,
+			[17] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34/FunctionObject_FunctionExpression_1DD156CC_L44C35,
+			[18] class Modules.Proxy_Validation_EdgeCases/Base/FunctionObject_FunctionExpression_63449D48_Base,
+			[19] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badConstructResultProxy/FunctionObject_FunctionExpression_06B3F2B0_L49C14,
+			[20] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34/FunctionObject_FunctionExpression_F9D274F7_L54C35,
+			[21] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_nullPrototypeProxy/FunctionObject_FunctionExpression_C27E696C_L59C19,
 			[22] object,
 			[23] object,
 			[24] bool,
 			[25] object,
-			[26] class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_9F07F033_L67C19,
-			[27] class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_11D74249_L72C33,
-			[28] class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_E36E315D_L77C12,
-			[29] class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_87888FCA_L85C12,
-			[30] class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_C0FBDA47_L93C12,
-			[31] class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_A2005DA7_L98C26,
-			[32] class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_5427424B_L103C12,
-			[33] class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_0EB74DCF_L108C22
+			[26] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badGetPrototypeProxy/FunctionObject_FunctionExpression_9F07F033_L67C19,
+			[27] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32/FunctionObject_FunctionExpression_11D74249_L72C33,
+			[28] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy/FunctionObject_FunctionExpression_E36E315D_L77C12,
+			[29] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy/FunctionObject_FunctionExpression_87888FCA_L85C12,
+			[30] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy/FunctionObject_FunctionExpression_C0FBDA47_L93C12,
+			[31] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25/FunctionObject_FunctionExpression_A2005DA7_L98C26,
+			[32] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy/FunctionObject_FunctionExpression_5427424B_L103C12,
+			[33] class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21/FunctionObject_FunctionExpression_0EB74DCF_L108C22
 		)
 
 		IL_0000: call void [JavaScriptRuntime]JavaScriptRuntime.PrototypeChain::Enable()
@@ -1391,13 +3524,13 @@
 		IL_0019: ldc.i4.0
 		IL_001a: ldelem.ref
 		IL_001b: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_0020: newobj instance void FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionDeclaration_91E97F91_log::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_0020: newobj instance void Modules.Proxy_Validation_EdgeCases/log/FunctionObject_FunctionDeclaration_91E97F91_log::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
 		IL_0025: ldc.i4.2
 		IL_0026: conv.r8
 		IL_0027: ldstr "log"
 		IL_002c: ldc.i4.0
 		IL_002d: ldc.i4.1
-		IL_002e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionDeclaration_91E97F91_log>(!!0, float64, string, bool, bool)
+		IL_002e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/log/FunctionObject_FunctionDeclaration_91E97F91_log>(!!0, float64, string, bool, bool)
 		IL_0033: stloc.1
 		IL_0034: nop
 		IL_0035: nop
@@ -1410,13 +3543,13 @@
 		IL_0045: ldloc.0
 		IL_0046: stelem.ref
 		IL_0047: stloc.s 6
-		IL_0049: newobj instance void FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_5445B54C_L12C21::.ctor()
+		IL_0049: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L12C20/FunctionObject_FunctionExpression_5445B54C_L12C21::.ctor()
 		IL_004e: ldc.i4.0
 		IL_004f: conv.r8
 		IL_0050: ldstr ""
 		IL_0055: ldc.i4.0
 		IL_0056: ldc.i4.1
-		IL_0057: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_5445B54C_L12C21>(!!0, float64, string, bool, bool)
+		IL_0057: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L12C20/FunctionObject_FunctionExpression_5445B54C_L12C21>(!!0, float64, string, bool, bool)
 		IL_005c: stloc.s 7
 		IL_005e: ldloc.1
 		IL_005f: ldloc.s 5
@@ -1433,13 +3566,13 @@
 		IL_007d: ldloc.0
 		IL_007e: stelem.ref
 		IL_007f: stloc.s 6
-		IL_0081: newobj instance void FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_83DA49A1_L16C22::.ctor()
+		IL_0081: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L16C21/FunctionObject_FunctionExpression_83DA49A1_L16C22::.ctor()
 		IL_0086: ldc.i4.0
 		IL_0087: conv.r8
 		IL_0088: ldstr ""
 		IL_008d: ldc.i4.0
 		IL_008e: ldc.i4.1
-		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_83DA49A1_L16C22>(!!0, float64, string, bool, bool)
+		IL_008f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L16C21/FunctionObject_FunctionExpression_83DA49A1_L16C22>(!!0, float64, string, bool, bool)
 		IL_0094: stloc.s 8
 		IL_0096: ldloc.1
 		IL_0097: ldloc.s 5
@@ -1456,13 +3589,13 @@
 		IL_00b5: ldloc.0
 		IL_00b6: stelem.ref
 		IL_00b7: stloc.s 6
-		IL_00b9: newobj instance void FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_284DD4EB_L20C25::.ctor()
+		IL_00b9: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L20C24/FunctionObject_FunctionExpression_284DD4EB_L20C25::.ctor()
 		IL_00be: ldc.i4.0
 		IL_00bf: conv.r8
 		IL_00c0: ldstr ""
 		IL_00c5: ldc.i4.0
 		IL_00c6: ldc.i4.1
-		IL_00c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_284DD4EB_L20C25>(!!0, float64, string, bool, bool)
+		IL_00c7: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L20C24/FunctionObject_FunctionExpression_284DD4EB_L20C25>(!!0, float64, string, bool, bool)
 		IL_00cc: stloc.s 9
 		IL_00ce: ldloc.1
 		IL_00cf: ldloc.s 5
@@ -1479,13 +3612,13 @@
 		IL_00ed: ldloc.0
 		IL_00ee: stelem.ref
 		IL_00ef: stloc.s 6
-		IL_00f1: newobj instance void FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_85F7517A_L24C26::.ctor()
+		IL_00f1: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L24C25/FunctionObject_FunctionExpression_85F7517A_L24C26::.ctor()
 		IL_00f6: ldc.i4.0
 		IL_00f7: conv.r8
 		IL_00f8: ldstr ""
 		IL_00fd: ldc.i4.0
 		IL_00fe: ldc.i4.1
-		IL_00ff: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_85F7517A_L24C26>(!!0, float64, string, bool, bool)
+		IL_00ff: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L24C25/FunctionObject_FunctionExpression_85F7517A_L24C26>(!!0, float64, string, bool, bool)
 		IL_0104: stloc.s 10
 		IL_0106: ldloc.1
 		IL_0107: ldloc.s 5
@@ -1502,13 +3635,13 @@
 		IL_0125: ldloc.0
 		IL_0126: stelem.ref
 		IL_0127: stloc.s 5
-		IL_0129: newobj instance void FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_35ED5A5E_L29C10::.ctor()
+		IL_0129: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_applyProxy/FunctionObject_FunctionExpression_35ED5A5E_L29C10::.ctor()
 		IL_012e: ldc.i4.0
 		IL_012f: conv.r8
 		IL_0130: ldstr ""
 		IL_0135: ldc.i4.0
 		IL_0136: ldc.i4.1
-		IL_0137: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_35ED5A5E_L29C10>(!!0, float64, string, bool, bool)
+		IL_0137: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_applyProxy/FunctionObject_FunctionExpression_35ED5A5E_L29C10>(!!0, float64, string, bool, bool)
 		IL_013c: stloc.s 12
 		IL_013e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0143: dup
@@ -1536,13 +3669,13 @@
 		IL_017a: ldc.i4.0
 		IL_017b: ldelem.ref
 		IL_017c: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_0181: newobj instance void FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_72AF61D9_L34C26::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_0181: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25/FunctionObject_FunctionExpression_72AF61D9_L34C26::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
 		IL_0186: ldc.i4.0
 		IL_0187: conv.r8
 		IL_0188: ldstr ""
 		IL_018d: ldc.i4.0
 		IL_018e: ldc.i4.1
-		IL_018f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_72AF61D9_L34C26>(!!0, float64, string, bool, bool)
+		IL_018f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25/FunctionObject_FunctionExpression_72AF61D9_L34C26>(!!0, float64, string, bool, bool)
 		IL_0194: stloc.s 15
 		IL_0196: ldloc.1
 		IL_0197: ldloc.s 5
@@ -1563,13 +3696,13 @@
 		IL_01bb: ldc.i4.0
 		IL_01bc: ldelem.ref
 		IL_01bd: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_01c2: newobj instance void FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_670E5585_L39C14::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_01c2: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy/FunctionObject_FunctionExpression_670E5585_L39C14::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
 		IL_01c7: ldc.i4.0
 		IL_01c8: conv.r8
 		IL_01c9: ldstr ""
 		IL_01ce: ldc.i4.0
 		IL_01cf: ldc.i4.1
-		IL_01d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_670E5585_L39C14>(!!0, float64, string, bool, bool)
+		IL_01d0: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy/FunctionObject_FunctionExpression_670E5585_L39C14>(!!0, float64, string, bool, bool)
 		IL_01d5: stloc.s 16
 		IL_01d7: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_01dc: dup
@@ -1597,13 +3730,13 @@
 		IL_0213: ldc.i4.0
 		IL_0214: ldelem.ref
 		IL_0215: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_021a: newobj instance void FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_1DD156CC_L44C35::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_021a: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34/FunctionObject_FunctionExpression_1DD156CC_L44C35::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
 		IL_021f: ldc.i4.0
 		IL_0220: conv.r8
 		IL_0221: ldstr ""
 		IL_0226: ldc.i4.0
 		IL_0227: ldc.i4.1
-		IL_0228: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_1DD156CC_L44C35>(!!0, float64, string, bool, bool)
+		IL_0228: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34/FunctionObject_FunctionExpression_1DD156CC_L44C35>(!!0, float64, string, bool, bool)
 		IL_022d: stloc.s 17
 		IL_022f: ldloc.1
 		IL_0230: ldloc.s 5
@@ -1618,13 +3751,13 @@
 		IL_0247: ldloc.0
 		IL_0248: stelem.ref
 		IL_0249: stloc.s 5
-		IL_024b: newobj instance void FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_63449D48_Base::.ctor()
+		IL_024b: newobj instance void Modules.Proxy_Validation_EdgeCases/Base/FunctionObject_FunctionExpression_63449D48_Base::.ctor()
 		IL_0250: ldc.i4.0
 		IL_0251: conv.r8
 		IL_0252: ldstr "Base"
 		IL_0257: ldc.i4.1
 		IL_0258: ldc.i4.1
-		IL_0259: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_63449D48_Base>(!!0, float64, string, bool, bool)
+		IL_0259: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/Base/FunctionObject_FunctionExpression_63449D48_Base>(!!0, float64, string, bool, bool)
 		IL_025e: stloc.s 18
 		IL_0260: ldc.i4.1
 		IL_0261: newarr [System.Runtime]System.Object
@@ -1633,13 +3766,13 @@
 		IL_0268: ldloc.0
 		IL_0269: stelem.ref
 		IL_026a: stloc.s 5
-		IL_026c: newobj instance void FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_06B3F2B0_L49C14::.ctor()
+		IL_026c: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_badConstructResultProxy/FunctionObject_FunctionExpression_06B3F2B0_L49C14::.ctor()
 		IL_0271: ldc.i4.0
 		IL_0272: conv.r8
 		IL_0273: ldstr ""
 		IL_0278: ldc.i4.0
 		IL_0279: ldc.i4.1
-		IL_027a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_06B3F2B0_L49C14>(!!0, float64, string, bool, bool)
+		IL_027a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badConstructResultProxy/FunctionObject_FunctionExpression_06B3F2B0_L49C14>(!!0, float64, string, bool, bool)
 		IL_027f: stloc.s 19
 		IL_0281: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0286: dup
@@ -1667,13 +3800,13 @@
 		IL_02bd: ldc.i4.0
 		IL_02be: ldelem.ref
 		IL_02bf: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_02c4: newobj instance void FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_F9D274F7_L54C35::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_02c4: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34/FunctionObject_FunctionExpression_F9D274F7_L54C35::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
 		IL_02c9: ldc.i4.0
 		IL_02ca: conv.r8
 		IL_02cb: ldstr ""
 		IL_02d0: ldc.i4.0
 		IL_02d1: ldc.i4.1
-		IL_02d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_F9D274F7_L54C35>(!!0, float64, string, bool, bool)
+		IL_02d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34/FunctionObject_FunctionExpression_F9D274F7_L54C35>(!!0, float64, string, bool, bool)
 		IL_02d7: stloc.s 20
 		IL_02d9: ldloc.1
 		IL_02da: ldloc.s 5
@@ -1690,13 +3823,13 @@
 		IL_02f8: ldloc.0
 		IL_02f9: stelem.ref
 		IL_02fa: stloc.s 5
-		IL_02fc: newobj instance void FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_C27E696C_L59C19::.ctor()
+		IL_02fc: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_nullPrototypeProxy/FunctionObject_FunctionExpression_C27E696C_L59C19::.ctor()
 		IL_0301: ldc.i4.0
 		IL_0302: conv.r8
 		IL_0303: ldstr ""
 		IL_0308: ldc.i4.0
 		IL_0309: ldc.i4.1
-		IL_030a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_C27E696C_L59C19>(!!0, float64, string, bool, bool)
+		IL_030a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_nullPrototypeProxy/FunctionObject_FunctionExpression_C27E696C_L59C19>(!!0, float64, string, bool, bool)
 		IL_030f: stloc.s 21
 		IL_0311: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0316: dup
@@ -1737,13 +3870,13 @@
 		IL_037e: ldloc.0
 		IL_037f: stelem.ref
 		IL_0380: stloc.s 5
-		IL_0382: newobj instance void FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_9F07F033_L67C19::.ctor()
+		IL_0382: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_badGetPrototypeProxy/FunctionObject_FunctionExpression_9F07F033_L67C19::.ctor()
 		IL_0387: ldc.i4.0
 		IL_0388: conv.r8
 		IL_0389: ldstr ""
 		IL_038e: ldc.i4.0
 		IL_038f: ldc.i4.1
-		IL_0390: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_9F07F033_L67C19>(!!0, float64, string, bool, bool)
+		IL_0390: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badGetPrototypeProxy/FunctionObject_FunctionExpression_9F07F033_L67C19>(!!0, float64, string, bool, bool)
 		IL_0395: stloc.s 26
 		IL_0397: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_039c: dup
@@ -1771,13 +3904,13 @@
 		IL_03d3: ldc.i4.0
 		IL_03d4: ldelem.ref
 		IL_03d5: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_03da: newobj instance void FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_11D74249_L72C33::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_03da: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32/FunctionObject_FunctionExpression_11D74249_L72C33::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
 		IL_03df: ldc.i4.0
 		IL_03e0: conv.r8
 		IL_03e1: ldstr ""
 		IL_03e6: ldc.i4.0
 		IL_03e7: ldc.i4.1
-		IL_03e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_11D74249_L72C33>(!!0, float64, string, bool, bool)
+		IL_03e8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32/FunctionObject_FunctionExpression_11D74249_L72C33>(!!0, float64, string, bool, bool)
 		IL_03ed: stloc.s 27
 		IL_03ef: ldloc.1
 		IL_03f0: ldloc.s 5
@@ -1798,13 +3931,13 @@
 		IL_0414: ldc.i4.0
 		IL_0415: ldelem.ref
 		IL_0416: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_041b: newobj instance void FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_E36E315D_L77C12::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_041b: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy/FunctionObject_FunctionExpression_E36E315D_L77C12::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
 		IL_0420: ldc.i4.0
 		IL_0421: conv.r8
 		IL_0422: ldstr ""
 		IL_0427: ldc.i4.0
 		IL_0428: ldc.i4.1
-		IL_0429: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_E36E315D_L77C12>(!!0, float64, string, bool, bool)
+		IL_0429: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy/FunctionObject_FunctionExpression_E36E315D_L77C12>(!!0, float64, string, bool, bool)
 		IL_042e: stloc.s 28
 		IL_0430: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0435: dup
@@ -1845,13 +3978,13 @@
 		IL_049f: ldc.i4.0
 		IL_04a0: ldelem.ref
 		IL_04a1: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_04a6: newobj instance void FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_87888FCA_L85C12::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_04a6: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy/FunctionObject_FunctionExpression_87888FCA_L85C12::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
 		IL_04ab: ldc.i4.0
 		IL_04ac: conv.r8
 		IL_04ad: ldstr ""
 		IL_04b2: ldc.i4.0
 		IL_04b3: ldc.i4.1
-		IL_04b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_87888FCA_L85C12>(!!0, float64, string, bool, bool)
+		IL_04b4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy/FunctionObject_FunctionExpression_87888FCA_L85C12>(!!0, float64, string, bool, bool)
 		IL_04b9: stloc.s 29
 		IL_04bb: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_04c0: dup
@@ -1888,13 +4021,13 @@
 		IL_0526: ldloc.0
 		IL_0527: stelem.ref
 		IL_0528: stloc.s 5
-		IL_052a: newobj instance void FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_C0FBDA47_L93C12::.ctor()
+		IL_052a: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy/FunctionObject_FunctionExpression_C0FBDA47_L93C12::.ctor()
 		IL_052f: ldc.i4.0
 		IL_0530: conv.r8
 		IL_0531: ldstr ""
 		IL_0536: ldc.i4.0
 		IL_0537: ldc.i4.1
-		IL_0538: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_C0FBDA47_L93C12>(!!0, float64, string, bool, bool)
+		IL_0538: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy/FunctionObject_FunctionExpression_C0FBDA47_L93C12>(!!0, float64, string, bool, bool)
 		IL_053d: stloc.s 30
 		IL_053f: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0544: dup
@@ -1922,13 +4055,13 @@
 		IL_057b: ldc.i4.0
 		IL_057c: ldelem.ref
 		IL_057d: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_0582: newobj instance void FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_A2005DA7_L98C26::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_0582: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25/FunctionObject_FunctionExpression_A2005DA7_L98C26::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
 		IL_0587: ldc.i4.0
 		IL_0588: conv.r8
 		IL_0589: ldstr ""
 		IL_058e: ldc.i4.0
 		IL_058f: ldc.i4.1
-		IL_0590: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_A2005DA7_L98C26>(!!0, float64, string, bool, bool)
+		IL_0590: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25/FunctionObject_FunctionExpression_A2005DA7_L98C26>(!!0, float64, string, bool, bool)
 		IL_0595: stloc.s 31
 		IL_0597: ldloc.1
 		IL_0598: ldloc.s 5
@@ -1945,13 +4078,13 @@
 		IL_05b6: ldloc.0
 		IL_05b7: stelem.ref
 		IL_05b8: stloc.s 5
-		IL_05ba: newobj instance void FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_5427424B_L103C12::.ctor()
+		IL_05ba: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy/FunctionObject_FunctionExpression_5427424B_L103C12::.ctor()
 		IL_05bf: ldc.i4.0
 		IL_05c0: conv.r8
 		IL_05c1: ldstr ""
 		IL_05c6: ldc.i4.0
 		IL_05c7: ldc.i4.1
-		IL_05c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_5427424B_L103C12>(!!0, float64, string, bool, bool)
+		IL_05c8: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy/FunctionObject_FunctionExpression_5427424B_L103C12>(!!0, float64, string, bool, bool)
 		IL_05cd: stloc.s 32
 		IL_05cf: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_05d4: dup
@@ -1979,13 +4112,13 @@
 		IL_060b: ldc.i4.0
 		IL_060c: ldelem.ref
 		IL_060d: castclass Modules.Proxy_Validation_EdgeCases/Scope
-		IL_0612: newobj instance void FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_0EB74DCF_L108C22::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
+		IL_0612: newobj instance void Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21/FunctionObject_FunctionExpression_0EB74DCF_L108C22::.ctor(class Modules.Proxy_Validation_EdgeCases/Scope)
 		IL_0617: ldc.i4.0
 		IL_0618: conv.r8
 		IL_0619: ldstr ""
 		IL_061e: ldc.i4.0
 		IL_061f: ldc.i4.1
-		IL_0620: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_0EB74DCF_L108C22>(!!0, float64, string, bool, bool)
+		IL_0620: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21/FunctionObject_FunctionExpression_0EB74DCF_L108C22>(!!0, float64, string, bool, bool)
 		IL_0625: stloc.s 33
 		IL_0627: ldloc.1
 		IL_0628: ldloc.s 5
@@ -1997,2139 +4130,6 @@
 	} // end of method Proxy_Validation_EdgeCases::__js_module_init__
 
 } // end of class Modules.Proxy_Validation_EdgeCases
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionDeclaration_91E97F91_log
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Proxy_Validation_EdgeCases/Scope _environment0_Proxy_Validation_EdgeCases
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Proxy_Validation_EdgeCases/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ad3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionDeclaration_91E97F91_log::_environment0_Proxy_Validation_EdgeCases
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_91E97F91_log::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2ae2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_91E97F91_log::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2ae5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_91E97F91_log::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ae8
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionDeclaration_91E97F91_log::_environment0_Proxy_Validation_EdgeCases
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0017: ldarg.2
-		IL_0018: ldc.i4.1
-		IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001e: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, string, object)
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionDeclaration_91E97F91_log::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b0d
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionDeclaration_91E97F91_log::_environment0_Proxy_Validation_EdgeCases
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.1
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.Proxy_Validation_EdgeCases/log::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object, string, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionDeclaration_91E97F91_log::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b2e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_91E97F91_log::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionDeclaration_91E97F91_log
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_5445B54C_L12C21
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2b3d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_5445B54C_L12C21::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2b45
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5445B54C_L12C21::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2b48
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5445B54C_L12C21::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b4b
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L12C20::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_5445B54C_L12C21::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b57
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L12C20::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_5445B54C_L12C21::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b5f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5445B54C_L12C21::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_5445B54C_L12C21
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_83DA49A1_L16C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2b6e
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_83DA49A1_L16C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2b76
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_83DA49A1_L16C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2b79
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_83DA49A1_L16C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b7c
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L16C21::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_83DA49A1_L16C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b88
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L16C21::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_83DA49A1_L16C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b90
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_83DA49A1_L16C22::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_83DA49A1_L16C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_284DD4EB_L20C25
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2b9f
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_284DD4EB_L20C25::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2ba7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_284DD4EB_L20C25::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2baa
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_284DD4EB_L20C25::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bad
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L20C24::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_284DD4EB_L20C25::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bb9
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L20C24::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_284DD4EB_L20C25::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bc1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_284DD4EB_L20C25::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_284DD4EB_L20C25
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_85F7517A_L24C26
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2bd0
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_85F7517A_L24C26::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2bd8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_85F7517A_L24C26::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2bdb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_85F7517A_L24C26::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bde
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L24C25::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_85F7517A_L24C26::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bea
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L24C25::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_85F7517A_L24C26::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bf2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_85F7517A_L24C26::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_85F7517A_L24C26
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_35ED5A5E_L29C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2c01
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_35ED5A5E_L29C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2c09
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_35ED5A5E_L29C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2c0c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_35ED5A5E_L29C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c0f
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_applyProxy::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_35ED5A5E_L29C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c1b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_applyProxy::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_35ED5A5E_L29C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c23
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_35ED5A5E_L29C10::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_35ED5A5E_L29C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_72AF61D9_L34C26
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Proxy_Validation_EdgeCases/Scope _environment0_Proxy_Validation_EdgeCases
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Proxy_Validation_EdgeCases/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c32
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_72AF61D9_L34C26::_environment0_Proxy_Validation_EdgeCases
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_72AF61D9_L34C26::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2c41
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_72AF61D9_L34C26::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2c44
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_72AF61D9_L34C26::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c47
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_72AF61D9_L34C26::_environment0_Proxy_Validation_EdgeCases
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_72AF61D9_L34C26::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c59
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_72AF61D9_L34C26::_environment0_Proxy_Validation_EdgeCases
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L34C25::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_72AF61D9_L34C26::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c67
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_72AF61D9_L34C26::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_72AF61D9_L34C26
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_670E5585_L39C14
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Proxy_Validation_EdgeCases/Scope _environment0_Proxy_Validation_EdgeCases
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Proxy_Validation_EdgeCases/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c76
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_670E5585_L39C14::_environment0_Proxy_Validation_EdgeCases
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_670E5585_L39C14::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2c85
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_670E5585_L39C14::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2c88
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_670E5585_L39C14::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c8b
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_670E5585_L39C14::_environment0_Proxy_Validation_EdgeCases
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_670E5585_L39C14::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c9d
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_670E5585_L39C14::_environment0_Proxy_Validation_EdgeCases
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_constructProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_670E5585_L39C14::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cab
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_670E5585_L39C14::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_670E5585_L39C14
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_1DD156CC_L44C35
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Proxy_Validation_EdgeCases/Scope _environment0_Proxy_Validation_EdgeCases
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Proxy_Validation_EdgeCases/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cba
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_1DD156CC_L44C35::_environment0_Proxy_Validation_EdgeCases
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1DD156CC_L44C35::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2cc9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1DD156CC_L44C35::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2ccc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1DD156CC_L44C35::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ccf
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_1DD156CC_L44C35::_environment0_Proxy_Validation_EdgeCases
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_1DD156CC_L44C35::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ce1
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_1DD156CC_L44C35::_environment0_Proxy_Validation_EdgeCases
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L44C34::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_1DD156CC_L44C35::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cef
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1DD156CC_L44C35::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_1DD156CC_L44C35
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_63449D48_Base
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2cfe
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_63449D48_Base::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2d06
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_63449D48_Base::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2d09
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_63449D48_Base::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d0c
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Proxy_Validation_EdgeCases/Base::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_63449D48_Base::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d18
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Proxy_Validation_EdgeCases/Base::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_63449D48_Base::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d20
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_63449D48_Base::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_63449D48_Base
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_06B3F2B0_L49C14
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2d2f
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_06B3F2B0_L49C14::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2d37
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_06B3F2B0_L49C14::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2d3a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_06B3F2B0_L49C14::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d3d
-		// Header size: 1
-		// Code size: 16 (0x10)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call float64 Modules.Proxy_Validation_EdgeCases/FunctionExpression_badConstructResultProxy::__js_call__(object)
-		IL_000a: box [System.Runtime]System.Double
-		IL_000f: ret
-	} // end of method FunctionObject_FunctionExpression_06B3F2B0_L49C14::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d4e
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call float64 Modules.Proxy_Validation_EdgeCases/FunctionExpression_badConstructResultProxy::__js_call__(object)
-		IL_0006: box [System.Runtime]System.Double
-		IL_000b: ret
-	} // end of method FunctionObject_FunctionExpression_06B3F2B0_L49C14::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d5b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_06B3F2B0_L49C14::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_06B3F2B0_L49C14
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_F9D274F7_L54C35
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Proxy_Validation_EdgeCases/Scope _environment0_Proxy_Validation_EdgeCases
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Proxy_Validation_EdgeCases/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d6a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_F9D274F7_L54C35::_environment0_Proxy_Validation_EdgeCases
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F9D274F7_L54C35::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2d79
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F9D274F7_L54C35::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2d7c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_F9D274F7_L54C35::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d7f
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_F9D274F7_L54C35::_environment0_Proxy_Validation_EdgeCases
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_F9D274F7_L54C35::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d91
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_F9D274F7_L54C35::_environment0_Proxy_Validation_EdgeCases
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L54C34::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_F9D274F7_L54C35::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d9f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_F9D274F7_L54C35::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_F9D274F7_L54C35
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_C27E696C_L59C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2dae
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_C27E696C_L59C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2db6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C27E696C_L59C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2db9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C27E696C_L59C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2dbc
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_nullPrototypeProxy::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_C27E696C_L59C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2dc8
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_nullPrototypeProxy::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_C27E696C_L59C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2dd0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C27E696C_L59C19::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_C27E696C_L59C19
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_9F07F033_L67C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2ddf
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_9F07F033_L67C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2de7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9F07F033_L67C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2dea
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9F07F033_L67C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ded
-		// Header size: 1
-		// Code size: 16 (0x10)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call float64 Modules.Proxy_Validation_EdgeCases/FunctionExpression_badGetPrototypeProxy::__js_call__(object)
-		IL_000a: box [System.Runtime]System.Double
-		IL_000f: ret
-	} // end of method FunctionObject_FunctionExpression_9F07F033_L67C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2dfe
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call float64 Modules.Proxy_Validation_EdgeCases/FunctionExpression_badGetPrototypeProxy::__js_call__(object)
-		IL_0006: box [System.Runtime]System.Double
-		IL_000b: ret
-	} // end of method FunctionObject_FunctionExpression_9F07F033_L67C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e0b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_9F07F033_L67C19::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_9F07F033_L67C19
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_11D74249_L72C33
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Proxy_Validation_EdgeCases/Scope _environment0_Proxy_Validation_EdgeCases
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Proxy_Validation_EdgeCases/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e1a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_11D74249_L72C33::_environment0_Proxy_Validation_EdgeCases
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_11D74249_L72C33::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2e29
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_11D74249_L72C33::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2e2c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_11D74249_L72C33::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e2f
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_11D74249_L72C33::_environment0_Proxy_Validation_EdgeCases
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_11D74249_L72C33::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e41
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_11D74249_L72C33::_environment0_Proxy_Validation_EdgeCases
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L72C32::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_11D74249_L72C33::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e4f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_11D74249_L72C33::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_11D74249_L72C33
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_E36E315D_L77C12
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Proxy_Validation_EdgeCases/Scope _environment0_Proxy_Validation_EdgeCases
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Proxy_Validation_EdgeCases/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e5e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_E36E315D_L77C12::_environment0_Proxy_Validation_EdgeCases
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E36E315D_L77C12::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2e6d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E36E315D_L77C12::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2e70
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E36E315D_L77C12::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e73
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_E36E315D_L77C12::_environment0_Proxy_Validation_EdgeCases
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_E36E315D_L77C12::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e85
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_E36E315D_L77C12::_environment0_Proxy_Validation_EdgeCases
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_arrayLikeOwnKeysProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_E36E315D_L77C12::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e93
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E36E315D_L77C12::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_E36E315D_L77C12
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_87888FCA_L85C12
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Proxy_Validation_EdgeCases/Scope _environment0_Proxy_Validation_EdgeCases
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Proxy_Validation_EdgeCases/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ea2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_87888FCA_L85C12::_environment0_Proxy_Validation_EdgeCases
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_87888FCA_L85C12::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2eb1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_87888FCA_L85C12::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2eb4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_87888FCA_L85C12::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2eb7
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_87888FCA_L85C12::_environment0_Proxy_Validation_EdgeCases
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_87888FCA_L85C12::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ec9
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_87888FCA_L85C12::_environment0_Proxy_Validation_EdgeCases
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_symbolOwnKeysProxy::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_87888FCA_L85C12::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ed7
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_87888FCA_L85C12::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_87888FCA_L85C12
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_C0FBDA47_L93C12
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2ee6
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_C0FBDA47_L93C12::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2eee
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C0FBDA47_L93C12::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2ef1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C0FBDA47_L93C12::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ef4
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_C0FBDA47_L93C12::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f00
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysProxy::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_C0FBDA47_L93C12::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f08
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C0FBDA47_L93C12::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_C0FBDA47_L93C12
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_A2005DA7_L98C26
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Proxy_Validation_EdgeCases/Scope _environment0_Proxy_Validation_EdgeCases
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Proxy_Validation_EdgeCases/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f17
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_A2005DA7_L98C26::_environment0_Proxy_Validation_EdgeCases
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A2005DA7_L98C26::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2f26
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A2005DA7_L98C26::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2f29
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_A2005DA7_L98C26::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f2c
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_A2005DA7_L98C26::_environment0_Proxy_Validation_EdgeCases
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_A2005DA7_L98C26::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f3e
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_A2005DA7_L98C26::_environment0_Proxy_Validation_EdgeCases
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L98C25::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_A2005DA7_L98C26::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f4c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_A2005DA7_L98C26::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_A2005DA7_L98C26
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_5427424B_L103C12
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2f5b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_5427424B_L103C12::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2f63
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5427424B_L103C12::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2f66
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5427424B_L103C12::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f69
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionExpression_5427424B_L103C12::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f75
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.Proxy_Validation_EdgeCases/FunctionExpression_badOwnKeysEntryProxy::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_5427424B_L103C12::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f7d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5427424B_L103C12::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_5427424B_L103C12
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_0EB74DCF_L108C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Proxy_Validation_EdgeCases/Scope _environment0_Proxy_Validation_EdgeCases
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Proxy_Validation_EdgeCases/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f8c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_0EB74DCF_L108C22::_environment0_Proxy_Validation_EdgeCases
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_0EB74DCF_L108C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2f9b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_0EB74DCF_L108C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2f9e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_0EB74DCF_L108C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2fa1
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_0EB74DCF_L108C22::_environment0_Proxy_Validation_EdgeCases
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_0EB74DCF_L108C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2fb3
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Proxy_Validation_EdgeCases/Scope FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_0EB74DCF_L108C22::_environment0_Proxy_Validation_EdgeCases
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Proxy_Validation_EdgeCases/FunctionExpression_L108C21::__js_call__(class Modules.Proxy_Validation_EdgeCases/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_0EB74DCF_L108C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2fc1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_0EB74DCF_L108C22::ConstructCore
-
-} // end of class FunctionObjects.Proxy_Validation_EdgeCases_DD0DDB56.FunctionObject_FunctionExpression_0EB74DCF_L108C22
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Algebra_Methods.verified.txt
+++ b/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Algebra_Methods.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_EA56ECA5_L18C10
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2709
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_EA56ECA5_L18C10::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2711
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_EA56ECA5_L18C10::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2714
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_EA56ECA5_L18C10::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2717
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Set_Algebra_Methods/FunctionExpression_setLike::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_EA56ECA5_L18C10::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x272a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Set_Algebra_Methods/FunctionExpression_setLike::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_EA56ECA5_L18C10::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2739
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_EA56ECA5_L18C10::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_EA56ECA5_L18C10
+
 
 		// Methods
 		.method public hidebysig static 
@@ -103,6 +204,94 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C83E3C37_L19C11
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2748
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10/FunctionObject_FunctionExpression_C83E3C37_L19C11::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_C83E3C37_L19C11::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2757
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C83E3C37_L19C11::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x275a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C83E3C37_L19C11::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x275d
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10/FunctionObject_FunctionExpression_C83E3C37_L19C11::_transitionalScopes
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10::__js_call__(object[], object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_C83E3C37_L19C11::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x276f
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld object[] Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10/FunctionObject_FunctionExpression_C83E3C37_L19C11::_transitionalScopes
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10::__js_call__(object[], object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_C83E3C37_L19C11::ConstructBodyCore
+
+		} // end of class FunctionObject_FunctionExpression_C83E3C37_L19C11
 
 
 		// Methods
@@ -348,7 +537,7 @@
 			[12] class [JavaScriptRuntime]JavaScriptRuntime.Set,
 			[13] class [JavaScriptRuntime]JavaScriptRuntime.Set,
 			[14] object[],
-			[15] class FunctionObjects.Set_Algebra_Methods_AA963BE5.FunctionObject_FunctionExpression_EA56ECA5_L18C10,
+			[15] class Modules.Set_Algebra_Methods/FunctionExpression_setLike/FunctionObject_FunctionExpression_EA56ECA5_L18C10,
 			[16] class [JavaScriptRuntime]JavaScriptRuntime.JsFuncNoScopes0,
 			[17] object,
 			[18] bool,
@@ -595,13 +784,13 @@
 		IL_0329: ldloc.0
 		IL_032a: stelem.ref
 		IL_032b: stloc.s 14
-		IL_032d: newobj instance void FunctionObjects.Set_Algebra_Methods_AA963BE5.FunctionObject_FunctionExpression_EA56ECA5_L18C10::.ctor()
+		IL_032d: newobj instance void Modules.Set_Algebra_Methods/FunctionExpression_setLike/FunctionObject_FunctionExpression_EA56ECA5_L18C10::.ctor()
 		IL_0332: ldc.i4.1
 		IL_0333: conv.r8
 		IL_0334: ldstr ""
 		IL_0339: ldc.i4.0
 		IL_033a: ldc.i4.1
-		IL_033b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Set_Algebra_Methods_AA963BE5.FunctionObject_FunctionExpression_EA56ECA5_L18C10>(!!0, float64, string, bool, bool)
+		IL_033b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_Algebra_Methods/FunctionExpression_setLike/FunctionObject_FunctionExpression_EA56ECA5_L18C10>(!!0, float64, string, bool, bool)
 		IL_0340: stloc.s 15
 		IL_0342: ldc.i4.1
 		IL_0343: newarr [System.Runtime]System.Object
@@ -742,195 +931,6 @@
 	} // end of method Set_Algebra_Methods::__js_module_init__
 
 } // end of class Modules.Set_Algebra_Methods
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Set_Algebra_Methods_AA963BE5.FunctionObject_FunctionExpression_EA56ECA5_L18C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2709
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_EA56ECA5_L18C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2711
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_EA56ECA5_L18C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2714
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_EA56ECA5_L18C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2717
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Set_Algebra_Methods/FunctionExpression_setLike::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_EA56ECA5_L18C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x272a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Set_Algebra_Methods/FunctionExpression_setLike::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_EA56ECA5_L18C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2739
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_EA56ECA5_L18C10::ConstructCore
-
-} // end of class FunctionObjects.Set_Algebra_Methods_AA963BE5.FunctionObject_FunctionExpression_EA56ECA5_L18C10
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Set_Algebra_Methods_AA963BE5.FunctionObject_FunctionExpression_C83E3C37_L19C11
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2748
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Set_Algebra_Methods_AA963BE5.FunctionObject_FunctionExpression_C83E3C37_L19C11::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C83E3C37_L19C11::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2757
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C83E3C37_L19C11::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x275a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C83E3C37_L19C11::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x275d
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Set_Algebra_Methods_AA963BE5.FunctionObject_FunctionExpression_C83E3C37_L19C11::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_C83E3C37_L19C11::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x276f
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Set_Algebra_Methods_AA963BE5.FunctionObject_FunctionExpression_C83E3C37_L19C11::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Set_Algebra_Methods/FunctionExpression_setLike_L19C10::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_C83E3C37_L19C11::ConstructBodyCore
-
-} // end of class FunctionObjects.Set_Algebra_Methods_AA963BE5.FunctionObject_FunctionExpression_C83E3C37_L19C11
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Constructor_Iterable.verified.txt
+++ b/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_Constructor_Iterable.verified.txt
@@ -57,6 +57,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_3451F94E_L9C17
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Set_Constructor_Iterable/Scope _environment0_Set_Constructor_Iterable
+				.field private initonly class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope _environment1_FunctionExpression_iterable
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Set_Constructor_Iterable/Scope capture0,
+						class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2a8a
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_3451F94E_L9C17::_environment0_Set_Constructor_Iterable
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_3451F94E_L9C17::_environment1_FunctionExpression_iterable
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_3451F94E_L9C17::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_3451F94E_L9C17::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2aa7
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_3451F94E_L9C17::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2aaa
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_3451F94E_L9C17::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2aad
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_3451F94E_L9C17::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_3451F94E_L9C17::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2abf
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_3451F94E_L9C17::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_3451F94E_L9C17::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2acd
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_3451F94E_L9C17::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_3451F94E_L9C17
+
 
 			// Methods
 			.method public hidebysig static 
@@ -190,6 +307,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E3E675E5_L4C22
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Set_Constructor_Iterable/Scope _environment0_Set_Constructor_Iterable
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Set_Constructor_Iterable/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a46
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E3E675E5_L4C22::_environment0_Set_Constructor_Iterable
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E3E675E5_L4C22::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2a55
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E3E675E5_L4C22::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2a58
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E3E675E5_L4C22::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a5b
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E3E675E5_L4C22::_environment0_Set_Constructor_Iterable
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Set_Constructor_Iterable/FunctionExpression_iterable::__js_call__(class Modules.Set_Constructor_Iterable/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_E3E675E5_L4C22::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a6d
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionObject_FunctionExpression_E3E675E5_L4C22::_environment0_Set_Constructor_Iterable
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Set_Constructor_Iterable/FunctionExpression_iterable::__js_call__(class Modules.Set_Constructor_Iterable/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_E3E675E5_L4C22::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a7b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E3E675E5_L4C22::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_E3E675E5_L4C22
 
 
 		// Methods
@@ -330,6 +554,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_ECF2574C_L33C17
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Set_Constructor_Iterable/Scope _environment0_Set_Constructor_Iterable
+				.field private initonly class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope _environment1_FunctionExpression_closableIterable
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Set_Constructor_Iterable/Scope capture0,
+						class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2b20
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_ECF2574C_L33C17::_environment0_Set_Constructor_Iterable
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_ECF2574C_L33C17::_environment1_FunctionExpression_closableIterable
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_ECF2574C_L33C17::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_ECF2574C_L33C17::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2b3d
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_ECF2574C_L33C17::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2b40
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_ECF2574C_L33C17::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2b43
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_ECF2574C_L33C17::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_ECF2574C_L33C17::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2b55
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_ECF2574C_L33C17::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_ECF2574C_L33C17::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2b63
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_ECF2574C_L33C17::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_ECF2574C_L33C17
+
 
 			// Methods
 			.method public hidebysig static 
@@ -459,6 +800,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_2F5B02BC_L40C19
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Set_Constructor_Iterable/Scope _environment0_Set_Constructor_Iterable
+				.field private initonly class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope _environment1_FunctionExpression_closableIterable
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Set_Constructor_Iterable/Scope capture0,
+						class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2b72
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18/FunctionObject_FunctionExpression_2F5B02BC_L40C19::_environment0_Set_Constructor_Iterable
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18/FunctionObject_FunctionExpression_2F5B02BC_L40C19::_environment1_FunctionExpression_closableIterable
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18/FunctionObject_FunctionExpression_2F5B02BC_L40C19::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_2F5B02BC_L40C19::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2b8f
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_2F5B02BC_L40C19::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2b92
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_2F5B02BC_L40C19::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2b95
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18/FunctionObject_FunctionExpression_2F5B02BC_L40C19::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_2F5B02BC_L40C19::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2ba7
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18/FunctionObject_FunctionExpression_2F5B02BC_L40C19::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_2F5B02BC_L40C19::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2bb5
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_2F5B02BC_L40C19::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_2F5B02BC_L40C19
+
 
 			// Methods
 			.method public hidebysig static 
@@ -520,6 +978,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_8C0CC403_L28C22
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Set_Constructor_Iterable/Scope _environment0_Set_Constructor_Iterable
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Set_Constructor_Iterable/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2adc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_8C0CC403_L28C22::_environment0_Set_Constructor_Iterable
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_8C0CC403_L28C22::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2aeb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_8C0CC403_L28C22::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2aee
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_8C0CC403_L28C22::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2af1
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_8C0CC403_L28C22::_environment0_Set_Constructor_Iterable
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable::__js_call__(class Modules.Set_Constructor_Iterable/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_8C0CC403_L28C22::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b03
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionObject_FunctionExpression_8C0CC403_L28C22::_environment0_Set_Constructor_Iterable
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable::__js_call__(class Modules.Set_Constructor_Iterable/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_8C0CC403_L28C22::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b11
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_8C0CC403_L28C22::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_8C0CC403_L28C22
 
 
 		// Methods
@@ -661,6 +1226,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C7D81525_L55C8
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2bc4
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_C7D81525_L55C8::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2bcc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C7D81525_L55C8::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2bcf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_C7D81525_L55C8::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bd2
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_C7D81525_L55C8::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2be5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_C7D81525_L55C8::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bf4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_C7D81525_L55C8::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_C7D81525_L55C8
+
 
 		// Methods
 		.method public hidebysig static 
@@ -759,6 +1425,123 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FCD9C04F_L63C17
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Set_Constructor_Iterable/Scope _environment0_Set_Constructor_Iterable
+				.field private initonly class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/Scope _environment1_FunctionExpression_unionSetLike_L58C8
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Set_Constructor_Iterable/Scope capture0,
+						class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2c47
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_FCD9C04F_L63C17::_environment0_Set_Constructor_Iterable
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/Scope Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_FCD9C04F_L63C17::_environment1_FunctionExpression_unionSetLike_L58C8
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_FCD9C04F_L63C17::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_FCD9C04F_L63C17::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2c64
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_FCD9C04F_L63C17::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2c67
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_FCD9C04F_L63C17::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2c6a
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_FCD9C04F_L63C17::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_FCD9C04F_L63C17::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2c7c
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike/FunctionObject_FunctionExpression_FCD9C04F_L63C17::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_FCD9C04F_L63C17::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2c8a
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_FCD9C04F_L63C17::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_FCD9C04F_L63C17
 
 
 			// Methods
@@ -889,6 +1672,123 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_71DDD6ED_L70C19
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Set_Constructor_Iterable/Scope _environment0_Set_Constructor_Iterable
+				.field private initonly class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/Scope _environment1_FunctionExpression_unionSetLike_L58C8
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Set_Constructor_Iterable/Scope capture0,
+						class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/Scope capture1,
+						object[] capture2
+					) cil managed 
+				{
+					// Method begins at RVA 0x2c99
+					// Header size: 1
+					// Code size: 28 (0x1c)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18/FunctionObject_FunctionExpression_71DDD6ED_L70C19::_environment0_Set_Constructor_Iterable
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/Scope Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18/FunctionObject_FunctionExpression_71DDD6ED_L70C19::_environment1_FunctionExpression_unionSetLike_L58C8
+					IL_0014: ldarg.0
+					IL_0015: ldarg.3
+					IL_0016: stfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18/FunctionObject_FunctionExpression_71DDD6ED_L70C19::_transitionalScopes
+					IL_001b: ret
+				} // end of method FunctionObject_FunctionExpression_71DDD6ED_L70C19::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2cb6
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_71DDD6ED_L70C19::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2cb9
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_71DDD6ED_L70C19::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2cbc
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18/FunctionObject_FunctionExpression_71DDD6ED_L70C19::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_71DDD6ED_L70C19::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2cce
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18/FunctionObject_FunctionExpression_71DDD6ED_L70C19::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_71DDD6ED_L70C19::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2cdc
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_71DDD6ED_L70C19::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_71DDD6ED_L70C19
+
 
 			// Methods
 			.method public hidebysig static 
@@ -950,6 +1850,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_47D15AD9_L58C9
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Set_Constructor_Iterable/Scope _environment0_Set_Constructor_Iterable
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Set_Constructor_Iterable/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c03
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject_FunctionExpression_47D15AD9_L58C9::_environment0_Set_Constructor_Iterable
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_47D15AD9_L58C9::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2c12
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_47D15AD9_L58C9::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2c15
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_47D15AD9_L58C9::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c18
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject_FunctionExpression_47D15AD9_L58C9::_environment0_Set_Constructor_Iterable
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8::__js_call__(class Modules.Set_Constructor_Iterable/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_47D15AD9_L58C9::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c2a
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Set_Constructor_Iterable/Scope Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionObject_FunctionExpression_47D15AD9_L58C9::_environment0_Set_Constructor_Iterable
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8::__js_call__(class Modules.Set_Constructor_Iterable/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_47D15AD9_L58C9::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2c38
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_47D15AD9_L58C9::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_47D15AD9_L58C9
 
 
 		// Methods
@@ -1428,1013 +2435,6 @@
 	} // end of method Set_Constructor_Iterable::__js_module_init__
 
 } // end of class Modules.Set_Constructor_Iterable
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_E3E675E5_L4C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Set_Constructor_Iterable/Scope _environment0_Set_Constructor_Iterable
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Set_Constructor_Iterable/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a46
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_E3E675E5_L4C22::_environment0_Set_Constructor_Iterable
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E3E675E5_L4C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a55
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E3E675E5_L4C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a58
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E3E675E5_L4C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a5b
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Set_Constructor_Iterable/Scope FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_E3E675E5_L4C22::_environment0_Set_Constructor_Iterable
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Set_Constructor_Iterable/FunctionExpression_iterable::__js_call__(class Modules.Set_Constructor_Iterable/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_E3E675E5_L4C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a6d
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Set_Constructor_Iterable/Scope FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_E3E675E5_L4C22::_environment0_Set_Constructor_Iterable
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Set_Constructor_Iterable/FunctionExpression_iterable::__js_call__(class Modules.Set_Constructor_Iterable/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_E3E675E5_L4C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a7b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E3E675E5_L4C22::ConstructCore
-
-} // end of class FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_E3E675E5_L4C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_3451F94E_L9C17
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Set_Constructor_Iterable/Scope _environment0_Set_Constructor_Iterable
-	.field private initonly class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope _environment1_FunctionExpression_iterable
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Set_Constructor_Iterable/Scope capture0,
-			class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a8a
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_3451F94E_L9C17::_environment0_Set_Constructor_Iterable
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Set_Constructor_Iterable/FunctionExpression_iterable/Scope FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_3451F94E_L9C17::_environment1_FunctionExpression_iterable
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_3451F94E_L9C17::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_3451F94E_L9C17::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2aa7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3451F94E_L9C17::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2aaa
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_3451F94E_L9C17::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2aad
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_3451F94E_L9C17::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_3451F94E_L9C17::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2abf
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_3451F94E_L9C17::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Set_Constructor_Iterable/FunctionExpression_iterable/FunctionExpression_iterable::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_3451F94E_L9C17::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2acd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_3451F94E_L9C17::ConstructCore
-
-} // end of class FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_3451F94E_L9C17
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_8C0CC403_L28C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Set_Constructor_Iterable/Scope _environment0_Set_Constructor_Iterable
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Set_Constructor_Iterable/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2adc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_8C0CC403_L28C22::_environment0_Set_Constructor_Iterable
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_8C0CC403_L28C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2aeb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_8C0CC403_L28C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2aee
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_8C0CC403_L28C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2af1
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Set_Constructor_Iterable/Scope FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_8C0CC403_L28C22::_environment0_Set_Constructor_Iterable
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable::__js_call__(class Modules.Set_Constructor_Iterable/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_8C0CC403_L28C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b03
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Set_Constructor_Iterable/Scope FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_8C0CC403_L28C22::_environment0_Set_Constructor_Iterable
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable::__js_call__(class Modules.Set_Constructor_Iterable/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_8C0CC403_L28C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b11
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_8C0CC403_L28C22::ConstructCore
-
-} // end of class FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_8C0CC403_L28C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_ECF2574C_L33C17
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Set_Constructor_Iterable/Scope _environment0_Set_Constructor_Iterable
-	.field private initonly class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope _environment1_FunctionExpression_closableIterable
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Set_Constructor_Iterable/Scope capture0,
-			class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b20
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_ECF2574C_L33C17::_environment0_Set_Constructor_Iterable
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_ECF2574C_L33C17::_environment1_FunctionExpression_closableIterable
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_ECF2574C_L33C17::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_ECF2574C_L33C17::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2b3d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_ECF2574C_L33C17::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2b40
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_ECF2574C_L33C17::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b43
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_ECF2574C_L33C17::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_ECF2574C_L33C17::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b55
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_ECF2574C_L33C17::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_ECF2574C_L33C17::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b63
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_ECF2574C_L33C17::ConstructCore
-
-} // end of class FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_ECF2574C_L33C17
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_2F5B02BC_L40C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Set_Constructor_Iterable/Scope _environment0_Set_Constructor_Iterable
-	.field private initonly class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope _environment1_FunctionExpression_closableIterable
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Set_Constructor_Iterable/Scope capture0,
-			class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b72
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_2F5B02BC_L40C19::_environment0_Set_Constructor_Iterable
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/Scope FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_2F5B02BC_L40C19::_environment1_FunctionExpression_closableIterable
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_2F5B02BC_L40C19::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_2F5B02BC_L40C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2b8f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2F5B02BC_L40C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2b92
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_2F5B02BC_L40C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b95
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_2F5B02BC_L40C19::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_2F5B02BC_L40C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ba7
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_2F5B02BC_L40C19::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Set_Constructor_Iterable/FunctionExpression_closableIterable/FunctionExpression_closableIterable_L40C18::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_2F5B02BC_L40C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bb5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_2F5B02BC_L40C19::ConstructCore
-
-} // end of class FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_2F5B02BC_L40C19
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_C7D81525_L55C8
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2bc4
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_C7D81525_L55C8::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2bcc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C7D81525_L55C8::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2bcf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C7D81525_L55C8::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bd2
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_C7D81525_L55C8::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2be5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C7D81525_L55C8::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bf4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C7D81525_L55C8::ConstructCore
-
-} // end of class FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_C7D81525_L55C8
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_47D15AD9_L58C9
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Set_Constructor_Iterable/Scope _environment0_Set_Constructor_Iterable
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Set_Constructor_Iterable/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c03
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_47D15AD9_L58C9::_environment0_Set_Constructor_Iterable
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_47D15AD9_L58C9::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2c12
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_47D15AD9_L58C9::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2c15
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_47D15AD9_L58C9::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c18
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Set_Constructor_Iterable/Scope FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_47D15AD9_L58C9::_environment0_Set_Constructor_Iterable
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8::__js_call__(class Modules.Set_Constructor_Iterable/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_47D15AD9_L58C9::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c2a
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Set_Constructor_Iterable/Scope FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_47D15AD9_L58C9::_environment0_Set_Constructor_Iterable
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8::__js_call__(class Modules.Set_Constructor_Iterable/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_47D15AD9_L58C9::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c38
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_47D15AD9_L58C9::ConstructCore
-
-} // end of class FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_47D15AD9_L58C9
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_FCD9C04F_L63C17
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Set_Constructor_Iterable/Scope _environment0_Set_Constructor_Iterable
-	.field private initonly class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/Scope _environment1_FunctionExpression_unionSetLike_L58C8
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Set_Constructor_Iterable/Scope capture0,
-			class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c47
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_FCD9C04F_L63C17::_environment0_Set_Constructor_Iterable
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/Scope FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_FCD9C04F_L63C17::_environment1_FunctionExpression_unionSetLike_L58C8
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_FCD9C04F_L63C17::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_FCD9C04F_L63C17::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2c64
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FCD9C04F_L63C17::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2c67
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FCD9C04F_L63C17::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c6a
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_FCD9C04F_L63C17::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_FCD9C04F_L63C17::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c7c
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_FCD9C04F_L63C17::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_FCD9C04F_L63C17::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c8a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_FCD9C04F_L63C17::ConstructCore
-
-} // end of class FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_FCD9C04F_L63C17
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_71DDD6ED_L70C19
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Set_Constructor_Iterable/Scope _environment0_Set_Constructor_Iterable
-	.field private initonly class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/Scope _environment1_FunctionExpression_unionSetLike_L58C8
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Set_Constructor_Iterable/Scope capture0,
-			class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/Scope capture1,
-			object[] capture2
-		) cil managed 
-	{
-		// Method begins at RVA 0x2c99
-		// Header size: 1
-		// Code size: 28 (0x1c)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Set_Constructor_Iterable/Scope FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_71DDD6ED_L70C19::_environment0_Set_Constructor_Iterable
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld class Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/Scope FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_71DDD6ED_L70C19::_environment1_FunctionExpression_unionSetLike_L58C8
-		IL_0014: ldarg.0
-		IL_0015: ldarg.3
-		IL_0016: stfld object[] FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_71DDD6ED_L70C19::_transitionalScopes
-		IL_001b: ret
-	} // end of method FunctionObject_FunctionExpression_71DDD6ED_L70C19::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2cb6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_71DDD6ED_L70C19::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2cb9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_71DDD6ED_L70C19::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cbc
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_71DDD6ED_L70C19::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_71DDD6ED_L70C19::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cce
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_71DDD6ED_L70C19::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Set_Constructor_Iterable/FunctionExpression_unionSetLike_L58C8/FunctionExpression_unionSetLike_L70C18::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_71DDD6ED_L70C19::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2cdc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_71DDD6ED_L70C19::ConstructCore
-
-} // end of class FunctionObjects.Set_Constructor_Iterable_4D9D841B.FunctionObject_FunctionExpression_71DDD6ED_L70C19
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_ForEach_Basic.verified.txt
+++ b/tests/Jroc.Tests/Set/Snapshots/GeneratorTests.Set_ForEach_Basic.verified.txt
@@ -31,6 +31,131 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_67D60462_L7C13
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Set_ForEach_Basic/Scope _environment0_Set_ForEach_Basic
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Set_ForEach_Basic/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2253
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Set_ForEach_Basic/Scope Modules.Set_ForEach_Basic/FunctionExpression_L7C12/FunctionObject_FunctionExpression_67D60462_L7C13::_environment0_Set_ForEach_Basic
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_67D60462_L7C13::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2262
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_67D60462_L7C13::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2265
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_67D60462_L7C13::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2268
+				// Header size: 1
+				// Code size: 38 (0x26)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Set_ForEach_Basic/Scope Modules.Set_ForEach_Basic/FunctionExpression_L7C12/FunctionObject_FunctionExpression_67D60462_L7C13::_environment0_Set_ForEach_Basic
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: ldarg.2
+				IL_001a: ldc.i4.2
+				IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0020: call object Modules.Set_ForEach_Basic/FunctionExpression_L7C12::__js_call__(class Modules.Set_ForEach_Basic/Scope, object, object, object, object)
+				IL_0025: ret
+			} // end of method FunctionObject_FunctionExpression_67D60462_L7C13::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x228f
+				// Header size: 1
+				// Code size: 34 (0x22)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Set_ForEach_Basic/Scope Modules.Set_ForEach_Basic/FunctionExpression_L7C12/FunctionObject_FunctionExpression_67D60462_L7C13::_environment0_Set_ForEach_Basic
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: ldarg.2
+				IL_0016: ldc.i4.2
+				IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001c: call object Modules.Set_ForEach_Basic/FunctionExpression_L7C12::__js_call__(class Modules.Set_ForEach_Basic/Scope, object, object, object, object)
+				IL_0021: ret
+			} // end of method FunctionObject_FunctionExpression_67D60462_L7C13::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22b2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_67D60462_L7C13::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_67D60462_L7C13
+
 
 		// Methods
 		.method public hidebysig static 
@@ -163,7 +288,7 @@
 			[3] class [JavaScriptRuntime]JavaScriptRuntime.Set,
 			[4] object,
 			[5] object[],
-			[6] class FunctionObjects.Set_ForEach_Basic_A93FD7D7.FunctionObject_FunctionExpression_67D60462_L7C13,
+			[6] class Modules.Set_ForEach_Basic/FunctionExpression_L7C12/FunctionObject_FunctionExpression_67D60462_L7C13,
 			[7] object,
 			[8] object
 		)
@@ -213,13 +338,13 @@
 		IL_0079: ldc.i4.0
 		IL_007a: ldelem.ref
 		IL_007b: castclass Modules.Set_ForEach_Basic/Scope
-		IL_0080: newobj instance void FunctionObjects.Set_ForEach_Basic_A93FD7D7.FunctionObject_FunctionExpression_67D60462_L7C13::.ctor(class Modules.Set_ForEach_Basic/Scope)
+		IL_0080: newobj instance void Modules.Set_ForEach_Basic/FunctionExpression_L7C12/FunctionObject_FunctionExpression_67D60462_L7C13::.ctor(class Modules.Set_ForEach_Basic/Scope)
 		IL_0085: ldc.i4.3
 		IL_0086: conv.r8
 		IL_0087: ldstr ""
 		IL_008c: ldc.i4.1
 		IL_008d: ldc.i4.1
-		IL_008e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Set_ForEach_Basic_A93FD7D7.FunctionObject_FunctionExpression_67D60462_L7C13>(!!0, float64, string, bool, bool)
+		IL_008e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Set_ForEach_Basic/FunctionExpression_L7C12/FunctionObject_FunctionExpression_67D60462_L7C13>(!!0, float64, string, bool, bool)
 		IL_0093: stloc.s 6
 		IL_0095: ldloc.s 4
 		IL_0097: ldstr "forEach"
@@ -276,131 +401,6 @@
 	} // end of method Set_ForEach_Basic::__js_module_init__
 
 } // end of class Modules.Set_ForEach_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Set_ForEach_Basic_A93FD7D7.FunctionObject_FunctionExpression_67D60462_L7C13
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Set_ForEach_Basic/Scope _environment0_Set_ForEach_Basic
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Set_ForEach_Basic/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2253
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Set_ForEach_Basic/Scope FunctionObjects.Set_ForEach_Basic_A93FD7D7.FunctionObject_FunctionExpression_67D60462_L7C13::_environment0_Set_ForEach_Basic
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_67D60462_L7C13::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2262
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_67D60462_L7C13::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2265
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_67D60462_L7C13::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2268
-		// Header size: 1
-		// Code size: 38 (0x26)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Set_ForEach_Basic/Scope FunctionObjects.Set_ForEach_Basic_A93FD7D7.FunctionObject_FunctionExpression_67D60462_L7C13::_environment0_Set_ForEach_Basic
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: ldarg.2
-		IL_001a: ldc.i4.2
-		IL_001b: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0020: call object Modules.Set_ForEach_Basic/FunctionExpression_L7C12::__js_call__(class Modules.Set_ForEach_Basic/Scope, object, object, object, object)
-		IL_0025: ret
-	} // end of method FunctionObject_FunctionExpression_67D60462_L7C13::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x228f
-		// Header size: 1
-		// Code size: 34 (0x22)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Set_ForEach_Basic/Scope FunctionObjects.Set_ForEach_Basic_A93FD7D7.FunctionObject_FunctionExpression_67D60462_L7C13::_environment0_Set_ForEach_Basic
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: ldarg.2
-		IL_0016: ldc.i4.2
-		IL_0017: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001c: call object Modules.Set_ForEach_Basic/FunctionExpression_L7C12::__js_call__(class Modules.Set_ForEach_Basic/Scope, object, object, object, object)
-		IL_0021: ret
-	} // end of method FunctionObject_FunctionExpression_67D60462_L7C13::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22b2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_67D60462_L7C13::ConstructCore
-
-} // end of class FunctionObjects.Set_ForEach_Basic_A93FD7D7.FunctionObject_FunctionExpression_67D60462_L7C13
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/ShapeCoverage/Snapshots/GeneratorTests.ShapeCoverage_MixedNumeric_BoxedArithmetic.verified.txt
+++ b/tests/Jroc.Tests/ShapeCoverage/Snapshots/GeneratorTests.ShapeCoverage_MixedNumeric_BoxedArithmetic.verified.txt
@@ -31,6 +31,109 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C9451BAE_id
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21bf
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_C9451BAE_id::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21c7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C9451BAE_id::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21ca
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C9451BAE_id::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21cd
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: call object Modules.ShapeCoverage_MixedNumeric_BoxedArithmetic/id::__js_call__(object, float64)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_C9451BAE_id::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21e5
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: call object Modules.ShapeCoverage_MixedNumeric_BoxedArithmetic/id::__js_call__(object, float64)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_C9451BAE_id::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f9
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C9451BAE_id::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C9451BAE_id
+
 
 		// Methods
 		.method public hidebysig static 
@@ -98,7 +201,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.ShapeCoverage_MixedNumeric_BoxedArithmetic/Scope,
-			[1] class FunctionObjects.ShapeCoverage_MixedNumeric_BoxedArithmetic_3173F6FC.FunctionObject_FunctionDeclaration_C9451BAE_id,
+			[1] class Modules.ShapeCoverage_MixedNumeric_BoxedArithmetic/id/FunctionObject_FunctionDeclaration_C9451BAE_id,
 			[2] float64,
 			[3] float64,
 			[4] object[],
@@ -116,13 +219,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 4
-		IL_0012: newobj instance void FunctionObjects.ShapeCoverage_MixedNumeric_BoxedArithmetic_3173F6FC.FunctionObject_FunctionDeclaration_C9451BAE_id::.ctor()
+		IL_0012: newobj instance void Modules.ShapeCoverage_MixedNumeric_BoxedArithmetic/id/FunctionObject_FunctionDeclaration_C9451BAE_id::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "id"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.ShapeCoverage_MixedNumeric_BoxedArithmetic_3173F6FC.FunctionObject_FunctionDeclaration_C9451BAE_id>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.ShapeCoverage_MixedNumeric_BoxedArithmetic/id/FunctionObject_FunctionDeclaration_C9451BAE_id>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: nop
@@ -222,109 +325,6 @@
 	} // end of method ShapeCoverage_MixedNumeric_BoxedArithmetic::__js_module_init__
 
 } // end of class Modules.ShapeCoverage_MixedNumeric_BoxedArithmetic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.ShapeCoverage_MixedNumeric_BoxedArithmetic_3173F6FC.FunctionObject_FunctionDeclaration_C9451BAE_id
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21bf
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_C9451BAE_id::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21c7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C9451BAE_id::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21ca
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C9451BAE_id::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21cd
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: call object Modules.ShapeCoverage_MixedNumeric_BoxedArithmetic/id::__js_call__(object, float64)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_C9451BAE_id::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21e5
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: call object Modules.ShapeCoverage_MixedNumeric_BoxedArithmetic/id::__js_call__(object, float64)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_C9451BAE_id::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f9
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C9451BAE_id::ConstructCore
-
-} // end of class FunctionObjects.ShapeCoverage_MixedNumeric_BoxedArithmetic_3173F6FC.FunctionObject_FunctionDeclaration_C9451BAE_id
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MemberCall_FastPath_CommonMethods.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_MemberCall_FastPath_CommonMethods.verified.txt
@@ -31,6 +31,109 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BA59C706_runCommon
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x24ae
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_BA59C706_runCommon::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24b6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BA59C706_runCommon::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24b9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BA59C706_runCommon::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24bc
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0011: call object Modules.String_MemberCall_FastPath_CommonMethods/runCommon::__js_call__(object, string)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_BA59C706_runCommon::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24d4
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: call object Modules.String_MemberCall_FastPath_CommonMethods/runCommon::__js_call__(object, string)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_BA59C706_runCommon::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24e8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BA59C706_runCommon::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_BA59C706_runCommon
+
 
 		// Methods
 		.method public hidebysig static 
@@ -333,7 +436,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_MemberCall_FastPath_CommonMethods/Scope,
-			[1] class FunctionObjects.String_MemberCall_FastPath_CommonMethods_BDA65493.FunctionObject_FunctionDeclaration_BA59C706_runCommon,
+			[1] class Modules.String_MemberCall_FastPath_CommonMethods/runCommon/FunctionObject_FunctionDeclaration_BA59C706_runCommon,
 			[2] object[],
 			[3] string
 		)
@@ -347,13 +450,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.String_MemberCall_FastPath_CommonMethods_BDA65493.FunctionObject_FunctionDeclaration_BA59C706_runCommon::.ctor()
+		IL_0011: newobj instance void Modules.String_MemberCall_FastPath_CommonMethods/runCommon/FunctionObject_FunctionDeclaration_BA59C706_runCommon::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "runCommon"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.String_MemberCall_FastPath_CommonMethods_BDA65493.FunctionObject_FunctionDeclaration_BA59C706_runCommon>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_MemberCall_FastPath_CommonMethods/runCommon/FunctionObject_FunctionDeclaration_BA59C706_runCommon>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -438,109 +541,6 @@
 	} // end of method String_MemberCall_FastPath_CommonMethods::__js_module_init__
 
 } // end of class Modules.String_MemberCall_FastPath_CommonMethods
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.String_MemberCall_FastPath_CommonMethods_BDA65493.FunctionObject_FunctionDeclaration_BA59C706_runCommon
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x24ae
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_BA59C706_runCommon::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24b6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BA59C706_runCommon::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24b9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BA59C706_runCommon::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24bc
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0011: call object Modules.String_MemberCall_FastPath_CommonMethods/runCommon::__js_call__(object, string)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_BA59C706_runCommon::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24d4
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_000d: call object Modules.String_MemberCall_FastPath_CommonMethods/runCommon::__js_call__(object, string)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_BA59C706_runCommon::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24e8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BA59C706_runCommon::ConstructCore
-
-} // end of class FunctionObjects.String_MemberCall_FastPath_CommonMethods_BDA65493.FunctionObject_FunctionDeclaration_BA59C706_runCommon
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_Custom.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_Custom.verified.txt
@@ -31,6 +31,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FB7F8382_L5C24
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.String_RegExp_SymbolDispatch_Custom/Scope _environment0_String_RegExp_SymbolDispatch_Custom
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.String_RegExp_SymbolDispatch_Custom/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x265b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L5C23/FunctionObject_FunctionExpression_FB7F8382_L5C24::_environment0_String_RegExp_SymbolDispatch_Custom
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_FB7F8382_L5C24::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x266a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_FB7F8382_L5C24::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x266d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_FB7F8382_L5C24::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2670
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L5C23/FunctionObject_FunctionExpression_FB7F8382_L5C24::_environment0_String_RegExp_SymbolDispatch_Custom
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L5C23::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_FB7F8382_L5C24::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2689
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L5C23/FunctionObject_FunctionExpression_FB7F8382_L5C24::_environment0_String_RegExp_SymbolDispatch_Custom
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L5C23::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_FB7F8382_L5C24::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x269e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_FB7F8382_L5C24::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_FB7F8382_L5C24
+
 
 		// Methods
 		.method public hidebysig static 
@@ -116,6 +229,125 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_5B4C2DE3_L11C26
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.String_RegExp_SymbolDispatch_Custom/Scope _environment0_String_RegExp_SymbolDispatch_Custom
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.String_RegExp_SymbolDispatch_Custom/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x26ad
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L11C25/FunctionObject_FunctionExpression_5B4C2DE3_L11C26::_environment0_String_RegExp_SymbolDispatch_Custom
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_5B4C2DE3_L11C26::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x26bc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5B4C2DE3_L11C26::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x26bf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_5B4C2DE3_L11C26::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x26c2
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L11C25/FunctionObject_FunctionExpression_5B4C2DE3_L11C26::_environment0_String_RegExp_SymbolDispatch_Custom
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L11C25::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionExpression_5B4C2DE3_L11C26::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26e2
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L11C25/FunctionObject_FunctionExpression_5B4C2DE3_L11C26::_environment0_String_RegExp_SymbolDispatch_Custom
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L11C25::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionExpression_5B4C2DE3_L11C26::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26fe
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_5B4C2DE3_L11C26::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_5B4C2DE3_L11C26
 
 
 		// Methods
@@ -208,6 +440,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_59AEF9EB_L18C25
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.String_RegExp_SymbolDispatch_Custom/Scope _environment0_String_RegExp_SymbolDispatch_Custom
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.String_RegExp_SymbolDispatch_Custom/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x270d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L18C24/FunctionObject_FunctionExpression_59AEF9EB_L18C25::_environment0_String_RegExp_SymbolDispatch_Custom
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_59AEF9EB_L18C25::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x271c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_59AEF9EB_L18C25::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x271f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_59AEF9EB_L18C25::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2722
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L18C24/FunctionObject_FunctionExpression_59AEF9EB_L18C25::_environment0_String_RegExp_SymbolDispatch_Custom
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L18C24::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_59AEF9EB_L18C25::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x273b
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L18C24/FunctionObject_FunctionExpression_59AEF9EB_L18C25::_environment0_String_RegExp_SymbolDispatch_Custom
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L18C24::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_59AEF9EB_L18C25::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2750
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_59AEF9EB_L18C25::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_59AEF9EB_L18C25
+
 
 		// Methods
 		.method public hidebysig static 
@@ -289,6 +634,125 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_999EB579_L24C24
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.String_RegExp_SymbolDispatch_Custom/Scope _environment0_String_RegExp_SymbolDispatch_Custom
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.String_RegExp_SymbolDispatch_Custom/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x275f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L24C23/FunctionObject_FunctionExpression_999EB579_L24C24::_environment0_String_RegExp_SymbolDispatch_Custom
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_999EB579_L24C24::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x276e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_999EB579_L24C24::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2771
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_999EB579_L24C24::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2774
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L24C23/FunctionObject_FunctionExpression_999EB579_L24C24::_environment0_String_RegExp_SymbolDispatch_Custom
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L24C23::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionExpression_999EB579_L24C24::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2794
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L24C23/FunctionObject_FunctionExpression_999EB579_L24C24::_environment0_String_RegExp_SymbolDispatch_Custom
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L24C23::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionExpression_999EB579_L24C24::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x27b0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_999EB579_L24C24::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_999EB579_L24C24
 
 
 		// Methods
@@ -459,10 +923,10 @@
 			[11] object,
 			[12] object,
 			[13] object[],
-			[14] class FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_FB7F8382_L5C24,
-			[15] class FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_5B4C2DE3_L11C26,
-			[16] class FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_59AEF9EB_L18C25,
-			[17] class FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_999EB579_L24C24,
+			[14] class Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L5C23/FunctionObject_FunctionExpression_FB7F8382_L5C24,
+			[15] class Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L11C25/FunctionObject_FunctionExpression_5B4C2DE3_L11C26,
+			[16] class Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L18C24/FunctionObject_FunctionExpression_59AEF9EB_L18C25,
+			[17] class Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L24C23/FunctionObject_FunctionExpression_999EB579_L24C24,
 			[18] string
 		)
 
@@ -491,13 +955,13 @@
 		IL_0038: ldc.i4.0
 		IL_0039: ldelem.ref
 		IL_003a: castclass Modules.String_RegExp_SymbolDispatch_Custom/Scope
-		IL_003f: newobj instance void FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_FB7F8382_L5C24::.ctor(class Modules.String_RegExp_SymbolDispatch_Custom/Scope)
+		IL_003f: newobj instance void Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L5C23/FunctionObject_FunctionExpression_FB7F8382_L5C24::.ctor(class Modules.String_RegExp_SymbolDispatch_Custom/Scope)
 		IL_0044: ldc.i4.1
 		IL_0045: conv.r8
 		IL_0046: ldstr ""
 		IL_004b: ldc.i4.1
 		IL_004c: ldc.i4.1
-		IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_FB7F8382_L5C24>(!!0, float64, string, bool, bool)
+		IL_004d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L5C23/FunctionObject_FunctionExpression_FB7F8382_L5C24>(!!0, float64, string, bool, bool)
 		IL_0052: stloc.s 14
 		IL_0054: ldloc.s 11
 		IL_0056: ldloc.s 12
@@ -522,13 +986,13 @@
 		IL_0083: ldc.i4.0
 		IL_0084: ldelem.ref
 		IL_0085: castclass Modules.String_RegExp_SymbolDispatch_Custom/Scope
-		IL_008a: newobj instance void FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_5B4C2DE3_L11C26::.ctor(class Modules.String_RegExp_SymbolDispatch_Custom/Scope)
+		IL_008a: newobj instance void Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L11C25/FunctionObject_FunctionExpression_5B4C2DE3_L11C26::.ctor(class Modules.String_RegExp_SymbolDispatch_Custom/Scope)
 		IL_008f: ldc.i4.2
 		IL_0090: conv.r8
 		IL_0091: ldstr ""
 		IL_0096: ldc.i4.1
 		IL_0097: ldc.i4.1
-		IL_0098: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_5B4C2DE3_L11C26>(!!0, float64, string, bool, bool)
+		IL_0098: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L11C25/FunctionObject_FunctionExpression_5B4C2DE3_L11C26>(!!0, float64, string, bool, bool)
 		IL_009d: stloc.s 15
 		IL_009f: ldloc.s 12
 		IL_00a1: ldloc.s 11
@@ -553,13 +1017,13 @@
 		IL_00ce: ldc.i4.0
 		IL_00cf: ldelem.ref
 		IL_00d0: castclass Modules.String_RegExp_SymbolDispatch_Custom/Scope
-		IL_00d5: newobj instance void FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_59AEF9EB_L18C25::.ctor(class Modules.String_RegExp_SymbolDispatch_Custom/Scope)
+		IL_00d5: newobj instance void Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L18C24/FunctionObject_FunctionExpression_59AEF9EB_L18C25::.ctor(class Modules.String_RegExp_SymbolDispatch_Custom/Scope)
 		IL_00da: ldc.i4.1
 		IL_00db: conv.r8
 		IL_00dc: ldstr ""
 		IL_00e1: ldc.i4.1
 		IL_00e2: ldc.i4.1
-		IL_00e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_59AEF9EB_L18C25>(!!0, float64, string, bool, bool)
+		IL_00e3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L18C24/FunctionObject_FunctionExpression_59AEF9EB_L18C25>(!!0, float64, string, bool, bool)
 		IL_00e8: stloc.s 16
 		IL_00ea: ldloc.s 11
 		IL_00ec: ldloc.s 12
@@ -584,13 +1048,13 @@
 		IL_0119: ldc.i4.0
 		IL_011a: ldelem.ref
 		IL_011b: castclass Modules.String_RegExp_SymbolDispatch_Custom/Scope
-		IL_0120: newobj instance void FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_999EB579_L24C24::.ctor(class Modules.String_RegExp_SymbolDispatch_Custom/Scope)
+		IL_0120: newobj instance void Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L24C23/FunctionObject_FunctionExpression_999EB579_L24C24::.ctor(class Modules.String_RegExp_SymbolDispatch_Custom/Scope)
 		IL_0125: ldc.i4.2
 		IL_0126: conv.r8
 		IL_0127: ldstr ""
 		IL_012c: ldc.i4.1
 		IL_012d: ldc.i4.1
-		IL_012e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_999EB579_L24C24>(!!0, float64, string, bool, bool)
+		IL_012e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L24C23/FunctionObject_FunctionExpression_999EB579_L24C24>(!!0, float64, string, bool, bool)
 		IL_0133: stloc.s 17
 		IL_0135: ldloc.s 12
 		IL_0137: ldloc.s 11
@@ -791,470 +1255,6 @@
 	} // end of method String_RegExp_SymbolDispatch_Custom::__js_module_init__
 
 } // end of class Modules.String_RegExp_SymbolDispatch_Custom
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_FB7F8382_L5C24
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.String_RegExp_SymbolDispatch_Custom/Scope _environment0_String_RegExp_SymbolDispatch_Custom
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.String_RegExp_SymbolDispatch_Custom/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x265b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_FB7F8382_L5C24::_environment0_String_RegExp_SymbolDispatch_Custom
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_FB7F8382_L5C24::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x266a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FB7F8382_L5C24::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x266d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FB7F8382_L5C24::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2670
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_FB7F8382_L5C24::_environment0_String_RegExp_SymbolDispatch_Custom
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L5C23::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_FB7F8382_L5C24::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2689
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_FB7F8382_L5C24::_environment0_String_RegExp_SymbolDispatch_Custom
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L5C23::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_FB7F8382_L5C24::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x269e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_FB7F8382_L5C24::ConstructCore
-
-} // end of class FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_FB7F8382_L5C24
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_5B4C2DE3_L11C26
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.String_RegExp_SymbolDispatch_Custom/Scope _environment0_String_RegExp_SymbolDispatch_Custom
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.String_RegExp_SymbolDispatch_Custom/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x26ad
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_5B4C2DE3_L11C26::_environment0_String_RegExp_SymbolDispatch_Custom
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5B4C2DE3_L11C26::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x26bc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5B4C2DE3_L11C26::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x26bf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_5B4C2DE3_L11C26::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x26c2
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_5B4C2DE3_L11C26::_environment0_String_RegExp_SymbolDispatch_Custom
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L11C25::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionExpression_5B4C2DE3_L11C26::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26e2
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_5B4C2DE3_L11C26::_environment0_String_RegExp_SymbolDispatch_Custom
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L11C25::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionExpression_5B4C2DE3_L11C26::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26fe
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_5B4C2DE3_L11C26::ConstructCore
-
-} // end of class FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_5B4C2DE3_L11C26
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_59AEF9EB_L18C25
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.String_RegExp_SymbolDispatch_Custom/Scope _environment0_String_RegExp_SymbolDispatch_Custom
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.String_RegExp_SymbolDispatch_Custom/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x270d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_59AEF9EB_L18C25::_environment0_String_RegExp_SymbolDispatch_Custom
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_59AEF9EB_L18C25::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x271c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_59AEF9EB_L18C25::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x271f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_59AEF9EB_L18C25::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2722
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_59AEF9EB_L18C25::_environment0_String_RegExp_SymbolDispatch_Custom
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L18C24::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_59AEF9EB_L18C25::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x273b
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_59AEF9EB_L18C25::_environment0_String_RegExp_SymbolDispatch_Custom
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L18C24::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_59AEF9EB_L18C25::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2750
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_59AEF9EB_L18C25::ConstructCore
-
-} // end of class FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_59AEF9EB_L18C25
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_999EB579_L24C24
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.String_RegExp_SymbolDispatch_Custom/Scope _environment0_String_RegExp_SymbolDispatch_Custom
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.String_RegExp_SymbolDispatch_Custom/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x275f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_999EB579_L24C24::_environment0_String_RegExp_SymbolDispatch_Custom
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_999EB579_L24C24::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x276e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_999EB579_L24C24::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2771
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_999EB579_L24C24::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2774
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_999EB579_L24C24::_environment0_String_RegExp_SymbolDispatch_Custom
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L24C23::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionExpression_999EB579_L24C24::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2794
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_Custom/Scope FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_999EB579_L24C24::_environment0_String_RegExp_SymbolDispatch_Custom
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.String_RegExp_SymbolDispatch_Custom/FunctionExpression_L24C23::__js_call__(class Modules.String_RegExp_SymbolDispatch_Custom/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionExpression_999EB579_L24C24::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27b0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_999EB579_L24C24::ConstructCore
-
-} // end of class FunctionObjects.String_RegExp_SymbolDispatch_Custom_4A62B883.FunctionObject_FunctionExpression_999EB579_L24C24
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_RegExpOverride.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_RegExpOverride.verified.txt
@@ -31,6 +31,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_61FDD2C4_L5C20
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope _environment0_String_RegExp_SymbolDispatch_RegExpOverride
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2597
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L5C19/FunctionObject_FunctionExpression_61FDD2C4_L5C20::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_61FDD2C4_L5C20::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x25a6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_61FDD2C4_L5C20::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x25a9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_61FDD2C4_L5C20::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x25ac
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L5C19/FunctionObject_FunctionExpression_61FDD2C4_L5C20::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L5C19::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_61FDD2C4_L5C20::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25c5
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L5C19/FunctionObject_FunctionExpression_61FDD2C4_L5C20::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L5C19::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_61FDD2C4_L5C20::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25da
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_61FDD2C4_L5C20::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_61FDD2C4_L5C20
+
 
 		// Methods
 		.method public hidebysig static 
@@ -123,6 +236,125 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_74F2042E_L12C22
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope _environment0_String_RegExp_SymbolDispatch_RegExpOverride
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x25e9
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L12C21/FunctionObject_FunctionExpression_74F2042E_L12C22::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_74F2042E_L12C22::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x25f8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_74F2042E_L12C22::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x25fb
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_74F2042E_L12C22::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x25fe
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L12C21/FunctionObject_FunctionExpression_74F2042E_L12C22::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L12C21::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionExpression_74F2042E_L12C22::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x261e
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L12C21/FunctionObject_FunctionExpression_74F2042E_L12C22::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L12C21::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionExpression_74F2042E_L12C22::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x263a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_74F2042E_L12C22::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_74F2042E_L12C22
 
 
 		// Methods
@@ -221,6 +453,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_BA49F324_L20C21
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope _environment0_String_RegExp_SymbolDispatch_RegExpOverride
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2649
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L20C20/FunctionObject_FunctionExpression_BA49F324_L20C21::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_BA49F324_L20C21::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2658
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_BA49F324_L20C21::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x265b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_BA49F324_L20C21::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x265e
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L20C20/FunctionObject_FunctionExpression_BA49F324_L20C21::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L20C20::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_BA49F324_L20C21::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2677
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L20C20/FunctionObject_FunctionExpression_BA49F324_L20C21::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L20C20::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_BA49F324_L20C21::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x268c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_BA49F324_L20C21::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_BA49F324_L20C21
+
 
 		// Methods
 		.method public hidebysig static 
@@ -310,6 +655,125 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_88EF580C_L27C20
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope _environment0_String_RegExp_SymbolDispatch_RegExpOverride
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x269b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L27C19/FunctionObject_FunctionExpression_88EF580C_L27C20::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_88EF580C_L27C20::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x26aa
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_88EF580C_L27C20::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x26ad
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_88EF580C_L27C20::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x26b0
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L27C19/FunctionObject_FunctionExpression_88EF580C_L27C20::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L27C19::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionExpression_88EF580C_L27C20::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26d0
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L27C19/FunctionObject_FunctionExpression_88EF580C_L27C20::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L27C19::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionExpression_88EF580C_L27C20::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26ec
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_88EF580C_L27C20::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_88EF580C_L27C20
 
 
 		// Methods
@@ -440,10 +904,10 @@
 			[3] object,
 			[4] object,
 			[5] object[],
-			[6] class FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_61FDD2C4_L5C20,
-			[7] class FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_74F2042E_L12C22,
-			[8] class FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_BA49F324_L20C21,
-			[9] class FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_88EF580C_L27C20
+			[6] class Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L5C19/FunctionObject_FunctionExpression_61FDD2C4_L5C20,
+			[7] class Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L12C21/FunctionObject_FunctionExpression_74F2042E_L12C22,
+			[8] class Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L20C20/FunctionObject_FunctionExpression_BA49F324_L20C21,
+			[9] class Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L27C19/FunctionObject_FunctionExpression_88EF580C_L27C20
 		)
 
 		IL_0000: newobj instance void Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope::.ctor()
@@ -473,13 +937,13 @@
 		IL_003f: ldc.i4.0
 		IL_0040: ldelem.ref
 		IL_0041: castclass Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope
-		IL_0046: newobj instance void FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_61FDD2C4_L5C20::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope)
+		IL_0046: newobj instance void Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L5C19/FunctionObject_FunctionExpression_61FDD2C4_L5C20::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope)
 		IL_004b: ldc.i4.1
 		IL_004c: conv.r8
 		IL_004d: ldstr ""
 		IL_0052: ldc.i4.1
 		IL_0053: ldc.i4.1
-		IL_0054: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_61FDD2C4_L5C20>(!!0, float64, string, bool, bool)
+		IL_0054: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L5C19/FunctionObject_FunctionExpression_61FDD2C4_L5C20>(!!0, float64, string, bool, bool)
 		IL_0059: stloc.s 6
 		IL_005b: ldloc.3
 		IL_005c: ldloc.s 4
@@ -504,13 +968,13 @@
 		IL_0088: ldc.i4.0
 		IL_0089: ldelem.ref
 		IL_008a: castclass Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope
-		IL_008f: newobj instance void FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_74F2042E_L12C22::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope)
+		IL_008f: newobj instance void Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L12C21/FunctionObject_FunctionExpression_74F2042E_L12C22::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope)
 		IL_0094: ldc.i4.2
 		IL_0095: conv.r8
 		IL_0096: ldstr ""
 		IL_009b: ldc.i4.1
 		IL_009c: ldc.i4.1
-		IL_009d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_74F2042E_L12C22>(!!0, float64, string, bool, bool)
+		IL_009d: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L12C21/FunctionObject_FunctionExpression_74F2042E_L12C22>(!!0, float64, string, bool, bool)
 		IL_00a2: stloc.s 7
 		IL_00a4: ldloc.s 4
 		IL_00a6: ldloc.3
@@ -535,13 +999,13 @@
 		IL_00d1: ldc.i4.0
 		IL_00d2: ldelem.ref
 		IL_00d3: castclass Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope
-		IL_00d8: newobj instance void FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_BA49F324_L20C21::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope)
+		IL_00d8: newobj instance void Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L20C20/FunctionObject_FunctionExpression_BA49F324_L20C21::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope)
 		IL_00dd: ldc.i4.1
 		IL_00de: conv.r8
 		IL_00df: ldstr ""
 		IL_00e4: ldc.i4.1
 		IL_00e5: ldc.i4.1
-		IL_00e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_BA49F324_L20C21>(!!0, float64, string, bool, bool)
+		IL_00e6: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L20C20/FunctionObject_FunctionExpression_BA49F324_L20C21>(!!0, float64, string, bool, bool)
 		IL_00eb: stloc.s 8
 		IL_00ed: ldloc.3
 		IL_00ee: ldloc.s 4
@@ -566,13 +1030,13 @@
 		IL_011a: ldc.i4.0
 		IL_011b: ldelem.ref
 		IL_011c: castclass Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope
-		IL_0121: newobj instance void FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_88EF580C_L27C20::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope)
+		IL_0121: newobj instance void Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L27C19/FunctionObject_FunctionExpression_88EF580C_L27C20::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope)
 		IL_0126: ldc.i4.2
 		IL_0127: conv.r8
 		IL_0128: ldstr ""
 		IL_012d: ldc.i4.1
 		IL_012e: ldc.i4.1
-		IL_012f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_88EF580C_L27C20>(!!0, float64, string, bool, bool)
+		IL_012f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L27C19/FunctionObject_FunctionExpression_88EF580C_L27C20>(!!0, float64, string, bool, bool)
 		IL_0134: stloc.s 9
 		IL_0136: ldloc.s 4
 		IL_0138: ldloc.3
@@ -676,470 +1140,6 @@
 	} // end of method String_RegExp_SymbolDispatch_RegExpOverride::__js_module_init__
 
 } // end of class Modules.String_RegExp_SymbolDispatch_RegExpOverride
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_61FDD2C4_L5C20
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope _environment0_String_RegExp_SymbolDispatch_RegExpOverride
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2597
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_61FDD2C4_L5C20::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_61FDD2C4_L5C20::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x25a6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_61FDD2C4_L5C20::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x25a9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_61FDD2C4_L5C20::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x25ac
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_61FDD2C4_L5C20::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L5C19::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_61FDD2C4_L5C20::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25c5
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_61FDD2C4_L5C20::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L5C19::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_61FDD2C4_L5C20::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25da
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_61FDD2C4_L5C20::ConstructCore
-
-} // end of class FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_61FDD2C4_L5C20
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_74F2042E_L12C22
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope _environment0_String_RegExp_SymbolDispatch_RegExpOverride
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x25e9
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_74F2042E_L12C22::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_74F2042E_L12C22::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x25f8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_74F2042E_L12C22::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x25fb
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_74F2042E_L12C22::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x25fe
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_74F2042E_L12C22::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L12C21::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionExpression_74F2042E_L12C22::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x261e
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_74F2042E_L12C22::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L12C21::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionExpression_74F2042E_L12C22::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x263a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_74F2042E_L12C22::ConstructCore
-
-} // end of class FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_74F2042E_L12C22
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_BA49F324_L20C21
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope _environment0_String_RegExp_SymbolDispatch_RegExpOverride
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2649
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_BA49F324_L20C21::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_BA49F324_L20C21::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2658
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_BA49F324_L20C21::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x265b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_BA49F324_L20C21::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x265e
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_BA49F324_L20C21::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L20C20::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_BA49F324_L20C21::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2677
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_BA49F324_L20C21::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L20C20::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_BA49F324_L20C21::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x268c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_BA49F324_L20C21::ConstructCore
-
-} // end of class FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_BA49F324_L20C21
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_88EF580C_L27C20
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope _environment0_String_RegExp_SymbolDispatch_RegExpOverride
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x269b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_88EF580C_L27C20::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_88EF580C_L27C20::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x26aa
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_88EF580C_L27C20::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x26ad
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_88EF580C_L27C20::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x26b0
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_88EF580C_L27C20::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L27C19::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionExpression_88EF580C_L27C20::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26d0
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_88EF580C_L27C20::_environment0_String_RegExp_SymbolDispatch_RegExpOverride
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_RegExpOverride/FunctionExpression_L27C19::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpOverride/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionExpression_88EF580C_L27C20::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26ec
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_88EF580C_L27C20::ConstructCore
-
-} // end of class FunctionObjects.String_RegExp_SymbolDispatch_RegExpOverride_095E9B4D.FunctionObject_FunctionExpression_88EF580C_L27C20
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_RegExpPrototypeOverride.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_RegExp_SymbolDispatch_RegExpPrototypeOverride.verified.txt
@@ -31,6 +31,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_4C2EA9D7_L10C23
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope _environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2653
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L10C22/FunctionObject_FunctionExpression_4C2EA9D7_L10C23::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_4C2EA9D7_L10C23::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2662
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_4C2EA9D7_L10C23::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2665
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_4C2EA9D7_L10C23::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2668
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L10C22/FunctionObject_FunctionExpression_4C2EA9D7_L10C23::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L10C22::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_4C2EA9D7_L10C23::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2681
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L10C22/FunctionObject_FunctionExpression_4C2EA9D7_L10C23::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L10C22::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_4C2EA9D7_L10C23::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2696
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_4C2EA9D7_L10C23::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_4C2EA9D7_L10C23
+
 
 		// Methods
 		.method public hidebysig static 
@@ -123,6 +236,125 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_BA77F64A_L17C25
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope _environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x26a5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L17C24/FunctionObject_FunctionExpression_BA77F64A_L17C25::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_BA77F64A_L17C25::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x26b4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_BA77F64A_L17C25::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x26b7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_BA77F64A_L17C25::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x26ba
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L17C24/FunctionObject_FunctionExpression_BA77F64A_L17C25::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call object Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L17C24::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionExpression_BA77F64A_L17C25::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26da
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L17C24/FunctionObject_FunctionExpression_BA77F64A_L17C25::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call object Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L17C24::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionExpression_BA77F64A_L17C25::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26f6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_BA77F64A_L17C25::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_BA77F64A_L17C25
 
 
 		// Methods
@@ -221,6 +453,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9B9859A2_L25C24
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope _environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2705
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L25C23/FunctionObject_FunctionExpression_9B9859A2_L25C24::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_9B9859A2_L25C24::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2714
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_9B9859A2_L25C24::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2717
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_9B9859A2_L25C24::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x271a
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L25C23/FunctionObject_FunctionExpression_9B9859A2_L25C24::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L25C23::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_9B9859A2_L25C24::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2733
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L25C23/FunctionObject_FunctionExpression_9B9859A2_L25C24::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L25C23::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_9B9859A2_L25C24::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2748
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_9B9859A2_L25C24::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_9B9859A2_L25C24
+
 
 		// Methods
 		.method public hidebysig static 
@@ -310,6 +655,125 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_E632B0CF_L32C23
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope _environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2757
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L32C22/FunctionObject_FunctionExpression_E632B0CF_L32C23::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E632B0CF_L32C23::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2766
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E632B0CF_L32C23::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2769
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_E632B0CF_L32C23::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x276c
+				// Header size: 1
+				// Code size: 31 (0x1f)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L32C22/FunctionObject_FunctionExpression_E632B0CF_L32C23::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: ldarg.2
+				IL_0013: ldc.i4.1
+				IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0019: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L32C22::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope, object, object, object)
+				IL_001e: ret
+			} // end of method FunctionObject_FunctionExpression_E632B0CF_L32C23::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x278c
+				// Header size: 1
+				// Code size: 27 (0x1b)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L32C22/FunctionObject_FunctionExpression_E632B0CF_L32C23::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: ldarg.2
+				IL_000f: ldc.i4.1
+				IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L32C22::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope, object, object, object)
+				IL_001a: ret
+			} // end of method FunctionObject_FunctionExpression_E632B0CF_L32C23::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x27a8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_E632B0CF_L32C23::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_E632B0CF_L32C23
 
 
 		// Methods
@@ -444,10 +908,10 @@
 			[7] class [JavaScriptRuntime]JavaScriptRuntime.RegExp,
 			[8] object,
 			[9] object[],
-			[10] class FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_4C2EA9D7_L10C23,
-			[11] class FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_BA77F64A_L17C25,
-			[12] class FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_9B9859A2_L25C24,
-			[13] class FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_E632B0CF_L32C23,
+			[10] class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L10C22/FunctionObject_FunctionExpression_4C2EA9D7_L10C23,
+			[11] class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L17C24/FunctionObject_FunctionExpression_BA77F64A_L17C25,
+			[12] class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L25C23/FunctionObject_FunctionExpression_9B9859A2_L25C24,
+			[13] class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L32C22/FunctionObject_FunctionExpression_E632B0CF_L32C23,
 			[14] object
 		)
 
@@ -510,13 +974,13 @@
 		IL_00a5: ldc.i4.0
 		IL_00a6: ldelem.ref
 		IL_00a7: castclass Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope
-		IL_00ac: newobj instance void FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_4C2EA9D7_L10C23::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope)
+		IL_00ac: newobj instance void Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L10C22/FunctionObject_FunctionExpression_4C2EA9D7_L10C23::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope)
 		IL_00b1: ldc.i4.1
 		IL_00b2: conv.r8
 		IL_00b3: ldstr ""
 		IL_00b8: ldc.i4.1
 		IL_00b9: ldc.i4.1
-		IL_00ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_4C2EA9D7_L10C23>(!!0, float64, string, bool, bool)
+		IL_00ba: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L10C22/FunctionObject_FunctionExpression_4C2EA9D7_L10C23>(!!0, float64, string, bool, bool)
 		IL_00bf: stloc.s 10
 		IL_00c1: ldloc.1
 		IL_00c2: ldloc.s 8
@@ -538,13 +1002,13 @@
 		IL_00e7: ldc.i4.0
 		IL_00e8: ldelem.ref
 		IL_00e9: castclass Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope
-		IL_00ee: newobj instance void FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_BA77F64A_L17C25::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope)
+		IL_00ee: newobj instance void Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L17C24/FunctionObject_FunctionExpression_BA77F64A_L17C25::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope)
 		IL_00f3: ldc.i4.2
 		IL_00f4: conv.r8
 		IL_00f5: ldstr ""
 		IL_00fa: ldc.i4.1
 		IL_00fb: ldc.i4.1
-		IL_00fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_BA77F64A_L17C25>(!!0, float64, string, bool, bool)
+		IL_00fc: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L17C24/FunctionObject_FunctionExpression_BA77F64A_L17C25>(!!0, float64, string, bool, bool)
 		IL_0101: stloc.s 11
 		IL_0103: ldloc.1
 		IL_0104: ldloc.s 8
@@ -566,13 +1030,13 @@
 		IL_0129: ldc.i4.0
 		IL_012a: ldelem.ref
 		IL_012b: castclass Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope
-		IL_0130: newobj instance void FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_9B9859A2_L25C24::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope)
+		IL_0130: newobj instance void Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L25C23/FunctionObject_FunctionExpression_9B9859A2_L25C24::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope)
 		IL_0135: ldc.i4.1
 		IL_0136: conv.r8
 		IL_0137: ldstr ""
 		IL_013c: ldc.i4.1
 		IL_013d: ldc.i4.1
-		IL_013e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_9B9859A2_L25C24>(!!0, float64, string, bool, bool)
+		IL_013e: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L25C23/FunctionObject_FunctionExpression_9B9859A2_L25C24>(!!0, float64, string, bool, bool)
 		IL_0143: stloc.s 12
 		IL_0145: ldloc.1
 		IL_0146: ldloc.s 8
@@ -594,13 +1058,13 @@
 		IL_016b: ldc.i4.0
 		IL_016c: ldelem.ref
 		IL_016d: castclass Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope
-		IL_0172: newobj instance void FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_E632B0CF_L32C23::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope)
+		IL_0172: newobj instance void Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L32C22/FunctionObject_FunctionExpression_E632B0CF_L32C23::.ctor(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope)
 		IL_0177: ldc.i4.2
 		IL_0178: conv.r8
 		IL_0179: ldstr ""
 		IL_017e: ldc.i4.1
 		IL_017f: ldc.i4.1
-		IL_0180: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_E632B0CF_L32C23>(!!0, float64, string, bool, bool)
+		IL_0180: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L32C22/FunctionObject_FunctionExpression_E632B0CF_L32C23>(!!0, float64, string, bool, bool)
 		IL_0185: stloc.s 13
 		IL_0187: ldloc.1
 		IL_0188: ldloc.s 8
@@ -740,470 +1204,6 @@
 	} // end of method String_RegExp_SymbolDispatch_RegExpPrototypeOverride::__js_module_init__
 
 } // end of class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_4C2EA9D7_L10C23
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope _environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2653
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_4C2EA9D7_L10C23::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_4C2EA9D7_L10C23::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2662
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_4C2EA9D7_L10C23::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2665
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_4C2EA9D7_L10C23::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2668
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_4C2EA9D7_L10C23::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L10C22::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_4C2EA9D7_L10C23::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2681
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_4C2EA9D7_L10C23::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L10C22::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_4C2EA9D7_L10C23::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2696
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_4C2EA9D7_L10C23::ConstructCore
-
-} // end of class FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_4C2EA9D7_L10C23
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_BA77F64A_L17C25
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope _environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x26a5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_BA77F64A_L17C25::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_BA77F64A_L17C25::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x26b4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_BA77F64A_L17C25::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x26b7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_BA77F64A_L17C25::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x26ba
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_BA77F64A_L17C25::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call object Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L17C24::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionExpression_BA77F64A_L17C25::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26da
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_BA77F64A_L17C25::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call object Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L17C24::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionExpression_BA77F64A_L17C25::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26f6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_BA77F64A_L17C25::ConstructCore
-
-} // end of class FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_BA77F64A_L17C25
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_9B9859A2_L25C24
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope _environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2705
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_9B9859A2_L25C24::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_9B9859A2_L25C24::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2714
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9B9859A2_L25C24::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2717
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9B9859A2_L25C24::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x271a
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_9B9859A2_L25C24::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L25C23::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_9B9859A2_L25C24::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2733
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_9B9859A2_L25C24::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L25C23::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_9B9859A2_L25C24::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2748
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_9B9859A2_L25C24::ConstructCore
-
-} // end of class FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_9B9859A2_L25C24
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_E632B0CF_L32C23
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope _environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2757
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_E632B0CF_L32C23::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E632B0CF_L32C23::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2766
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E632B0CF_L32C23::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2769
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_E632B0CF_L32C23::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x276c
-		// Header size: 1
-		// Code size: 31 (0x1f)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_E632B0CF_L32C23::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: ldarg.2
-		IL_0013: ldc.i4.1
-		IL_0014: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0019: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L32C22::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope, object, object, object)
-		IL_001e: ret
-	} // end of method FunctionObject_FunctionExpression_E632B0CF_L32C23::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x278c
-		// Header size: 1
-		// Code size: 27 (0x1b)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_E632B0CF_L32C23::_environment0_String_RegExp_SymbolDispatch_RegExpPrototypeOverride
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: ldarg.2
-		IL_000f: ldc.i4.1
-		IL_0010: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0015: call class [JavaScriptRuntime]JavaScriptRuntime.Array Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/FunctionExpression_L32C22::__js_call__(class Modules.String_RegExp_SymbolDispatch_RegExpPrototypeOverride/Scope, object, object, object)
-		IL_001a: ret
-	} // end of method FunctionObject_FunctionExpression_E632B0CF_L32C23::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x27a8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_E632B0CF_L32C23::ConstructCore
-
-} // end of class FunctionObjects.String_RegExp_SymbolDispatch_RegExpPrototypeOverride_78B5B159.FunctionObject_FunctionExpression_E632B0CF_L32C23
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Repeat_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_Repeat_Basic.verified.txt
@@ -73,6 +73,127 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.String_Repeat_Basic/Scope _environment0_String_Repeat_Basic
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.String_Repeat_Basic/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x22a4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.String_Repeat_Basic/Scope Modules.String_Repeat_Basic/logRepeat/FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::_environment0_String_Repeat_Basic
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22b3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22b6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22b9
+				// Header size: 1
+				// Code size: 36 (0x24)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_Repeat_Basic/Scope Modules.String_Repeat_Basic/logRepeat/FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::_environment0_String_Repeat_Basic
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0017: ldarg.2
+				IL_0018: ldc.i4.1
+				IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001e: call object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, string, object)
+				IL_0023: ret
+			} // end of method FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22de
+				// Header size: 1
+				// Code size: 32 (0x20)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_Repeat_Basic/Scope Modules.String_Repeat_Basic/logRepeat/FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::_environment0_String_Repeat_Basic
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0013: ldarg.2
+				IL_0014: ldc.i4.1
+				IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001a: call object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, string, object)
+				IL_001f: ret
+			} // end of method FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22ff
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat
+
 
 		// Methods
 		.method public hidebysig static 
@@ -263,7 +384,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_Repeat_Basic/Scope,
-			[1] class FunctionObjects.String_Repeat_Basic_F6F7CC87.FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat,
+			[1] class Modules.String_Repeat_Basic/logRepeat/FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat,
 			[2] object[],
 			[3] float64,
 			[4] object
@@ -282,13 +403,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.String_Repeat_Basic/Scope
-		IL_0019: newobj instance void FunctionObjects.String_Repeat_Basic_F6F7CC87.FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::.ctor(class Modules.String_Repeat_Basic/Scope)
+		IL_0019: newobj instance void Modules.String_Repeat_Basic/logRepeat/FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::.ctor(class Modules.String_Repeat_Basic/Scope)
 		IL_001e: ldc.i4.2
 		IL_001f: conv.r8
 		IL_0020: ldstr "logRepeat"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.String_Repeat_Basic_F6F7CC87.FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_Repeat_Basic/logRepeat/FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
@@ -355,127 +476,6 @@
 	} // end of method String_Repeat_Basic::__js_module_init__
 
 } // end of class Modules.String_Repeat_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.String_Repeat_Basic_F6F7CC87.FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.String_Repeat_Basic/Scope _environment0_String_Repeat_Basic
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.String_Repeat_Basic/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x22a4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.String_Repeat_Basic/Scope FunctionObjects.String_Repeat_Basic_F6F7CC87.FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::_environment0_String_Repeat_Basic
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22b3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22b6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22b9
-		// Header size: 1
-		// Code size: 36 (0x24)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_Repeat_Basic/Scope FunctionObjects.String_Repeat_Basic_F6F7CC87.FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::_environment0_String_Repeat_Basic
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0017: ldarg.2
-		IL_0018: ldc.i4.1
-		IL_0019: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001e: call object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, string, object)
-		IL_0023: ret
-	} // end of method FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22de
-		// Header size: 1
-		// Code size: 32 (0x20)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_Repeat_Basic/Scope FunctionObjects.String_Repeat_Basic_F6F7CC87.FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::_environment0_String_Repeat_Basic
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0013: ldarg.2
-		IL_0014: ldc.i4.1
-		IL_0015: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001a: call object Modules.String_Repeat_Basic/logRepeat::__js_call__(class Modules.String_Repeat_Basic/Scope, object, string, object)
-		IL_001f: ret
-	} // end of method FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22ff
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat::ConstructCore
-
-} // end of class FunctionObjects.String_Repeat_Basic_F6F7CC87.FunctionObject_FunctionDeclaration_E66C5EEF_logRepeat
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_StartsWith_NestedParam.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_StartsWith_NestedParam.verified.txt
@@ -35,6 +35,126 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7C9A65CE_inner
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.String_StartsWith_NestedParam/outer/Scope _environment1_outer
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.String_StartsWith_NestedParam/outer/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x21c1
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.String_StartsWith_NestedParam/outer/Scope Modules.String_StartsWith_NestedParam/outer/inner/FunctionObject_FunctionDeclaration_7C9A65CE_inner::_environment1_outer
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.String_StartsWith_NestedParam/outer/inner/FunctionObject_FunctionDeclaration_7C9A65CE_inner::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionDeclaration_7C9A65CE_inner::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x21d7
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_7C9A65CE_inner::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x21da
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_7C9A65CE_inner::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x21dd
+					// Header size: 1
+					// Code size: 29 (0x1d)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.String_StartsWith_NestedParam/outer/inner/FunctionObject_FunctionDeclaration_7C9A65CE_inner::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: ldarg.2
+					IL_000c: ldc.i4.0
+					IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0017: call object Modules.String_StartsWith_NestedParam/outer/inner::__js_call__(object[], object, string)
+					IL_001c: ret
+				} // end of method FunctionObject_FunctionDeclaration_7C9A65CE_inner::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x21fb
+					// Header size: 1
+					// Code size: 25 (0x19)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.String_StartsWith_NestedParam/outer/inner/FunctionObject_FunctionDeclaration_7C9A65CE_inner::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: ldarg.2
+					IL_0008: ldc.i4.0
+					IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+					IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+					IL_0013: call object Modules.String_StartsWith_NestedParam/outer/inner::__js_call__(object[], object, string)
+					IL_0018: ret
+				} // end of method FunctionObject_FunctionDeclaration_7C9A65CE_inner::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2215
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionDeclaration_7C9A65CE_inner::ConstructCore
+
+			} // end of class FunctionObject_FunctionDeclaration_7C9A65CE_inner
+
 
 			// Methods
 			.method public hidebysig static 
@@ -99,6 +219,119 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_402202F9_outer
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.String_StartsWith_NestedParam/Scope _environment0_String_StartsWith_NestedParam
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.String_StartsWith_NestedParam/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x216f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.String_StartsWith_NestedParam/Scope Modules.String_StartsWith_NestedParam/outer/FunctionObject_FunctionDeclaration_402202F9_outer::_environment0_String_StartsWith_NestedParam
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_402202F9_outer::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x217e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_402202F9_outer::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2181
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_402202F9_outer::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2184
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_StartsWith_NestedParam/Scope Modules.String_StartsWith_NestedParam/outer/FunctionObject_FunctionDeclaration_402202F9_outer::_environment0_String_StartsWith_NestedParam
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.String_StartsWith_NestedParam/outer::__js_call__(class Modules.String_StartsWith_NestedParam/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_402202F9_outer::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x219d
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_StartsWith_NestedParam/Scope Modules.String_StartsWith_NestedParam/outer/FunctionObject_FunctionDeclaration_402202F9_outer::_environment0_String_StartsWith_NestedParam
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.String_StartsWith_NestedParam/outer::__js_call__(class Modules.String_StartsWith_NestedParam/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_402202F9_outer::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21b2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_402202F9_outer::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_402202F9_outer
+
 
 		// Methods
 		.method public hidebysig static 
@@ -119,7 +352,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.String_StartsWith_NestedParam/outer/Scope,
-				[1] class FunctionObjects.String_StartsWith_NestedParam_C4239E17.FunctionObject_FunctionDeclaration_7C9A65CE_inner,
+				[1] class Modules.String_StartsWith_NestedParam/outer/inner/FunctionObject_FunctionDeclaration_7C9A65CE_inner,
 				[2] object[]
 			)
 
@@ -144,13 +377,13 @@
 			IL_001e: ldelem.ref
 			IL_001f: castclass Modules.String_StartsWith_NestedParam/outer/Scope
 			IL_0024: ldloc.2
-			IL_0025: newobj instance void FunctionObjects.String_StartsWith_NestedParam_C4239E17.FunctionObject_FunctionDeclaration_7C9A65CE_inner::.ctor(class Modules.String_StartsWith_NestedParam/outer/Scope, object[])
+			IL_0025: newobj instance void Modules.String_StartsWith_NestedParam/outer/inner/FunctionObject_FunctionDeclaration_7C9A65CE_inner::.ctor(class Modules.String_StartsWith_NestedParam/outer/Scope, object[])
 			IL_002a: ldc.i4.1
 			IL_002b: conv.r8
 			IL_002c: ldstr "inner"
 			IL_0031: ldc.i4.0
 			IL_0032: ldc.i4.1
-			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.String_StartsWith_NestedParam_C4239E17.FunctionObject_FunctionDeclaration_7C9A65CE_inner>(!!0, float64, string, bool, bool)
+			IL_0033: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_StartsWith_NestedParam/outer/inner/FunctionObject_FunctionDeclaration_7C9A65CE_inner>(!!0, float64, string, bool, bool)
 			IL_0038: stloc.1
 			IL_0039: nop
 			IL_003a: ldc.i4.2
@@ -221,7 +454,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_StartsWith_NestedParam/Scope,
-			[1] class FunctionObjects.String_StartsWith_NestedParam_C4239E17.FunctionObject_FunctionDeclaration_402202F9_outer,
+			[1] class Modules.String_StartsWith_NestedParam/outer/FunctionObject_FunctionDeclaration_402202F9_outer,
 			[2] object[],
 			[3] object,
 			[4] object
@@ -240,13 +473,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.String_StartsWith_NestedParam/Scope
-		IL_0019: newobj instance void FunctionObjects.String_StartsWith_NestedParam_C4239E17.FunctionObject_FunctionDeclaration_402202F9_outer::.ctor(class Modules.String_StartsWith_NestedParam/Scope)
+		IL_0019: newobj instance void Modules.String_StartsWith_NestedParam/outer/FunctionObject_FunctionDeclaration_402202F9_outer::.ctor(class Modules.String_StartsWith_NestedParam/Scope)
 		IL_001e: ldc.i4.1
 		IL_001f: conv.r8
 		IL_0020: ldstr "outer"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.String_StartsWith_NestedParam_C4239E17.FunctionObject_FunctionDeclaration_402202F9_outer>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_StartsWith_NestedParam/outer/FunctionObject_FunctionDeclaration_402202F9_outer>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
@@ -270,239 +503,6 @@
 	} // end of method String_StartsWith_NestedParam::__js_module_init__
 
 } // end of class Modules.String_StartsWith_NestedParam
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.String_StartsWith_NestedParam_C4239E17.FunctionObject_FunctionDeclaration_402202F9_outer
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.String_StartsWith_NestedParam/Scope _environment0_String_StartsWith_NestedParam
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.String_StartsWith_NestedParam/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x216f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.String_StartsWith_NestedParam/Scope FunctionObjects.String_StartsWith_NestedParam_C4239E17.FunctionObject_FunctionDeclaration_402202F9_outer::_environment0_String_StartsWith_NestedParam
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_402202F9_outer::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x217e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_402202F9_outer::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2181
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_402202F9_outer::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2184
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_StartsWith_NestedParam/Scope FunctionObjects.String_StartsWith_NestedParam_C4239E17.FunctionObject_FunctionDeclaration_402202F9_outer::_environment0_String_StartsWith_NestedParam
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.String_StartsWith_NestedParam/outer::__js_call__(class Modules.String_StartsWith_NestedParam/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_402202F9_outer::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x219d
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_StartsWith_NestedParam/Scope FunctionObjects.String_StartsWith_NestedParam_C4239E17.FunctionObject_FunctionDeclaration_402202F9_outer::_environment0_String_StartsWith_NestedParam
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.String_StartsWith_NestedParam/outer::__js_call__(class Modules.String_StartsWith_NestedParam/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_402202F9_outer::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21b2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_402202F9_outer::ConstructCore
-
-} // end of class FunctionObjects.String_StartsWith_NestedParam_C4239E17.FunctionObject_FunctionDeclaration_402202F9_outer
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.String_StartsWith_NestedParam_C4239E17.FunctionObject_FunctionDeclaration_7C9A65CE_inner
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.String_StartsWith_NestedParam/outer/Scope _environment1_outer
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.String_StartsWith_NestedParam/outer/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x21c1
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.String_StartsWith_NestedParam/outer/Scope FunctionObjects.String_StartsWith_NestedParam_C4239E17.FunctionObject_FunctionDeclaration_7C9A65CE_inner::_environment1_outer
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.String_StartsWith_NestedParam_C4239E17.FunctionObject_FunctionDeclaration_7C9A65CE_inner::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_7C9A65CE_inner::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21d7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7C9A65CE_inner::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21da
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7C9A65CE_inner::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21dd
-		// Header size: 1
-		// Code size: 29 (0x1d)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.String_StartsWith_NestedParam_C4239E17.FunctionObject_FunctionDeclaration_7C9A65CE_inner::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0017: call object Modules.String_StartsWith_NestedParam/outer/inner::__js_call__(object[], object, string)
-		IL_001c: ret
-	} // end of method FunctionObject_FunctionDeclaration_7C9A65CE_inner::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21fb
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.String_StartsWith_NestedParam_C4239E17.FunctionObject_FunctionDeclaration_7C9A65CE_inner::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0013: call object Modules.String_StartsWith_NestedParam/outer/inner::__js_call__(object[], object, string)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_7C9A65CE_inner::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2215
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_7C9A65CE_inner::ConstructCore
-
-} // end of class FunctionObjects.String_StartsWith_NestedParam_C4239E17.FunctionObject_FunctionDeclaration_7C9A65CE_inner
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_Basic.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_Basic.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_06484AB7_tag
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21bb
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_06484AB7_tag::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21c3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_06484AB7_tag::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21c6
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_06484AB7_tag::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21c9
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.String_TaggedTemplate_Basic/tag::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_06484AB7_tag::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21dc
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.String_TaggedTemplate_Basic/tag::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_06484AB7_tag::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21eb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_06484AB7_tag::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_06484AB7_tag
+
 
 		// Methods
 		.method public hidebysig static 
@@ -119,7 +220,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_TaggedTemplate_Basic/Scope,
-			[1] class FunctionObjects.String_TaggedTemplate_Basic_02C5BCB2.FunctionObject_FunctionDeclaration_06484AB7_tag,
+			[1] class Modules.String_TaggedTemplate_Basic/tag/FunctionObject_FunctionDeclaration_06484AB7_tag,
 			[2] float64,
 			[3] float64,
 			[4] object,
@@ -139,13 +240,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 5
-		IL_0012: newobj instance void FunctionObjects.String_TaggedTemplate_Basic_02C5BCB2.FunctionObject_FunctionDeclaration_06484AB7_tag::.ctor()
+		IL_0012: newobj instance void Modules.String_TaggedTemplate_Basic/tag/FunctionObject_FunctionDeclaration_06484AB7_tag::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "tag"
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.String_TaggedTemplate_Basic_02C5BCB2.FunctionObject_FunctionDeclaration_06484AB7_tag>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_TaggedTemplate_Basic/tag/FunctionObject_FunctionDeclaration_06484AB7_tag>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: nop
 		IL_0027: nop
@@ -229,107 +330,6 @@
 	} // end of method String_TaggedTemplate_Basic::__js_module_init__
 
 } // end of class Modules.String_TaggedTemplate_Basic
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.String_TaggedTemplate_Basic_02C5BCB2.FunctionObject_FunctionDeclaration_06484AB7_tag
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21bb
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_06484AB7_tag::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21c3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_06484AB7_tag::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21c6
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_06484AB7_tag::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21c9
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.String_TaggedTemplate_Basic/tag::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_06484AB7_tag::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21dc
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.String_TaggedTemplate_Basic/tag::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_06484AB7_tag::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21eb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_06484AB7_tag::ConstructCore
-
-} // end of class FunctionObjects.String_TaggedTemplate_Basic_02C5BCB2.FunctionObject_FunctionDeclaration_06484AB7_tag
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_EvaluationOrder.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_EvaluationOrder.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_39EEBD13_tag
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2241
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_39EEBD13_tag::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2249
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_39EEBD13_tag::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x224c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_39EEBD13_tag::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x224f
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.String_TaggedTemplate_EvaluationOrder/tag::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_39EEBD13_tag::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2262
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.String_TaggedTemplate_EvaluationOrder/tag::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_39EEBD13_tag::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2271
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_39EEBD13_tag::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_39EEBD13_tag
+
 
 		// Methods
 		.method public hidebysig static 
@@ -89,6 +190,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BD4F3B6C_getValue
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.String_TaggedTemplate_EvaluationOrder/Scope _environment0_String_TaggedTemplate_EvaluationOrder
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.String_TaggedTemplate_EvaluationOrder/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2280
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.String_TaggedTemplate_EvaluationOrder/Scope Modules.String_TaggedTemplate_EvaluationOrder/getValue/FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::_environment0_String_TaggedTemplate_EvaluationOrder
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x228f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2292
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2295
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_TaggedTemplate_EvaluationOrder/Scope Modules.String_TaggedTemplate_EvaluationOrder/getValue/FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::_environment0_String_TaggedTemplate_EvaluationOrder
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.String_TaggedTemplate_EvaluationOrder/getValue::__js_call__(class Modules.String_TaggedTemplate_EvaluationOrder/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22a7
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.String_TaggedTemplate_EvaluationOrder/Scope Modules.String_TaggedTemplate_EvaluationOrder/getValue/FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::_environment0_String_TaggedTemplate_EvaluationOrder
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.String_TaggedTemplate_EvaluationOrder/getValue::__js_call__(class Modules.String_TaggedTemplate_EvaluationOrder/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22b5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_BD4F3B6C_getValue
 
 
 		// Methods
@@ -200,8 +408,8 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_TaggedTemplate_EvaluationOrder/Scope,
-			[1] class FunctionObjects.String_TaggedTemplate_EvaluationOrder_078F1596.FunctionObject_FunctionDeclaration_39EEBD13_tag,
-			[2] class FunctionObjects.String_TaggedTemplate_EvaluationOrder_078F1596.FunctionObject_FunctionDeclaration_BD4F3B6C_getValue,
+			[1] class Modules.String_TaggedTemplate_EvaluationOrder/tag/FunctionObject_FunctionDeclaration_39EEBD13_tag,
+			[2] class Modules.String_TaggedTemplate_EvaluationOrder/getValue/FunctionObject_FunctionDeclaration_BD4F3B6C_getValue,
 			[3] object,
 			[4] object[],
 			[5] object[],
@@ -220,13 +428,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 4
-		IL_0012: newobj instance void FunctionObjects.String_TaggedTemplate_EvaluationOrder_078F1596.FunctionObject_FunctionDeclaration_39EEBD13_tag::.ctor()
+		IL_0012: newobj instance void Modules.String_TaggedTemplate_EvaluationOrder/tag/FunctionObject_FunctionDeclaration_39EEBD13_tag::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "tag"
 		IL_001e: ldc.i4.1
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.String_TaggedTemplate_EvaluationOrder_078F1596.FunctionObject_FunctionDeclaration_39EEBD13_tag>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_TaggedTemplate_EvaluationOrder/tag/FunctionObject_FunctionDeclaration_39EEBD13_tag>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -239,13 +447,13 @@
 		IL_0034: ldc.i4.0
 		IL_0035: ldelem.ref
 		IL_0036: castclass Modules.String_TaggedTemplate_EvaluationOrder/Scope
-		IL_003b: newobj instance void FunctionObjects.String_TaggedTemplate_EvaluationOrder_078F1596.FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::.ctor(class Modules.String_TaggedTemplate_EvaluationOrder/Scope)
+		IL_003b: newobj instance void Modules.String_TaggedTemplate_EvaluationOrder/getValue/FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::.ctor(class Modules.String_TaggedTemplate_EvaluationOrder/Scope)
 		IL_0040: ldc.i4.0
 		IL_0041: conv.r8
 		IL_0042: ldstr "getValue"
 		IL_0047: ldc.i4.0
 		IL_0048: ldc.i4.1
-		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.String_TaggedTemplate_EvaluationOrder_078F1596.FunctionObject_FunctionDeclaration_BD4F3B6C_getValue>(!!0, float64, string, bool, bool)
+		IL_0049: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_TaggedTemplate_EvaluationOrder/getValue/FunctionObject_FunctionDeclaration_BD4F3B6C_getValue>(!!0, float64, string, bool, bool)
 		IL_004e: stloc.2
 		IL_004f: nop
 		IL_0050: nop
@@ -336,214 +544,6 @@
 	} // end of method String_TaggedTemplate_EvaluationOrder::__js_module_init__
 
 } // end of class Modules.String_TaggedTemplate_EvaluationOrder
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.String_TaggedTemplate_EvaluationOrder_078F1596.FunctionObject_FunctionDeclaration_39EEBD13_tag
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2241
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_39EEBD13_tag::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2249
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_39EEBD13_tag::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x224c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_39EEBD13_tag::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x224f
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.String_TaggedTemplate_EvaluationOrder/tag::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_39EEBD13_tag::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2262
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.String_TaggedTemplate_EvaluationOrder/tag::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_39EEBD13_tag::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2271
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_39EEBD13_tag::ConstructCore
-
-} // end of class FunctionObjects.String_TaggedTemplate_EvaluationOrder_078F1596.FunctionObject_FunctionDeclaration_39EEBD13_tag
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.String_TaggedTemplate_EvaluationOrder_078F1596.FunctionObject_FunctionDeclaration_BD4F3B6C_getValue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.String_TaggedTemplate_EvaluationOrder/Scope _environment0_String_TaggedTemplate_EvaluationOrder
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.String_TaggedTemplate_EvaluationOrder/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2280
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.String_TaggedTemplate_EvaluationOrder/Scope FunctionObjects.String_TaggedTemplate_EvaluationOrder_078F1596.FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::_environment0_String_TaggedTemplate_EvaluationOrder
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x228f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2292
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2295
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_TaggedTemplate_EvaluationOrder/Scope FunctionObjects.String_TaggedTemplate_EvaluationOrder_078F1596.FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::_environment0_String_TaggedTemplate_EvaluationOrder
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.String_TaggedTemplate_EvaluationOrder/getValue::__js_call__(class Modules.String_TaggedTemplate_EvaluationOrder/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22a7
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.String_TaggedTemplate_EvaluationOrder/Scope FunctionObjects.String_TaggedTemplate_EvaluationOrder_078F1596.FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::_environment0_String_TaggedTemplate_EvaluationOrder
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.String_TaggedTemplate_EvaluationOrder/getValue::__js_call__(class Modules.String_TaggedTemplate_EvaluationOrder/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22b5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BD4F3B6C_getValue::ConstructCore
-
-} // end of class FunctionObjects.String_TaggedTemplate_EvaluationOrder_078F1596.FunctionObject_FunctionDeclaration_BD4F3B6C_getValue
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_NoSubstitutions.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_NoSubstitutions.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BBF496DE_tag
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2174
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_BBF496DE_tag::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x217c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BBF496DE_tag::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x217f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BBF496DE_tag::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2182
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.String_TaggedTemplate_NoSubstitutions/tag::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_BBF496DE_tag::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2195
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.String_TaggedTemplate_NoSubstitutions/tag::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BBF496DE_tag::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21a4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BBF496DE_tag::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_BBF496DE_tag
+
 
 		// Methods
 		.method public hidebysig static 
@@ -129,7 +230,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_TaggedTemplate_NoSubstitutions/Scope,
-			[1] class FunctionObjects.String_TaggedTemplate_NoSubstitutions_667DBB9B.FunctionObject_FunctionDeclaration_BBF496DE_tag,
+			[1] class Modules.String_TaggedTemplate_NoSubstitutions/tag/FunctionObject_FunctionDeclaration_BBF496DE_tag,
 			[2] object,
 			[3] object[],
 			[4] object[],
@@ -145,13 +246,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.String_TaggedTemplate_NoSubstitutions_667DBB9B.FunctionObject_FunctionDeclaration_BBF496DE_tag::.ctor()
+		IL_0011: newobj instance void Modules.String_TaggedTemplate_NoSubstitutions/tag/FunctionObject_FunctionDeclaration_BBF496DE_tag::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "tag"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.String_TaggedTemplate_NoSubstitutions_667DBB9B.FunctionObject_FunctionDeclaration_BBF496DE_tag>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_TaggedTemplate_NoSubstitutions/tag/FunctionObject_FunctionDeclaration_BBF496DE_tag>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -201,107 +302,6 @@
 	} // end of method String_TaggedTemplate_NoSubstitutions::__js_module_init__
 
 } // end of class Modules.String_TaggedTemplate_NoSubstitutions
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.String_TaggedTemplate_NoSubstitutions_667DBB9B.FunctionObject_FunctionDeclaration_BBF496DE_tag
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2174
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_BBF496DE_tag::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x217c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BBF496DE_tag::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x217f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BBF496DE_tag::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2182
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.String_TaggedTemplate_NoSubstitutions/tag::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_BBF496DE_tag::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2195
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.String_TaggedTemplate_NoSubstitutions/tag::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BBF496DE_tag::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21a4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BBF496DE_tag::ConstructCore
-
-} // end of class FunctionObjects.String_TaggedTemplate_NoSubstitutions_667DBB9B.FunctionObject_FunctionDeclaration_BBF496DE_tag
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_RawStrings.verified.txt
+++ b/tests/Jroc.Tests/String/Snapshots/GeneratorTests.String_TaggedTemplate_RawStrings.verified.txt
@@ -31,6 +31,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A859B7DD_tag
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21ff
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_A859B7DD_tag::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2207
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A859B7DD_tag::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x220a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A859B7DD_tag::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x220d
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.String_TaggedTemplate_RawStrings/tag::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_A859B7DD_tag::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2220
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.String_TaggedTemplate_RawStrings/tag::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A859B7DD_tag::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x222f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A859B7DD_tag::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_A859B7DD_tag
+
 
 		// Methods
 		.method public hidebysig static 
@@ -169,7 +270,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.String_TaggedTemplate_RawStrings/Scope,
-			[1] class FunctionObjects.String_TaggedTemplate_RawStrings_CC1AFB30.FunctionObject_FunctionDeclaration_A859B7DD_tag,
+			[1] class Modules.String_TaggedTemplate_RawStrings/tag/FunctionObject_FunctionDeclaration_A859B7DD_tag,
 			[2] object[],
 			[3] object[],
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Array
@@ -184,13 +285,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.String_TaggedTemplate_RawStrings_CC1AFB30.FunctionObject_FunctionDeclaration_A859B7DD_tag::.ctor()
+		IL_0011: newobj instance void Modules.String_TaggedTemplate_RawStrings/tag/FunctionObject_FunctionDeclaration_A859B7DD_tag::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "tag"
 		IL_001d: ldc.i4.1
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.String_TaggedTemplate_RawStrings_CC1AFB30.FunctionObject_FunctionDeclaration_A859B7DD_tag>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.String_TaggedTemplate_RawStrings/tag/FunctionObject_FunctionDeclaration_A859B7DD_tag>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -245,107 +346,6 @@
 	} // end of method String_TaggedTemplate_RawStrings::__js_module_init__
 
 } // end of class Modules.String_TaggedTemplate_RawStrings
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.String_TaggedTemplate_RawStrings_CC1AFB30.FunctionObject_FunctionDeclaration_A859B7DD_tag
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21ff
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_A859B7DD_tag::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2207
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A859B7DD_tag::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x220a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A859B7DD_tag::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x220d
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.String_TaggedTemplate_RawStrings/tag::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_A859B7DD_tag::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2220
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.String_TaggedTemplate_RawStrings/tag::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A859B7DD_tag::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x222f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A859B7DD_tag::ConstructCore
-
-} // end of class FunctionObjects.String_TaggedTemplate_RawStrings_CC1AFB30.FunctionObject_FunctionDeclaration_A859B7DD_tag
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/TryCatch/Snapshots/GeneratorTests.TryFinally_Return.verified.txt
+++ b/tests/Jroc.Tests/TryCatch/Snapshots/GeneratorTests.TryFinally_Return.verified.txt
@@ -73,6 +73,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5219E8A7_f
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2120
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_5219E8A7_f::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2128
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5219E8A7_f::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x212b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5219E8A7_f::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x212e
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.TryFinally_Return/f::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_5219E8A7_f::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x213a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.TryFinally_Return/f::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_5219E8A7_f::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2142
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5219E8A7_f::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_5219E8A7_f
+
 
 		// Methods
 		.method public hidebysig static 
@@ -170,7 +265,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.TryFinally_Return/Scope,
-			[1] class FunctionObjects.TryFinally_Return_81FADB04.FunctionObject_FunctionDeclaration_5219E8A7_f,
+			[1] class Modules.TryFinally_Return/f/FunctionObject_FunctionDeclaration_5219E8A7_f,
 			[2] object[]
 		)
 
@@ -183,13 +278,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.TryFinally_Return_81FADB04.FunctionObject_FunctionDeclaration_5219E8A7_f::.ctor()
+		IL_0011: newobj instance void Modules.TryFinally_Return/f/FunctionObject_FunctionDeclaration_5219E8A7_f::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "f"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TryFinally_Return_81FADB04.FunctionObject_FunctionDeclaration_5219E8A7_f>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TryFinally_Return/f/FunctionObject_FunctionDeclaration_5219E8A7_f>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -201,101 +296,6 @@
 	} // end of method TryFinally_Return::__js_module_init__
 
 } // end of class Modules.TryFinally_Return
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TryFinally_Return_81FADB04.FunctionObject_FunctionDeclaration_5219E8A7_f
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2120
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_5219E8A7_f::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2128
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5219E8A7_f::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x212b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5219E8A7_f::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x212e
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.TryFinally_Return/f::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_5219E8A7_f::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x213a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.TryFinally_Return/f::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_5219E8A7_f::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2142
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5219E8A7_f::ConstructCore
-
-} // end of class FunctionObjects.TryFinally_Return_81FADB04.FunctionObject_FunctionDeclaration_5219E8A7_f
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.BeanCounter_Class_Index_Assign.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.BeanCounter_Class_Index_Assign.verified.txt
@@ -71,6 +71,155 @@
 
 		} // end of class Scope_setBeanCount
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_DE5ACEE0_BeanCounter
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x220e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.BeanCounter_Class_Index_Assign/BeanCounter/FunctionObject_ClassConstructor_DE5ACEE0_BeanCounter::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_DE5ACEE0_BeanCounter::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x221d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_DE5ACEE0_BeanCounter::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2220
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_DE5ACEE0_BeanCounter::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2223
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_DE5ACEE0_BeanCounter::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x222f
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_DE5ACEE0_BeanCounter::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_DE5ACEE0_BeanCounter
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x223b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2243
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2246
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2249
+				// Header size: 1
+				// Code size: 26 (0x1a)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.BeanCounter_Class_Index_Assign/BeanCounter
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: call instance object Modules.BeanCounter_Class_Index_Assign/BeanCounter::setBeanCount(object, object)
+				IL_0019: ret
+			} // end of method FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount::CallCore
+
+		} // end of class FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount
+
 
 		// Fields
 		.field public class [JavaScriptRuntime]JavaScriptRuntime.Int32Array beanCounts
@@ -295,155 +444,6 @@
 	} // end of method BeanCounter_Class_Index_Assign::__js_module_init__
 
 } // end of class Modules.BeanCounter_Class_Index_Assign
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BeanCounter_Class_Index_Assign_8424236F.FunctionObject_ClassConstructor_DE5ACEE0_BeanCounter
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x220e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.BeanCounter_Class_Index_Assign_8424236F.FunctionObject_ClassConstructor_DE5ACEE0_BeanCounter::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_DE5ACEE0_BeanCounter::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x221d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_DE5ACEE0_BeanCounter::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2220
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_DE5ACEE0_BeanCounter::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2223
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_DE5ACEE0_BeanCounter::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x222f
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_DE5ACEE0_BeanCounter::ConstructCore
-
-} // end of class FunctionObjects.BeanCounter_Class_Index_Assign_8424236F.FunctionObject_ClassConstructor_DE5ACEE0_BeanCounter
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.BeanCounter_Class_Index_Assign_8424236F.FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x223b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2243
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2246
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2249
-		// Header size: 1
-		// Code size: 26 (0x1a)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.BeanCounter_Class_Index_Assign/BeanCounter
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: call instance object Modules.BeanCounter_Class_Index_Assign/BeanCounter::setBeanCount(object, object)
-		IL_0019: ret
-	} // end of method FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount::CallCore
-
-} // end of class FunctionObjects.BeanCounter_Class_Index_Assign_8424236F.FunctionObject_ClassMethod_AA3A8FD8_BeanCounter_setBeanCount
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Float64Array_Callback_Methods.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Float64Array_Callback_Methods.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_802B628E_L5C24
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x248b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_802B628E_L5C24::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2493
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_802B628E_L5C24::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2496
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_802B628E_L5C24::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2499
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L5C23::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionExpression_802B628E_L5C24::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24b3
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L5C23::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionExpression_802B628E_L5C24::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24c9
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_802B628E_L5C24::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_802B628E_L5C24
+
 
 		// Methods
 		.method public hidebysig static 
@@ -85,6 +192,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1281CCCF_L9C27
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x24d8
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_1281CCCF_L9C27::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24e0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_1281CCCF_L9C27::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24e3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_1281CCCF_L9C27::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24e6
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L9C26::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_1281CCCF_L9C27::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24f9
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L9C26::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_1281CCCF_L9C27::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2508
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_1281CCCF_L9C27::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_1281CCCF_L9C27
+
 
 		// Methods
 		.method public hidebysig static 
@@ -134,6 +342,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_1DD803E1_L13C26
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2517
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_1DD803E1_L13C26::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x251f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_1DD803E1_L13C26::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2522
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_1DD803E1_L13C26::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2525
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L13C25::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_1DD803E1_L13C26::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2538
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L13C25::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_1DD803E1_L13C26::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2547
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_1DD803E1_L13C26::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_1DD803E1_L13C26
 
 
 		// Methods
@@ -185,6 +494,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_AF6B9F7C_L17C25
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2556
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_AF6B9F7C_L17C25::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x255e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_AF6B9F7C_L17C25::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2561
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_AF6B9F7C_L17C25::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2564
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L17C24::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_AF6B9F7C_L17C25::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2577
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L17C24::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_AF6B9F7C_L17C25::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2586
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_AF6B9F7C_L17C25::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_AF6B9F7C_L17C25
+
 
 		// Methods
 		.method public hidebysig static 
@@ -234,6 +644,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_091FFC5B_L21C25
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2595
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_091FFC5B_L21C25::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x259d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_091FFC5B_L21C25::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x25a0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_091FFC5B_L21C25::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x25a3
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L21C24::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_091FFC5B_L21C25::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25b6
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L21C24::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_091FFC5B_L21C25::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25c5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_091FFC5B_L21C25::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_091FFC5B_L21C25
 
 
 		// Methods
@@ -285,6 +796,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_7EDB3801_L25C30
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x25d4
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_7EDB3801_L25C30::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x25dc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7EDB3801_L25C30::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x25df
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_7EDB3801_L25C30::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x25e2
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L25C29::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_7EDB3801_L25C30::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25f5
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L25C29::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_7EDB3801_L25C30::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2604
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_7EDB3801_L25C30::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_7EDB3801_L25C30
+
 
 		// Methods
 		.method public hidebysig static 
@@ -334,6 +946,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_83EEFAA3_L30C16
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Float64Array_Callback_Methods/Scope _environment0_Float64Array_Callback_Methods
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Float64Array_Callback_Methods/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2613
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Float64Array_Callback_Methods/Scope Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15/FunctionObject_FunctionExpression_83EEFAA3_L30C16::_environment0_Float64Array_Callback_Methods
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_83EEFAA3_L30C16::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2622
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_83EEFAA3_L30C16::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2625
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_83EEFAA3_L30C16::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2628
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Float64Array_Callback_Methods/Scope Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15/FunctionObject_FunctionExpression_83EEFAA3_L30C16::_environment0_Float64Array_Callback_Methods
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15::__js_call__(class Modules.Float64Array_Callback_Methods/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionExpression_83EEFAA3_L30C16::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2641
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Float64Array_Callback_Methods/Scope Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15/FunctionObject_FunctionExpression_83EEFAA3_L30C16::_environment0_Float64Array_Callback_Methods
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15::__js_call__(class Modules.Float64Array_Callback_Methods/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionExpression_83EEFAA3_L30C16::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2656
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_83EEFAA3_L30C16::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_83EEFAA3_L30C16
 
 
 		// Methods
@@ -397,6 +1122,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FC8E004A_L35C27
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2665
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_FC8E004A_L35C27::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x266d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_FC8E004A_L35C27::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2670
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_FC8E004A_L35C27::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2673
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L35C26::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionExpression_FC8E004A_L35C27::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x268d
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L35C26::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionExpression_FC8E004A_L35C27::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26a3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_FC8E004A_L35C27::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_FC8E004A_L35C27
 
 
 		// Methods
@@ -476,15 +1308,15 @@
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[3] object,
 			[4] object[],
-			[5] class FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_802B628E_L5C24,
+			[5] class Modules.Float64Array_Callback_Methods/FunctionExpression_L5C23/FunctionObject_FunctionExpression_802B628E_L5C24,
 			[6] object,
-			[7] class FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_1281CCCF_L9C27,
-			[8] class FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_1DD803E1_L13C26,
-			[9] class FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_AF6B9F7C_L17C25,
-			[10] class FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_091FFC5B_L21C25,
-			[11] class FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_7EDB3801_L25C30,
-			[12] class FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_83EEFAA3_L30C16,
-			[13] class FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_FC8E004A_L35C27
+			[7] class Modules.Float64Array_Callback_Methods/FunctionExpression_L9C26/FunctionObject_FunctionExpression_1281CCCF_L9C27,
+			[8] class Modules.Float64Array_Callback_Methods/FunctionExpression_L13C25/FunctionObject_FunctionExpression_1DD803E1_L13C26,
+			[9] class Modules.Float64Array_Callback_Methods/FunctionExpression_L17C24/FunctionObject_FunctionExpression_AF6B9F7C_L17C25,
+			[10] class Modules.Float64Array_Callback_Methods/FunctionExpression_L21C24/FunctionObject_FunctionExpression_091FFC5B_L21C25,
+			[11] class Modules.Float64Array_Callback_Methods/FunctionExpression_L25C29/FunctionObject_FunctionExpression_7EDB3801_L25C30,
+			[12] class Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15/FunctionObject_FunctionExpression_83EEFAA3_L30C16,
+			[13] class Modules.Float64Array_Callback_Methods/FunctionExpression_L35C26/FunctionObject_FunctionExpression_FC8E004A_L35C27
 		)
 
 		IL_0000: newobj instance void Modules.Float64Array_Callback_Methods/Scope::.ctor()
@@ -516,13 +1348,13 @@
 		IL_005a: ldloc.0
 		IL_005b: stelem.ref
 		IL_005c: stloc.s 4
-		IL_005e: newobj instance void FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_802B628E_L5C24::.ctor()
+		IL_005e: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L5C23/FunctionObject_FunctionExpression_802B628E_L5C24::.ctor()
 		IL_0063: ldc.i4.2
 		IL_0064: conv.r8
 		IL_0065: ldstr ""
 		IL_006a: ldc.i4.0
 		IL_006b: ldc.i4.1
-		IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_802B628E_L5C24>(!!0, float64, string, bool, bool)
+		IL_006c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L5C23/FunctionObject_FunctionExpression_802B628E_L5C24>(!!0, float64, string, bool, bool)
 		IL_0071: stloc.s 5
 		IL_0073: ldloc.1
 		IL_0074: ldstr "map"
@@ -551,13 +1383,13 @@
 		IL_00c1: ldloc.0
 		IL_00c2: stelem.ref
 		IL_00c3: stloc.s 4
-		IL_00c5: newobj instance void FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_1281CCCF_L9C27::.ctor()
+		IL_00c5: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L9C26/FunctionObject_FunctionExpression_1281CCCF_L9C27::.ctor()
 		IL_00ca: ldc.i4.1
 		IL_00cb: conv.r8
 		IL_00cc: ldstr ""
 		IL_00d1: ldc.i4.0
 		IL_00d2: ldc.i4.1
-		IL_00d3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_1281CCCF_L9C27>(!!0, float64, string, bool, bool)
+		IL_00d3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L9C26/FunctionObject_FunctionExpression_1281CCCF_L9C27>(!!0, float64, string, bool, bool)
 		IL_00d8: stloc.s 7
 		IL_00da: ldloc.1
 		IL_00db: ldstr "filter"
@@ -586,13 +1418,13 @@
 		IL_0124: ldloc.0
 		IL_0125: stelem.ref
 		IL_0126: stloc.s 4
-		IL_0128: newobj instance void FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_1DD803E1_L13C26::.ctor()
+		IL_0128: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L13C25/FunctionObject_FunctionExpression_1DD803E1_L13C26::.ctor()
 		IL_012d: ldc.i4.1
 		IL_012e: conv.r8
 		IL_012f: ldstr ""
 		IL_0134: ldc.i4.0
 		IL_0135: ldc.i4.1
-		IL_0136: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_1DD803E1_L13C26>(!!0, float64, string, bool, bool)
+		IL_0136: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L13C25/FunctionObject_FunctionExpression_1DD803E1_L13C26>(!!0, float64, string, bool, bool)
 		IL_013b: stloc.s 8
 		IL_013d: ldloc.1
 		IL_013e: ldstr "every"
@@ -615,13 +1447,13 @@
 		IL_0173: ldloc.0
 		IL_0174: stelem.ref
 		IL_0175: stloc.s 4
-		IL_0177: newobj instance void FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_AF6B9F7C_L17C25::.ctor()
+		IL_0177: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L17C24/FunctionObject_FunctionExpression_AF6B9F7C_L17C25::.ctor()
 		IL_017c: ldc.i4.1
 		IL_017d: conv.r8
 		IL_017e: ldstr ""
 		IL_0183: ldc.i4.0
 		IL_0184: ldc.i4.1
-		IL_0185: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_AF6B9F7C_L17C25>(!!0, float64, string, bool, bool)
+		IL_0185: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L17C24/FunctionObject_FunctionExpression_AF6B9F7C_L17C25>(!!0, float64, string, bool, bool)
 		IL_018a: stloc.s 9
 		IL_018c: ldloc.1
 		IL_018d: ldstr "some"
@@ -644,13 +1476,13 @@
 		IL_01c0: ldloc.0
 		IL_01c1: stelem.ref
 		IL_01c2: stloc.s 4
-		IL_01c4: newobj instance void FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_091FFC5B_L21C25::.ctor()
+		IL_01c4: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L21C24/FunctionObject_FunctionExpression_091FFC5B_L21C25::.ctor()
 		IL_01c9: ldc.i4.1
 		IL_01ca: conv.r8
 		IL_01cb: ldstr ""
 		IL_01d0: ldc.i4.0
 		IL_01d1: ldc.i4.1
-		IL_01d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_091FFC5B_L21C25>(!!0, float64, string, bool, bool)
+		IL_01d2: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L21C24/FunctionObject_FunctionExpression_091FFC5B_L21C25>(!!0, float64, string, bool, bool)
 		IL_01d7: stloc.s 10
 		IL_01d9: ldloc.1
 		IL_01da: ldstr "find"
@@ -673,13 +1505,13 @@
 		IL_020f: ldloc.0
 		IL_0210: stelem.ref
 		IL_0211: stloc.s 4
-		IL_0213: newobj instance void FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_7EDB3801_L25C30::.ctor()
+		IL_0213: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L25C29/FunctionObject_FunctionExpression_7EDB3801_L25C30::.ctor()
 		IL_0218: ldc.i4.1
 		IL_0219: conv.r8
 		IL_021a: ldstr ""
 		IL_021f: ldc.i4.0
 		IL_0220: ldc.i4.1
-		IL_0221: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_7EDB3801_L25C30>(!!0, float64, string, bool, bool)
+		IL_0221: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L25C29/FunctionObject_FunctionExpression_7EDB3801_L25C30>(!!0, float64, string, bool, bool)
 		IL_0226: stloc.s 11
 		IL_0228: ldloc.1
 		IL_0229: ldstr "findIndex"
@@ -706,13 +1538,13 @@
 		IL_0266: ldc.i4.0
 		IL_0267: ldelem.ref
 		IL_0268: castclass Modules.Float64Array_Callback_Methods/Scope
-		IL_026d: newobj instance void FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_83EEFAA3_L30C16::.ctor(class Modules.Float64Array_Callback_Methods/Scope)
+		IL_026d: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15/FunctionObject_FunctionExpression_83EEFAA3_L30C16::.ctor(class Modules.Float64Array_Callback_Methods/Scope)
 		IL_0272: ldc.i4.1
 		IL_0273: conv.r8
 		IL_0274: ldstr ""
 		IL_0279: ldc.i4.0
 		IL_027a: ldc.i4.1
-		IL_027b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_83EEFAA3_L30C16>(!!0, float64, string, bool, bool)
+		IL_027b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15/FunctionObject_FunctionExpression_83EEFAA3_L30C16>(!!0, float64, string, bool, bool)
 		IL_0280: stloc.s 12
 		IL_0282: ldloc.1
 		IL_0283: ldstr "forEach"
@@ -742,13 +1574,13 @@
 		IL_02cf: ldloc.0
 		IL_02d0: stelem.ref
 		IL_02d1: stloc.s 4
-		IL_02d3: newobj instance void FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_FC8E004A_L35C27::.ctor()
+		IL_02d3: newobj instance void Modules.Float64Array_Callback_Methods/FunctionExpression_L35C26/FunctionObject_FunctionExpression_FC8E004A_L35C27::.ctor()
 		IL_02d8: ldc.i4.2
 		IL_02d9: conv.r8
 		IL_02da: ldstr ""
 		IL_02df: ldc.i4.0
 		IL_02e0: ldc.i4.1
-		IL_02e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_FC8E004A_L35C27>(!!0, float64, string, bool, bool)
+		IL_02e1: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Float64Array_Callback_Methods/FunctionExpression_L35C26/FunctionObject_FunctionExpression_FC8E004A_L35C27>(!!0, float64, string, bool, bool)
 		IL_02e6: stloc.s 13
 		IL_02e8: ldloc.1
 		IL_02e9: ldstr "reduce"
@@ -766,838 +1598,6 @@
 	} // end of method Float64Array_Callback_Methods::__js_module_init__
 
 } // end of class Modules.Float64Array_Callback_Methods
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_802B628E_L5C24
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x248b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_802B628E_L5C24::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2493
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_802B628E_L5C24::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2496
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_802B628E_L5C24::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2499
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L5C23::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_802B628E_L5C24::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24b3
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L5C23::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_802B628E_L5C24::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24c9
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_802B628E_L5C24::ConstructCore
-
-} // end of class FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_802B628E_L5C24
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_1281CCCF_L9C27
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x24d8
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_1281CCCF_L9C27::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24e0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1281CCCF_L9C27::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24e3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1281CCCF_L9C27::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24e6
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L9C26::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_1281CCCF_L9C27::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24f9
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L9C26::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1281CCCF_L9C27::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2508
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1281CCCF_L9C27::ConstructCore
-
-} // end of class FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_1281CCCF_L9C27
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_1DD803E1_L13C26
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2517
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_1DD803E1_L13C26::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x251f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1DD803E1_L13C26::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2522
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_1DD803E1_L13C26::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2525
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L13C25::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_1DD803E1_L13C26::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2538
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L13C25::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1DD803E1_L13C26::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2547
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_1DD803E1_L13C26::ConstructCore
-
-} // end of class FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_1DD803E1_L13C26
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_AF6B9F7C_L17C25
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2556
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_AF6B9F7C_L17C25::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x255e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_AF6B9F7C_L17C25::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2561
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_AF6B9F7C_L17C25::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2564
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L17C24::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_AF6B9F7C_L17C25::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2577
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L17C24::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_AF6B9F7C_L17C25::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2586
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_AF6B9F7C_L17C25::ConstructCore
-
-} // end of class FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_AF6B9F7C_L17C25
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_091FFC5B_L21C25
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2595
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_091FFC5B_L21C25::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x259d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_091FFC5B_L21C25::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x25a0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_091FFC5B_L21C25::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x25a3
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L21C24::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_091FFC5B_L21C25::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25b6
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L21C24::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_091FFC5B_L21C25::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25c5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_091FFC5B_L21C25::ConstructCore
-
-} // end of class FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_091FFC5B_L21C25
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_7EDB3801_L25C30
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x25d4
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_7EDB3801_L25C30::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x25dc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7EDB3801_L25C30::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x25df
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_7EDB3801_L25C30::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x25e2
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L25C29::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_7EDB3801_L25C30::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25f5
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L25C29::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7EDB3801_L25C30::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2604
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_7EDB3801_L25C30::ConstructCore
-
-} // end of class FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_7EDB3801_L25C30
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_83EEFAA3_L30C16
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Float64Array_Callback_Methods/Scope _environment0_Float64Array_Callback_Methods
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Float64Array_Callback_Methods/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2613
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Float64Array_Callback_Methods/Scope FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_83EEFAA3_L30C16::_environment0_Float64Array_Callback_Methods
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_83EEFAA3_L30C16::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2622
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_83EEFAA3_L30C16::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2625
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_83EEFAA3_L30C16::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2628
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Float64Array_Callback_Methods/Scope FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_83EEFAA3_L30C16::_environment0_Float64Array_Callback_Methods
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15::__js_call__(class Modules.Float64Array_Callback_Methods/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionExpression_83EEFAA3_L30C16::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2641
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Float64Array_Callback_Methods/Scope FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_83EEFAA3_L30C16::_environment0_Float64Array_Callback_Methods
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L30C15::__js_call__(class Modules.Float64Array_Callback_Methods/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionExpression_83EEFAA3_L30C16::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2656
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_83EEFAA3_L30C16::ConstructCore
-
-} // end of class FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_83EEFAA3_L30C16
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_FC8E004A_L35C27
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2665
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_FC8E004A_L35C27::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x266d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FC8E004A_L35C27::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2670
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FC8E004A_L35C27::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2673
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L35C26::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_FC8E004A_L35C27::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x268d
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.Float64Array_Callback_Methods/FunctionExpression_L35C26::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_FC8E004A_L35C27::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26a3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_FC8E004A_L35C27::ConstructCore
-
-} // end of class FunctionObjects.Float64Array_Callback_Methods_B4A0FFE7.FunctionObject_FunctionExpression_FC8E004A_L35C27
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive.verified.txt
@@ -367,6 +367,291 @@
 
 		} // end of class Scope_For_L50C7
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_CF24C66C_BitArray
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b6b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray/FunctionObject_ClassConstructor_CF24C66C_BitArray::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_CF24C66C_BitArray::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2b7a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_CF24C66C_BitArray::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2b7d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_CF24C66C_BitArray::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b80
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_CF24C66C_BitArray::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b8c
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_CF24C66C_BitArray::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_CF24C66C_BitArray
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2b98
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2ba0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2ba3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ba6
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0012: call instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitTrue(float64)
+				IL_0017: ret
+			} // end of method FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue::CallCore
+
+		} // end of class FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2bbf
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2bc7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2bca
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bcd
+				// Header size: 1
+				// Code size: 33 (0x21)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: ldarg.2
+				IL_0015: ldc.i4.2
+				IL_0016: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001b: call instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue(object, object, object)
+				IL_0020: ret
+			} // end of method FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue::CallCore
+
+		} // end of class FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2bef
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2bf7
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2bfa
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2bfd
+				// Header size: 1
+				// Code size: 33 (0x21)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: ldarg.2
+				IL_0015: ldc.i4.2
+				IL_0016: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001b: call instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue_Naive(object, object, object)
+				IL_0020: ret
+			} // end of method FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive::CallCore
+
+		} // end of class FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive
+
 
 		// Fields
 		.field private object[] _scopes
@@ -1593,291 +1878,6 @@
 	} // end of method Prime_SetBitsTrue_LargeStep_OptimizedVsNaive::__js_module_init__
 
 } // end of class Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive_97EFC1BD.FunctionObject_ClassConstructor_CF24C66C_BitArray
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b6b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive_97EFC1BD.FunctionObject_ClassConstructor_CF24C66C_BitArray::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_CF24C66C_BitArray::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2b7a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_CF24C66C_BitArray::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2b7d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_CF24C66C_BitArray::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b80
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_CF24C66C_BitArray::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b8c
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_CF24C66C_BitArray::ConstructCore
-
-} // end of class FunctionObjects.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive_97EFC1BD.FunctionObject_ClassConstructor_CF24C66C_BitArray
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive_97EFC1BD.FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2b98
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2ba0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2ba3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ba6
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0012: call instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitTrue(float64)
-		IL_0017: ret
-	} // end of method FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue::CallCore
-
-} // end of class FunctionObjects.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive_97EFC1BD.FunctionObject_ClassMethod_BF99AAC4_BitArray_setBitTrue
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive_97EFC1BD.FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2bbf
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2bc7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2bca
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bcd
-		// Header size: 1
-		// Code size: 33 (0x21)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: ldarg.2
-		IL_0015: ldc.i4.2
-		IL_0016: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001b: call instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue(object, object, object)
-		IL_0020: ret
-	} // end of method FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue::CallCore
-
-} // end of class FunctionObjects.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive_97EFC1BD.FunctionObject_ClassMethod_3695BF95_BitArray_setBitsTrue
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive_97EFC1BD.FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2bef
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2bf7
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2bfa
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2bfd
-		// Header size: 1
-		// Code size: 33 (0x21)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: ldarg.2
-		IL_0015: ldc.i4.2
-		IL_0016: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001b: call instance object Modules.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive/BitArray::setBitsTrue_Naive(object, object, object)
-		IL_0020: ret
-	} // end of method FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive::CallCore
-
-} // end of class FunctionObjects.Prime_SetBitsTrue_LargeStep_OptimizedVsNaive_97EFC1BD.FunctionObject_ClassMethod_7675C207_BitArray_setBitsTrue_Naive
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_SmallStep_WordValueOrAssign.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.Prime_SetBitsTrue_SmallStep_WordValueOrAssign.verified.txt
@@ -195,6 +195,285 @@
 
 		} // end of class Scope_testBitTrue
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_4DDDF0E6_BitArray
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a0d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray/FunctionObject_ClassConstructor_4DDDF0E6_BitArray::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_4DDDF0E6_BitArray::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2a1c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_4DDDF0E6_BitArray::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2a1f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_4DDDF0E6_BitArray::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a22
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_4DDDF0E6_BitArray::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a2e
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_4DDDF0E6_BitArray::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_4DDDF0E6_BitArray
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2a3a
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2a42
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2a45
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a48
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance object Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::setBitTrue(object)
+				IL_0012: ret
+			} // end of method FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue::CallCore
+
+		} // end of class FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2a5c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2a64
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2a67
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a6a
+				// Header size: 1
+				// Code size: 33 (0x21)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: ldarg.2
+				IL_0015: ldc.i4.2
+				IL_0016: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001b: call instance object Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::setBitsTrue(object, object, object)
+				IL_0020: ret
+			} // end of method FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue::CallCore
+
+		} // end of class FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2a8c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2a94
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2a97
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a9a
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
+				IL_0006: ldarg.2
+				IL_0007: ldc.i4.0
+				IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000d: call instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
+				IL_0012: box [System.Runtime]System.Double
+				IL_0017: ret
+			} // end of method FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue::CallCore
+
+		} // end of class FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue
+
 
 		// Fields
 		.field private object[] _scopes
@@ -1216,285 +1495,6 @@
 	} // end of method Prime_SetBitsTrue_SmallStep_WordValueOrAssign::__js_module_init__
 
 } // end of class Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Prime_SetBitsTrue_SmallStep_WordValueOrAssign_DF1A5687.FunctionObject_ClassConstructor_4DDDF0E6_BitArray
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a0d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Prime_SetBitsTrue_SmallStep_WordValueOrAssign_DF1A5687.FunctionObject_ClassConstructor_4DDDF0E6_BitArray::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_4DDDF0E6_BitArray::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a1c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_4DDDF0E6_BitArray::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a1f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_4DDDF0E6_BitArray::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a22
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_4DDDF0E6_BitArray::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a2e
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_4DDDF0E6_BitArray::ConstructCore
-
-} // end of class FunctionObjects.Prime_SetBitsTrue_SmallStep_WordValueOrAssign_DF1A5687.FunctionObject_ClassConstructor_4DDDF0E6_BitArray
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Prime_SetBitsTrue_SmallStep_WordValueOrAssign_DF1A5687.FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2a3a
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a42
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a45
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a48
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance object Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::setBitTrue(object)
-		IL_0012: ret
-	} // end of method FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue::CallCore
-
-} // end of class FunctionObjects.Prime_SetBitsTrue_SmallStep_WordValueOrAssign_DF1A5687.FunctionObject_ClassMethod_D6CC051A_BitArray_setBitTrue
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Prime_SetBitsTrue_SmallStep_WordValueOrAssign_DF1A5687.FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2a5c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a64
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a67
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a6a
-		// Header size: 1
-		// Code size: 33 (0x21)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: ldarg.2
-		IL_0015: ldc.i4.2
-		IL_0016: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001b: call instance object Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::setBitsTrue(object, object, object)
-		IL_0020: ret
-	} // end of method FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue::CallCore
-
-} // end of class FunctionObjects.Prime_SetBitsTrue_SmallStep_WordValueOrAssign_DF1A5687.FunctionObject_ClassMethod_B1538923_BitArray_setBitsTrue
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Prime_SetBitsTrue_SmallStep_WordValueOrAssign_DF1A5687.FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2a8c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a94
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a97
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a9a
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray
-		IL_0006: ldarg.2
-		IL_0007: ldc.i4.0
-		IL_0008: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000d: call instance float64 Modules.Prime_SetBitsTrue_SmallStep_WordValueOrAssign/BitArray::testBitTrue(object)
-		IL_0012: box [System.Runtime]System.Double
-		IL_0017: ret
-	} // end of method FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue::CallCore
-
-} // end of class FunctionObjects.Prime_SetBitsTrue_SmallStep_WordValueOrAssign_DF1A5687.FunctionObject_ClassMethod_BCC24DF0_BitArray_testBitTrue
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_SignedAndClamped_ConversionSemantics.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_SignedAndClamped_ConversionSemantics.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_0242BF45_L17C10
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope _environment0_TypedArray_SignedAndClamped_ConversionSemantics
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2537
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject_FunctionExpression_0242BF45_L17C10::_environment0_TypedArray_SignedAndClamped_ConversionSemantics
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_0242BF45_L17C10::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2546
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_0242BF45_L17C10::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2549
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_0242BF45_L17C10::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x254c
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject_FunctionExpression_0242BF45_L17C10::_environment0_TypedArray_SignedAndClamped_ConversionSemantics
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue::__js_call__(class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionExpression_0242BF45_L17C10::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x255e
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue/FunctionObject_FunctionExpression_0242BF45_L17C10::_environment0_TypedArray_SignedAndClamped_ConversionSemantics
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue::__js_call__(class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionExpression_0242BF45_L17C10::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x256c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_0242BF45_L17C10::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_0242BF45_L17C10
+
 
 		// Methods
 		.method public hidebysig static 
@@ -489,113 +596,6 @@
 	} // end of method TypedArray_SignedAndClamped_ConversionSemantics::__js_module_init__
 
 } // end of class Modules.TypedArray_SignedAndClamped_ConversionSemantics
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TypedArray_SignedAndClamped_ConversionSemantics_05315922.FunctionObject_FunctionExpression_0242BF45_L17C10
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope _environment0_TypedArray_SignedAndClamped_ConversionSemantics
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2537
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope FunctionObjects.TypedArray_SignedAndClamped_ConversionSemantics_05315922.FunctionObject_FunctionExpression_0242BF45_L17C10::_environment0_TypedArray_SignedAndClamped_ConversionSemantics
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_0242BF45_L17C10::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2546
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_0242BF45_L17C10::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2549
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_0242BF45_L17C10::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x254c
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope FunctionObjects.TypedArray_SignedAndClamped_ConversionSemantics_05315922.FunctionObject_FunctionExpression_0242BF45_L17C10::_environment0_TypedArray_SignedAndClamped_ConversionSemantics
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue::__js_call__(class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_0242BF45_L17C10::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x255e
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope FunctionObjects.TypedArray_SignedAndClamped_ConversionSemantics_05315922.FunctionObject_FunctionExpression_0242BF45_L17C10::_environment0_TypedArray_SignedAndClamped_ConversionSemantics
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.TypedArray_SignedAndClamped_ConversionSemantics/FunctionExpression_dynamicValue::__js_call__(class Modules.TypedArray_SignedAndClamped_ConversionSemantics/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_0242BF45_L17C10::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x256c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_0242BF45_L17C10::ConstructCore
-
-} // end of class FunctionObjects.TypedArray_SignedAndClamped_ConversionSemantics_05315922.FunctionObject_FunctionExpression_0242BF45_L17C10
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_Static_From_Of.verified.txt
+++ b/tests/Jroc.Tests/TypedArray/Snapshots/GeneratorTests.TypedArray_Static_From_Of.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_467B3866_L3C50
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2319
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_467B3866_L3C50::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2321
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_467B3866_L3C50::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2324
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_467B3866_L3C50::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2327
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: ldarg.2
+				IL_000d: ldc.i4.1
+				IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0013: call object Modules.TypedArray_Static_From_Of/FunctionExpression_mapped::__js_call__(object, object, object)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionExpression_467B3866_L3C50::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2341
+				// Header size: 1
+				// Code size: 21 (0x15)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: ldarg.2
+				IL_0009: ldc.i4.1
+				IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000f: call object Modules.TypedArray_Static_From_Of/FunctionExpression_mapped::__js_call__(object, object, object)
+				IL_0014: ret
+			} // end of method FunctionObject_FunctionExpression_467B3866_L3C50::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2357
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_467B3866_L3C50::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_467B3866_L3C50
+
 
 		// Methods
 		.method public hidebysig static 
@@ -94,6 +201,107 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_9A551ACB_L14C55
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2366
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionExpression_9A551ACB_L14C55::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x236e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_9A551ACB_L14C55::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2371
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionExpression_9A551ACB_L14C55::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2374
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.TypedArray_Static_From_Of/FunctionExpression_floats::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionExpression_9A551ACB_L14C55::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2387
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.TypedArray_Static_From_Of/FunctionExpression_floats::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_9A551ACB_L14C55::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2396
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionExpression_9A551ACB_L14C55::ConstructCore
+
+		} // end of class FunctionObject_FunctionExpression_9A551ACB_L14C55
 
 
 		// Methods
@@ -164,13 +372,13 @@
 			[4] class [JavaScriptRuntime]JavaScriptRuntime.Float64Array,
 			[5] class [JavaScriptRuntime]JavaScriptRuntime.Array,
 			[6] object[],
-			[7] class FunctionObjects.TypedArray_Static_From_Of_9F23F53C.FunctionObject_FunctionExpression_467B3866_L3C50,
+			[7] class Modules.TypedArray_Static_From_Of/FunctionExpression_mapped/FunctionObject_FunctionExpression_467B3866_L3C50,
 			[8] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[9] object,
 			[10] class [JavaScriptRuntime]JavaScriptRuntime.Int32Array,
 			[11] object,
 			[12] class [JavaScriptRuntime]JavaScriptRuntime.Uint8Array,
-			[13] class FunctionObjects.TypedArray_Static_From_Of_9F23F53C.FunctionObject_FunctionExpression_9A551ACB_L14C55,
+			[13] class Modules.TypedArray_Static_From_Of/FunctionExpression_floats/FunctionObject_FunctionExpression_9A551ACB_L14C55,
 			[14] class [JavaScriptRuntime]JavaScriptRuntime.Float64Array
 		)
 
@@ -197,13 +405,13 @@
 		IL_0045: ldloc.0
 		IL_0046: stelem.ref
 		IL_0047: stloc.s 6
-		IL_0049: newobj instance void FunctionObjects.TypedArray_Static_From_Of_9F23F53C.FunctionObject_FunctionExpression_467B3866_L3C50::.ctor()
+		IL_0049: newobj instance void Modules.TypedArray_Static_From_Of/FunctionExpression_mapped/FunctionObject_FunctionExpression_467B3866_L3C50::.ctor()
 		IL_004e: ldc.i4.2
 		IL_004f: conv.r8
 		IL_0050: ldstr ""
 		IL_0055: ldc.i4.1
 		IL_0056: ldc.i4.1
-		IL_0057: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TypedArray_Static_From_Of_9F23F53C.FunctionObject_FunctionExpression_467B3866_L3C50>(!!0, float64, string, bool, bool)
+		IL_0057: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_Static_From_Of/FunctionExpression_mapped/FunctionObject_FunctionExpression_467B3866_L3C50>(!!0, float64, string, bool, bool)
 		IL_005c: stloc.s 7
 		IL_005e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
 		IL_0063: dup
@@ -323,13 +531,13 @@
 		IL_01f4: ldloc.0
 		IL_01f5: stelem.ref
 		IL_01f6: stloc.s 6
-		IL_01f8: newobj instance void FunctionObjects.TypedArray_Static_From_Of_9F23F53C.FunctionObject_FunctionExpression_9A551ACB_L14C55::.ctor()
+		IL_01f8: newobj instance void Modules.TypedArray_Static_From_Of/FunctionExpression_floats/FunctionObject_FunctionExpression_9A551ACB_L14C55::.ctor()
 		IL_01fd: ldc.i4.1
 		IL_01fe: conv.r8
 		IL_01ff: ldstr ""
 		IL_0204: ldc.i4.0
 		IL_0205: ldc.i4.1
-		IL_0206: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.TypedArray_Static_From_Of_9F23F53C.FunctionObject_FunctionExpression_9A551ACB_L14C55>(!!0, float64, string, bool, bool)
+		IL_0206: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.TypedArray_Static_From_Of/FunctionExpression_floats/FunctionObject_FunctionExpression_9A551ACB_L14C55>(!!0, float64, string, bool, bool)
 		IL_020b: stloc.s 13
 		IL_020d: ldloc.s 12
 		IL_020f: ldloc.s 13
@@ -356,214 +564,6 @@
 	} // end of method TypedArray_Static_From_Of::__js_module_init__
 
 } // end of class Modules.TypedArray_Static_From_Of
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TypedArray_Static_From_Of_9F23F53C.FunctionObject_FunctionExpression_467B3866_L3C50
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2319
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_467B3866_L3C50::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2321
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_467B3866_L3C50::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2324
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_467B3866_L3C50::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2327
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: ldarg.2
-		IL_000d: ldc.i4.1
-		IL_000e: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0013: call object Modules.TypedArray_Static_From_Of/FunctionExpression_mapped::__js_call__(object, object, object)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionExpression_467B3866_L3C50::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2341
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: ldarg.2
-		IL_0009: ldc.i4.1
-		IL_000a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000f: call object Modules.TypedArray_Static_From_Of/FunctionExpression_mapped::__js_call__(object, object, object)
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_467B3866_L3C50::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2357
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_467B3866_L3C50::ConstructCore
-
-} // end of class FunctionObjects.TypedArray_Static_From_Of_9F23F53C.FunctionObject_FunctionExpression_467B3866_L3C50
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.TypedArray_Static_From_Of_9F23F53C.FunctionObject_FunctionExpression_9A551ACB_L14C55
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2366
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_9A551ACB_L14C55::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x236e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9A551ACB_L14C55::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2371
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_9A551ACB_L14C55::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2374
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.TypedArray_Static_From_Of/FunctionExpression_floats::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionExpression_9A551ACB_L14C55::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2387
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.TypedArray_Static_From_Of/FunctionExpression_floats::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_9A551ACB_L14C55::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2396
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_9A551ACB_L14C55::ConstructCore
-
-} // end of class FunctionObjects.TypedArray_Static_From_Of_9F23F53C.FunctionObject_FunctionExpression_9A551ACB_L14C55
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_DoubleNot_NaNTruthiness.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_DoubleNot_NaNTruthiness.verified.txt
@@ -91,6 +91,211 @@
 
 		} // end of class Scope_ctor
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_8999139A_C
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2188
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.UnaryOperator_DoubleNot_NaNTruthiness/C/FunctionObject_ClassConstructor_8999139A_C::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_8999139A_C::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2197
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_8999139A_C::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x219a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_8999139A_C::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x219d
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_8999139A_C::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21a9
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_8999139A_C::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_8999139A_C
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_1A72E20C_C_returnNaN
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21b5
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_1A72E20C_C_returnNaN::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21bd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_1A72E20C_C_returnNaN::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21c0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_1A72E20C_C_returnNaN::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21c3
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.UnaryOperator_DoubleNot_NaNTruthiness/C
+				IL_0006: call instance float64 Modules.UnaryOperator_DoubleNot_NaNTruthiness/C::returnNaN()
+				IL_000b: box [System.Runtime]System.Double
+				IL_0010: ret
+			} // end of method FunctionObject_ClassMethod_1A72E20C_C_returnNaN::CallCore
+
+		} // end of class FunctionObject_ClassMethod_1A72E20C_C_returnNaN
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_F42D957A_C_returnNumber
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21d5
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_F42D957A_C_returnNumber::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21dd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_F42D957A_C_returnNumber::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21e0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_F42D957A_C_returnNumber::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21e3
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.UnaryOperator_DoubleNot_NaNTruthiness/C
+				IL_0006: call instance float64 Modules.UnaryOperator_DoubleNot_NaNTruthiness/C::returnNumber()
+				IL_000b: box [System.Runtime]System.Double
+				IL_0010: ret
+			} // end of method FunctionObject_ClassMethod_F42D957A_C_returnNumber::CallCore
+
+		} // end of class FunctionObject_ClassMethod_F42D957A_C_returnNumber
+
 
 		// Methods
 		.method public hidebysig specialname rtspecialname 
@@ -268,211 +473,6 @@
 	} // end of method UnaryOperator_DoubleNot_NaNTruthiness::__js_module_init__
 
 } // end of class Modules.UnaryOperator_DoubleNot_NaNTruthiness
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_DoubleNot_NaNTruthiness_A2020A58.FunctionObject_ClassConstructor_8999139A_C
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2188
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.UnaryOperator_DoubleNot_NaNTruthiness_A2020A58.FunctionObject_ClassConstructor_8999139A_C::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_8999139A_C::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2197
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_8999139A_C::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x219a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_8999139A_C::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x219d
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_8999139A_C::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21a9
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_8999139A_C::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_DoubleNot_NaNTruthiness_A2020A58.FunctionObject_ClassConstructor_8999139A_C
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_DoubleNot_NaNTruthiness_A2020A58.FunctionObject_ClassMethod_1A72E20C_C_returnNaN
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21b5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_1A72E20C_C_returnNaN::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21bd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_1A72E20C_C_returnNaN::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21c0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_1A72E20C_C_returnNaN::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21c3
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.UnaryOperator_DoubleNot_NaNTruthiness/C
-		IL_0006: call instance float64 Modules.UnaryOperator_DoubleNot_NaNTruthiness/C::returnNaN()
-		IL_000b: box [System.Runtime]System.Double
-		IL_0010: ret
-	} // end of method FunctionObject_ClassMethod_1A72E20C_C_returnNaN::CallCore
-
-} // end of class FunctionObjects.UnaryOperator_DoubleNot_NaNTruthiness_A2020A58.FunctionObject_ClassMethod_1A72E20C_C_returnNaN
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_DoubleNot_NaNTruthiness_A2020A58.FunctionObject_ClassMethod_F42D957A_C_returnNumber
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21d5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_F42D957A_C_returnNumber::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21dd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_F42D957A_C_returnNumber::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21e0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_F42D957A_C_returnNumber::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21e3
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.UnaryOperator_DoubleNot_NaNTruthiness/C
-		IL_0006: call instance float64 Modules.UnaryOperator_DoubleNot_NaNTruthiness/C::returnNumber()
-		IL_000b: box [System.Runtime]System.Double
-		IL_0010: ret
-	} // end of method FunctionObject_ClassMethod_F42D957A_C_returnNumber::CallCore
-
-} // end of class FunctionObjects.UnaryOperator_DoubleNot_NaNTruthiness_A2020A58.FunctionObject_ClassMethod_F42D957A_C_returnNumber
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix.verified.txt
@@ -31,6 +31,127 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_4F8A7BA1_logCase
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2506
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_4F8A7BA1_logCase::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x250e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4F8A7BA1_logCase::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2511
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_4F8A7BA1_logCase::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2514
+				// Header size: 1
+				// Code size: 44 (0x2c)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: ldarg.2
+				IL_0019: ldc.i4.2
+				IL_001a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001f: ldarg.2
+				IL_0020: ldc.i4.3
+				IL_0021: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0026: call object Modules.UnaryOperator_MinusMinusPostfix/logCase::__js_call__(object, string, object, object, object)
+				IL_002b: ret
+			} // end of method FunctionObject_FunctionDeclaration_4F8A7BA1_logCase::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2541
+				// Header size: 1
+				// Code size: 40 (0x28)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: ldarg.2
+				IL_0015: ldc.i4.2
+				IL_0016: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001b: ldarg.2
+				IL_001c: ldc.i4.3
+				IL_001d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0022: call object Modules.UnaryOperator_MinusMinusPostfix/logCase::__js_call__(object, string, object, object, object)
+				IL_0027: ret
+			} // end of method FunctionObject_FunctionDeclaration_4F8A7BA1_logCase::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x256a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_4F8A7BA1_logCase::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_4F8A7BA1_logCase
+
 
 		// Methods
 		.method public hidebysig static 
@@ -103,6 +224,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.UnaryOperator_MinusMinusPostfix/Scope _environment0_UnaryOperator_MinusMinusPostfix
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.UnaryOperator_MinusMinusPostfix/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2579
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/capturedDouble/FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::_environment0_UnaryOperator_MinusMinusPostfix
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2588
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x258b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x258e
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/capturedDouble/FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::_environment0_UnaryOperator_MinusMinusPostfix
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.UnaryOperator_MinusMinusPostfix/capturedDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25a0
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/capturedDouble/FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::_environment0_UnaryOperator_MinusMinusPostfix
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.UnaryOperator_MinusMinusPostfix/capturedDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25ae
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble
 
 
 		// Methods
@@ -224,6 +452,121 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_58646066_argDouble
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.UnaryOperator_MinusMinusPostfix/Scope _environment0_UnaryOperator_MinusMinusPostfix
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.UnaryOperator_MinusMinusPostfix/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x25bd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/argDouble/FunctionObject_FunctionDeclaration_58646066_argDouble::_environment0_UnaryOperator_MinusMinusPostfix
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_58646066_argDouble::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x25cc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_58646066_argDouble::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x25cf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_58646066_argDouble::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x25d2
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/argDouble/FunctionObject_FunctionDeclaration_58646066_argDouble::_environment0_UnaryOperator_MinusMinusPostfix
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: call object Modules.UnaryOperator_MinusMinusPostfix/argDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object, float64)
+				IL_001c: ret
+			} // end of method FunctionObject_FunctionDeclaration_58646066_argDouble::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25f0
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/argDouble/FunctionObject_FunctionDeclaration_58646066_argDouble::_environment0_UnaryOperator_MinusMinusPostfix
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0013: call object Modules.UnaryOperator_MinusMinusPostfix/argDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object, float64)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_58646066_argDouble::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x260a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_58646066_argDouble::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_58646066_argDouble
+
 
 		// Methods
 		.method public hidebysig static 
@@ -327,6 +670,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8932E6C6_capturedString
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.UnaryOperator_MinusMinusPostfix/Scope _environment0_UnaryOperator_MinusMinusPostfix
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.UnaryOperator_MinusMinusPostfix/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2619
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/capturedString/FunctionObject_FunctionDeclaration_8932E6C6_capturedString::_environment0_UnaryOperator_MinusMinusPostfix
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8932E6C6_capturedString::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2628
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8932E6C6_capturedString::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x262b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8932E6C6_capturedString::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x262e
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/capturedString/FunctionObject_FunctionDeclaration_8932E6C6_capturedString::_environment0_UnaryOperator_MinusMinusPostfix
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.UnaryOperator_MinusMinusPostfix/capturedString::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_8932E6C6_capturedString::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2640
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/capturedString/FunctionObject_FunctionDeclaration_8932E6C6_capturedString::_environment0_UnaryOperator_MinusMinusPostfix
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.UnaryOperator_MinusMinusPostfix/capturedString::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_8932E6C6_capturedString::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x264e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8932E6C6_capturedString::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_8932E6C6_capturedString
 
 
 		// Methods
@@ -443,6 +893,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_1EBCC0DE_argString
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.UnaryOperator_MinusMinusPostfix/Scope _environment0_UnaryOperator_MinusMinusPostfix
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.UnaryOperator_MinusMinusPostfix/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x265d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/argString/FunctionObject_FunctionDeclaration_1EBCC0DE_argString::_environment0_UnaryOperator_MinusMinusPostfix
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_1EBCC0DE_argString::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x266c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1EBCC0DE_argString::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x266f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_1EBCC0DE_argString::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2672
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/argString/FunctionObject_FunctionDeclaration_1EBCC0DE_argString::_environment0_UnaryOperator_MinusMinusPostfix
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.UnaryOperator_MinusMinusPostfix/argString::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_1EBCC0DE_argString::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x268b
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope Modules.UnaryOperator_MinusMinusPostfix/argString/FunctionObject_FunctionDeclaration_1EBCC0DE_argString::_environment0_UnaryOperator_MinusMinusPostfix
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.UnaryOperator_MinusMinusPostfix/argString::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_1EBCC0DE_argString::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26a0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_1EBCC0DE_argString::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_1EBCC0DE_argString
 
 
 		// Methods
@@ -596,17 +1159,17 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_MinusMinusPostfix/Scope,
-			[1] class FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble,
-			[2] class FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_58646066_argDouble,
-			[3] class FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_8932E6C6_capturedString,
-			[4] class FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_1EBCC0DE_argString,
+			[1] class Modules.UnaryOperator_MinusMinusPostfix/capturedDouble/FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble,
+			[2] class Modules.UnaryOperator_MinusMinusPostfix/argDouble/FunctionObject_FunctionDeclaration_58646066_argDouble,
+			[3] class Modules.UnaryOperator_MinusMinusPostfix/capturedString/FunctionObject_FunctionDeclaration_8932E6C6_capturedString,
+			[4] class Modules.UnaryOperator_MinusMinusPostfix/argString/FunctionObject_FunctionDeclaration_1EBCC0DE_argString,
 			[5] float64,
 			[6] object,
 			[7] object,
 			[8] object,
 			[9] string,
 			[10] object[],
-			[11] class FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_4F8A7BA1_logCase,
+			[11] class Modules.UnaryOperator_MinusMinusPostfix/logCase/FunctionObject_FunctionDeclaration_4F8A7BA1_logCase,
 			[12] object,
 			[13] object,
 			[14] string,
@@ -623,13 +1186,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 10
-		IL_0012: newobj instance void FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_4F8A7BA1_logCase::.ctor()
+		IL_0012: newobj instance void Modules.UnaryOperator_MinusMinusPostfix/logCase/FunctionObject_FunctionDeclaration_4F8A7BA1_logCase::.ctor()
 		IL_0017: ldc.i4.4
 		IL_0018: conv.r8
 		IL_0019: ldstr "logCase"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_4F8A7BA1_logCase>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPostfix/logCase/FunctionObject_FunctionDeclaration_4F8A7BA1_logCase>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.s 11
 		IL_0027: ldloc.0
 		IL_0028: ldloc.s 11
@@ -645,13 +1208,13 @@
 		IL_003d: ldc.i4.0
 		IL_003e: ldelem.ref
 		IL_003f: castclass Modules.UnaryOperator_MinusMinusPostfix/Scope
-		IL_0044: newobj instance void FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::.ctor(class Modules.UnaryOperator_MinusMinusPostfix/Scope)
+		IL_0044: newobj instance void Modules.UnaryOperator_MinusMinusPostfix/capturedDouble/FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::.ctor(class Modules.UnaryOperator_MinusMinusPostfix/Scope)
 		IL_0049: ldc.i4.0
 		IL_004a: conv.r8
 		IL_004b: ldstr "capturedDouble"
 		IL_0050: ldc.i4.0
 		IL_0051: ldc.i4.1
-		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble>(!!0, float64, string, bool, bool)
+		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPostfix/capturedDouble/FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble>(!!0, float64, string, bool, bool)
 		IL_0057: stloc.1
 		IL_0058: ldc.i4.1
 		IL_0059: newarr [System.Runtime]System.Object
@@ -664,13 +1227,13 @@
 		IL_0066: ldc.i4.0
 		IL_0067: ldelem.ref
 		IL_0068: castclass Modules.UnaryOperator_MinusMinusPostfix/Scope
-		IL_006d: newobj instance void FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_58646066_argDouble::.ctor(class Modules.UnaryOperator_MinusMinusPostfix/Scope)
+		IL_006d: newobj instance void Modules.UnaryOperator_MinusMinusPostfix/argDouble/FunctionObject_FunctionDeclaration_58646066_argDouble::.ctor(class Modules.UnaryOperator_MinusMinusPostfix/Scope)
 		IL_0072: ldc.i4.1
 		IL_0073: conv.r8
 		IL_0074: ldstr "argDouble"
 		IL_0079: ldc.i4.0
 		IL_007a: ldc.i4.1
-		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_58646066_argDouble>(!!0, float64, string, bool, bool)
+		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPostfix/argDouble/FunctionObject_FunctionDeclaration_58646066_argDouble>(!!0, float64, string, bool, bool)
 		IL_0080: stloc.2
 		IL_0081: ldc.i4.1
 		IL_0082: newarr [System.Runtime]System.Object
@@ -683,13 +1246,13 @@
 		IL_008f: ldc.i4.0
 		IL_0090: ldelem.ref
 		IL_0091: castclass Modules.UnaryOperator_MinusMinusPostfix/Scope
-		IL_0096: newobj instance void FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_8932E6C6_capturedString::.ctor(class Modules.UnaryOperator_MinusMinusPostfix/Scope)
+		IL_0096: newobj instance void Modules.UnaryOperator_MinusMinusPostfix/capturedString/FunctionObject_FunctionDeclaration_8932E6C6_capturedString::.ctor(class Modules.UnaryOperator_MinusMinusPostfix/Scope)
 		IL_009b: ldc.i4.0
 		IL_009c: conv.r8
 		IL_009d: ldstr "capturedString"
 		IL_00a2: ldc.i4.0
 		IL_00a3: ldc.i4.1
-		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_8932E6C6_capturedString>(!!0, float64, string, bool, bool)
+		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPostfix/capturedString/FunctionObject_FunctionDeclaration_8932E6C6_capturedString>(!!0, float64, string, bool, bool)
 		IL_00a9: stloc.3
 		IL_00aa: ldc.i4.1
 		IL_00ab: newarr [System.Runtime]System.Object
@@ -702,13 +1265,13 @@
 		IL_00b8: ldc.i4.0
 		IL_00b9: ldelem.ref
 		IL_00ba: castclass Modules.UnaryOperator_MinusMinusPostfix/Scope
-		IL_00bf: newobj instance void FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_1EBCC0DE_argString::.ctor(class Modules.UnaryOperator_MinusMinusPostfix/Scope)
+		IL_00bf: newobj instance void Modules.UnaryOperator_MinusMinusPostfix/argString/FunctionObject_FunctionDeclaration_1EBCC0DE_argString::.ctor(class Modules.UnaryOperator_MinusMinusPostfix/Scope)
 		IL_00c4: ldc.i4.1
 		IL_00c5: conv.r8
 		IL_00c6: ldstr "argString"
 		IL_00cb: ldc.i4.0
 		IL_00cc: ldc.i4.1
-		IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_1EBCC0DE_argString>(!!0, float64, string, bool, bool)
+		IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPostfix/argString/FunctionObject_FunctionDeclaration_1EBCC0DE_argString>(!!0, float64, string, bool, bool)
 		IL_00d2: stloc.s 4
 		IL_00d4: nop
 		IL_00d5: nop
@@ -846,569 +1409,6 @@
 	} // end of method UnaryOperator_MinusMinusPostfix::__js_module_init__
 
 } // end of class Modules.UnaryOperator_MinusMinusPostfix
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_4F8A7BA1_logCase
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2506
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_4F8A7BA1_logCase::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x250e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4F8A7BA1_logCase::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2511
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_4F8A7BA1_logCase::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2514
-		// Header size: 1
-		// Code size: 44 (0x2c)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: ldarg.2
-		IL_0019: ldc.i4.2
-		IL_001a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001f: ldarg.2
-		IL_0020: ldc.i4.3
-		IL_0021: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0026: call object Modules.UnaryOperator_MinusMinusPostfix/logCase::__js_call__(object, string, object, object, object)
-		IL_002b: ret
-	} // end of method FunctionObject_FunctionDeclaration_4F8A7BA1_logCase::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2541
-		// Header size: 1
-		// Code size: 40 (0x28)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: ldarg.2
-		IL_0015: ldc.i4.2
-		IL_0016: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001b: ldarg.2
-		IL_001c: ldc.i4.3
-		IL_001d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0022: call object Modules.UnaryOperator_MinusMinusPostfix/logCase::__js_call__(object, string, object, object, object)
-		IL_0027: ret
-	} // end of method FunctionObject_FunctionDeclaration_4F8A7BA1_logCase::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x256a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_4F8A7BA1_logCase::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_4F8A7BA1_logCase
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.UnaryOperator_MinusMinusPostfix/Scope _environment0_UnaryOperator_MinusMinusPostfix
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.UnaryOperator_MinusMinusPostfix/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2579
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.UnaryOperator_MinusMinusPostfix/Scope FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::_environment0_UnaryOperator_MinusMinusPostfix
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2588
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x258b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x258e
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::_environment0_UnaryOperator_MinusMinusPostfix
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.UnaryOperator_MinusMinusPostfix/capturedDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25a0
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::_environment0_UnaryOperator_MinusMinusPostfix
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.UnaryOperator_MinusMinusPostfix/capturedDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25ae
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_3AF89BAE_capturedDouble
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_58646066_argDouble
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.UnaryOperator_MinusMinusPostfix/Scope _environment0_UnaryOperator_MinusMinusPostfix
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.UnaryOperator_MinusMinusPostfix/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x25bd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.UnaryOperator_MinusMinusPostfix/Scope FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_58646066_argDouble::_environment0_UnaryOperator_MinusMinusPostfix
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_58646066_argDouble::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x25cc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_58646066_argDouble::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x25cf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_58646066_argDouble::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x25d2
-		// Header size: 1
-		// Code size: 29 (0x1d)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_58646066_argDouble::_environment0_UnaryOperator_MinusMinusPostfix
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0017: call object Modules.UnaryOperator_MinusMinusPostfix/argDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object, float64)
-		IL_001c: ret
-	} // end of method FunctionObject_FunctionDeclaration_58646066_argDouble::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25f0
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_58646066_argDouble::_environment0_UnaryOperator_MinusMinusPostfix
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0013: call object Modules.UnaryOperator_MinusMinusPostfix/argDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object, float64)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_58646066_argDouble::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x260a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_58646066_argDouble::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_58646066_argDouble
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_8932E6C6_capturedString
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.UnaryOperator_MinusMinusPostfix/Scope _environment0_UnaryOperator_MinusMinusPostfix
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.UnaryOperator_MinusMinusPostfix/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2619
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.UnaryOperator_MinusMinusPostfix/Scope FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_8932E6C6_capturedString::_environment0_UnaryOperator_MinusMinusPostfix
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8932E6C6_capturedString::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2628
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8932E6C6_capturedString::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x262b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8932E6C6_capturedString::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x262e
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_8932E6C6_capturedString::_environment0_UnaryOperator_MinusMinusPostfix
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.UnaryOperator_MinusMinusPostfix/capturedString::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_8932E6C6_capturedString::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2640
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_8932E6C6_capturedString::_environment0_UnaryOperator_MinusMinusPostfix
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.UnaryOperator_MinusMinusPostfix/capturedString::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_8932E6C6_capturedString::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x264e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8932E6C6_capturedString::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_8932E6C6_capturedString
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_1EBCC0DE_argString
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.UnaryOperator_MinusMinusPostfix/Scope _environment0_UnaryOperator_MinusMinusPostfix
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.UnaryOperator_MinusMinusPostfix/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x265d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.UnaryOperator_MinusMinusPostfix/Scope FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_1EBCC0DE_argString::_environment0_UnaryOperator_MinusMinusPostfix
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_1EBCC0DE_argString::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x266c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1EBCC0DE_argString::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x266f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_1EBCC0DE_argString::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2672
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_1EBCC0DE_argString::_environment0_UnaryOperator_MinusMinusPostfix
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.UnaryOperator_MinusMinusPostfix/argString::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_1EBCC0DE_argString::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x268b
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPostfix/Scope FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_1EBCC0DE_argString::_environment0_UnaryOperator_MinusMinusPostfix
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.UnaryOperator_MinusMinusPostfix/argString::__js_call__(class Modules.UnaryOperator_MinusMinusPostfix/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_1EBCC0DE_argString::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26a0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_1EBCC0DE_argString::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_MinusMinusPostfix_0E47328A.FunctionObject_FunctionDeclaration_1EBCC0DE_argString
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix_InFunctionSwitch.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix_InFunctionSwitch.verified.txt
@@ -53,6 +53,109 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BBDAFA63_bump
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21e9
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_BBDAFA63_bump::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21f1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BBDAFA63_bump::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21f4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BBDAFA63_bump::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f7
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0011: call object Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch/bump::__js_call__(object, string)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_BBDAFA63_bump::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x220f
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: call object Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch/bump::__js_call__(object, string)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_BBDAFA63_bump::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2223
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BBDAFA63_bump::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_BBDAFA63_bump
+
 
 		// Methods
 		.method public hidebysig static 
@@ -214,7 +317,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch/Scope,
-			[1] class FunctionObjects.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_43A4A068.FunctionObject_FunctionDeclaration_BBDAFA63_bump,
+			[1] class Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch/bump/FunctionObject_FunctionDeclaration_BBDAFA63_bump,
 			[2] object[]
 		)
 
@@ -227,13 +330,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_43A4A068.FunctionObject_FunctionDeclaration_BBDAFA63_bump::.ctor()
+		IL_0011: newobj instance void Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch/bump/FunctionObject_FunctionDeclaration_BBDAFA63_bump::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "bump"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_43A4A068.FunctionObject_FunctionDeclaration_BBDAFA63_bump>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch/bump/FunctionObject_FunctionDeclaration_BBDAFA63_bump>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -262,109 +365,6 @@
 	} // end of method UnaryOperator_MinusMinusPostfix_InFunctionSwitch::__js_module_init__
 
 } // end of class Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_43A4A068.FunctionObject_FunctionDeclaration_BBDAFA63_bump
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21e9
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_BBDAFA63_bump::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21f1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BBDAFA63_bump::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21f4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BBDAFA63_bump::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f7
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0011: call object Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch/bump::__js_call__(object, string)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_BBDAFA63_bump::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x220f
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_000d: call object Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch/bump::__js_call__(object, string)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_BBDAFA63_bump::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2223
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BBDAFA63_bump::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_43A4A068.FunctionObject_FunctionDeclaration_BBDAFA63_bump
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal.verified.txt
@@ -53,6 +53,109 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BBF9B0A8_bump
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21f8
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_BBF9B0A8_bump::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2200
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BBF9B0A8_bump::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2203
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BBF9B0A8_bump::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2206
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0011: call object Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_BBF9B0A8_bump::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x221e
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: call object Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_BBF9B0A8_bump::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2232
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BBF9B0A8_bump::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_BBF9B0A8_bump
+
 
 		// Methods
 		.method public hidebysig static 
@@ -231,7 +334,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal/Scope,
-			[1] class FunctionObjects.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal_E8EFFDA1.FunctionObject_FunctionDeclaration_BBF9B0A8_bump,
+			[1] class Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal/bump/FunctionObject_FunctionDeclaration_BBF9B0A8_bump,
 			[2] object[]
 		)
 
@@ -244,13 +347,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal_E8EFFDA1.FunctionObject_FunctionDeclaration_BBF9B0A8_bump::.ctor()
+		IL_0011: newobj instance void Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal/bump/FunctionObject_FunctionDeclaration_BBF9B0A8_bump::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "bump"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal_E8EFFDA1.FunctionObject_FunctionDeclaration_BBF9B0A8_bump>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal/bump/FunctionObject_FunctionDeclaration_BBF9B0A8_bump>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -279,109 +382,6 @@
 	} // end of method UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal::__js_module_init__
 
 } // end of class Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal_E8EFFDA1.FunctionObject_FunctionDeclaration_BBF9B0A8_bump
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21f8
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_BBF9B0A8_bump::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2200
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BBF9B0A8_bump::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2203
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BBF9B0A8_bump::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2206
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0011: call object Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_BBF9B0A8_bump::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x221e
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_000d: call object Modules.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_BBF9B0A8_bump::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2232
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BBF9B0A8_bump::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_MinusMinusPostfix_InFunctionSwitch_ObjectLocal_E8EFFDA1.FunctionObject_FunctionDeclaration_BBF9B0A8_bump
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix.verified.txt
@@ -31,6 +31,127 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_538EA9FA_logCase
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x24d0
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_538EA9FA_logCase::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24d8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_538EA9FA_logCase::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24db
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_538EA9FA_logCase::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24de
+				// Header size: 1
+				// Code size: 44 (0x2c)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: ldarg.2
+				IL_0019: ldc.i4.2
+				IL_001a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001f: ldarg.2
+				IL_0020: ldc.i4.3
+				IL_0021: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0026: call object Modules.UnaryOperator_MinusMinusPrefix/logCase::__js_call__(object, string, object, object, object)
+				IL_002b: ret
+			} // end of method FunctionObject_FunctionDeclaration_538EA9FA_logCase::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x250b
+				// Header size: 1
+				// Code size: 40 (0x28)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: ldarg.2
+				IL_0015: ldc.i4.2
+				IL_0016: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001b: ldarg.2
+				IL_001c: ldc.i4.3
+				IL_001d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0022: call object Modules.UnaryOperator_MinusMinusPrefix/logCase::__js_call__(object, string, object, object, object)
+				IL_0027: ret
+			} // end of method FunctionObject_FunctionDeclaration_538EA9FA_logCase::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2534
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_538EA9FA_logCase::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_538EA9FA_logCase
+
 
 		// Methods
 		.method public hidebysig static 
@@ -103,6 +224,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.UnaryOperator_MinusMinusPrefix/Scope _environment0_UnaryOperator_MinusMinusPrefix
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.UnaryOperator_MinusMinusPrefix/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2543
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/capturedDouble/FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::_environment0_UnaryOperator_MinusMinusPrefix
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2552
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2555
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2558
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/capturedDouble/FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::_environment0_UnaryOperator_MinusMinusPrefix
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.UnaryOperator_MinusMinusPrefix/capturedDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x256a
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/capturedDouble/FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::_environment0_UnaryOperator_MinusMinusPrefix
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.UnaryOperator_MinusMinusPrefix/capturedDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2578
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble
 
 
 		// Methods
@@ -217,6 +445,121 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.UnaryOperator_MinusMinusPrefix/Scope _environment0_UnaryOperator_MinusMinusPrefix
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.UnaryOperator_MinusMinusPrefix/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2587
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/argDouble/FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::_environment0_UnaryOperator_MinusMinusPrefix
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2596
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2599
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x259c
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/argDouble/FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::_environment0_UnaryOperator_MinusMinusPrefix
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: call object Modules.UnaryOperator_MinusMinusPrefix/argDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object, float64)
+				IL_001c: ret
+			} // end of method FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25ba
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/argDouble/FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::_environment0_UnaryOperator_MinusMinusPrefix
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0013: call object Modules.UnaryOperator_MinusMinusPrefix/argDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object, float64)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25d4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble
+
 
 		// Methods
 		.method public hidebysig static 
@@ -320,6 +663,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3BEB03B7_capturedString
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.UnaryOperator_MinusMinusPrefix/Scope _environment0_UnaryOperator_MinusMinusPrefix
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.UnaryOperator_MinusMinusPrefix/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x25e3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/capturedString/FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::_environment0_UnaryOperator_MinusMinusPrefix
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x25f2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x25f5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x25f8
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/capturedString/FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::_environment0_UnaryOperator_MinusMinusPrefix
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.UnaryOperator_MinusMinusPrefix/capturedString::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x260a
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/capturedString/FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::_environment0_UnaryOperator_MinusMinusPrefix
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.UnaryOperator_MinusMinusPrefix/capturedString::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2618
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_3BEB03B7_capturedString
 
 
 		// Methods
@@ -429,6 +879,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_770CD1D9_argString
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.UnaryOperator_MinusMinusPrefix/Scope _environment0_UnaryOperator_MinusMinusPrefix
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.UnaryOperator_MinusMinusPrefix/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2627
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/argString/FunctionObject_FunctionDeclaration_770CD1D9_argString::_environment0_UnaryOperator_MinusMinusPrefix
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_770CD1D9_argString::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2636
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_770CD1D9_argString::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2639
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_770CD1D9_argString::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x263c
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/argString/FunctionObject_FunctionDeclaration_770CD1D9_argString::_environment0_UnaryOperator_MinusMinusPrefix
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.UnaryOperator_MinusMinusPrefix/argString::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_770CD1D9_argString::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2655
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope Modules.UnaryOperator_MinusMinusPrefix/argString/FunctionObject_FunctionDeclaration_770CD1D9_argString::_environment0_UnaryOperator_MinusMinusPrefix
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.UnaryOperator_MinusMinusPrefix/argString::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_770CD1D9_argString::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x266a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_770CD1D9_argString::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_770CD1D9_argString
 
 
 		// Methods
@@ -575,17 +1138,17 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_MinusMinusPrefix/Scope,
-			[1] class FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble,
-			[2] class FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble,
-			[3] class FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_3BEB03B7_capturedString,
-			[4] class FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_770CD1D9_argString,
+			[1] class Modules.UnaryOperator_MinusMinusPrefix/capturedDouble/FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble,
+			[2] class Modules.UnaryOperator_MinusMinusPrefix/argDouble/FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble,
+			[3] class Modules.UnaryOperator_MinusMinusPrefix/capturedString/FunctionObject_FunctionDeclaration_3BEB03B7_capturedString,
+			[4] class Modules.UnaryOperator_MinusMinusPrefix/argString/FunctionObject_FunctionDeclaration_770CD1D9_argString,
 			[5] float64,
 			[6] object,
 			[7] object,
 			[8] object,
 			[9] string,
 			[10] object[],
-			[11] class FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_538EA9FA_logCase,
+			[11] class Modules.UnaryOperator_MinusMinusPrefix/logCase/FunctionObject_FunctionDeclaration_538EA9FA_logCase,
 			[12] object,
 			[13] string,
 			[14] float64,
@@ -601,13 +1164,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 10
-		IL_0012: newobj instance void FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_538EA9FA_logCase::.ctor()
+		IL_0012: newobj instance void Modules.UnaryOperator_MinusMinusPrefix/logCase/FunctionObject_FunctionDeclaration_538EA9FA_logCase::.ctor()
 		IL_0017: ldc.i4.4
 		IL_0018: conv.r8
 		IL_0019: ldstr "logCase"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_538EA9FA_logCase>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPrefix/logCase/FunctionObject_FunctionDeclaration_538EA9FA_logCase>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.s 11
 		IL_0027: ldloc.0
 		IL_0028: ldloc.s 11
@@ -623,13 +1186,13 @@
 		IL_003d: ldc.i4.0
 		IL_003e: ldelem.ref
 		IL_003f: castclass Modules.UnaryOperator_MinusMinusPrefix/Scope
-		IL_0044: newobj instance void FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::.ctor(class Modules.UnaryOperator_MinusMinusPrefix/Scope)
+		IL_0044: newobj instance void Modules.UnaryOperator_MinusMinusPrefix/capturedDouble/FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::.ctor(class Modules.UnaryOperator_MinusMinusPrefix/Scope)
 		IL_0049: ldc.i4.0
 		IL_004a: conv.r8
 		IL_004b: ldstr "capturedDouble"
 		IL_0050: ldc.i4.0
 		IL_0051: ldc.i4.1
-		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble>(!!0, float64, string, bool, bool)
+		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPrefix/capturedDouble/FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble>(!!0, float64, string, bool, bool)
 		IL_0057: stloc.1
 		IL_0058: ldc.i4.1
 		IL_0059: newarr [System.Runtime]System.Object
@@ -642,13 +1205,13 @@
 		IL_0066: ldc.i4.0
 		IL_0067: ldelem.ref
 		IL_0068: castclass Modules.UnaryOperator_MinusMinusPrefix/Scope
-		IL_006d: newobj instance void FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::.ctor(class Modules.UnaryOperator_MinusMinusPrefix/Scope)
+		IL_006d: newobj instance void Modules.UnaryOperator_MinusMinusPrefix/argDouble/FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::.ctor(class Modules.UnaryOperator_MinusMinusPrefix/Scope)
 		IL_0072: ldc.i4.1
 		IL_0073: conv.r8
 		IL_0074: ldstr "argDouble"
 		IL_0079: ldc.i4.0
 		IL_007a: ldc.i4.1
-		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble>(!!0, float64, string, bool, bool)
+		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPrefix/argDouble/FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble>(!!0, float64, string, bool, bool)
 		IL_0080: stloc.2
 		IL_0081: ldc.i4.1
 		IL_0082: newarr [System.Runtime]System.Object
@@ -661,13 +1224,13 @@
 		IL_008f: ldc.i4.0
 		IL_0090: ldelem.ref
 		IL_0091: castclass Modules.UnaryOperator_MinusMinusPrefix/Scope
-		IL_0096: newobj instance void FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::.ctor(class Modules.UnaryOperator_MinusMinusPrefix/Scope)
+		IL_0096: newobj instance void Modules.UnaryOperator_MinusMinusPrefix/capturedString/FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::.ctor(class Modules.UnaryOperator_MinusMinusPrefix/Scope)
 		IL_009b: ldc.i4.0
 		IL_009c: conv.r8
 		IL_009d: ldstr "capturedString"
 		IL_00a2: ldc.i4.0
 		IL_00a3: ldc.i4.1
-		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_3BEB03B7_capturedString>(!!0, float64, string, bool, bool)
+		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPrefix/capturedString/FunctionObject_FunctionDeclaration_3BEB03B7_capturedString>(!!0, float64, string, bool, bool)
 		IL_00a9: stloc.3
 		IL_00aa: ldc.i4.1
 		IL_00ab: newarr [System.Runtime]System.Object
@@ -680,13 +1243,13 @@
 		IL_00b8: ldc.i4.0
 		IL_00b9: ldelem.ref
 		IL_00ba: castclass Modules.UnaryOperator_MinusMinusPrefix/Scope
-		IL_00bf: newobj instance void FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_770CD1D9_argString::.ctor(class Modules.UnaryOperator_MinusMinusPrefix/Scope)
+		IL_00bf: newobj instance void Modules.UnaryOperator_MinusMinusPrefix/argString/FunctionObject_FunctionDeclaration_770CD1D9_argString::.ctor(class Modules.UnaryOperator_MinusMinusPrefix/Scope)
 		IL_00c4: ldc.i4.1
 		IL_00c5: conv.r8
 		IL_00c6: ldstr "argString"
 		IL_00cb: ldc.i4.0
 		IL_00cc: ldc.i4.1
-		IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_770CD1D9_argString>(!!0, float64, string, bool, bool)
+		IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPrefix/argString/FunctionObject_FunctionDeclaration_770CD1D9_argString>(!!0, float64, string, bool, bool)
 		IL_00d2: stloc.s 4
 		IL_00d4: nop
 		IL_00d5: nop
@@ -817,569 +1380,6 @@
 	} // end of method UnaryOperator_MinusMinusPrefix::__js_module_init__
 
 } // end of class Modules.UnaryOperator_MinusMinusPrefix
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_538EA9FA_logCase
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x24d0
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_538EA9FA_logCase::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24d8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_538EA9FA_logCase::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24db
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_538EA9FA_logCase::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24de
-		// Header size: 1
-		// Code size: 44 (0x2c)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: ldarg.2
-		IL_0019: ldc.i4.2
-		IL_001a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001f: ldarg.2
-		IL_0020: ldc.i4.3
-		IL_0021: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0026: call object Modules.UnaryOperator_MinusMinusPrefix/logCase::__js_call__(object, string, object, object, object)
-		IL_002b: ret
-	} // end of method FunctionObject_FunctionDeclaration_538EA9FA_logCase::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x250b
-		// Header size: 1
-		// Code size: 40 (0x28)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: ldarg.2
-		IL_0015: ldc.i4.2
-		IL_0016: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001b: ldarg.2
-		IL_001c: ldc.i4.3
-		IL_001d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0022: call object Modules.UnaryOperator_MinusMinusPrefix/logCase::__js_call__(object, string, object, object, object)
-		IL_0027: ret
-	} // end of method FunctionObject_FunctionDeclaration_538EA9FA_logCase::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2534
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_538EA9FA_logCase::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_538EA9FA_logCase
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.UnaryOperator_MinusMinusPrefix/Scope _environment0_UnaryOperator_MinusMinusPrefix
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.UnaryOperator_MinusMinusPrefix/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2543
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.UnaryOperator_MinusMinusPrefix/Scope FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::_environment0_UnaryOperator_MinusMinusPrefix
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2552
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2555
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2558
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::_environment0_UnaryOperator_MinusMinusPrefix
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.UnaryOperator_MinusMinusPrefix/capturedDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x256a
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::_environment0_UnaryOperator_MinusMinusPrefix
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.UnaryOperator_MinusMinusPrefix/capturedDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2578
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_C706FAEB_capturedDouble
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.UnaryOperator_MinusMinusPrefix/Scope _environment0_UnaryOperator_MinusMinusPrefix
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.UnaryOperator_MinusMinusPrefix/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2587
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.UnaryOperator_MinusMinusPrefix/Scope FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::_environment0_UnaryOperator_MinusMinusPrefix
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2596
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2599
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x259c
-		// Header size: 1
-		// Code size: 29 (0x1d)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::_environment0_UnaryOperator_MinusMinusPrefix
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0017: call object Modules.UnaryOperator_MinusMinusPrefix/argDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object, float64)
-		IL_001c: ret
-	} // end of method FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25ba
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::_environment0_UnaryOperator_MinusMinusPrefix
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0013: call object Modules.UnaryOperator_MinusMinusPrefix/argDouble::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object, float64)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25d4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_D2CEF5DD_argDouble
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_3BEB03B7_capturedString
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.UnaryOperator_MinusMinusPrefix/Scope _environment0_UnaryOperator_MinusMinusPrefix
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.UnaryOperator_MinusMinusPrefix/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x25e3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.UnaryOperator_MinusMinusPrefix/Scope FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::_environment0_UnaryOperator_MinusMinusPrefix
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x25f2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x25f5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x25f8
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::_environment0_UnaryOperator_MinusMinusPrefix
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.UnaryOperator_MinusMinusPrefix/capturedString::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x260a
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::_environment0_UnaryOperator_MinusMinusPrefix
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.UnaryOperator_MinusMinusPrefix/capturedString::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2618
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3BEB03B7_capturedString::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_3BEB03B7_capturedString
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_770CD1D9_argString
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.UnaryOperator_MinusMinusPrefix/Scope _environment0_UnaryOperator_MinusMinusPrefix
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.UnaryOperator_MinusMinusPrefix/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2627
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.UnaryOperator_MinusMinusPrefix/Scope FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_770CD1D9_argString::_environment0_UnaryOperator_MinusMinusPrefix
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_770CD1D9_argString::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2636
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_770CD1D9_argString::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2639
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_770CD1D9_argString::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x263c
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_770CD1D9_argString::_environment0_UnaryOperator_MinusMinusPrefix
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.UnaryOperator_MinusMinusPrefix/argString::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_770CD1D9_argString::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2655
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_MinusMinusPrefix/Scope FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_770CD1D9_argString::_environment0_UnaryOperator_MinusMinusPrefix
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.UnaryOperator_MinusMinusPrefix/argString::__js_call__(class Modules.UnaryOperator_MinusMinusPrefix/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_770CD1D9_argString::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x266a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_770CD1D9_argString::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_MinusMinusPrefix_5331A291.FunctionObject_FunctionDeclaration_770CD1D9_argString
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix_InFunctionSwitch.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix_InFunctionSwitch.verified.txt
@@ -53,6 +53,109 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8981CE7C_bump
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21e9
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_8981CE7C_bump::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21f1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8981CE7C_bump::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21f4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8981CE7C_bump::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f7
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0011: call object Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch/bump::__js_call__(object, string)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_8981CE7C_bump::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x220f
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: call object Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch/bump::__js_call__(object, string)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_8981CE7C_bump::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2223
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8981CE7C_bump::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_8981CE7C_bump
+
 
 		// Methods
 		.method public hidebysig static 
@@ -214,7 +317,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch/Scope,
-			[1] class FunctionObjects.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_AAFCB385.FunctionObject_FunctionDeclaration_8981CE7C_bump,
+			[1] class Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch/bump/FunctionObject_FunctionDeclaration_8981CE7C_bump,
 			[2] object[]
 		)
 
@@ -227,13 +330,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_AAFCB385.FunctionObject_FunctionDeclaration_8981CE7C_bump::.ctor()
+		IL_0011: newobj instance void Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch/bump/FunctionObject_FunctionDeclaration_8981CE7C_bump::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "bump"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_AAFCB385.FunctionObject_FunctionDeclaration_8981CE7C_bump>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch/bump/FunctionObject_FunctionDeclaration_8981CE7C_bump>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -262,109 +365,6 @@
 	} // end of method UnaryOperator_MinusMinusPrefix_InFunctionSwitch::__js_module_init__
 
 } // end of class Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_AAFCB385.FunctionObject_FunctionDeclaration_8981CE7C_bump
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21e9
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_8981CE7C_bump::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21f1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8981CE7C_bump::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21f4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8981CE7C_bump::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f7
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0011: call object Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch/bump::__js_call__(object, string)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_8981CE7C_bump::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x220f
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_000d: call object Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch/bump::__js_call__(object, string)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_8981CE7C_bump::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2223
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8981CE7C_bump::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_AAFCB385.FunctionObject_FunctionDeclaration_8981CE7C_bump
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal.verified.txt
@@ -53,6 +53,109 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_429B5AEB_bump
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21f8
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_429B5AEB_bump::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2200
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_429B5AEB_bump::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2203
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_429B5AEB_bump::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2206
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0011: call object Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_429B5AEB_bump::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x221e
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: call object Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_429B5AEB_bump::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2232
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_429B5AEB_bump::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_429B5AEB_bump
+
 
 		// Methods
 		.method public hidebysig static 
@@ -231,7 +334,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal/Scope,
-			[1] class FunctionObjects.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal_BE003C70.FunctionObject_FunctionDeclaration_429B5AEB_bump,
+			[1] class Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal/bump/FunctionObject_FunctionDeclaration_429B5AEB_bump,
 			[2] object[]
 		)
 
@@ -244,13 +347,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal_BE003C70.FunctionObject_FunctionDeclaration_429B5AEB_bump::.ctor()
+		IL_0011: newobj instance void Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal/bump/FunctionObject_FunctionDeclaration_429B5AEB_bump::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "bump"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal_BE003C70.FunctionObject_FunctionDeclaration_429B5AEB_bump>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal/bump/FunctionObject_FunctionDeclaration_429B5AEB_bump>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -279,109 +382,6 @@
 	} // end of method UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal::__js_module_init__
 
 } // end of class Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal_BE003C70.FunctionObject_FunctionDeclaration_429B5AEB_bump
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21f8
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_429B5AEB_bump::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2200
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_429B5AEB_bump::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2203
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_429B5AEB_bump::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2206
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0011: call object Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_429B5AEB_bump::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x221e
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_000d: call object Modules.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_429B5AEB_bump::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2232
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_429B5AEB_bump::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_MinusMinusPrefix_InFunctionSwitch_ObjectLocal_BE003C70.FunctionObject_FunctionDeclaration_429B5AEB_bump
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction.verified.txt
@@ -35,6 +35,118 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_66FA40A5_inner
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope _environment1_outer
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x22e3
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner/FunctionObject_FunctionDeclaration_66FA40A5_inner::_environment1_outer
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner/FunctionObject_FunctionDeclaration_66FA40A5_inner::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionDeclaration_66FA40A5_inner::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x22f9
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_66FA40A5_inner::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x22fc
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_66FA40A5_inner::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x22ff
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner/FunctionObject_FunctionDeclaration_66FA40A5_inner::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionDeclaration_66FA40A5_inner::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2311
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner/FunctionObject_FunctionDeclaration_66FA40A5_inner::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionDeclaration_66FA40A5_inner::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x231f
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionDeclaration_66FA40A5_inner::ConstructCore
+
+			} // end of class FunctionObject_FunctionDeclaration_66FA40A5_inner
+
 
 			// Methods
 			.method public hidebysig static 
@@ -213,6 +325,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7FD34D3A_outer
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope _environment0_UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x229f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/FunctionObject_FunctionDeclaration_7FD34D3A_outer::_environment0_UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_7FD34D3A_outer::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x22ae
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7FD34D3A_outer::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x22b1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7FD34D3A_outer::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x22b4
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/FunctionObject_FunctionDeclaration_7FD34D3A_outer::_environment0_UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer::__js_call__(class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_7FD34D3A_outer::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22c6
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/FunctionObject_FunctionDeclaration_7FD34D3A_outer::_environment0_UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer::__js_call__(class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_7FD34D3A_outer::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x22d4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_7FD34D3A_outer::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_7FD34D3A_outer
+
 
 		// Methods
 		.method public hidebysig static 
@@ -232,7 +451,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope,
-				[1] class FunctionObjects.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction_9F9382B8.FunctionObject_FunctionDeclaration_66FA40A5_inner,
+				[1] class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner/FunctionObject_FunctionDeclaration_66FA40A5_inner,
 				[2] object[],
 				[3] object,
 				[4] object
@@ -256,13 +475,13 @@
 			IL_0017: ldelem.ref
 			IL_0018: castclass Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope
 			IL_001d: ldloc.2
-			IL_001e: newobj instance void FunctionObjects.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction_9F9382B8.FunctionObject_FunctionDeclaration_66FA40A5_inner::.ctor(class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope, object[])
+			IL_001e: newobj instance void Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner/FunctionObject_FunctionDeclaration_66FA40A5_inner::.ctor(class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope, object[])
 			IL_0023: ldc.i4.0
 			IL_0024: conv.r8
 			IL_0025: ldstr "inner"
 			IL_002a: ldc.i4.0
 			IL_002b: ldc.i4.1
-			IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction_9F9382B8.FunctionObject_FunctionDeclaration_66FA40A5_inner>(!!0, float64, string, bool, bool)
+			IL_002c: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner/FunctionObject_FunctionDeclaration_66FA40A5_inner>(!!0, float64, string, bool, bool)
 			IL_0031: stloc.1
 			IL_0032: ldloc.0
 			IL_0033: ldc.r8 3
@@ -340,7 +559,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope,
-			[1] class FunctionObjects.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction_9F9382B8.FunctionObject_FunctionDeclaration_7FD34D3A_outer,
+			[1] class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/FunctionObject_FunctionDeclaration_7FD34D3A_outer,
 			[2] object[]
 		)
 
@@ -357,13 +576,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope
-		IL_0019: newobj instance void FunctionObjects.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction_9F9382B8.FunctionObject_FunctionDeclaration_7FD34D3A_outer::.ctor(class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope)
+		IL_0019: newobj instance void Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/FunctionObject_FunctionDeclaration_7FD34D3A_outer::.ctor(class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "outer"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction_9F9382B8.FunctionObject_FunctionDeclaration_7FD34D3A_outer>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/FunctionObject_FunctionDeclaration_7FD34D3A_outer>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: nop
@@ -375,225 +594,6 @@
 	} // end of method UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction::__js_module_init__
 
 } // end of class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction_9F9382B8.FunctionObject_FunctionDeclaration_7FD34D3A_outer
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope _environment0_UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x229f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope FunctionObjects.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction_9F9382B8.FunctionObject_FunctionDeclaration_7FD34D3A_outer::_environment0_UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_7FD34D3A_outer::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22ae
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7FD34D3A_outer::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22b1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7FD34D3A_outer::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22b4
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope FunctionObjects.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction_9F9382B8.FunctionObject_FunctionDeclaration_7FD34D3A_outer::_environment0_UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer::__js_call__(class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_7FD34D3A_outer::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22c6
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope FunctionObjects.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction_9F9382B8.FunctionObject_FunctionDeclaration_7FD34D3A_outer::_environment0_UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer::__js_call__(class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_7FD34D3A_outer::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x22d4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_7FD34D3A_outer::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction_9F9382B8.FunctionObject_FunctionDeclaration_7FD34D3A_outer
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction_9F9382B8.FunctionObject_FunctionDeclaration_66FA40A5_inner
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope _environment1_outer
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x22e3
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/Scope FunctionObjects.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction_9F9382B8.FunctionObject_FunctionDeclaration_66FA40A5_inner::_environment1_outer
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction_9F9382B8.FunctionObject_FunctionDeclaration_66FA40A5_inner::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionDeclaration_66FA40A5_inner::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x22f9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_66FA40A5_inner::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x22fc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_66FA40A5_inner::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x22ff
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction_9F9382B8.FunctionObject_FunctionDeclaration_66FA40A5_inner::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_66FA40A5_inner::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2311
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction_9F9382B8.FunctionObject_FunctionDeclaration_66FA40A5_inner::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction/outer/inner::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_66FA40A5_inner::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x231f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_66FA40A5_inner::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_PlusPlusMinusMinusCapturedFromNestedFunction_9F9382B8.FunctionObject_FunctionDeclaration_66FA40A5_inner
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix.verified.txt
@@ -31,6 +31,127 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E6DD4761_logCase
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2506
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6DD4761_logCase::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x250e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6DD4761_logCase::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2511
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6DD4761_logCase::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2514
+				// Header size: 1
+				// Code size: 44 (0x2c)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: ldarg.2
+				IL_0019: ldc.i4.2
+				IL_001a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001f: ldarg.2
+				IL_0020: ldc.i4.3
+				IL_0021: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0026: call object Modules.UnaryOperator_PlusPlusPostfix/logCase::__js_call__(object, string, object, object, object)
+				IL_002b: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6DD4761_logCase::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2541
+				// Header size: 1
+				// Code size: 40 (0x28)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: ldarg.2
+				IL_0015: ldc.i4.2
+				IL_0016: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001b: ldarg.2
+				IL_001c: ldc.i4.3
+				IL_001d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0022: call object Modules.UnaryOperator_PlusPlusPostfix/logCase::__js_call__(object, string, object, object, object)
+				IL_0027: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6DD4761_logCase::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x256a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6DD4761_logCase::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E6DD4761_logCase
+
 
 		// Methods
 		.method public hidebysig static 
@@ -103,6 +224,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.UnaryOperator_PlusPlusPostfix/Scope _environment0_UnaryOperator_PlusPlusPostfix
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.UnaryOperator_PlusPlusPostfix/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2579
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/capturedDouble/FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::_environment0_UnaryOperator_PlusPlusPostfix
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2588
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x258b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x258e
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/capturedDouble/FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::_environment0_UnaryOperator_PlusPlusPostfix
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.UnaryOperator_PlusPlusPostfix/capturedDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25a0
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/capturedDouble/FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::_environment0_UnaryOperator_PlusPlusPostfix
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.UnaryOperator_PlusPlusPostfix/capturedDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25ae
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble
 
 
 		// Methods
@@ -224,6 +452,121 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E6366926_argDouble
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.UnaryOperator_PlusPlusPostfix/Scope _environment0_UnaryOperator_PlusPlusPostfix
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.UnaryOperator_PlusPlusPostfix/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x25bd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/argDouble/FunctionObject_FunctionDeclaration_E6366926_argDouble::_environment0_UnaryOperator_PlusPlusPostfix
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6366926_argDouble::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x25cc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6366926_argDouble::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x25cf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6366926_argDouble::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x25d2
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/argDouble/FunctionObject_FunctionDeclaration_E6366926_argDouble::_environment0_UnaryOperator_PlusPlusPostfix
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: call object Modules.UnaryOperator_PlusPlusPostfix/argDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object, float64)
+				IL_001c: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6366926_argDouble::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25f0
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/argDouble/FunctionObject_FunctionDeclaration_E6366926_argDouble::_environment0_UnaryOperator_PlusPlusPostfix
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0013: call object Modules.UnaryOperator_PlusPlusPostfix/argDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object, float64)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6366926_argDouble::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x260a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E6366926_argDouble::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E6366926_argDouble
+
 
 		// Methods
 		.method public hidebysig static 
@@ -327,6 +670,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C0242C86_capturedString
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.UnaryOperator_PlusPlusPostfix/Scope _environment0_UnaryOperator_PlusPlusPostfix
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.UnaryOperator_PlusPlusPostfix/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2619
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/capturedString/FunctionObject_FunctionDeclaration_C0242C86_capturedString::_environment0_UnaryOperator_PlusPlusPostfix
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C0242C86_capturedString::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2628
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C0242C86_capturedString::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x262b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C0242C86_capturedString::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x262e
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/capturedString/FunctionObject_FunctionDeclaration_C0242C86_capturedString::_environment0_UnaryOperator_PlusPlusPostfix
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.UnaryOperator_PlusPlusPostfix/capturedString::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_C0242C86_capturedString::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2640
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/capturedString/FunctionObject_FunctionDeclaration_C0242C86_capturedString::_environment0_UnaryOperator_PlusPlusPostfix
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.UnaryOperator_PlusPlusPostfix/capturedString::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_C0242C86_capturedString::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x264e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C0242C86_capturedString::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C0242C86_capturedString
 
 
 		// Methods
@@ -443,6 +893,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E97FE89E_argString
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.UnaryOperator_PlusPlusPostfix/Scope _environment0_UnaryOperator_PlusPlusPostfix
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.UnaryOperator_PlusPlusPostfix/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x265d
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/argString/FunctionObject_FunctionDeclaration_E97FE89E_argString::_environment0_UnaryOperator_PlusPlusPostfix
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E97FE89E_argString::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x266c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E97FE89E_argString::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x266f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E97FE89E_argString::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2672
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/argString/FunctionObject_FunctionDeclaration_E97FE89E_argString::_environment0_UnaryOperator_PlusPlusPostfix
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.UnaryOperator_PlusPlusPostfix/argString::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_E97FE89E_argString::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x268b
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope Modules.UnaryOperator_PlusPlusPostfix/argString/FunctionObject_FunctionDeclaration_E97FE89E_argString::_environment0_UnaryOperator_PlusPlusPostfix
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.UnaryOperator_PlusPlusPostfix/argString::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_E97FE89E_argString::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x26a0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E97FE89E_argString::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E97FE89E_argString
 
 
 		// Methods
@@ -596,17 +1159,17 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusPostfix/Scope,
-			[1] class FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble,
-			[2] class FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_E6366926_argDouble,
-			[3] class FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_C0242C86_capturedString,
-			[4] class FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_E97FE89E_argString,
+			[1] class Modules.UnaryOperator_PlusPlusPostfix/capturedDouble/FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble,
+			[2] class Modules.UnaryOperator_PlusPlusPostfix/argDouble/FunctionObject_FunctionDeclaration_E6366926_argDouble,
+			[3] class Modules.UnaryOperator_PlusPlusPostfix/capturedString/FunctionObject_FunctionDeclaration_C0242C86_capturedString,
+			[4] class Modules.UnaryOperator_PlusPlusPostfix/argString/FunctionObject_FunctionDeclaration_E97FE89E_argString,
 			[5] float64,
 			[6] object,
 			[7] object,
 			[8] object,
 			[9] string,
 			[10] object[],
-			[11] class FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_E6DD4761_logCase,
+			[11] class Modules.UnaryOperator_PlusPlusPostfix/logCase/FunctionObject_FunctionDeclaration_E6DD4761_logCase,
 			[12] object,
 			[13] object,
 			[14] string,
@@ -623,13 +1186,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 10
-		IL_0012: newobj instance void FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_E6DD4761_logCase::.ctor()
+		IL_0012: newobj instance void Modules.UnaryOperator_PlusPlusPostfix/logCase/FunctionObject_FunctionDeclaration_E6DD4761_logCase::.ctor()
 		IL_0017: ldc.i4.4
 		IL_0018: conv.r8
 		IL_0019: ldstr "logCase"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_E6DD4761_logCase>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPostfix/logCase/FunctionObject_FunctionDeclaration_E6DD4761_logCase>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.s 11
 		IL_0027: ldloc.0
 		IL_0028: ldloc.s 11
@@ -645,13 +1208,13 @@
 		IL_003d: ldc.i4.0
 		IL_003e: ldelem.ref
 		IL_003f: castclass Modules.UnaryOperator_PlusPlusPostfix/Scope
-		IL_0044: newobj instance void FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::.ctor(class Modules.UnaryOperator_PlusPlusPostfix/Scope)
+		IL_0044: newobj instance void Modules.UnaryOperator_PlusPlusPostfix/capturedDouble/FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::.ctor(class Modules.UnaryOperator_PlusPlusPostfix/Scope)
 		IL_0049: ldc.i4.0
 		IL_004a: conv.r8
 		IL_004b: ldstr "capturedDouble"
 		IL_0050: ldc.i4.0
 		IL_0051: ldc.i4.1
-		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble>(!!0, float64, string, bool, bool)
+		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPostfix/capturedDouble/FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble>(!!0, float64, string, bool, bool)
 		IL_0057: stloc.1
 		IL_0058: ldc.i4.1
 		IL_0059: newarr [System.Runtime]System.Object
@@ -664,13 +1227,13 @@
 		IL_0066: ldc.i4.0
 		IL_0067: ldelem.ref
 		IL_0068: castclass Modules.UnaryOperator_PlusPlusPostfix/Scope
-		IL_006d: newobj instance void FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_E6366926_argDouble::.ctor(class Modules.UnaryOperator_PlusPlusPostfix/Scope)
+		IL_006d: newobj instance void Modules.UnaryOperator_PlusPlusPostfix/argDouble/FunctionObject_FunctionDeclaration_E6366926_argDouble::.ctor(class Modules.UnaryOperator_PlusPlusPostfix/Scope)
 		IL_0072: ldc.i4.1
 		IL_0073: conv.r8
 		IL_0074: ldstr "argDouble"
 		IL_0079: ldc.i4.0
 		IL_007a: ldc.i4.1
-		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_E6366926_argDouble>(!!0, float64, string, bool, bool)
+		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPostfix/argDouble/FunctionObject_FunctionDeclaration_E6366926_argDouble>(!!0, float64, string, bool, bool)
 		IL_0080: stloc.2
 		IL_0081: ldc.i4.1
 		IL_0082: newarr [System.Runtime]System.Object
@@ -683,13 +1246,13 @@
 		IL_008f: ldc.i4.0
 		IL_0090: ldelem.ref
 		IL_0091: castclass Modules.UnaryOperator_PlusPlusPostfix/Scope
-		IL_0096: newobj instance void FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_C0242C86_capturedString::.ctor(class Modules.UnaryOperator_PlusPlusPostfix/Scope)
+		IL_0096: newobj instance void Modules.UnaryOperator_PlusPlusPostfix/capturedString/FunctionObject_FunctionDeclaration_C0242C86_capturedString::.ctor(class Modules.UnaryOperator_PlusPlusPostfix/Scope)
 		IL_009b: ldc.i4.0
 		IL_009c: conv.r8
 		IL_009d: ldstr "capturedString"
 		IL_00a2: ldc.i4.0
 		IL_00a3: ldc.i4.1
-		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_C0242C86_capturedString>(!!0, float64, string, bool, bool)
+		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPostfix/capturedString/FunctionObject_FunctionDeclaration_C0242C86_capturedString>(!!0, float64, string, bool, bool)
 		IL_00a9: stloc.3
 		IL_00aa: ldc.i4.1
 		IL_00ab: newarr [System.Runtime]System.Object
@@ -702,13 +1265,13 @@
 		IL_00b8: ldc.i4.0
 		IL_00b9: ldelem.ref
 		IL_00ba: castclass Modules.UnaryOperator_PlusPlusPostfix/Scope
-		IL_00bf: newobj instance void FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_E97FE89E_argString::.ctor(class Modules.UnaryOperator_PlusPlusPostfix/Scope)
+		IL_00bf: newobj instance void Modules.UnaryOperator_PlusPlusPostfix/argString/FunctionObject_FunctionDeclaration_E97FE89E_argString::.ctor(class Modules.UnaryOperator_PlusPlusPostfix/Scope)
 		IL_00c4: ldc.i4.1
 		IL_00c5: conv.r8
 		IL_00c6: ldstr "argString"
 		IL_00cb: ldc.i4.0
 		IL_00cc: ldc.i4.1
-		IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_E97FE89E_argString>(!!0, float64, string, bool, bool)
+		IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPostfix/argString/FunctionObject_FunctionDeclaration_E97FE89E_argString>(!!0, float64, string, bool, bool)
 		IL_00d2: stloc.s 4
 		IL_00d4: nop
 		IL_00d5: nop
@@ -846,569 +1409,6 @@
 	} // end of method UnaryOperator_PlusPlusPostfix::__js_module_init__
 
 } // end of class Modules.UnaryOperator_PlusPlusPostfix
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_E6DD4761_logCase
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2506
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6DD4761_logCase::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x250e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6DD4761_logCase::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2511
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6DD4761_logCase::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2514
-		// Header size: 1
-		// Code size: 44 (0x2c)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: ldarg.2
-		IL_0019: ldc.i4.2
-		IL_001a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001f: ldarg.2
-		IL_0020: ldc.i4.3
-		IL_0021: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0026: call object Modules.UnaryOperator_PlusPlusPostfix/logCase::__js_call__(object, string, object, object, object)
-		IL_002b: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6DD4761_logCase::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2541
-		// Header size: 1
-		// Code size: 40 (0x28)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: ldarg.2
-		IL_0015: ldc.i4.2
-		IL_0016: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001b: ldarg.2
-		IL_001c: ldc.i4.3
-		IL_001d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0022: call object Modules.UnaryOperator_PlusPlusPostfix/logCase::__js_call__(object, string, object, object, object)
-		IL_0027: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6DD4761_logCase::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x256a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6DD4761_logCase::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_E6DD4761_logCase
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.UnaryOperator_PlusPlusPostfix/Scope _environment0_UnaryOperator_PlusPlusPostfix
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.UnaryOperator_PlusPlusPostfix/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2579
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.UnaryOperator_PlusPlusPostfix/Scope FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::_environment0_UnaryOperator_PlusPlusPostfix
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2588
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x258b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x258e
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::_environment0_UnaryOperator_PlusPlusPostfix
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.UnaryOperator_PlusPlusPostfix/capturedDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25a0
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::_environment0_UnaryOperator_PlusPlusPostfix
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.UnaryOperator_PlusPlusPostfix/capturedDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25ae
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_F6E12F6E_capturedDouble
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_E6366926_argDouble
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.UnaryOperator_PlusPlusPostfix/Scope _environment0_UnaryOperator_PlusPlusPostfix
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.UnaryOperator_PlusPlusPostfix/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x25bd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.UnaryOperator_PlusPlusPostfix/Scope FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_E6366926_argDouble::_environment0_UnaryOperator_PlusPlusPostfix
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6366926_argDouble::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x25cc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6366926_argDouble::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x25cf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6366926_argDouble::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x25d2
-		// Header size: 1
-		// Code size: 29 (0x1d)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_E6366926_argDouble::_environment0_UnaryOperator_PlusPlusPostfix
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0017: call object Modules.UnaryOperator_PlusPlusPostfix/argDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object, float64)
-		IL_001c: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6366926_argDouble::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25f0
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_E6366926_argDouble::_environment0_UnaryOperator_PlusPlusPostfix
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0013: call object Modules.UnaryOperator_PlusPlusPostfix/argDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object, float64)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6366926_argDouble::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x260a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E6366926_argDouble::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_E6366926_argDouble
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_C0242C86_capturedString
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.UnaryOperator_PlusPlusPostfix/Scope _environment0_UnaryOperator_PlusPlusPostfix
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.UnaryOperator_PlusPlusPostfix/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2619
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.UnaryOperator_PlusPlusPostfix/Scope FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_C0242C86_capturedString::_environment0_UnaryOperator_PlusPlusPostfix
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C0242C86_capturedString::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2628
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C0242C86_capturedString::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x262b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C0242C86_capturedString::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x262e
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_C0242C86_capturedString::_environment0_UnaryOperator_PlusPlusPostfix
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.UnaryOperator_PlusPlusPostfix/capturedString::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_C0242C86_capturedString::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2640
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_C0242C86_capturedString::_environment0_UnaryOperator_PlusPlusPostfix
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.UnaryOperator_PlusPlusPostfix/capturedString::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_C0242C86_capturedString::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x264e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C0242C86_capturedString::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_C0242C86_capturedString
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_E97FE89E_argString
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.UnaryOperator_PlusPlusPostfix/Scope _environment0_UnaryOperator_PlusPlusPostfix
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.UnaryOperator_PlusPlusPostfix/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x265d
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.UnaryOperator_PlusPlusPostfix/Scope FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_E97FE89E_argString::_environment0_UnaryOperator_PlusPlusPostfix
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E97FE89E_argString::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x266c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E97FE89E_argString::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x266f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E97FE89E_argString::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2672
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_E97FE89E_argString::_environment0_UnaryOperator_PlusPlusPostfix
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.UnaryOperator_PlusPlusPostfix/argString::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_E97FE89E_argString::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x268b
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPostfix/Scope FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_E97FE89E_argString::_environment0_UnaryOperator_PlusPlusPostfix
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.UnaryOperator_PlusPlusPostfix/argString::__js_call__(class Modules.UnaryOperator_PlusPlusPostfix/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_E97FE89E_argString::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x26a0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E97FE89E_argString::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_PlusPlusPostfix_1D4BBF4A.FunctionObject_FunctionDeclaration_E97FE89E_argString
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix_InFunctionSwitch.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix_InFunctionSwitch.verified.txt
@@ -53,6 +53,109 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_301E9C23_bump
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21e9
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_301E9C23_bump::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21f1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_301E9C23_bump::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21f4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_301E9C23_bump::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f7
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0011: call object Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch/bump::__js_call__(object, string)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_301E9C23_bump::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x220f
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: call object Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch/bump::__js_call__(object, string)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_301E9C23_bump::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2223
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_301E9C23_bump::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_301E9C23_bump
+
 
 		// Methods
 		.method public hidebysig static 
@@ -214,7 +317,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch/Scope,
-			[1] class FunctionObjects.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_3526DA28.FunctionObject_FunctionDeclaration_301E9C23_bump,
+			[1] class Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch/bump/FunctionObject_FunctionDeclaration_301E9C23_bump,
 			[2] object[]
 		)
 
@@ -227,13 +330,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_3526DA28.FunctionObject_FunctionDeclaration_301E9C23_bump::.ctor()
+		IL_0011: newobj instance void Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch/bump/FunctionObject_FunctionDeclaration_301E9C23_bump::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "bump"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_3526DA28.FunctionObject_FunctionDeclaration_301E9C23_bump>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch/bump/FunctionObject_FunctionDeclaration_301E9C23_bump>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -262,109 +365,6 @@
 	} // end of method UnaryOperator_PlusPlusPostfix_InFunctionSwitch::__js_module_init__
 
 } // end of class Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_3526DA28.FunctionObject_FunctionDeclaration_301E9C23_bump
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21e9
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_301E9C23_bump::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21f1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_301E9C23_bump::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21f4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_301E9C23_bump::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f7
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0011: call object Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch/bump::__js_call__(object, string)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_301E9C23_bump::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x220f
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_000d: call object Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch/bump::__js_call__(object, string)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_301E9C23_bump::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2223
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_301E9C23_bump::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_3526DA28.FunctionObject_FunctionDeclaration_301E9C23_bump
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal.verified.txt
@@ -53,6 +53,109 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_5BEC1868_bump
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21f8
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_5BEC1868_bump::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2200
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5BEC1868_bump::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2203
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_5BEC1868_bump::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2206
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0011: call object Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_5BEC1868_bump::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x221e
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: call object Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_5BEC1868_bump::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2232
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_5BEC1868_bump::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_5BEC1868_bump
+
 
 		// Methods
 		.method public hidebysig static 
@@ -231,7 +334,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal/Scope,
-			[1] class FunctionObjects.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal_9C2E6861.FunctionObject_FunctionDeclaration_5BEC1868_bump,
+			[1] class Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal/bump/FunctionObject_FunctionDeclaration_5BEC1868_bump,
 			[2] object[]
 		)
 
@@ -244,13 +347,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal_9C2E6861.FunctionObject_FunctionDeclaration_5BEC1868_bump::.ctor()
+		IL_0011: newobj instance void Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal/bump/FunctionObject_FunctionDeclaration_5BEC1868_bump::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "bump"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal_9C2E6861.FunctionObject_FunctionDeclaration_5BEC1868_bump>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal/bump/FunctionObject_FunctionDeclaration_5BEC1868_bump>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -279,109 +382,6 @@
 	} // end of method UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal::__js_module_init__
 
 } // end of class Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal_9C2E6861.FunctionObject_FunctionDeclaration_5BEC1868_bump
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21f8
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_5BEC1868_bump::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2200
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5BEC1868_bump::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2203
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_5BEC1868_bump::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2206
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0011: call object Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_5BEC1868_bump::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x221e
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_000d: call object Modules.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_5BEC1868_bump::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2232
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_5BEC1868_bump::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_PlusPlusPostfix_InFunctionSwitch_ObjectLocal_9C2E6861.FunctionObject_FunctionDeclaration_5BEC1868_bump
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix.verified.txt
@@ -31,6 +31,127 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_ADE1F2BA_logCase
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x24d0
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_ADE1F2BA_logCase::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x24d8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_ADE1F2BA_logCase::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x24db
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_ADE1F2BA_logCase::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x24de
+				// Header size: 1
+				// Code size: 44 (0x2c)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0011: ldarg.2
+				IL_0012: ldc.i4.1
+				IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0018: ldarg.2
+				IL_0019: ldc.i4.2
+				IL_001a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001f: ldarg.2
+				IL_0020: ldc.i4.3
+				IL_0021: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0026: call object Modules.UnaryOperator_PlusPlusPrefix/logCase::__js_call__(object, string, object, object, object)
+				IL_002b: ret
+			} // end of method FunctionObject_FunctionDeclaration_ADE1F2BA_logCase::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x250b
+				// Header size: 1
+				// Code size: 40 (0x28)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: ldarg.2
+				IL_000e: ldc.i4.1
+				IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0014: ldarg.2
+				IL_0015: ldc.i4.2
+				IL_0016: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_001b: ldarg.2
+				IL_001c: ldc.i4.3
+				IL_001d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0022: call object Modules.UnaryOperator_PlusPlusPrefix/logCase::__js_call__(object, string, object, object, object)
+				IL_0027: ret
+			} // end of method FunctionObject_FunctionDeclaration_ADE1F2BA_logCase::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2534
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_ADE1F2BA_logCase::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_ADE1F2BA_logCase
+
 
 		// Methods
 		.method public hidebysig static 
@@ -103,6 +224,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.UnaryOperator_PlusPlusPrefix/Scope _environment0_UnaryOperator_PlusPlusPrefix
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.UnaryOperator_PlusPlusPrefix/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2543
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/capturedDouble/FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::_environment0_UnaryOperator_PlusPlusPrefix
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2552
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2555
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2558
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/capturedDouble/FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::_environment0_UnaryOperator_PlusPlusPrefix
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.UnaryOperator_PlusPlusPrefix/capturedDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x256a
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/capturedDouble/FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::_environment0_UnaryOperator_PlusPlusPrefix
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.UnaryOperator_PlusPlusPrefix/capturedDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2578
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble
 
 
 		// Methods
@@ -217,6 +445,121 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3BB8A99D_argDouble
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.UnaryOperator_PlusPlusPrefix/Scope _environment0_UnaryOperator_PlusPlusPrefix
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.UnaryOperator_PlusPlusPrefix/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2587
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/argDouble/FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::_environment0_UnaryOperator_PlusPlusPrefix
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2596
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2599
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x259c
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/argDouble/FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::_environment0_UnaryOperator_PlusPlusPrefix
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: call object Modules.UnaryOperator_PlusPlusPrefix/argDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object, float64)
+				IL_001c: ret
+			} // end of method FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25ba
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/argDouble/FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::_environment0_UnaryOperator_PlusPlusPrefix
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0013: call object Modules.UnaryOperator_PlusPlusPrefix/argDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object, float64)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x25d4
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_3BB8A99D_argDouble
+
 
 		// Methods
 		.method public hidebysig static 
@@ -320,6 +663,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3D09EA77_capturedString
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.UnaryOperator_PlusPlusPrefix/Scope _environment0_UnaryOperator_PlusPlusPrefix
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.UnaryOperator_PlusPlusPrefix/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x25e3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/capturedString/FunctionObject_FunctionDeclaration_3D09EA77_capturedString::_environment0_UnaryOperator_PlusPlusPrefix
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3D09EA77_capturedString::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x25f2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3D09EA77_capturedString::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x25f5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3D09EA77_capturedString::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x25f8
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/capturedString/FunctionObject_FunctionDeclaration_3D09EA77_capturedString::_environment0_UnaryOperator_PlusPlusPrefix
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.UnaryOperator_PlusPlusPrefix/capturedString::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_3D09EA77_capturedString::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x260a
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/capturedString/FunctionObject_FunctionDeclaration_3D09EA77_capturedString::_environment0_UnaryOperator_PlusPlusPrefix
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.UnaryOperator_PlusPlusPrefix/capturedString::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_3D09EA77_capturedString::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2618
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3D09EA77_capturedString::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_3D09EA77_capturedString
 
 
 		// Methods
@@ -429,6 +879,119 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_B37D5999_argString
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.UnaryOperator_PlusPlusPrefix/Scope _environment0_UnaryOperator_PlusPlusPrefix
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.UnaryOperator_PlusPlusPrefix/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2627
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/argString/FunctionObject_FunctionDeclaration_B37D5999_argString::_environment0_UnaryOperator_PlusPlusPrefix
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B37D5999_argString::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2636
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B37D5999_argString::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2639
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_B37D5999_argString::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x263c
+				// Header size: 1
+				// Code size: 24 (0x18)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/argString/FunctionObject_FunctionDeclaration_B37D5999_argString::_environment0_UnaryOperator_PlusPlusPrefix
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call object Modules.UnaryOperator_PlusPlusPrefix/argString::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object, object)
+				IL_0017: ret
+			} // end of method FunctionObject_FunctionDeclaration_B37D5999_argString::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2655
+				// Header size: 1
+				// Code size: 20 (0x14)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope Modules.UnaryOperator_PlusPlusPrefix/argString/FunctionObject_FunctionDeclaration_B37D5999_argString::_environment0_UnaryOperator_PlusPlusPrefix
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call object Modules.UnaryOperator_PlusPlusPrefix/argString::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object, object)
+				IL_0013: ret
+			} // end of method FunctionObject_FunctionDeclaration_B37D5999_argString::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x266a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_B37D5999_argString::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_B37D5999_argString
 
 
 		// Methods
@@ -575,17 +1138,17 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusPrefix/Scope,
-			[1] class FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble,
-			[2] class FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_3BB8A99D_argDouble,
-			[3] class FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_3D09EA77_capturedString,
-			[4] class FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_B37D5999_argString,
+			[1] class Modules.UnaryOperator_PlusPlusPrefix/capturedDouble/FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble,
+			[2] class Modules.UnaryOperator_PlusPlusPrefix/argDouble/FunctionObject_FunctionDeclaration_3BB8A99D_argDouble,
+			[3] class Modules.UnaryOperator_PlusPlusPrefix/capturedString/FunctionObject_FunctionDeclaration_3D09EA77_capturedString,
+			[4] class Modules.UnaryOperator_PlusPlusPrefix/argString/FunctionObject_FunctionDeclaration_B37D5999_argString,
 			[5] float64,
 			[6] object,
 			[7] object,
 			[8] object,
 			[9] string,
 			[10] object[],
-			[11] class FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_ADE1F2BA_logCase,
+			[11] class Modules.UnaryOperator_PlusPlusPrefix/logCase/FunctionObject_FunctionDeclaration_ADE1F2BA_logCase,
 			[12] object,
 			[13] string,
 			[14] float64,
@@ -601,13 +1164,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 10
-		IL_0012: newobj instance void FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_ADE1F2BA_logCase::.ctor()
+		IL_0012: newobj instance void Modules.UnaryOperator_PlusPlusPrefix/logCase/FunctionObject_FunctionDeclaration_ADE1F2BA_logCase::.ctor()
 		IL_0017: ldc.i4.4
 		IL_0018: conv.r8
 		IL_0019: ldstr "logCase"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.1
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_ADE1F2BA_logCase>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPrefix/logCase/FunctionObject_FunctionDeclaration_ADE1F2BA_logCase>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.s 11
 		IL_0027: ldloc.0
 		IL_0028: ldloc.s 11
@@ -623,13 +1186,13 @@
 		IL_003d: ldc.i4.0
 		IL_003e: ldelem.ref
 		IL_003f: castclass Modules.UnaryOperator_PlusPlusPrefix/Scope
-		IL_0044: newobj instance void FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::.ctor(class Modules.UnaryOperator_PlusPlusPrefix/Scope)
+		IL_0044: newobj instance void Modules.UnaryOperator_PlusPlusPrefix/capturedDouble/FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::.ctor(class Modules.UnaryOperator_PlusPlusPrefix/Scope)
 		IL_0049: ldc.i4.0
 		IL_004a: conv.r8
 		IL_004b: ldstr "capturedDouble"
 		IL_0050: ldc.i4.0
 		IL_0051: ldc.i4.1
-		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble>(!!0, float64, string, bool, bool)
+		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPrefix/capturedDouble/FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble>(!!0, float64, string, bool, bool)
 		IL_0057: stloc.1
 		IL_0058: ldc.i4.1
 		IL_0059: newarr [System.Runtime]System.Object
@@ -642,13 +1205,13 @@
 		IL_0066: ldc.i4.0
 		IL_0067: ldelem.ref
 		IL_0068: castclass Modules.UnaryOperator_PlusPlusPrefix/Scope
-		IL_006d: newobj instance void FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::.ctor(class Modules.UnaryOperator_PlusPlusPrefix/Scope)
+		IL_006d: newobj instance void Modules.UnaryOperator_PlusPlusPrefix/argDouble/FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::.ctor(class Modules.UnaryOperator_PlusPlusPrefix/Scope)
 		IL_0072: ldc.i4.1
 		IL_0073: conv.r8
 		IL_0074: ldstr "argDouble"
 		IL_0079: ldc.i4.0
 		IL_007a: ldc.i4.1
-		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_3BB8A99D_argDouble>(!!0, float64, string, bool, bool)
+		IL_007b: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPrefix/argDouble/FunctionObject_FunctionDeclaration_3BB8A99D_argDouble>(!!0, float64, string, bool, bool)
 		IL_0080: stloc.2
 		IL_0081: ldc.i4.1
 		IL_0082: newarr [System.Runtime]System.Object
@@ -661,13 +1224,13 @@
 		IL_008f: ldc.i4.0
 		IL_0090: ldelem.ref
 		IL_0091: castclass Modules.UnaryOperator_PlusPlusPrefix/Scope
-		IL_0096: newobj instance void FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_3D09EA77_capturedString::.ctor(class Modules.UnaryOperator_PlusPlusPrefix/Scope)
+		IL_0096: newobj instance void Modules.UnaryOperator_PlusPlusPrefix/capturedString/FunctionObject_FunctionDeclaration_3D09EA77_capturedString::.ctor(class Modules.UnaryOperator_PlusPlusPrefix/Scope)
 		IL_009b: ldc.i4.0
 		IL_009c: conv.r8
 		IL_009d: ldstr "capturedString"
 		IL_00a2: ldc.i4.0
 		IL_00a3: ldc.i4.1
-		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_3D09EA77_capturedString>(!!0, float64, string, bool, bool)
+		IL_00a4: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPrefix/capturedString/FunctionObject_FunctionDeclaration_3D09EA77_capturedString>(!!0, float64, string, bool, bool)
 		IL_00a9: stloc.3
 		IL_00aa: ldc.i4.1
 		IL_00ab: newarr [System.Runtime]System.Object
@@ -680,13 +1243,13 @@
 		IL_00b8: ldc.i4.0
 		IL_00b9: ldelem.ref
 		IL_00ba: castclass Modules.UnaryOperator_PlusPlusPrefix/Scope
-		IL_00bf: newobj instance void FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_B37D5999_argString::.ctor(class Modules.UnaryOperator_PlusPlusPrefix/Scope)
+		IL_00bf: newobj instance void Modules.UnaryOperator_PlusPlusPrefix/argString/FunctionObject_FunctionDeclaration_B37D5999_argString::.ctor(class Modules.UnaryOperator_PlusPlusPrefix/Scope)
 		IL_00c4: ldc.i4.1
 		IL_00c5: conv.r8
 		IL_00c6: ldstr "argString"
 		IL_00cb: ldc.i4.0
 		IL_00cc: ldc.i4.1
-		IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_B37D5999_argString>(!!0, float64, string, bool, bool)
+		IL_00cd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPrefix/argString/FunctionObject_FunctionDeclaration_B37D5999_argString>(!!0, float64, string, bool, bool)
 		IL_00d2: stloc.s 4
 		IL_00d4: nop
 		IL_00d5: nop
@@ -817,569 +1380,6 @@
 	} // end of method UnaryOperator_PlusPlusPrefix::__js_module_init__
 
 } // end of class Modules.UnaryOperator_PlusPlusPrefix
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_ADE1F2BA_logCase
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x24d0
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_ADE1F2BA_logCase::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x24d8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_ADE1F2BA_logCase::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x24db
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_ADE1F2BA_logCase::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x24de
-		// Header size: 1
-		// Code size: 44 (0x2c)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0011: ldarg.2
-		IL_0012: ldc.i4.1
-		IL_0013: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0018: ldarg.2
-		IL_0019: ldc.i4.2
-		IL_001a: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001f: ldarg.2
-		IL_0020: ldc.i4.3
-		IL_0021: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0026: call object Modules.UnaryOperator_PlusPlusPrefix/logCase::__js_call__(object, string, object, object, object)
-		IL_002b: ret
-	} // end of method FunctionObject_FunctionDeclaration_ADE1F2BA_logCase::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x250b
-		// Header size: 1
-		// Code size: 40 (0x28)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_000d: ldarg.2
-		IL_000e: ldc.i4.1
-		IL_000f: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0014: ldarg.2
-		IL_0015: ldc.i4.2
-		IL_0016: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_001b: ldarg.2
-		IL_001c: ldc.i4.3
-		IL_001d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0022: call object Modules.UnaryOperator_PlusPlusPrefix/logCase::__js_call__(object, string, object, object, object)
-		IL_0027: ret
-	} // end of method FunctionObject_FunctionDeclaration_ADE1F2BA_logCase::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2534
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_ADE1F2BA_logCase::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_ADE1F2BA_logCase
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.UnaryOperator_PlusPlusPrefix/Scope _environment0_UnaryOperator_PlusPlusPrefix
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.UnaryOperator_PlusPlusPrefix/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2543
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.UnaryOperator_PlusPlusPrefix/Scope FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::_environment0_UnaryOperator_PlusPlusPrefix
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2552
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2555
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2558
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::_environment0_UnaryOperator_PlusPlusPrefix
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.UnaryOperator_PlusPlusPrefix/capturedDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x256a
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::_environment0_UnaryOperator_PlusPlusPrefix
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.UnaryOperator_PlusPlusPrefix/capturedDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2578
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_9E6139AB_capturedDouble
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_3BB8A99D_argDouble
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.UnaryOperator_PlusPlusPrefix/Scope _environment0_UnaryOperator_PlusPlusPrefix
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.UnaryOperator_PlusPlusPrefix/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2587
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.UnaryOperator_PlusPlusPrefix/Scope FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::_environment0_UnaryOperator_PlusPlusPrefix
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2596
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2599
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x259c
-		// Header size: 1
-		// Code size: 29 (0x1d)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::_environment0_UnaryOperator_PlusPlusPrefix
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0017: call object Modules.UnaryOperator_PlusPlusPrefix/argDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object, float64)
-		IL_001c: ret
-	} // end of method FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25ba
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::_environment0_UnaryOperator_PlusPlusPrefix
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0013: call object Modules.UnaryOperator_PlusPlusPrefix/argDouble::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object, float64)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x25d4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3BB8A99D_argDouble::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_3BB8A99D_argDouble
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_3D09EA77_capturedString
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.UnaryOperator_PlusPlusPrefix/Scope _environment0_UnaryOperator_PlusPlusPrefix
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.UnaryOperator_PlusPlusPrefix/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x25e3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.UnaryOperator_PlusPlusPrefix/Scope FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_3D09EA77_capturedString::_environment0_UnaryOperator_PlusPlusPrefix
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3D09EA77_capturedString::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x25f2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3D09EA77_capturedString::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x25f5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3D09EA77_capturedString::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x25f8
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_3D09EA77_capturedString::_environment0_UnaryOperator_PlusPlusPrefix
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.UnaryOperator_PlusPlusPrefix/capturedString::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_3D09EA77_capturedString::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x260a
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_3D09EA77_capturedString::_environment0_UnaryOperator_PlusPlusPrefix
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.UnaryOperator_PlusPlusPrefix/capturedString::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_3D09EA77_capturedString::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2618
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3D09EA77_capturedString::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_3D09EA77_capturedString
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_B37D5999_argString
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.UnaryOperator_PlusPlusPrefix/Scope _environment0_UnaryOperator_PlusPlusPrefix
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.UnaryOperator_PlusPlusPrefix/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2627
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.UnaryOperator_PlusPlusPrefix/Scope FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_B37D5999_argString::_environment0_UnaryOperator_PlusPlusPrefix
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B37D5999_argString::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2636
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B37D5999_argString::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2639
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_B37D5999_argString::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x263c
-		// Header size: 1
-		// Code size: 24 (0x18)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_B37D5999_argString::_environment0_UnaryOperator_PlusPlusPrefix
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call object Modules.UnaryOperator_PlusPlusPrefix/argString::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object, object)
-		IL_0017: ret
-	} // end of method FunctionObject_FunctionDeclaration_B37D5999_argString::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2655
-		// Header size: 1
-		// Code size: 20 (0x14)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.UnaryOperator_PlusPlusPrefix/Scope FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_B37D5999_argString::_environment0_UnaryOperator_PlusPlusPrefix
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call object Modules.UnaryOperator_PlusPlusPrefix/argString::__js_call__(class Modules.UnaryOperator_PlusPlusPrefix/Scope, object, object)
-		IL_0013: ret
-	} // end of method FunctionObject_FunctionDeclaration_B37D5999_argString::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x266a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_B37D5999_argString::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_PlusPlusPrefix_3EA28F51.FunctionObject_FunctionDeclaration_B37D5999_argString
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix_InFunctionSwitch.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix_InFunctionSwitch.verified.txt
@@ -53,6 +53,109 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_E66FC83C_bump
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21e9
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_E66FC83C_bump::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21f1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E66FC83C_bump::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21f4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_E66FC83C_bump::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f7
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0011: call object Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch/bump::__js_call__(object, string)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_E66FC83C_bump::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x220f
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: call object Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch/bump::__js_call__(object, string)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_E66FC83C_bump::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2223
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_E66FC83C_bump::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_E66FC83C_bump
+
 
 		// Methods
 		.method public hidebysig static 
@@ -214,7 +317,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch/Scope,
-			[1] class FunctionObjects.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_BB082445.FunctionObject_FunctionDeclaration_E66FC83C_bump,
+			[1] class Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch/bump/FunctionObject_FunctionDeclaration_E66FC83C_bump,
 			[2] object[]
 		)
 
@@ -227,13 +330,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_BB082445.FunctionObject_FunctionDeclaration_E66FC83C_bump::.ctor()
+		IL_0011: newobj instance void Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch/bump/FunctionObject_FunctionDeclaration_E66FC83C_bump::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "bump"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_BB082445.FunctionObject_FunctionDeclaration_E66FC83C_bump>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch/bump/FunctionObject_FunctionDeclaration_E66FC83C_bump>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -262,109 +365,6 @@
 	} // end of method UnaryOperator_PlusPlusPrefix_InFunctionSwitch::__js_module_init__
 
 } // end of class Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_BB082445.FunctionObject_FunctionDeclaration_E66FC83C_bump
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21e9
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_E66FC83C_bump::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21f1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E66FC83C_bump::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21f4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_E66FC83C_bump::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f7
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0011: call object Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch/bump::__js_call__(object, string)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_E66FC83C_bump::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x220f
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_000d: call object Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch/bump::__js_call__(object, string)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_E66FC83C_bump::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2223
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_E66FC83C_bump::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_BB082445.FunctionObject_FunctionDeclaration_E66FC83C_bump
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal.verified.txt
+++ b/tests/Jroc.Tests/UnaryOperator/Snapshots/GeneratorTests.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal.verified.txt
@@ -53,6 +53,109 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A71D4CAB_bump
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x21f8
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_A71D4CAB_bump::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2200
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A71D4CAB_bump::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2203
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A71D4CAB_bump::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2206
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_0011: call object Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_A71D4CAB_bump::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x221e
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
+				IL_000d: call object Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_A71D4CAB_bump::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2232
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A71D4CAB_bump::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_A71D4CAB_bump
+
 
 		// Methods
 		.method public hidebysig static 
@@ -231,7 +334,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal/Scope,
-			[1] class FunctionObjects.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal_188D8530.FunctionObject_FunctionDeclaration_A71D4CAB_bump,
+			[1] class Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal/bump/FunctionObject_FunctionDeclaration_A71D4CAB_bump,
 			[2] object[]
 		)
 
@@ -244,13 +347,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal_188D8530.FunctionObject_FunctionDeclaration_A71D4CAB_bump::.ctor()
+		IL_0011: newobj instance void Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal/bump/FunctionObject_FunctionDeclaration_A71D4CAB_bump::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "bump"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal_188D8530.FunctionObject_FunctionDeclaration_A71D4CAB_bump>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal/bump/FunctionObject_FunctionDeclaration_A71D4CAB_bump>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -279,109 +382,6 @@
 	} // end of method UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal::__js_module_init__
 
 } // end of class Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal_188D8530.FunctionObject_FunctionDeclaration_A71D4CAB_bump
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21f8
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_A71D4CAB_bump::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2200
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A71D4CAB_bump::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2203
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A71D4CAB_bump::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2206
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_0011: call object Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_A71D4CAB_bump::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x221e
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call string [JavaScriptRuntime]JavaScriptRuntime.DotNet2JSConversions::ToString(object)
-		IL_000d: call object Modules.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal/bump::__js_call__(object, string)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_A71D4CAB_bump::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2232
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A71D4CAB_bump::ConstructCore
-
-} // end of class FunctionObjects.UnaryOperator_PlusPlusPrefix_InFunctionSwitch_ObjectLocal_188D8530.FunctionObject_FunctionDeclaration_A71D4CAB_bump
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_BoolStringFieldType.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_BoolStringFieldType.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_BA7E0883_run
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Variable_CapturedConst_BoolStringFieldType/Scope _environment0_Variable_CapturedConst_BoolStringFieldType
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Variable_CapturedConst_BoolStringFieldType/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2104
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Variable_CapturedConst_BoolStringFieldType/Scope Modules.Variable_CapturedConst_BoolStringFieldType/run/FunctionObject_FunctionDeclaration_BA7E0883_run::_environment0_Variable_CapturedConst_BoolStringFieldType
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BA7E0883_run::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2113
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BA7E0883_run::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2116
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_BA7E0883_run::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2119
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Variable_CapturedConst_BoolStringFieldType/Scope Modules.Variable_CapturedConst_BoolStringFieldType/run/FunctionObject_FunctionDeclaration_BA7E0883_run::_environment0_Variable_CapturedConst_BoolStringFieldType
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Variable_CapturedConst_BoolStringFieldType/run::__js_call__(class Modules.Variable_CapturedConst_BoolStringFieldType/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_BA7E0883_run::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x212b
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Variable_CapturedConst_BoolStringFieldType/Scope Modules.Variable_CapturedConst_BoolStringFieldType/run/FunctionObject_FunctionDeclaration_BA7E0883_run::_environment0_Variable_CapturedConst_BoolStringFieldType
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Variable_CapturedConst_BoolStringFieldType/run::__js_call__(class Modules.Variable_CapturedConst_BoolStringFieldType/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_BA7E0883_run::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2139
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_BA7E0883_run::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_BA7E0883_run
+
 
 		// Methods
 		.method public hidebysig static 
@@ -115,7 +222,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_CapturedConst_BoolStringFieldType/Scope,
-			[1] class FunctionObjects.Variable_CapturedConst_BoolStringFieldType_75778F2F.FunctionObject_FunctionDeclaration_BA7E0883_run,
+			[1] class Modules.Variable_CapturedConst_BoolStringFieldType/run/FunctionObject_FunctionDeclaration_BA7E0883_run,
 			[2] object[],
 			[3] object,
 			[4] object
@@ -134,13 +241,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Variable_CapturedConst_BoolStringFieldType/Scope
-		IL_0019: newobj instance void FunctionObjects.Variable_CapturedConst_BoolStringFieldType_75778F2F.FunctionObject_FunctionDeclaration_BA7E0883_run::.ctor(class Modules.Variable_CapturedConst_BoolStringFieldType/Scope)
+		IL_0019: newobj instance void Modules.Variable_CapturedConst_BoolStringFieldType/run/FunctionObject_FunctionDeclaration_BA7E0883_run::.ctor(class Modules.Variable_CapturedConst_BoolStringFieldType/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "run"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_CapturedConst_BoolStringFieldType_75778F2F.FunctionObject_FunctionDeclaration_BA7E0883_run>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_CapturedConst_BoolStringFieldType/run/FunctionObject_FunctionDeclaration_BA7E0883_run>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldloc.0
@@ -167,113 +274,6 @@
 	} // end of method Variable_CapturedConst_BoolStringFieldType::__js_module_init__
 
 } // end of class Modules.Variable_CapturedConst_BoolStringFieldType
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_CapturedConst_BoolStringFieldType_75778F2F.FunctionObject_FunctionDeclaration_BA7E0883_run
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Variable_CapturedConst_BoolStringFieldType/Scope _environment0_Variable_CapturedConst_BoolStringFieldType
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Variable_CapturedConst_BoolStringFieldType/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2104
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Variable_CapturedConst_BoolStringFieldType/Scope FunctionObjects.Variable_CapturedConst_BoolStringFieldType_75778F2F.FunctionObject_FunctionDeclaration_BA7E0883_run::_environment0_Variable_CapturedConst_BoolStringFieldType
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BA7E0883_run::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2113
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BA7E0883_run::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2116
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_BA7E0883_run::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2119
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Variable_CapturedConst_BoolStringFieldType/Scope FunctionObjects.Variable_CapturedConst_BoolStringFieldType_75778F2F.FunctionObject_FunctionDeclaration_BA7E0883_run::_environment0_Variable_CapturedConst_BoolStringFieldType
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Variable_CapturedConst_BoolStringFieldType/run::__js_call__(class Modules.Variable_CapturedConst_BoolStringFieldType/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_BA7E0883_run::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x212b
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Variable_CapturedConst_BoolStringFieldType/Scope FunctionObjects.Variable_CapturedConst_BoolStringFieldType_75778F2F.FunctionObject_FunctionDeclaration_BA7E0883_run::_environment0_Variable_CapturedConst_BoolStringFieldType
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Variable_CapturedConst_BoolStringFieldType/run::__js_call__(class Modules.Variable_CapturedConst_BoolStringFieldType/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_BA7E0883_run::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2139
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_BA7E0883_run::ConstructCore
-
-} // end of class FunctionObjects.Variable_CapturedConst_BoolStringFieldType_75778F2F.FunctionObject_FunctionDeclaration_BA7E0883_run
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_NumberFieldType.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_CapturedConst_NumberFieldType.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_0E8E929B_run
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Variable_CapturedConst_NumberFieldType/Scope _environment0_Variable_CapturedConst_NumberFieldType
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Variable_CapturedConst_NumberFieldType/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x20ef
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Variable_CapturedConst_NumberFieldType/Scope Modules.Variable_CapturedConst_NumberFieldType/run/FunctionObject_FunctionDeclaration_0E8E929B_run::_environment0_Variable_CapturedConst_NumberFieldType
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0E8E929B_run::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x20fe
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0E8E929B_run::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2101
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_0E8E929B_run::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2104
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Variable_CapturedConst_NumberFieldType/Scope Modules.Variable_CapturedConst_NumberFieldType/run/FunctionObject_FunctionDeclaration_0E8E929B_run::_environment0_Variable_CapturedConst_NumberFieldType
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Variable_CapturedConst_NumberFieldType/run::__js_call__(class Modules.Variable_CapturedConst_NumberFieldType/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_0E8E929B_run::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2116
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Variable_CapturedConst_NumberFieldType/Scope Modules.Variable_CapturedConst_NumberFieldType/run/FunctionObject_FunctionDeclaration_0E8E929B_run::_environment0_Variable_CapturedConst_NumberFieldType
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Variable_CapturedConst_NumberFieldType/run::__js_call__(class Modules.Variable_CapturedConst_NumberFieldType/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_0E8E929B_run::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2124
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_0E8E929B_run::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_0E8E929B_run
+
 
 		// Methods
 		.method public hidebysig static 
@@ -106,7 +213,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_CapturedConst_NumberFieldType/Scope,
-			[1] class FunctionObjects.Variable_CapturedConst_NumberFieldType_2CB3BAF7.FunctionObject_FunctionDeclaration_0E8E929B_run,
+			[1] class Modules.Variable_CapturedConst_NumberFieldType/run/FunctionObject_FunctionDeclaration_0E8E929B_run,
 			[2] object[],
 			[3] object,
 			[4] object
@@ -125,13 +232,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Variable_CapturedConst_NumberFieldType/Scope
-		IL_0019: newobj instance void FunctionObjects.Variable_CapturedConst_NumberFieldType_2CB3BAF7.FunctionObject_FunctionDeclaration_0E8E929B_run::.ctor(class Modules.Variable_CapturedConst_NumberFieldType/Scope)
+		IL_0019: newobj instance void Modules.Variable_CapturedConst_NumberFieldType/run/FunctionObject_FunctionDeclaration_0E8E929B_run::.ctor(class Modules.Variable_CapturedConst_NumberFieldType/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "run"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_CapturedConst_NumberFieldType_2CB3BAF7.FunctionObject_FunctionDeclaration_0E8E929B_run>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_CapturedConst_NumberFieldType/run/FunctionObject_FunctionDeclaration_0E8E929B_run>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: ldloc.0
@@ -155,113 +262,6 @@
 	} // end of method Variable_CapturedConst_NumberFieldType::__js_module_init__
 
 } // end of class Modules.Variable_CapturedConst_NumberFieldType
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_CapturedConst_NumberFieldType_2CB3BAF7.FunctionObject_FunctionDeclaration_0E8E929B_run
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Variable_CapturedConst_NumberFieldType/Scope _environment0_Variable_CapturedConst_NumberFieldType
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Variable_CapturedConst_NumberFieldType/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x20ef
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Variable_CapturedConst_NumberFieldType/Scope FunctionObjects.Variable_CapturedConst_NumberFieldType_2CB3BAF7.FunctionObject_FunctionDeclaration_0E8E929B_run::_environment0_Variable_CapturedConst_NumberFieldType
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0E8E929B_run::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x20fe
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0E8E929B_run::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2101
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_0E8E929B_run::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2104
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Variable_CapturedConst_NumberFieldType/Scope FunctionObjects.Variable_CapturedConst_NumberFieldType_2CB3BAF7.FunctionObject_FunctionDeclaration_0E8E929B_run::_environment0_Variable_CapturedConst_NumberFieldType
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Variable_CapturedConst_NumberFieldType/run::__js_call__(class Modules.Variable_CapturedConst_NumberFieldType/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_0E8E929B_run::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2116
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Variable_CapturedConst_NumberFieldType/Scope FunctionObjects.Variable_CapturedConst_NumberFieldType_2CB3BAF7.FunctionObject_FunctionDeclaration_0E8E929B_run::_environment0_Variable_CapturedConst_NumberFieldType
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Variable_CapturedConst_NumberFieldType/run::__js_call__(class Modules.Variable_CapturedConst_NumberFieldType/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_0E8E929B_run::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2124
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_0E8E929B_run::ConstructCore
-
-} // end of class FunctionObjects.Variable_CapturedConst_NumberFieldType_2CB3BAF7.FunctionObject_FunctionDeclaration_0E8E929B_run
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ConstPrimitivePropagation.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ConstPrimitivePropagation.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_747086A3_readLate
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Variable_ConstPrimitivePropagation/Scope _environment0_Variable_ConstPrimitivePropagation
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Variable_ConstPrimitivePropagation/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2dcf
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Variable_ConstPrimitivePropagation/Scope Modules.Variable_ConstPrimitivePropagation/readLate/FunctionObject_FunctionDeclaration_747086A3_readLate::_environment0_Variable_ConstPrimitivePropagation
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_747086A3_readLate::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2dde
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_747086A3_readLate::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2de1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_747086A3_readLate::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2de4
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Variable_ConstPrimitivePropagation/Scope Modules.Variable_ConstPrimitivePropagation/readLate/FunctionObject_FunctionDeclaration_747086A3_readLate::_environment0_Variable_ConstPrimitivePropagation
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Variable_ConstPrimitivePropagation/readLate::__js_call__(class Modules.Variable_ConstPrimitivePropagation/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_747086A3_readLate::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2df6
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Variable_ConstPrimitivePropagation/Scope Modules.Variable_ConstPrimitivePropagation/readLate/FunctionObject_FunctionDeclaration_747086A3_readLate::_environment0_Variable_ConstPrimitivePropagation
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Variable_ConstPrimitivePropagation/readLate::__js_call__(class Modules.Variable_ConstPrimitivePropagation/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_747086A3_readLate::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e04
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_747086A3_readLate::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_747086A3_readLate
+
 
 		// Methods
 		.method public hidebysig static 
@@ -265,6 +372,113 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Variable_ConstPrimitivePropagation/Scope _environment0_Variable_ConstPrimitivePropagation
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Variable_ConstPrimitivePropagation/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f42
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Variable_ConstPrimitivePropagation/Scope Modules.Variable_ConstPrimitivePropagation/sameCallableTdz/FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::_environment0_Variable_ConstPrimitivePropagation
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2f51
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2f54
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f57
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Variable_ConstPrimitivePropagation/Scope Modules.Variable_ConstPrimitivePropagation/sameCallableTdz/FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::_environment0_Variable_ConstPrimitivePropagation
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Variable_ConstPrimitivePropagation/sameCallableTdz::__js_call__(class Modules.Variable_ConstPrimitivePropagation/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f69
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Variable_ConstPrimitivePropagation/Scope Modules.Variable_ConstPrimitivePropagation/sameCallableTdz/FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::_environment0_Variable_ConstPrimitivePropagation
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Variable_ConstPrimitivePropagation/sameCallableTdz::__js_call__(class Modules.Variable_ConstPrimitivePropagation/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f77
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz
 
 
 		// Methods
@@ -589,6 +803,209 @@
 
 		} // end of class Scope_shadow
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_684D8BC2_Reader
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d6c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Variable_ConstPrimitivePropagation/Reader/FunctionObject_ClassConstructor_684D8BC2_Reader::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_684D8BC2_Reader::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2d7b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_684D8BC2_Reader::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2d7e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_684D8BC2_Reader::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d81
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_684D8BC2_Reader::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2d8d
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_684D8BC2_Reader::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_684D8BC2_Reader
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_3DE6B5BB_Reader_read
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2d99
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_3DE6B5BB_Reader_read::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2da1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_3DE6B5BB_Reader_read::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2da4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_3DE6B5BB_Reader_read::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2da7
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Variable_ConstPrimitivePropagation/Reader
+				IL_0006: call instance object Modules.Variable_ConstPrimitivePropagation/Reader::read()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_3DE6B5BB_Reader_read::CallCore
+
+		} // end of class FunctionObject_ClassMethod_3DE6B5BB_Reader_read
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_53B63CFF_Reader_shadow
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2db4
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_53B63CFF_Reader_shadow::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2dbc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_53B63CFF_Reader_shadow::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2dbf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_53B63CFF_Reader_shadow::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2dc2
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Variable_ConstPrimitivePropagation/Reader
+				IL_0006: call instance object Modules.Variable_ConstPrimitivePropagation/Reader::shadow()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_53B63CFF_Reader_shadow::CallCore
+
+		} // end of class FunctionObject_ClassMethod_53B63CFF_Reader_shadow
+
 
 		// Fields
 		.field private object[] _scopes
@@ -743,6 +1160,150 @@
 
 		} // end of class Scope_read
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_C9CF370F_WrittenReader
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e13
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Variable_ConstPrimitivePropagation/WrittenReader/FunctionObject_ClassConstructor_C9CF370F_WrittenReader::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_C9CF370F_WrittenReader::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2e22
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_C9CF370F_WrittenReader::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2e25
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_C9CF370F_WrittenReader::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e28
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_C9CF370F_WrittenReader::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e34
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_C9CF370F_WrittenReader::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_C9CF370F_WrittenReader
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_F21E7C12_WrittenReader_read
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2e40
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_F21E7C12_WrittenReader_read::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2e48
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_F21E7C12_WrittenReader_read::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2e4b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_F21E7C12_WrittenReader_read::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e4e
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Variable_ConstPrimitivePropagation/WrittenReader
+				IL_0006: call instance float64 Modules.Variable_ConstPrimitivePropagation/WrittenReader::read()
+				IL_000b: box [System.Runtime]System.Double
+				IL_0010: ret
+			} // end of method FunctionObject_ClassMethod_F21E7C12_WrittenReader_read::CallCore
+
+		} // end of class FunctionObject_ClassMethod_F21E7C12_WrittenReader_read
+
 
 		// Fields
 		.field private object[] _scopes
@@ -839,6 +1400,150 @@
 			} // end of method Scope_read::.ctor
 
 		} // end of class Scope_read
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_9780F786_PatternReader
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e60
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Variable_ConstPrimitivePropagation/PatternReader/FunctionObject_ClassConstructor_9780F786_PatternReader::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_9780F786_PatternReader::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2e6f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_9780F786_PatternReader::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2e72
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_9780F786_PatternReader::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e75
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_9780F786_PatternReader::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e81
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_9780F786_PatternReader::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_9780F786_PatternReader
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_1232A1A1_PatternReader_read
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2e8d
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_1232A1A1_PatternReader_read::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2e95
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_1232A1A1_PatternReader_read::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2e98
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_1232A1A1_PatternReader_read::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2e9b
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Variable_ConstPrimitivePropagation/PatternReader
+				IL_0006: call instance float64 Modules.Variable_ConstPrimitivePropagation/PatternReader::read()
+				IL_000b: box [System.Runtime]System.Double
+				IL_0010: ret
+			} // end of method FunctionObject_ClassMethod_1232A1A1_PatternReader_read::CallCore
+
+		} // end of class FunctionObject_ClassMethod_1232A1A1_PatternReader_read
 
 
 		// Fields
@@ -937,6 +1642,150 @@
 
 		} // end of class Scope_read
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_7E4AB268_LoopReader
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ead
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Variable_ConstPrimitivePropagation/LoopReader/FunctionObject_ClassConstructor_7E4AB268_LoopReader::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_7E4AB268_LoopReader::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2ebc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_7E4AB268_LoopReader::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2ebf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_7E4AB268_LoopReader::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ec2
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_7E4AB268_LoopReader::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ece
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_7E4AB268_LoopReader::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_7E4AB268_LoopReader
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_30F34DFD_LoopReader_read
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2eda
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_30F34DFD_LoopReader_read::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2ee2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_30F34DFD_LoopReader_read::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2ee5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_30F34DFD_LoopReader_read::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ee8
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Variable_ConstPrimitivePropagation/LoopReader
+				IL_0006: call instance float64 Modules.Variable_ConstPrimitivePropagation/LoopReader::read()
+				IL_000b: box [System.Runtime]System.Double
+				IL_0010: ret
+			} // end of method FunctionObject_ClassMethod_30F34DFD_LoopReader_read::CallCore
+
+		} // end of class FunctionObject_ClassMethod_30F34DFD_LoopReader_read
+
 
 		// Fields
 		.field private object[] _scopes
@@ -1033,6 +1882,149 @@
 			} // end of method Scope_read::.ctor
 
 		} // end of class Scope_read
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassConstructor_10AB8F4A_DestructuredReader
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly object[] _transitionalScopes
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					object[] capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2efa
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld object[] Modules.Variable_ConstPrimitivePropagation/DestructuredReader/FunctionObject_ClassConstructor_10AB8F4A_DestructuredReader::_transitionalScopes
+				IL_000d: ret
+			} // end of method FunctionObject_ClassConstructor_10AB8F4A_DestructuredReader::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2f09
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_10AB8F4A_DestructuredReader::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2f0c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassConstructor_10AB8F4A_DestructuredReader::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f0f
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_10AB8F4A_DestructuredReader::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f1b
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
+				IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
+				IL_000a: throw
+			} // end of method FunctionObject_ClassConstructor_10AB8F4A_DestructuredReader::ConstructCore
+
+		} // end of class FunctionObject_ClassConstructor_10AB8F4A_DestructuredReader
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_ClassMethod_98A4F65F_DestructuredReader_read
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2f27
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_ClassMethod_98A4F65F_DestructuredReader_read::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2f2f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_98A4F65F_DestructuredReader_read::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2f32
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_ClassMethod_98A4F65F_DestructuredReader_read::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2f35
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: castclass Modules.Variable_ConstPrimitivePropagation/DestructuredReader
+				IL_0006: call instance object Modules.Variable_ConstPrimitivePropagation/DestructuredReader::read()
+				IL_000b: ret
+			} // end of method FunctionObject_ClassMethod_98A4F65F_DestructuredReader_read::CallCore
+
+		} // end of class FunctionObject_ClassMethod_98A4F65F_DestructuredReader_read
 
 
 		// Fields
@@ -1362,8 +2354,8 @@
 		.maxstack 12
 		.locals init (
 			[0] class Modules.Variable_ConstPrimitivePropagation/Scope,
-			[1] class FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_FunctionDeclaration_747086A3_readLate,
-			[2] class FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz,
+			[1] class Modules.Variable_ConstPrimitivePropagation/readLate/FunctionObject_FunctionDeclaration_747086A3_readLate,
+			[2] class Modules.Variable_ConstPrimitivePropagation/sameCallableTdz/FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz,
 			[3] class Modules.Variable_ConstPrimitivePropagation/Reader,
 			[4] float64,
 			[5] class [System.Runtime]System.Exception,
@@ -1419,13 +2411,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Variable_ConstPrimitivePropagation/Scope
-		IL_001b: newobj instance void FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_FunctionDeclaration_747086A3_readLate::.ctor(class Modules.Variable_ConstPrimitivePropagation/Scope)
+		IL_001b: newobj instance void Modules.Variable_ConstPrimitivePropagation/readLate/FunctionObject_FunctionDeclaration_747086A3_readLate::.ctor(class Modules.Variable_ConstPrimitivePropagation/Scope)
 		IL_0020: ldc.i4.0
 		IL_0021: conv.r8
 		IL_0022: ldstr "readLate"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_FunctionDeclaration_747086A3_readLate>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_ConstPrimitivePropagation/readLate/FunctionObject_FunctionDeclaration_747086A3_readLate>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: ldc.i4.1
 		IL_0030: newarr [System.Runtime]System.Object
@@ -1438,13 +2430,13 @@
 		IL_003d: ldc.i4.0
 		IL_003e: ldelem.ref
 		IL_003f: castclass Modules.Variable_ConstPrimitivePropagation/Scope
-		IL_0044: newobj instance void FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::.ctor(class Modules.Variable_ConstPrimitivePropagation/Scope)
+		IL_0044: newobj instance void Modules.Variable_ConstPrimitivePropagation/sameCallableTdz/FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::.ctor(class Modules.Variable_ConstPrimitivePropagation/Scope)
 		IL_0049: ldc.i4.0
 		IL_004a: conv.r8
 		IL_004b: ldstr "sameCallableTdz"
 		IL_0050: ldc.i4.0
 		IL_0051: ldc.i4.1
-		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz>(!!0, float64, string, bool, bool)
+		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_ConstPrimitivePropagation/sameCallableTdz/FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz>(!!0, float64, string, bool, bool)
 		IL_0057: stloc.2
 		IL_0058: nop
 		IL_0059: nop
@@ -2214,998 +3206,6 @@
 	} // end of method Variable_ConstPrimitivePropagation::__js_module_init__
 
 } // end of class Modules.Variable_ConstPrimitivePropagation
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_ClassConstructor_684D8BC2_Reader
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d6c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_ClassConstructor_684D8BC2_Reader::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_684D8BC2_Reader::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2d7b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_684D8BC2_Reader::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2d7e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_684D8BC2_Reader::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d81
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_684D8BC2_Reader::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2d8d
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_684D8BC2_Reader::ConstructCore
-
-} // end of class FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_ClassConstructor_684D8BC2_Reader
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_ClassMethod_3DE6B5BB_Reader_read
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2d99
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_3DE6B5BB_Reader_read::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2da1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_3DE6B5BB_Reader_read::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2da4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_3DE6B5BB_Reader_read::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2da7
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Variable_ConstPrimitivePropagation/Reader
-		IL_0006: call instance object Modules.Variable_ConstPrimitivePropagation/Reader::read()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_3DE6B5BB_Reader_read::CallCore
-
-} // end of class FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_ClassMethod_3DE6B5BB_Reader_read
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_ClassMethod_53B63CFF_Reader_shadow
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2db4
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_53B63CFF_Reader_shadow::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2dbc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_53B63CFF_Reader_shadow::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2dbf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_53B63CFF_Reader_shadow::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2dc2
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Variable_ConstPrimitivePropagation/Reader
-		IL_0006: call instance object Modules.Variable_ConstPrimitivePropagation/Reader::shadow()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_53B63CFF_Reader_shadow::CallCore
-
-} // end of class FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_ClassMethod_53B63CFF_Reader_shadow
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_FunctionDeclaration_747086A3_readLate
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Variable_ConstPrimitivePropagation/Scope _environment0_Variable_ConstPrimitivePropagation
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Variable_ConstPrimitivePropagation/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2dcf
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Variable_ConstPrimitivePropagation/Scope FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_FunctionDeclaration_747086A3_readLate::_environment0_Variable_ConstPrimitivePropagation
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_747086A3_readLate::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2dde
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_747086A3_readLate::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2de1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_747086A3_readLate::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2de4
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Variable_ConstPrimitivePropagation/Scope FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_FunctionDeclaration_747086A3_readLate::_environment0_Variable_ConstPrimitivePropagation
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Variable_ConstPrimitivePropagation/readLate::__js_call__(class Modules.Variable_ConstPrimitivePropagation/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_747086A3_readLate::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2df6
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Variable_ConstPrimitivePropagation/Scope FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_FunctionDeclaration_747086A3_readLate::_environment0_Variable_ConstPrimitivePropagation
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Variable_ConstPrimitivePropagation/readLate::__js_call__(class Modules.Variable_ConstPrimitivePropagation/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_747086A3_readLate::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e04
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_747086A3_readLate::ConstructCore
-
-} // end of class FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_FunctionDeclaration_747086A3_readLate
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_ClassConstructor_C9CF370F_WrittenReader
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e13
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_ClassConstructor_C9CF370F_WrittenReader::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_C9CF370F_WrittenReader::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2e22
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_C9CF370F_WrittenReader::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2e25
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_C9CF370F_WrittenReader::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e28
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_C9CF370F_WrittenReader::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e34
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_C9CF370F_WrittenReader::ConstructCore
-
-} // end of class FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_ClassConstructor_C9CF370F_WrittenReader
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_ClassMethod_F21E7C12_WrittenReader_read
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2e40
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_F21E7C12_WrittenReader_read::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2e48
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_F21E7C12_WrittenReader_read::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2e4b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_F21E7C12_WrittenReader_read::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e4e
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Variable_ConstPrimitivePropagation/WrittenReader
-		IL_0006: call instance float64 Modules.Variable_ConstPrimitivePropagation/WrittenReader::read()
-		IL_000b: box [System.Runtime]System.Double
-		IL_0010: ret
-	} // end of method FunctionObject_ClassMethod_F21E7C12_WrittenReader_read::CallCore
-
-} // end of class FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_ClassMethod_F21E7C12_WrittenReader_read
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_ClassConstructor_9780F786_PatternReader
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e60
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_ClassConstructor_9780F786_PatternReader::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_9780F786_PatternReader::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2e6f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_9780F786_PatternReader::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2e72
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_9780F786_PatternReader::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e75
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_9780F786_PatternReader::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e81
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_9780F786_PatternReader::ConstructCore
-
-} // end of class FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_ClassConstructor_9780F786_PatternReader
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_ClassMethod_1232A1A1_PatternReader_read
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2e8d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_1232A1A1_PatternReader_read::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2e95
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_1232A1A1_PatternReader_read::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2e98
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_1232A1A1_PatternReader_read::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2e9b
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Variable_ConstPrimitivePropagation/PatternReader
-		IL_0006: call instance float64 Modules.Variable_ConstPrimitivePropagation/PatternReader::read()
-		IL_000b: box [System.Runtime]System.Double
-		IL_0010: ret
-	} // end of method FunctionObject_ClassMethod_1232A1A1_PatternReader_read::CallCore
-
-} // end of class FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_ClassMethod_1232A1A1_PatternReader_read
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_ClassConstructor_7E4AB268_LoopReader
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ead
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_ClassConstructor_7E4AB268_LoopReader::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_7E4AB268_LoopReader::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2ebc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_7E4AB268_LoopReader::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2ebf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_7E4AB268_LoopReader::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ec2
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_7E4AB268_LoopReader::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ece
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_7E4AB268_LoopReader::ConstructCore
-
-} // end of class FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_ClassConstructor_7E4AB268_LoopReader
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_ClassMethod_30F34DFD_LoopReader_read
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2eda
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_30F34DFD_LoopReader_read::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2ee2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_30F34DFD_LoopReader_read::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2ee5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_30F34DFD_LoopReader_read::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ee8
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Variable_ConstPrimitivePropagation/LoopReader
-		IL_0006: call instance float64 Modules.Variable_ConstPrimitivePropagation/LoopReader::read()
-		IL_000b: box [System.Runtime]System.Double
-		IL_0010: ret
-	} // end of method FunctionObject_ClassMethod_30F34DFD_LoopReader_read::CallCore
-
-} // end of class FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_ClassMethod_30F34DFD_LoopReader_read
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_ClassConstructor_10AB8F4A_DestructuredReader
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			object[] capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2efa
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld object[] FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_ClassConstructor_10AB8F4A_DestructuredReader::_transitionalScopes
-		IL_000d: ret
-	} // end of method FunctionObject_ClassConstructor_10AB8F4A_DestructuredReader::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2f09
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_10AB8F4A_DestructuredReader::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2f0c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassConstructor_10AB8F4A_DestructuredReader::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f0f
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Class constructor cannot be invoked without 'new'"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_10AB8F4A_DestructuredReader::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f1b
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: ldstr "Generated construction adapter is reserved for the callable-family construction migration"
-		IL_0005: newobj instance void [JavaScriptRuntime]JavaScriptRuntime.TypeError::.ctor(string)
-		IL_000a: throw
-	} // end of method FunctionObject_ClassConstructor_10AB8F4A_DestructuredReader::ConstructCore
-
-} // end of class FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_ClassConstructor_10AB8F4A_DestructuredReader
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_ClassMethod_98A4F65F_DestructuredReader_read
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2f27
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_ClassMethod_98A4F65F_DestructuredReader_read::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2f2f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_98A4F65F_DestructuredReader_read::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2f32
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_ClassMethod_98A4F65F_DestructuredReader_read::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f35
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: castclass Modules.Variable_ConstPrimitivePropagation/DestructuredReader
-		IL_0006: call instance object Modules.Variable_ConstPrimitivePropagation/DestructuredReader::read()
-		IL_000b: ret
-	} // end of method FunctionObject_ClassMethod_98A4F65F_DestructuredReader_read::CallCore
-
-} // end of class FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_ClassMethod_98A4F65F_DestructuredReader_read
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Variable_ConstPrimitivePropagation/Scope _environment0_Variable_ConstPrimitivePropagation
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Variable_ConstPrimitivePropagation/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f42
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Variable_ConstPrimitivePropagation/Scope FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::_environment0_Variable_ConstPrimitivePropagation
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2f51
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2f54
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f57
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Variable_ConstPrimitivePropagation/Scope FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::_environment0_Variable_ConstPrimitivePropagation
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Variable_ConstPrimitivePropagation/sameCallableTdz::__js_call__(class Modules.Variable_ConstPrimitivePropagation/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f69
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Variable_ConstPrimitivePropagation/Scope FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::_environment0_Variable_ConstPrimitivePropagation
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Variable_ConstPrimitivePropagation/sameCallableTdz::__js_call__(class Modules.Variable_ConstPrimitivePropagation/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2f77
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz::ConstructCore
-
-} // end of class FunctionObjects.Variable_ConstPrimitivePropagation_58CF6D64.FunctionObject_FunctionDeclaration_A5C35AA9_sameCallableTdz
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ConstPrimitivePropagation_With.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ConstPrimitivePropagation_With.verified.txt
@@ -31,6 +31,122 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_6DBEEA65_receive
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x23fb
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_6DBEEA65_receive::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2403
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6DBEEA65_receive::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2406
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_6DBEEA65_receive::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2409
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_6DBEEA65_receive::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2411
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Variable_ConstPrimitivePropagation_With/receive::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_6DBEEA65_receive::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2424
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Variable_ConstPrimitivePropagation_With/receive::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6DBEEA65_receive::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2433
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_6DBEEA65_receive::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_6DBEEA65_receive
+
 
 		// Methods
 		.method public hidebysig static 
@@ -76,6 +192,122 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2442
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x244a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x244d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2450
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2458
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Variable_ConstPrimitivePropagation_With/receiveIdentifier::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x246b
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Variable_ConstPrimitivePropagation_With/receiveIdentifier::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x247a
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier
 
 
 		// Methods
@@ -813,8 +1045,8 @@
 			[1] object,
 			[2] object,
 			[3] object[],
-			[4] class FunctionObjects.Variable_ConstPrimitivePropagation_With_B4ED9F95.FunctionObject_FunctionDeclaration_6DBEEA65_receive,
-			[5] class FunctionObjects.Variable_ConstPrimitivePropagation_With_B4ED9F95.FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier,
+			[4] class Modules.Variable_ConstPrimitivePropagation_With/receive/FunctionObject_FunctionDeclaration_6DBEEA65_receive,
+			[5] class Modules.Variable_ConstPrimitivePropagation_With/receiveIdentifier/FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier,
 			[6] class Modules.Variable_ConstPrimitivePropagation_With/ArrowFunction_L11C20/FunctionObject,
 			[7] class Modules.Variable_ConstPrimitivePropagation_With/ArrowFunction_L17C30/FunctionObject,
 			[8] object,
@@ -831,13 +1063,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.Variable_ConstPrimitivePropagation_With_B4ED9F95.FunctionObject_FunctionDeclaration_6DBEEA65_receive::.ctor()
+		IL_0011: newobj instance void Modules.Variable_ConstPrimitivePropagation_With/receive/FunctionObject_FunctionDeclaration_6DBEEA65_receive::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "receive"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.0
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_ConstPrimitivePropagation_With_B4ED9F95.FunctionObject_FunctionDeclaration_6DBEEA65_receive>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_ConstPrimitivePropagation_With/receive/FunctionObject_FunctionDeclaration_6DBEEA65_receive>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.s 4
 		IL_0026: ldloc.0
 		IL_0027: ldloc.s 4
@@ -849,13 +1081,13 @@
 		IL_0036: ldloc.0
 		IL_0037: stelem.ref
 		IL_0038: stloc.3
-		IL_0039: newobj instance void FunctionObjects.Variable_ConstPrimitivePropagation_With_B4ED9F95.FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier::.ctor()
+		IL_0039: newobj instance void Modules.Variable_ConstPrimitivePropagation_With/receiveIdentifier/FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier::.ctor()
 		IL_003e: ldc.i4.1
 		IL_003f: conv.r8
 		IL_0040: ldstr "receiveIdentifier"
 		IL_0045: ldc.i4.0
 		IL_0046: ldc.i4.0
-		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_ConstPrimitivePropagation_With_B4ED9F95.FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier>(!!0, float64, string, bool, bool)
+		IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_ConstPrimitivePropagation_With/receiveIdentifier/FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier>(!!0, float64, string, bool, bool)
 		IL_004c: stloc.s 5
 		IL_004e: ldloc.0
 		IL_004f: ldloc.s 5
@@ -1022,238 +1254,6 @@
 	} // end of method Variable_ConstPrimitivePropagation_With::__js_module_init__
 
 } // end of class Modules.Variable_ConstPrimitivePropagation_With
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_ConstPrimitivePropagation_With_B4ED9F95.FunctionObject_FunctionDeclaration_6DBEEA65_receive
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x23fb
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_6DBEEA65_receive::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2403
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6DBEEA65_receive::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2406
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_6DBEEA65_receive::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2409
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_6DBEEA65_receive::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2411
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Variable_ConstPrimitivePropagation_With/receive::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_6DBEEA65_receive::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2424
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Variable_ConstPrimitivePropagation_With/receive::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6DBEEA65_receive::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2433
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_6DBEEA65_receive::ConstructCore
-
-} // end of class FunctionObjects.Variable_ConstPrimitivePropagation_With_B4ED9F95.FunctionObject_FunctionDeclaration_6DBEEA65_receive
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_ConstPrimitivePropagation_With_B4ED9F95.FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2442
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x244a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x244d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2450
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2458
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Variable_ConstPrimitivePropagation_With/receiveIdentifier::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x246b
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Variable_ConstPrimitivePropagation_With/receiveIdentifier::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x247a
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier::ConstructCore
-
-} // end of class FunctionObjects.Variable_ConstPrimitivePropagation_With_B4ED9F95.FunctionObject_FunctionDeclaration_97C798BE_receiveIdentifier
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage.verified.txt
@@ -73,6 +73,107 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_68DA2840_logError
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2478
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_68DA2840_logError::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2480
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_68DA2840_logError::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2483
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_68DA2840_logError::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2486
+				// Header size: 1
+				// Code size: 18 (0x12)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/logError::__js_call__(object, object)
+				IL_0011: ret
+			} // end of method FunctionObject_FunctionDeclaration_68DA2840_logError::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2499
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/logError::__js_call__(object, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_68DA2840_logError::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x24a8
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_68DA2840_logError::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_68DA2840_logError
+
 
 		// Methods
 		.method public hidebysig static 
@@ -887,7 +988,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/Scope,
-			[1] class FunctionObjects.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage_9F5D8C11.FunctionObject_FunctionDeclaration_68DA2840_logError,
+			[1] class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/logError/FunctionObject_FunctionDeclaration_68DA2840_logError,
 			[2] object[],
 			[3] object[],
 			[4] class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/ArrowFunction_L12C10/FunctionObject,
@@ -905,13 +1006,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.2
-		IL_0011: newobj instance void FunctionObjects.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage_9F5D8C11.FunctionObject_FunctionDeclaration_68DA2840_logError::.ctor()
+		IL_0011: newobj instance void Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/logError/FunctionObject_FunctionDeclaration_68DA2840_logError::.ctor()
 		IL_0016: ldc.i4.1
 		IL_0017: conv.r8
 		IL_0018: ldstr "logError"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage_9F5D8C11.FunctionObject_FunctionDeclaration_68DA2840_logError>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/logError/FunctionObject_FunctionDeclaration_68DA2840_logError>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: nop
@@ -1041,107 +1142,6 @@
 	} // end of method Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage::__js_module_init__
 
 } // end of class Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage_9F5D8C11.FunctionObject_FunctionDeclaration_68DA2840_logError
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2478
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_68DA2840_logError::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2480
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_68DA2840_logError::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2483
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_68DA2840_logError::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2486
-		// Header size: 1
-		// Code size: 18 (0x12)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/logError::__js_call__(object, object)
-		IL_0011: ret
-	} // end of method FunctionObject_FunctionDeclaration_68DA2840_logError::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2499
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call object Modules.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage/logError::__js_call__(object, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_68DA2840_logError::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x24a8
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_68DA2840_logError::ConstructCore
-
-} // end of class FunctionObjects.Variable_Destructuring_NullOrUndefined_ThrowsNodeMessage_9F5D8C11.FunctionObject_FunctionDeclaration_68DA2840_logError
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_LetFunctionNestedShadowing.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_LetFunctionNestedShadowing.verified.txt
@@ -35,6 +35,101 @@
 
 			} // end of class Scope
 
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_2693B1C5_inner
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor () cil managed 
+				{
+					// Method begins at RVA 0x21b2
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionDeclaration_2693B1C5_inner::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x21ba
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_2693B1C5_inner::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x21bd
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionDeclaration_2693B1C5_inner::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x21c0
+					// Header size: 1
+					// Code size: 11 (0xb)
+					.maxstack 8
+
+					IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_0005: call object Modules.Variable_LetFunctionNestedShadowing/outer/inner::__js_call__(object)
+					IL_000a: ret
+				} // end of method FunctionObject_FunctionDeclaration_2693B1C5_inner::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x21cc
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.3
+					IL_0001: call object Modules.Variable_LetFunctionNestedShadowing/outer/inner::__js_call__(object)
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionDeclaration_2693B1C5_inner::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x21d4
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionDeclaration_2693B1C5_inner::ConstructCore
+
+			} // end of class FunctionObject_FunctionDeclaration_2693B1C5_inner
+
 
 			// Methods
 			.method public hidebysig static 
@@ -99,6 +194,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9FF23D5A_outer
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2181
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_9FF23D5A_outer::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2189
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9FF23D5A_outer::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x218c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9FF23D5A_outer::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x218f
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Variable_LetFunctionNestedShadowing/outer::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_9FF23D5A_outer::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x219b
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Variable_LetFunctionNestedShadowing/outer::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_9FF23D5A_outer::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21a3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9FF23D5A_outer::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9FF23D5A_outer
+
 
 		// Methods
 		.method public hidebysig static 
@@ -115,7 +305,7 @@
 			.maxstack 8
 			.locals init (
 				[0] class Modules.Variable_LetFunctionNestedShadowing/outer/Scope,
-				[1] class FunctionObjects.Variable_LetFunctionNestedShadowing_D0539158.FunctionObject_FunctionDeclaration_2693B1C5_inner,
+				[1] class Modules.Variable_LetFunctionNestedShadowing/outer/inner/FunctionObject_FunctionDeclaration_2693B1C5_inner,
 				[2] float64,
 				[3] object[],
 				[4] object
@@ -125,13 +315,13 @@
 			IL_0005: stloc.0
 			IL_0006: ldsfld object[] [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::EmptyScopes
 			IL_000b: stloc.3
-			IL_000c: newobj instance void FunctionObjects.Variable_LetFunctionNestedShadowing_D0539158.FunctionObject_FunctionDeclaration_2693B1C5_inner::.ctor()
+			IL_000c: newobj instance void Modules.Variable_LetFunctionNestedShadowing/outer/inner/FunctionObject_FunctionDeclaration_2693B1C5_inner::.ctor()
 			IL_0011: ldc.i4.0
 			IL_0012: conv.r8
 			IL_0013: ldstr "inner"
 			IL_0018: ldc.i4.0
 			IL_0019: ldc.i4.1
-			IL_001a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_LetFunctionNestedShadowing_D0539158.FunctionObject_FunctionDeclaration_2693B1C5_inner>(!!0, float64, string, bool, bool)
+			IL_001a: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_LetFunctionNestedShadowing/outer/inner/FunctionObject_FunctionDeclaration_2693B1C5_inner>(!!0, float64, string, bool, bool)
 			IL_001f: stloc.1
 			IL_0020: ldc.r8 1
 			IL_0029: stloc.2
@@ -200,7 +390,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_LetFunctionNestedShadowing/Scope,
-			[1] class FunctionObjects.Variable_LetFunctionNestedShadowing_D0539158.FunctionObject_FunctionDeclaration_9FF23D5A_outer,
+			[1] class Modules.Variable_LetFunctionNestedShadowing/outer/FunctionObject_FunctionDeclaration_9FF23D5A_outer,
 			[2] float64,
 			[3] object[],
 			[4] object
@@ -215,13 +405,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.Variable_LetFunctionNestedShadowing_D0539158.FunctionObject_FunctionDeclaration_9FF23D5A_outer::.ctor()
+		IL_0011: newobj instance void Modules.Variable_LetFunctionNestedShadowing/outer/FunctionObject_FunctionDeclaration_9FF23D5A_outer::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "outer"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_LetFunctionNestedShadowing_D0539158.FunctionObject_FunctionDeclaration_9FF23D5A_outer>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_LetFunctionNestedShadowing/outer/FunctionObject_FunctionDeclaration_9FF23D5A_outer>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: ldc.r8 0.0
@@ -245,196 +435,6 @@
 	} // end of method Variable_LetFunctionNestedShadowing::__js_module_init__
 
 } // end of class Modules.Variable_LetFunctionNestedShadowing
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_LetFunctionNestedShadowing_D0539158.FunctionObject_FunctionDeclaration_9FF23D5A_outer
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2181
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_9FF23D5A_outer::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2189
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9FF23D5A_outer::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x218c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9FF23D5A_outer::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x218f
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Variable_LetFunctionNestedShadowing/outer::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_9FF23D5A_outer::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x219b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Variable_LetFunctionNestedShadowing/outer::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_9FF23D5A_outer::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21a3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9FF23D5A_outer::ConstructCore
-
-} // end of class FunctionObjects.Variable_LetFunctionNestedShadowing_D0539158.FunctionObject_FunctionDeclaration_9FF23D5A_outer
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_LetFunctionNestedShadowing_D0539158.FunctionObject_FunctionDeclaration_2693B1C5_inner
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x21b2
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_2693B1C5_inner::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21ba
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2693B1C5_inner::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21bd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_2693B1C5_inner::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21c0
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Variable_LetFunctionNestedShadowing/outer/inner::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_2693B1C5_inner::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21cc
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Variable_LetFunctionNestedShadowing/outer/inner::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_2693B1C5_inner::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21d4
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_2693B1C5_inner::ConstructCore
-
-} // end of class FunctionObjects.Variable_LetFunctionNestedShadowing_D0539158.FunctionObject_FunctionDeclaration_2693B1C5_inner
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_LetShadowing.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_LetShadowing.verified.txt
@@ -31,6 +31,101 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_D5D45A6E_f
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x210c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_D5D45A6E_f::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2114
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D5D45A6E_f::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2117
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_D5D45A6E_f::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x211a
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Variable_LetShadowing/f::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_D5D45A6E_f::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2126
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Variable_LetShadowing/f::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_D5D45A6E_f::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x212e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_D5D45A6E_f::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_D5D45A6E_f
+
 
 		// Methods
 		.method public hidebysig static 
@@ -111,7 +206,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_LetShadowing/Scope,
-			[1] class FunctionObjects.Variable_LetShadowing_CE4DD539.FunctionObject_FunctionDeclaration_D5D45A6E_f,
+			[1] class Modules.Variable_LetShadowing/f/FunctionObject_FunctionDeclaration_D5D45A6E_f,
 			[2] float64,
 			[3] object[],
 			[4] object
@@ -126,13 +221,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.3
-		IL_0011: newobj instance void FunctionObjects.Variable_LetShadowing_CE4DD539.FunctionObject_FunctionDeclaration_D5D45A6E_f::.ctor()
+		IL_0011: newobj instance void Modules.Variable_LetShadowing/f/FunctionObject_FunctionDeclaration_D5D45A6E_f::.ctor()
 		IL_0016: ldc.i4.0
 		IL_0017: conv.r8
 		IL_0018: ldstr "f"
 		IL_001d: ldc.i4.0
 		IL_001e: ldc.i4.1
-		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_LetShadowing_CE4DD539.FunctionObject_FunctionDeclaration_D5D45A6E_f>(!!0, float64, string, bool, bool)
+		IL_001f: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_LetShadowing/f/FunctionObject_FunctionDeclaration_D5D45A6E_f>(!!0, float64, string, bool, bool)
 		IL_0024: stloc.1
 		IL_0025: nop
 		IL_0026: ldc.r8 1
@@ -156,101 +251,6 @@
 	} // end of method Variable_LetShadowing::__js_module_init__
 
 } // end of class Modules.Variable_LetShadowing
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_LetShadowing_CE4DD539.FunctionObject_FunctionDeclaration_D5D45A6E_f
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x210c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_D5D45A6E_f::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2114
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D5D45A6E_f::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2117
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_D5D45A6E_f::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x211a
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Variable_LetShadowing/f::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_D5D45A6E_f::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2126
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Variable_LetShadowing/f::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_D5D45A6E_f::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x212e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_D5D45A6E_f::ConstructCore
-
-} // end of class FunctionObjects.Variable_LetShadowing_CE4DD539.FunctionObject_FunctionDeclaration_D5D45A6E_f
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_NumericLetLocalSpecialization.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_NumericLetLocalSpecialization.verified.txt
@@ -115,6 +115,136 @@
 
 		} // end of class Scope_For_L8C9
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_DF2B5EED_calculate
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Variable_NumericLetLocalSpecialization/Scope _environment0_Variable_NumericLetLocalSpecialization
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Variable_NumericLetLocalSpecialization/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x287e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/calculate/FunctionObject_FunctionDeclaration_DF2B5EED_calculate::_environment0_Variable_NumericLetLocalSpecialization
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DF2B5EED_calculate::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x288d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DF2B5EED_calculate::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2890
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_DF2B5EED_calculate::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2893
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_DF2B5EED_calculate::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x289b
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/calculate/FunctionObject_FunctionDeclaration_DF2B5EED_calculate::_environment0_Variable_NumericLetLocalSpecialization
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: call object Modules.Variable_NumericLetLocalSpecialization/calculate::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object, float64)
+				IL_001c: ret
+			} // end of method FunctionObject_FunctionDeclaration_DF2B5EED_calculate::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x28b9
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/calculate/FunctionObject_FunctionDeclaration_DF2B5EED_calculate::_environment0_Variable_NumericLetLocalSpecialization
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0013: call object Modules.Variable_NumericLetLocalSpecialization/calculate::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object, float64)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_DF2B5EED_calculate::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x28d3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_DF2B5EED_calculate::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_DF2B5EED_calculate
+
 
 		// Methods
 		.method public hidebysig static 
@@ -330,6 +460,136 @@
 
 		} // end of class Scope_For_L40C9
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Variable_NumericLetLocalSpecialization/Scope _environment0_Variable_NumericLetLocalSpecialization
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Variable_NumericLetLocalSpecialization/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x28e2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/drawLineShape/FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::_environment0_Variable_NumericLetLocalSpecialization
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x28f1
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x28f4
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x28f7
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x28ff
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/drawLineShape/FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::_environment0_Variable_NumericLetLocalSpecialization
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: call object Modules.Variable_NumericLetLocalSpecialization/drawLineShape::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object, float64)
+				IL_001c: ret
+			} // end of method FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x291d
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/drawLineShape/FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::_environment0_Variable_NumericLetLocalSpecialization
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0013: call object Modules.Variable_NumericLetLocalSpecialization/drawLineShape::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object, float64)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2937
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape
+
 
 		// Methods
 		.method public hidebysig static 
@@ -523,6 +783,116 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2946
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x294e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2951
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2954
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x295c
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Variable_NumericLetLocalSpecialization/temporalDeadZoneRead::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2968
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Variable_NumericLetLocalSpecialization/temporalDeadZoneRead::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2970
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead
+
 
 		// Methods
 		.method public hidebysig static 
@@ -666,6 +1036,124 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x297f
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2987
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x298a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x298d
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2995
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0011: call object Modules.Variable_NumericLetLocalSpecialization/conditionallyInitialized::__js_call__(object, bool)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x29ad
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_000d: call object Modules.Variable_NumericLetLocalSpecialization/conditionallyInitialized::__js_call__(object, bool)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x29c1
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized
+
 
 		// Methods
 		.method public hidebysig static 
@@ -753,6 +1241,124 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_FCCC06F6_mixedType
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x29d0
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_FCCC06F6_mixedType::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x29d8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_FCCC06F6_mixedType::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x29db
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_FCCC06F6_mixedType::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x29de
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_FCCC06F6_mixedType::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x29e6
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0011: call object Modules.Variable_NumericLetLocalSpecialization/mixedType::__js_call__(object, bool)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_FCCC06F6_mixedType::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x29fe
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_000d: call object Modules.Variable_NumericLetLocalSpecialization/mixedType::__js_call__(object, bool)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_FCCC06F6_mixedType::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a12
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_FCCC06F6_mixedType::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_FCCC06F6_mixedType
+
 
 		// Methods
 		.method public hidebysig static 
@@ -822,6 +1428,133 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_C3124A9F_L81C12
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Variable_NumericLetLocalSpecialization/captured/Scope _environment1_captured
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Variable_NumericLetLocalSpecialization/captured/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x2a6d
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Variable_NumericLetLocalSpecialization/captured/Scope Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11/FunctionObject_FunctionExpression_C3124A9F_L81C12::_environment1_captured
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11/FunctionObject_FunctionExpression_C3124A9F_L81C12::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionExpression_C3124A9F_L81C12::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2a83
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_C3124A9F_L81C12::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2a86
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_C3124A9F_L81C12::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object ResolveThisArgumentCore (
+						object thisArgument
+					) cil managed 
+				{
+					// Method begins at RVA 0x2a89
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_C3124A9F_L81C12::ResolveThisArgumentCore
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2a91
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11/FunctionObject_FunctionExpression_C3124A9F_L81C12::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_C3124A9F_L81C12::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2aa3
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11/FunctionObject_FunctionExpression_C3124A9F_L81C12::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_C3124A9F_L81C12::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x2ab1
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_C3124A9F_L81C12::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_C3124A9F_L81C12
 
 
 			// Methods
@@ -894,6 +1627,128 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_85087881_captured
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Variable_NumericLetLocalSpecialization/Scope _environment0_Variable_NumericLetLocalSpecialization
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Variable_NumericLetLocalSpecialization/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a21
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/captured/FunctionObject_FunctionDeclaration_85087881_captured::_environment0_Variable_NumericLetLocalSpecialization
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_85087881_captured::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2a30
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_85087881_captured::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2a33
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_85087881_captured::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a36
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_85087881_captured::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a3e
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/captured/FunctionObject_FunctionDeclaration_85087881_captured::_environment0_Variable_NumericLetLocalSpecialization
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Variable_NumericLetLocalSpecialization/captured::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_85087881_captured::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a50
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/captured/FunctionObject_FunctionDeclaration_85087881_captured::_environment0_Variable_NumericLetLocalSpecialization
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Variable_NumericLetLocalSpecialization/captured::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_85087881_captured::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a5e
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_85087881_captured::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_85087881_captured
+
 
 		// Methods
 		.method public hidebysig static 
@@ -914,7 +1769,7 @@
 			.locals init (
 				[0] class Modules.Variable_NumericLetLocalSpecialization/captured/Scope,
 				[1] object[],
-				[2] class FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionExpression_C3124A9F_L81C12
+				[2] class Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11/FunctionObject_FunctionExpression_C3124A9F_L81C12
 			)
 
 			IL_0000: newobj instance void Modules.Variable_NumericLetLocalSpecialization/captured/Scope::.ctor()
@@ -942,13 +1797,13 @@
 			IL_0032: ldelem.ref
 			IL_0033: castclass Modules.Variable_NumericLetLocalSpecialization/captured/Scope
 			IL_0038: ldloc.1
-			IL_0039: newobj instance void FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionExpression_C3124A9F_L81C12::.ctor(class Modules.Variable_NumericLetLocalSpecialization/captured/Scope, object[])
+			IL_0039: newobj instance void Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11/FunctionObject_FunctionExpression_C3124A9F_L81C12::.ctor(class Modules.Variable_NumericLetLocalSpecialization/captured/Scope, object[])
 			IL_003e: ldc.i4.0
 			IL_003f: conv.r8
 			IL_0040: ldstr ""
 			IL_0045: ldc.i4.0
 			IL_0046: ldc.i4.0
-			IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionExpression_C3124A9F_L81C12>(!!0, float64, string, bool, bool)
+			IL_0047: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11/FunctionObject_FunctionExpression_C3124A9F_L81C12>(!!0, float64, string, bool, bool)
 			IL_004c: stloc.2
 			IL_004d: ldloc.2
 			IL_004e: ret
@@ -1001,6 +1856,128 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9A712F73_shadowedSource
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Variable_NumericLetLocalSpecialization/Scope _environment0_Variable_NumericLetLocalSpecialization
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Variable_NumericLetLocalSpecialization/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ac0
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/shadowedSource/FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::_environment0_Variable_NumericLetLocalSpecialization
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2acf
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2ad2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ad5
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2add
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/shadowedSource/FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::_environment0_Variable_NumericLetLocalSpecialization
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Variable_NumericLetLocalSpecialization/shadowedSource::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2aef
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/shadowedSource/FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::_environment0_Variable_NumericLetLocalSpecialization
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Variable_NumericLetLocalSpecialization/shadowedSource::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2afd
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9A712F73_shadowedSource
 
 
 		// Methods
@@ -1115,6 +2092,136 @@
 			} // end of method Scope_For_L101C9::.ctor
 
 		} // end of class Scope_For_L101C9
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_F3E23859_loopCarried
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Variable_NumericLetLocalSpecialization/Scope _environment0_Variable_NumericLetLocalSpecialization
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Variable_NumericLetLocalSpecialization/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b0c
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/loopCarried/FunctionObject_FunctionDeclaration_F3E23859_loopCarried::_environment0_Variable_NumericLetLocalSpecialization
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F3E23859_loopCarried::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2b1b
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F3E23859_loopCarried::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2b1e
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_F3E23859_loopCarried::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b21
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_F3E23859_loopCarried::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b29
+				// Header size: 1
+				// Code size: 29 (0x1d)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/loopCarried/FunctionObject_FunctionDeclaration_F3E23859_loopCarried::_environment0_Variable_NumericLetLocalSpecialization
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: ldarg.2
+				IL_000c: ldc.i4.0
+				IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0017: call object Modules.Variable_NumericLetLocalSpecialization/loopCarried::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object, float64)
+				IL_001c: ret
+			} // end of method FunctionObject_FunctionDeclaration_F3E23859_loopCarried::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b47
+				// Header size: 1
+				// Code size: 25 (0x19)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope Modules.Variable_NumericLetLocalSpecialization/loopCarried/FunctionObject_FunctionDeclaration_F3E23859_loopCarried::_environment0_Variable_NumericLetLocalSpecialization
+				IL_0006: ldarg.3
+				IL_0007: ldarg.2
+				IL_0008: ldc.i4.0
+				IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0013: call object Modules.Variable_NumericLetLocalSpecialization/loopCarried::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object, float64)
+				IL_0018: ret
+			} // end of method FunctionObject_FunctionDeclaration_F3E23859_loopCarried::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2b61
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_F3E23859_loopCarried::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_F3E23859_loopCarried
 
 
 		// Methods
@@ -1263,14 +2370,14 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_NumericLetLocalSpecialization/Scope,
-			[1] class FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_DF2B5EED_calculate,
-			[2] class FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape,
-			[3] class FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead,
-			[4] class FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized,
-			[5] class FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_FCCC06F6_mixedType,
-			[6] class FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_85087881_captured,
-			[7] class FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_9A712F73_shadowedSource,
-			[8] class FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_F3E23859_loopCarried,
+			[1] class Modules.Variable_NumericLetLocalSpecialization/calculate/FunctionObject_FunctionDeclaration_DF2B5EED_calculate,
+			[2] class Modules.Variable_NumericLetLocalSpecialization/drawLineShape/FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape,
+			[3] class Modules.Variable_NumericLetLocalSpecialization/temporalDeadZoneRead/FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead,
+			[4] class Modules.Variable_NumericLetLocalSpecialization/conditionallyInitialized/FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized,
+			[5] class Modules.Variable_NumericLetLocalSpecialization/mixedType/FunctionObject_FunctionDeclaration_FCCC06F6_mixedType,
+			[6] class Modules.Variable_NumericLetLocalSpecialization/captured/FunctionObject_FunctionDeclaration_85087881_captured,
+			[7] class Modules.Variable_NumericLetLocalSpecialization/shadowedSource/FunctionObject_FunctionDeclaration_9A712F73_shadowedSource,
+			[8] class Modules.Variable_NumericLetLocalSpecialization/loopCarried/FunctionObject_FunctionDeclaration_F3E23859_loopCarried,
 			[9] object,
 			[10] object[],
 			[11] object,
@@ -1290,13 +2397,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Variable_NumericLetLocalSpecialization/Scope
-		IL_001b: newobj instance void FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_DF2B5EED_calculate::.ctor(class Modules.Variable_NumericLetLocalSpecialization/Scope)
+		IL_001b: newobj instance void Modules.Variable_NumericLetLocalSpecialization/calculate/FunctionObject_FunctionDeclaration_DF2B5EED_calculate::.ctor(class Modules.Variable_NumericLetLocalSpecialization/Scope)
 		IL_0020: ldc.i4.1
 		IL_0021: conv.r8
 		IL_0022: ldstr "calculate"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.0
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_DF2B5EED_calculate>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericLetLocalSpecialization/calculate/FunctionObject_FunctionDeclaration_DF2B5EED_calculate>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: ldc.i4.1
 		IL_0030: newarr [System.Runtime]System.Object
@@ -1309,13 +2416,13 @@
 		IL_003d: ldc.i4.0
 		IL_003e: ldelem.ref
 		IL_003f: castclass Modules.Variable_NumericLetLocalSpecialization/Scope
-		IL_0044: newobj instance void FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::.ctor(class Modules.Variable_NumericLetLocalSpecialization/Scope)
+		IL_0044: newobj instance void Modules.Variable_NumericLetLocalSpecialization/drawLineShape/FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::.ctor(class Modules.Variable_NumericLetLocalSpecialization/Scope)
 		IL_0049: ldc.i4.1
 		IL_004a: conv.r8
 		IL_004b: ldstr "drawLineShape"
 		IL_0050: ldc.i4.0
 		IL_0051: ldc.i4.0
-		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape>(!!0, float64, string, bool, bool)
+		IL_0052: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericLetLocalSpecialization/drawLineShape/FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape>(!!0, float64, string, bool, bool)
 		IL_0057: stloc.2
 		IL_0058: ldc.i4.1
 		IL_0059: newarr [System.Runtime]System.Object
@@ -1324,13 +2431,13 @@
 		IL_0060: ldloc.0
 		IL_0061: stelem.ref
 		IL_0062: stloc.s 10
-		IL_0064: newobj instance void FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead::.ctor()
+		IL_0064: newobj instance void Modules.Variable_NumericLetLocalSpecialization/temporalDeadZoneRead/FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead::.ctor()
 		IL_0069: ldc.i4.0
 		IL_006a: conv.r8
 		IL_006b: ldstr "temporalDeadZoneRead"
 		IL_0070: ldc.i4.0
 		IL_0071: ldc.i4.0
-		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead>(!!0, float64, string, bool, bool)
+		IL_0072: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericLetLocalSpecialization/temporalDeadZoneRead/FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead>(!!0, float64, string, bool, bool)
 		IL_0077: stloc.3
 		IL_0078: ldc.i4.1
 		IL_0079: newarr [System.Runtime]System.Object
@@ -1339,13 +2446,13 @@
 		IL_0080: ldloc.0
 		IL_0081: stelem.ref
 		IL_0082: stloc.s 10
-		IL_0084: newobj instance void FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized::.ctor()
+		IL_0084: newobj instance void Modules.Variable_NumericLetLocalSpecialization/conditionallyInitialized/FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized::.ctor()
 		IL_0089: ldc.i4.1
 		IL_008a: conv.r8
 		IL_008b: ldstr "conditionallyInitialized"
 		IL_0090: ldc.i4.0
 		IL_0091: ldc.i4.0
-		IL_0092: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized>(!!0, float64, string, bool, bool)
+		IL_0092: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericLetLocalSpecialization/conditionallyInitialized/FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized>(!!0, float64, string, bool, bool)
 		IL_0097: stloc.s 4
 		IL_0099: ldc.i4.1
 		IL_009a: newarr [System.Runtime]System.Object
@@ -1354,13 +2461,13 @@
 		IL_00a1: ldloc.0
 		IL_00a2: stelem.ref
 		IL_00a3: stloc.s 10
-		IL_00a5: newobj instance void FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_FCCC06F6_mixedType::.ctor()
+		IL_00a5: newobj instance void Modules.Variable_NumericLetLocalSpecialization/mixedType/FunctionObject_FunctionDeclaration_FCCC06F6_mixedType::.ctor()
 		IL_00aa: ldc.i4.1
 		IL_00ab: conv.r8
 		IL_00ac: ldstr "mixedType"
 		IL_00b1: ldc.i4.0
 		IL_00b2: ldc.i4.0
-		IL_00b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_FCCC06F6_mixedType>(!!0, float64, string, bool, bool)
+		IL_00b3: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericLetLocalSpecialization/mixedType/FunctionObject_FunctionDeclaration_FCCC06F6_mixedType>(!!0, float64, string, bool, bool)
 		IL_00b8: stloc.s 5
 		IL_00ba: ldc.i4.1
 		IL_00bb: newarr [System.Runtime]System.Object
@@ -1373,13 +2480,13 @@
 		IL_00c8: ldc.i4.0
 		IL_00c9: ldelem.ref
 		IL_00ca: castclass Modules.Variable_NumericLetLocalSpecialization/Scope
-		IL_00cf: newobj instance void FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_85087881_captured::.ctor(class Modules.Variable_NumericLetLocalSpecialization/Scope)
+		IL_00cf: newobj instance void Modules.Variable_NumericLetLocalSpecialization/captured/FunctionObject_FunctionDeclaration_85087881_captured::.ctor(class Modules.Variable_NumericLetLocalSpecialization/Scope)
 		IL_00d4: ldc.i4.0
 		IL_00d5: conv.r8
 		IL_00d6: ldstr "captured"
 		IL_00db: ldc.i4.0
 		IL_00dc: ldc.i4.0
-		IL_00dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_85087881_captured>(!!0, float64, string, bool, bool)
+		IL_00dd: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericLetLocalSpecialization/captured/FunctionObject_FunctionDeclaration_85087881_captured>(!!0, float64, string, bool, bool)
 		IL_00e2: stloc.s 6
 		IL_00e4: ldc.i4.1
 		IL_00e5: newarr [System.Runtime]System.Object
@@ -1392,13 +2499,13 @@
 		IL_00f2: ldc.i4.0
 		IL_00f3: ldelem.ref
 		IL_00f4: castclass Modules.Variable_NumericLetLocalSpecialization/Scope
-		IL_00f9: newobj instance void FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::.ctor(class Modules.Variable_NumericLetLocalSpecialization/Scope)
+		IL_00f9: newobj instance void Modules.Variable_NumericLetLocalSpecialization/shadowedSource/FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::.ctor(class Modules.Variable_NumericLetLocalSpecialization/Scope)
 		IL_00fe: ldc.i4.0
 		IL_00ff: conv.r8
 		IL_0100: ldstr "shadowedSource"
 		IL_0105: ldc.i4.0
 		IL_0106: ldc.i4.0
-		IL_0107: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_9A712F73_shadowedSource>(!!0, float64, string, bool, bool)
+		IL_0107: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericLetLocalSpecialization/shadowedSource/FunctionObject_FunctionDeclaration_9A712F73_shadowedSource>(!!0, float64, string, bool, bool)
 		IL_010c: stloc.s 7
 		IL_010e: ldc.i4.1
 		IL_010f: newarr [System.Runtime]System.Object
@@ -1411,13 +2518,13 @@
 		IL_011c: ldc.i4.0
 		IL_011d: ldelem.ref
 		IL_011e: castclass Modules.Variable_NumericLetLocalSpecialization/Scope
-		IL_0123: newobj instance void FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_F3E23859_loopCarried::.ctor(class Modules.Variable_NumericLetLocalSpecialization/Scope)
+		IL_0123: newobj instance void Modules.Variable_NumericLetLocalSpecialization/loopCarried/FunctionObject_FunctionDeclaration_F3E23859_loopCarried::.ctor(class Modules.Variable_NumericLetLocalSpecialization/Scope)
 		IL_0128: ldc.i4.1
 		IL_0129: conv.r8
 		IL_012a: ldstr "loopCarried"
 		IL_012f: ldc.i4.0
 		IL_0130: ldc.i4.0
-		IL_0131: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_F3E23859_loopCarried>(!!0, float64, string, bool, bool)
+		IL_0131: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericLetLocalSpecialization/loopCarried/FunctionObject_FunctionDeclaration_F3E23859_loopCarried>(!!0, float64, string, bool, bool)
 		IL_0136: stloc.s 8
 		IL_0138: nop
 		IL_0139: nop
@@ -1585,1113 +2692,6 @@
 	} // end of method Variable_NumericLetLocalSpecialization::__js_module_init__
 
 } // end of class Modules.Variable_NumericLetLocalSpecialization
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_DF2B5EED_calculate
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Variable_NumericLetLocalSpecialization/Scope _environment0_Variable_NumericLetLocalSpecialization
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Variable_NumericLetLocalSpecialization/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x287e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Variable_NumericLetLocalSpecialization/Scope FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_DF2B5EED_calculate::_environment0_Variable_NumericLetLocalSpecialization
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DF2B5EED_calculate::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x288d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DF2B5EED_calculate::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2890
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_DF2B5EED_calculate::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2893
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_DF2B5EED_calculate::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x289b
-		// Header size: 1
-		// Code size: 29 (0x1d)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_DF2B5EED_calculate::_environment0_Variable_NumericLetLocalSpecialization
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0017: call object Modules.Variable_NumericLetLocalSpecialization/calculate::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object, float64)
-		IL_001c: ret
-	} // end of method FunctionObject_FunctionDeclaration_DF2B5EED_calculate::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28b9
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_DF2B5EED_calculate::_environment0_Variable_NumericLetLocalSpecialization
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0013: call object Modules.Variable_NumericLetLocalSpecialization/calculate::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object, float64)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_DF2B5EED_calculate::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28d3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_DF2B5EED_calculate::ConstructCore
-
-} // end of class FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_DF2B5EED_calculate
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Variable_NumericLetLocalSpecialization/Scope _environment0_Variable_NumericLetLocalSpecialization
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Variable_NumericLetLocalSpecialization/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x28e2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Variable_NumericLetLocalSpecialization/Scope FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::_environment0_Variable_NumericLetLocalSpecialization
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x28f1
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x28f4
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x28f7
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x28ff
-		// Header size: 1
-		// Code size: 29 (0x1d)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::_environment0_Variable_NumericLetLocalSpecialization
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0017: call object Modules.Variable_NumericLetLocalSpecialization/drawLineShape::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object, float64)
-		IL_001c: ret
-	} // end of method FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x291d
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::_environment0_Variable_NumericLetLocalSpecialization
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0013: call object Modules.Variable_NumericLetLocalSpecialization/drawLineShape::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object, float64)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2937
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape::ConstructCore
-
-} // end of class FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_FC418FA0_drawLineShape
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2946
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x294e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2951
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2954
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x295c
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Variable_NumericLetLocalSpecialization/temporalDeadZoneRead::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2968
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Variable_NumericLetLocalSpecialization/temporalDeadZoneRead::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2970
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead::ConstructCore
-
-} // end of class FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_77B6A235_temporalDeadZoneRead
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x297f
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2987
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x298a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x298d
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2995
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-		IL_0011: call object Modules.Variable_NumericLetLocalSpecialization/conditionallyInitialized::__js_call__(object, bool)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29ad
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-		IL_000d: call object Modules.Variable_NumericLetLocalSpecialization/conditionallyInitialized::__js_call__(object, bool)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29c1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized::ConstructCore
-
-} // end of class FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_CDF389C0_conditionallyInitialized
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_FCCC06F6_mixedType
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x29d0
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_FCCC06F6_mixedType::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x29d8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_FCCC06F6_mixedType::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x29db
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_FCCC06F6_mixedType::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x29de
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_FCCC06F6_mixedType::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x29e6
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-		IL_0011: call object Modules.Variable_NumericLetLocalSpecialization/mixedType::__js_call__(object, bool)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_FCCC06F6_mixedType::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29fe
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-		IL_000d: call object Modules.Variable_NumericLetLocalSpecialization/mixedType::__js_call__(object, bool)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_FCCC06F6_mixedType::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a12
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_FCCC06F6_mixedType::ConstructCore
-
-} // end of class FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_FCCC06F6_mixedType
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_85087881_captured
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Variable_NumericLetLocalSpecialization/Scope _environment0_Variable_NumericLetLocalSpecialization
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Variable_NumericLetLocalSpecialization/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a21
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Variable_NumericLetLocalSpecialization/Scope FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_85087881_captured::_environment0_Variable_NumericLetLocalSpecialization
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_85087881_captured::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a30
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_85087881_captured::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a33
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_85087881_captured::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a36
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_85087881_captured::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a3e
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_85087881_captured::_environment0_Variable_NumericLetLocalSpecialization
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Variable_NumericLetLocalSpecialization/captured::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_85087881_captured::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a50
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_85087881_captured::_environment0_Variable_NumericLetLocalSpecialization
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Variable_NumericLetLocalSpecialization/captured::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_85087881_captured::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a5e
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_85087881_captured::ConstructCore
-
-} // end of class FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_85087881_captured
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionExpression_C3124A9F_L81C12
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Variable_NumericLetLocalSpecialization/captured/Scope _environment1_captured
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Variable_NumericLetLocalSpecialization/captured/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a6d
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Variable_NumericLetLocalSpecialization/captured/Scope FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionExpression_C3124A9F_L81C12::_environment1_captured
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionExpression_C3124A9F_L81C12::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_C3124A9F_L81C12::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a83
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C3124A9F_L81C12::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a86
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_C3124A9F_L81C12::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a89
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_C3124A9F_L81C12::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a91
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionExpression_C3124A9F_L81C12::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_C3124A9F_L81C12::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2aa3
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionExpression_C3124A9F_L81C12::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Variable_NumericLetLocalSpecialization/captured/FunctionExpression_L81C11::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_C3124A9F_L81C12::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ab1
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_C3124A9F_L81C12::ConstructCore
-
-} // end of class FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionExpression_C3124A9F_L81C12
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_9A712F73_shadowedSource
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Variable_NumericLetLocalSpecialization/Scope _environment0_Variable_NumericLetLocalSpecialization
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Variable_NumericLetLocalSpecialization/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ac0
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Variable_NumericLetLocalSpecialization/Scope FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::_environment0_Variable_NumericLetLocalSpecialization
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2acf
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2ad2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ad5
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2add
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::_environment0_Variable_NumericLetLocalSpecialization
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Variable_NumericLetLocalSpecialization/shadowedSource::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2aef
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::_environment0_Variable_NumericLetLocalSpecialization
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Variable_NumericLetLocalSpecialization/shadowedSource::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2afd
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9A712F73_shadowedSource::ConstructCore
-
-} // end of class FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_9A712F73_shadowedSource
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_F3E23859_loopCarried
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Variable_NumericLetLocalSpecialization/Scope _environment0_Variable_NumericLetLocalSpecialization
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Variable_NumericLetLocalSpecialization/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b0c
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Variable_NumericLetLocalSpecialization/Scope FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_F3E23859_loopCarried::_environment0_Variable_NumericLetLocalSpecialization
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F3E23859_loopCarried::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2b1b
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F3E23859_loopCarried::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2b1e
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_F3E23859_loopCarried::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b21
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_F3E23859_loopCarried::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b29
-		// Header size: 1
-		// Code size: 29 (0x1d)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_F3E23859_loopCarried::_environment0_Variable_NumericLetLocalSpecialization
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: ldarg.2
-		IL_000c: ldc.i4.0
-		IL_000d: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0012: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0017: call object Modules.Variable_NumericLetLocalSpecialization/loopCarried::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object, float64)
-		IL_001c: ret
-	} // end of method FunctionObject_FunctionDeclaration_F3E23859_loopCarried::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b47
-		// Header size: 1
-		// Code size: 25 (0x19)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Variable_NumericLetLocalSpecialization/Scope FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_F3E23859_loopCarried::_environment0_Variable_NumericLetLocalSpecialization
-		IL_0006: ldarg.3
-		IL_0007: ldarg.2
-		IL_0008: ldc.i4.0
-		IL_0009: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000e: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0013: call object Modules.Variable_NumericLetLocalSpecialization/loopCarried::__js_call__(class Modules.Variable_NumericLetLocalSpecialization/Scope, object, float64)
-		IL_0018: ret
-	} // end of method FunctionObject_FunctionDeclaration_F3E23859_loopCarried::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2b61
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_F3E23859_loopCarried::ConstructCore
-
-} // end of class FunctionObjects.Variable_NumericLetLocalSpecialization_42A330F0.FunctionObject_FunctionDeclaration_F3E23859_loopCarried
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_NumericVarLocalSpecialization.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_NumericVarLocalSpecialization.verified.txt
@@ -93,6 +93,124 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_C962BB39_calculate
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x27ed
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_C962BB39_calculate::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x27f5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C962BB39_calculate::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x27f8
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_C962BB39_calculate::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x27fb
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_C962BB39_calculate::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2803
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_0011: call object Modules.Variable_NumericVarLocalSpecialization/calculate::__js_call__(object, float64)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_C962BB39_calculate::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x281b
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
+				IL_000d: call object Modules.Variable_NumericVarLocalSpecialization/calculate::__js_call__(object, float64)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_C962BB39_calculate::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x282f
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_C962BB39_calculate::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_C962BB39_calculate
+
 
 		// Methods
 		.method public hidebysig static 
@@ -194,6 +312,118 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x283e
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2846
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2849
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x284c
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2854
+				// Header size: 1
+				// Code size: 16 (0x10)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call float64 Modules.Variable_NumericVarLocalSpecialization/readBeforeInitialization::__js_call__(object)
+				IL_000a: box [System.Runtime]System.Double
+				IL_000f: ret
+			} // end of method FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2865
+				// Header size: 1
+				// Code size: 12 (0xc)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call float64 Modules.Variable_NumericVarLocalSpecialization/readBeforeInitialization::__js_call__(object)
+				IL_0006: box [System.Runtime]System.Double
+				IL_000b: ret
+			} // end of method FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2872
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization
 
 
 		// Methods
@@ -306,6 +536,124 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2881
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2889
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x288c
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x288f
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2897
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0011: call object Modules.Variable_NumericVarLocalSpecialization/conditionallyInitialized::__js_call__(object, bool)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x28af
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_000d: call object Modules.Variable_NumericVarLocalSpecialization/conditionallyInitialized::__js_call__(object, bool)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x28c3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized
+
 
 		// Methods
 		.method public hidebysig static 
@@ -393,6 +741,124 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_75C6D3A2_mixedType
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x28d2
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_75C6D3A2_mixedType::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x28da
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_75C6D3A2_mixedType::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x28dd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_75C6D3A2_mixedType::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x28e0
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_75C6D3A2_mixedType::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x28e8
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0011: call object Modules.Variable_NumericVarLocalSpecialization/mixedType::__js_call__(object, bool)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_75C6D3A2_mixedType::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2900
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_000d: call object Modules.Variable_NumericVarLocalSpecialization/mixedType::__js_call__(object, bool)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_75C6D3A2_mixedType::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2914
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_75C6D3A2_mixedType::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_75C6D3A2_mixedType
+
 
 		// Methods
 		.method public hidebysig static 
@@ -457,6 +923,133 @@
 				} // end of method Scope::.ctor
 
 			} // end of class Scope
+
+			.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionExpression_FEB4A694_L42C12
+				extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+			{
+				// Fields
+				.field private initonly class Modules.Variable_NumericVarLocalSpecialization/captured/Scope _environment1_captured
+				.field private initonly object[] _transitionalScopes
+
+				// Methods
+				.method public hidebysig specialname rtspecialname 
+					instance void .ctor (
+						class Modules.Variable_NumericVarLocalSpecialization/captured/Scope capture0,
+						object[] capture1
+					) cil managed 
+				{
+					// Method begins at RVA 0x296f
+					// Header size: 1
+					// Code size: 21 (0x15)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+					IL_0006: ldarg.0
+					IL_0007: ldarg.1
+					IL_0008: stfld class Modules.Variable_NumericVarLocalSpecialization/captured/Scope Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11/FunctionObject_FunctionExpression_FEB4A694_L42C12::_environment1_captured
+					IL_000d: ldarg.0
+					IL_000e: ldarg.2
+					IL_000f: stfld object[] Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11/FunctionObject_FunctionExpression_FEB4A694_L42C12::_transitionalScopes
+					IL_0014: ret
+				} // end of method FunctionObject_FunctionExpression_FEB4A694_L42C12::.ctor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_IsConstructor () cil managed 
+				{
+					// Method begins at RVA 0x2985
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.1
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_FEB4A694_L42C12::get_IsConstructor
+
+				.method public hidebysig specialname virtual 
+					instance bool get_RequiresInvocationContext () cil managed 
+				{
+					// Method begins at RVA 0x2988
+					// Header size: 1
+					// Code size: 2 (0x2)
+					.maxstack 8
+
+					IL_0000: ldc.i4.0
+					IL_0001: ret
+				} // end of method FunctionObject_FunctionExpression_FEB4A694_L42C12::get_RequiresInvocationContext
+
+				.method family hidebysig virtual 
+					instance object ResolveThisArgumentCore (
+						object thisArgument
+					) cil managed 
+				{
+					// Method begins at RVA 0x298b
+					// Header size: 1
+					// Code size: 7 (0x7)
+					.maxstack 8
+
+					IL_0000: ldarg.1
+					IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+					IL_0006: ret
+				} // end of method FunctionObject_FunctionExpression_FEB4A694_L42C12::ResolveThisArgumentCore
+
+				.method family hidebysig virtual 
+					instance object CallCore (
+						object thisArgument,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+					) cil managed 
+				{
+					// Method begins at RVA 0x2993
+					// Header size: 1
+					// Code size: 17 (0x11)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11/FunctionObject_FunctionExpression_FEB4A694_L42C12::_transitionalScopes
+					IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+					IL_000b: call object Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11::__js_call__(object[], object)
+					IL_0010: ret
+				} // end of method FunctionObject_FunctionExpression_FEB4A694_L42C12::CallCore
+
+				.method family hidebysig virtual 
+					instance object ConstructBodyCore (
+						object receiver,
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x29a5
+					// Header size: 1
+					// Code size: 13 (0xd)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldfld object[] Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11/FunctionObject_FunctionExpression_FEB4A694_L42C12::_transitionalScopes
+					IL_0006: ldarg.3
+					IL_0007: call object Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11::__js_call__(object[], object)
+					IL_000c: ret
+				} // end of method FunctionObject_FunctionExpression_FEB4A694_L42C12::ConstructBodyCore
+
+				.method family hidebysig virtual 
+					instance object ConstructCore (
+						[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+						object newTarget
+					) cil managed 
+				{
+					// Method begins at RVA 0x29b3
+					// Header size: 1
+					// Code size: 14 (0xe)
+					.maxstack 8
+
+					IL_0000: ldarg.0
+					IL_0001: ldarg.1
+					IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+					IL_0007: ldarg.2
+					IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+					IL_000d: ret
+				} // end of method FunctionObject_FunctionExpression_FEB4A694_L42C12::ConstructCore
+
+			} // end of class FunctionObject_FunctionExpression_FEB4A694_L42C12
 
 
 			// Methods
@@ -529,6 +1122,128 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_EAC4700D_captured
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Variable_NumericVarLocalSpecialization/Scope _environment0_Variable_NumericVarLocalSpecialization
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Variable_NumericVarLocalSpecialization/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2923
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Variable_NumericVarLocalSpecialization/Scope Modules.Variable_NumericVarLocalSpecialization/captured/FunctionObject_FunctionDeclaration_EAC4700D_captured::_environment0_Variable_NumericVarLocalSpecialization
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_EAC4700D_captured::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2932
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_EAC4700D_captured::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2935
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_EAC4700D_captured::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2938
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_EAC4700D_captured::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2940
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Variable_NumericVarLocalSpecialization/Scope Modules.Variable_NumericVarLocalSpecialization/captured/FunctionObject_FunctionDeclaration_EAC4700D_captured::_environment0_Variable_NumericVarLocalSpecialization
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Variable_NumericVarLocalSpecialization/captured::__js_call__(class Modules.Variable_NumericVarLocalSpecialization/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_EAC4700D_captured::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2952
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Variable_NumericVarLocalSpecialization/Scope Modules.Variable_NumericVarLocalSpecialization/captured/FunctionObject_FunctionDeclaration_EAC4700D_captured::_environment0_Variable_NumericVarLocalSpecialization
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Variable_NumericVarLocalSpecialization/captured::__js_call__(class Modules.Variable_NumericVarLocalSpecialization/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_EAC4700D_captured::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2960
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_EAC4700D_captured::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_EAC4700D_captured
+
 
 		// Methods
 		.method public hidebysig static 
@@ -549,7 +1264,7 @@
 			.locals init (
 				[0] class Modules.Variable_NumericVarLocalSpecialization/captured/Scope,
 				[1] object[],
-				[2] class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionExpression_FEB4A694_L42C12
+				[2] class Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11/FunctionObject_FunctionExpression_FEB4A694_L42C12
 			)
 
 			IL_0000: newobj instance void Modules.Variable_NumericVarLocalSpecialization/captured/Scope::.ctor()
@@ -574,13 +1289,13 @@
 			IL_002b: ldelem.ref
 			IL_002c: castclass Modules.Variable_NumericVarLocalSpecialization/captured/Scope
 			IL_0031: ldloc.1
-			IL_0032: newobj instance void FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionExpression_FEB4A694_L42C12::.ctor(class Modules.Variable_NumericVarLocalSpecialization/captured/Scope, object[])
+			IL_0032: newobj instance void Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11/FunctionObject_FunctionExpression_FEB4A694_L42C12::.ctor(class Modules.Variable_NumericVarLocalSpecialization/captured/Scope, object[])
 			IL_0037: ldc.i4.0
 			IL_0038: conv.r8
 			IL_0039: ldstr ""
 			IL_003e: ldc.i4.0
 			IL_003f: ldc.i4.0
-			IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionExpression_FEB4A694_L42C12>(!!0, float64, string, bool, bool)
+			IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11/FunctionObject_FunctionExpression_FEB4A694_L42C12>(!!0, float64, string, bool, bool)
 			IL_0045: stloc.2
 			IL_0046: ldloc.2
 			IL_0047: ret
@@ -611,6 +1326,116 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3357054A_hoistedDependency
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x29c2
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_3357054A_hoistedDependency::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x29ca
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3357054A_hoistedDependency::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x29cd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3357054A_hoistedDependency::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x29d0
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_3357054A_hoistedDependency::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x29d8
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Variable_NumericVarLocalSpecialization/hoistedDependency::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_3357054A_hoistedDependency::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x29e4
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Variable_NumericVarLocalSpecialization/hoistedDependency::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_3357054A_hoistedDependency::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x29ec
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3357054A_hoistedDependency::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_3357054A_hoistedDependency
 
 
 		// Methods
@@ -667,6 +1492,128 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Variable_NumericVarLocalSpecialization/Scope _environment0_Variable_NumericVarLocalSpecialization
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Variable_NumericVarLocalSpecialization/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x29fb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Variable_NumericVarLocalSpecialization/Scope Modules.Variable_NumericVarLocalSpecialization/objectLiteralWrite/FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::_environment0_Variable_NumericVarLocalSpecialization
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2a0a
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2a0d
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a10
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a18
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Variable_NumericVarLocalSpecialization/Scope Modules.Variable_NumericVarLocalSpecialization/objectLiteralWrite/FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::_environment0_Variable_NumericVarLocalSpecialization
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Variable_NumericVarLocalSpecialization/objectLiteralWrite::__js_call__(class Modules.Variable_NumericVarLocalSpecialization/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a2a
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Variable_NumericVarLocalSpecialization/Scope Modules.Variable_NumericVarLocalSpecialization/objectLiteralWrite/FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::_environment0_Variable_NumericVarLocalSpecialization
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Variable_NumericVarLocalSpecialization/objectLiteralWrite::__js_call__(class Modules.Variable_NumericVarLocalSpecialization/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a38
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite
 
 
 		// Methods
@@ -789,6 +1736,124 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2a47
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2a4f
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2a52
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a55
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a5d
+				// Header size: 1
+				// Code size: 23 (0x17)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: ldarg.2
+				IL_0006: ldc.i4.0
+				IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_000c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_0011: call object Modules.Variable_NumericVarLocalSpecialization/labeledBreak::__js_call__(object, bool)
+				IL_0016: ret
+			} // end of method FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a75
+				// Header size: 1
+				// Code size: 19 (0x13)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: ldarg.2
+				IL_0002: ldc.i4.0
+				IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
+				IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
+				IL_000d: call object Modules.Variable_NumericVarLocalSpecialization/labeledBreak::__js_call__(object, bool)
+				IL_0012: ret
+			} // end of method FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2a89
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak
+
 
 		// Methods
 		.method public hidebysig static 
@@ -853,6 +1918,116 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_A3543986_optionalWrite
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2a98
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_A3543986_optionalWrite::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2aa0
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A3543986_optionalWrite::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2aa3
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_A3543986_optionalWrite::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2aa6
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_A3543986_optionalWrite::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2aae
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Variable_NumericVarLocalSpecialization/optionalWrite::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_A3543986_optionalWrite::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2aba
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Variable_NumericVarLocalSpecialization/optionalWrite::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_A3543986_optionalWrite::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ac2
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_A3543986_optionalWrite::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_A3543986_optionalWrite
 
 
 		// Methods
@@ -957,6 +2132,116 @@
 			} // end of method Scope::.ctor
 
 		} // end of class Scope
+
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_3B56324F_shadowedSource
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor () cil managed 
+			{
+				// Method begins at RVA 0x2ad1
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_3B56324F_shadowedSource::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2ad9
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3B56324F_shadowedSource::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2adc
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_3B56324F_shadowedSource::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object ResolveThisArgumentCore (
+					object thisArgument
+				) cil managed 
+			{
+				// Method begins at RVA 0x2adf
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.1
+				IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_3B56324F_shadowedSource::ResolveThisArgumentCore
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2ae7
+				// Header size: 1
+				// Code size: 11 (0xb)
+				.maxstack 8
+
+				IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_0005: call object Modules.Variable_NumericVarLocalSpecialization/shadowedSource::__js_call__(object)
+				IL_000a: ret
+			} // end of method FunctionObject_FunctionDeclaration_3B56324F_shadowedSource::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2af3
+				// Header size: 1
+				// Code size: 7 (0x7)
+				.maxstack 8
+
+				IL_0000: ldarg.3
+				IL_0001: call object Modules.Variable_NumericVarLocalSpecialization/shadowedSource::__js_call__(object)
+				IL_0006: ret
+			} // end of method FunctionObject_FunctionDeclaration_3B56324F_shadowedSource::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2afb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_3B56324F_shadowedSource::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_3B56324F_shadowedSource
 
 
 		// Methods
@@ -1128,16 +2413,16 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_NumericVarLocalSpecialization/Scope,
-			[1] class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_C962BB39_calculate,
-			[2] class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization,
-			[3] class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized,
-			[4] class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_75C6D3A2_mixedType,
-			[5] class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_EAC4700D_captured,
-			[6] class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_3357054A_hoistedDependency,
-			[7] class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite,
-			[8] class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak,
-			[9] class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_A3543986_optionalWrite,
-			[10] class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_3B56324F_shadowedSource,
+			[1] class Modules.Variable_NumericVarLocalSpecialization/calculate/FunctionObject_FunctionDeclaration_C962BB39_calculate,
+			[2] class Modules.Variable_NumericVarLocalSpecialization/readBeforeInitialization/FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization,
+			[3] class Modules.Variable_NumericVarLocalSpecialization/conditionallyInitialized/FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized,
+			[4] class Modules.Variable_NumericVarLocalSpecialization/mixedType/FunctionObject_FunctionDeclaration_75C6D3A2_mixedType,
+			[5] class Modules.Variable_NumericVarLocalSpecialization/captured/FunctionObject_FunctionDeclaration_EAC4700D_captured,
+			[6] class Modules.Variable_NumericVarLocalSpecialization/hoistedDependency/FunctionObject_FunctionDeclaration_3357054A_hoistedDependency,
+			[7] class Modules.Variable_NumericVarLocalSpecialization/objectLiteralWrite/FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite,
+			[8] class Modules.Variable_NumericVarLocalSpecialization/labeledBreak/FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak,
+			[9] class Modules.Variable_NumericVarLocalSpecialization/optionalWrite/FunctionObject_FunctionDeclaration_A3543986_optionalWrite,
+			[10] class Modules.Variable_NumericVarLocalSpecialization/shadowedSource/FunctionObject_FunctionDeclaration_3B56324F_shadowedSource,
 			[11] object,
 			[12] object[],
 			[13] object,
@@ -1155,13 +2440,13 @@
 		IL_000e: ldloc.0
 		IL_000f: stelem.ref
 		IL_0010: stloc.s 12
-		IL_0012: newobj instance void FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_C962BB39_calculate::.ctor()
+		IL_0012: newobj instance void Modules.Variable_NumericVarLocalSpecialization/calculate/FunctionObject_FunctionDeclaration_C962BB39_calculate::.ctor()
 		IL_0017: ldc.i4.1
 		IL_0018: conv.r8
 		IL_0019: ldstr "calculate"
 		IL_001e: ldc.i4.0
 		IL_001f: ldc.i4.0
-		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_C962BB39_calculate>(!!0, float64, string, bool, bool)
+		IL_0020: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/calculate/FunctionObject_FunctionDeclaration_C962BB39_calculate>(!!0, float64, string, bool, bool)
 		IL_0025: stloc.1
 		IL_0026: ldc.i4.1
 		IL_0027: newarr [System.Runtime]System.Object
@@ -1170,13 +2455,13 @@
 		IL_002e: ldloc.0
 		IL_002f: stelem.ref
 		IL_0030: stloc.s 12
-		IL_0032: newobj instance void FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization::.ctor()
+		IL_0032: newobj instance void Modules.Variable_NumericVarLocalSpecialization/readBeforeInitialization/FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization::.ctor()
 		IL_0037: ldc.i4.0
 		IL_0038: conv.r8
 		IL_0039: ldstr "readBeforeInitialization"
 		IL_003e: ldc.i4.0
 		IL_003f: ldc.i4.0
-		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization>(!!0, float64, string, bool, bool)
+		IL_0040: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/readBeforeInitialization/FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization>(!!0, float64, string, bool, bool)
 		IL_0045: stloc.2
 		IL_0046: ldc.i4.1
 		IL_0047: newarr [System.Runtime]System.Object
@@ -1185,13 +2470,13 @@
 		IL_004e: ldloc.0
 		IL_004f: stelem.ref
 		IL_0050: stloc.s 12
-		IL_0052: newobj instance void FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized::.ctor()
+		IL_0052: newobj instance void Modules.Variable_NumericVarLocalSpecialization/conditionallyInitialized/FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized::.ctor()
 		IL_0057: ldc.i4.1
 		IL_0058: conv.r8
 		IL_0059: ldstr "conditionallyInitialized"
 		IL_005e: ldc.i4.0
 		IL_005f: ldc.i4.0
-		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized>(!!0, float64, string, bool, bool)
+		IL_0060: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/conditionallyInitialized/FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized>(!!0, float64, string, bool, bool)
 		IL_0065: stloc.3
 		IL_0066: ldc.i4.1
 		IL_0067: newarr [System.Runtime]System.Object
@@ -1200,13 +2485,13 @@
 		IL_006e: ldloc.0
 		IL_006f: stelem.ref
 		IL_0070: stloc.s 12
-		IL_0072: newobj instance void FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_75C6D3A2_mixedType::.ctor()
+		IL_0072: newobj instance void Modules.Variable_NumericVarLocalSpecialization/mixedType/FunctionObject_FunctionDeclaration_75C6D3A2_mixedType::.ctor()
 		IL_0077: ldc.i4.1
 		IL_0078: conv.r8
 		IL_0079: ldstr "mixedType"
 		IL_007e: ldc.i4.0
 		IL_007f: ldc.i4.0
-		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_75C6D3A2_mixedType>(!!0, float64, string, bool, bool)
+		IL_0080: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/mixedType/FunctionObject_FunctionDeclaration_75C6D3A2_mixedType>(!!0, float64, string, bool, bool)
 		IL_0085: stloc.s 4
 		IL_0087: ldc.i4.1
 		IL_0088: newarr [System.Runtime]System.Object
@@ -1219,13 +2504,13 @@
 		IL_0095: ldc.i4.0
 		IL_0096: ldelem.ref
 		IL_0097: castclass Modules.Variable_NumericVarLocalSpecialization/Scope
-		IL_009c: newobj instance void FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_EAC4700D_captured::.ctor(class Modules.Variable_NumericVarLocalSpecialization/Scope)
+		IL_009c: newobj instance void Modules.Variable_NumericVarLocalSpecialization/captured/FunctionObject_FunctionDeclaration_EAC4700D_captured::.ctor(class Modules.Variable_NumericVarLocalSpecialization/Scope)
 		IL_00a1: ldc.i4.0
 		IL_00a2: conv.r8
 		IL_00a3: ldstr "captured"
 		IL_00a8: ldc.i4.0
 		IL_00a9: ldc.i4.0
-		IL_00aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_EAC4700D_captured>(!!0, float64, string, bool, bool)
+		IL_00aa: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/captured/FunctionObject_FunctionDeclaration_EAC4700D_captured>(!!0, float64, string, bool, bool)
 		IL_00af: stloc.s 5
 		IL_00b1: ldc.i4.1
 		IL_00b2: newarr [System.Runtime]System.Object
@@ -1234,13 +2519,13 @@
 		IL_00b9: ldloc.0
 		IL_00ba: stelem.ref
 		IL_00bb: stloc.s 12
-		IL_00bd: newobj instance void FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_3357054A_hoistedDependency::.ctor()
+		IL_00bd: newobj instance void Modules.Variable_NumericVarLocalSpecialization/hoistedDependency/FunctionObject_FunctionDeclaration_3357054A_hoistedDependency::.ctor()
 		IL_00c2: ldc.i4.0
 		IL_00c3: conv.r8
 		IL_00c4: ldstr "hoistedDependency"
 		IL_00c9: ldc.i4.0
 		IL_00ca: ldc.i4.0
-		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_3357054A_hoistedDependency>(!!0, float64, string, bool, bool)
+		IL_00cb: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/hoistedDependency/FunctionObject_FunctionDeclaration_3357054A_hoistedDependency>(!!0, float64, string, bool, bool)
 		IL_00d0: stloc.s 6
 		IL_00d2: ldc.i4.1
 		IL_00d3: newarr [System.Runtime]System.Object
@@ -1253,13 +2538,13 @@
 		IL_00e0: ldc.i4.0
 		IL_00e1: ldelem.ref
 		IL_00e2: castclass Modules.Variable_NumericVarLocalSpecialization/Scope
-		IL_00e7: newobj instance void FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::.ctor(class Modules.Variable_NumericVarLocalSpecialization/Scope)
+		IL_00e7: newobj instance void Modules.Variable_NumericVarLocalSpecialization/objectLiteralWrite/FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::.ctor(class Modules.Variable_NumericVarLocalSpecialization/Scope)
 		IL_00ec: ldc.i4.0
 		IL_00ed: conv.r8
 		IL_00ee: ldstr "objectLiteralWrite"
 		IL_00f3: ldc.i4.0
 		IL_00f4: ldc.i4.0
-		IL_00f5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite>(!!0, float64, string, bool, bool)
+		IL_00f5: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/objectLiteralWrite/FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite>(!!0, float64, string, bool, bool)
 		IL_00fa: stloc.s 7
 		IL_00fc: ldc.i4.1
 		IL_00fd: newarr [System.Runtime]System.Object
@@ -1268,13 +2553,13 @@
 		IL_0104: ldloc.0
 		IL_0105: stelem.ref
 		IL_0106: stloc.s 12
-		IL_0108: newobj instance void FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak::.ctor()
+		IL_0108: newobj instance void Modules.Variable_NumericVarLocalSpecialization/labeledBreak/FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak::.ctor()
 		IL_010d: ldc.i4.1
 		IL_010e: conv.r8
 		IL_010f: ldstr "labeledBreak"
 		IL_0114: ldc.i4.0
 		IL_0115: ldc.i4.0
-		IL_0116: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak>(!!0, float64, string, bool, bool)
+		IL_0116: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/labeledBreak/FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak>(!!0, float64, string, bool, bool)
 		IL_011b: stloc.s 8
 		IL_011d: ldc.i4.1
 		IL_011e: newarr [System.Runtime]System.Object
@@ -1283,13 +2568,13 @@
 		IL_0125: ldloc.0
 		IL_0126: stelem.ref
 		IL_0127: stloc.s 12
-		IL_0129: newobj instance void FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_A3543986_optionalWrite::.ctor()
+		IL_0129: newobj instance void Modules.Variable_NumericVarLocalSpecialization/optionalWrite/FunctionObject_FunctionDeclaration_A3543986_optionalWrite::.ctor()
 		IL_012e: ldc.i4.0
 		IL_012f: conv.r8
 		IL_0130: ldstr "optionalWrite"
 		IL_0135: ldc.i4.0
 		IL_0136: ldc.i4.0
-		IL_0137: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_A3543986_optionalWrite>(!!0, float64, string, bool, bool)
+		IL_0137: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/optionalWrite/FunctionObject_FunctionDeclaration_A3543986_optionalWrite>(!!0, float64, string, bool, bool)
 		IL_013c: stloc.s 9
 		IL_013e: ldc.i4.1
 		IL_013f: newarr [System.Runtime]System.Object
@@ -1298,13 +2583,13 @@
 		IL_0146: ldloc.0
 		IL_0147: stelem.ref
 		IL_0148: stloc.s 12
-		IL_014a: newobj instance void FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_3B56324F_shadowedSource::.ctor()
+		IL_014a: newobj instance void Modules.Variable_NumericVarLocalSpecialization/shadowedSource/FunctionObject_FunctionDeclaration_3B56324F_shadowedSource::.ctor()
 		IL_014f: ldc.i4.0
 		IL_0150: conv.r8
 		IL_0151: ldstr "shadowedSource"
 		IL_0156: ldc.i4.0
 		IL_0157: ldc.i4.0
-		IL_0158: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_3B56324F_shadowedSource>(!!0, float64, string, bool, bool)
+		IL_0158: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_NumericVarLocalSpecialization/shadowedSource/FunctionObject_FunctionDeclaration_3B56324F_shadowedSource>(!!0, float64, string, bool, bool)
 		IL_015d: stloc.s 10
 		IL_015f: nop
 		IL_0160: nop
@@ -1494,1291 +2779,6 @@
 	} // end of method Variable_NumericVarLocalSpecialization::__js_module_init__
 
 } // end of class Modules.Variable_NumericVarLocalSpecialization
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_C962BB39_calculate
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x27ed
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_C962BB39_calculate::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x27f5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C962BB39_calculate::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x27f8
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_C962BB39_calculate::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x27fb
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_C962BB39_calculate::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2803
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_0011: call object Modules.Variable_NumericVarLocalSpecialization/calculate::__js_call__(object, float64)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_C962BB39_calculate::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x281b
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call float64 [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToNumber(object)
-		IL_000d: call object Modules.Variable_NumericVarLocalSpecialization/calculate::__js_call__(object, float64)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_C962BB39_calculate::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x282f
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_C962BB39_calculate::ConstructCore
-
-} // end of class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_C962BB39_calculate
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x283e
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2846
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2849
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x284c
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2854
-		// Header size: 1
-		// Code size: 16 (0x10)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call float64 Modules.Variable_NumericVarLocalSpecialization/readBeforeInitialization::__js_call__(object)
-		IL_000a: box [System.Runtime]System.Double
-		IL_000f: ret
-	} // end of method FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2865
-		// Header size: 1
-		// Code size: 12 (0xc)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call float64 Modules.Variable_NumericVarLocalSpecialization/readBeforeInitialization::__js_call__(object)
-		IL_0006: box [System.Runtime]System.Double
-		IL_000b: ret
-	} // end of method FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2872
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization::ConstructCore
-
-} // end of class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_3583737C_readBeforeInitialization
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2881
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2889
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x288c
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x288f
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2897
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-		IL_0011: call object Modules.Variable_NumericVarLocalSpecialization/conditionallyInitialized::__js_call__(object, bool)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28af
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-		IL_000d: call object Modules.Variable_NumericVarLocalSpecialization/conditionallyInitialized::__js_call__(object, bool)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x28c3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized::ConstructCore
-
-} // end of class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_741F38C4_conditionallyInitialized
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_75C6D3A2_mixedType
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x28d2
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_75C6D3A2_mixedType::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x28da
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_75C6D3A2_mixedType::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x28dd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_75C6D3A2_mixedType::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x28e0
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_75C6D3A2_mixedType::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x28e8
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-		IL_0011: call object Modules.Variable_NumericVarLocalSpecialization/mixedType::__js_call__(object, bool)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_75C6D3A2_mixedType::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2900
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-		IL_000d: call object Modules.Variable_NumericVarLocalSpecialization/mixedType::__js_call__(object, bool)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_75C6D3A2_mixedType::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2914
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_75C6D3A2_mixedType::ConstructCore
-
-} // end of class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_75C6D3A2_mixedType
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_EAC4700D_captured
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Variable_NumericVarLocalSpecialization/Scope _environment0_Variable_NumericVarLocalSpecialization
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Variable_NumericVarLocalSpecialization/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2923
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Variable_NumericVarLocalSpecialization/Scope FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_EAC4700D_captured::_environment0_Variable_NumericVarLocalSpecialization
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_EAC4700D_captured::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2932
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_EAC4700D_captured::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2935
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_EAC4700D_captured::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2938
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_EAC4700D_captured::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2940
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Variable_NumericVarLocalSpecialization/Scope FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_EAC4700D_captured::_environment0_Variable_NumericVarLocalSpecialization
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Variable_NumericVarLocalSpecialization/captured::__js_call__(class Modules.Variable_NumericVarLocalSpecialization/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_EAC4700D_captured::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2952
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Variable_NumericVarLocalSpecialization/Scope FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_EAC4700D_captured::_environment0_Variable_NumericVarLocalSpecialization
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Variable_NumericVarLocalSpecialization/captured::__js_call__(class Modules.Variable_NumericVarLocalSpecialization/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_EAC4700D_captured::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2960
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_EAC4700D_captured::ConstructCore
-
-} // end of class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_EAC4700D_captured
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionExpression_FEB4A694_L42C12
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Variable_NumericVarLocalSpecialization/captured/Scope _environment1_captured
-	.field private initonly object[] _transitionalScopes
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Variable_NumericVarLocalSpecialization/captured/Scope capture0,
-			object[] capture1
-		) cil managed 
-	{
-		// Method begins at RVA 0x296f
-		// Header size: 1
-		// Code size: 21 (0x15)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Variable_NumericVarLocalSpecialization/captured/Scope FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionExpression_FEB4A694_L42C12::_environment1_captured
-		IL_000d: ldarg.0
-		IL_000e: ldarg.2
-		IL_000f: stfld object[] FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionExpression_FEB4A694_L42C12::_transitionalScopes
-		IL_0014: ret
-	} // end of method FunctionObject_FunctionExpression_FEB4A694_L42C12::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2985
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FEB4A694_L42C12::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2988
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionExpression_FEB4A694_L42C12::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x298b
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionExpression_FEB4A694_L42C12::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2993
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionExpression_FEB4A694_L42C12::_transitionalScopes
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11::__js_call__(object[], object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionExpression_FEB4A694_L42C12::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29a5
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld object[] FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionExpression_FEB4A694_L42C12::_transitionalScopes
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Variable_NumericVarLocalSpecialization/captured/FunctionExpression_L42C11::__js_call__(object[], object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionExpression_FEB4A694_L42C12::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29b3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionExpression_FEB4A694_L42C12::ConstructCore
-
-} // end of class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionExpression_FEB4A694_L42C12
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_3357054A_hoistedDependency
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x29c2
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_3357054A_hoistedDependency::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x29ca
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3357054A_hoistedDependency::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x29cd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3357054A_hoistedDependency::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x29d0
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_3357054A_hoistedDependency::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x29d8
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Variable_NumericVarLocalSpecialization/hoistedDependency::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_3357054A_hoistedDependency::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29e4
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Variable_NumericVarLocalSpecialization/hoistedDependency::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_3357054A_hoistedDependency::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x29ec
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3357054A_hoistedDependency::ConstructCore
-
-} // end of class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_3357054A_hoistedDependency
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Variable_NumericVarLocalSpecialization/Scope _environment0_Variable_NumericVarLocalSpecialization
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Variable_NumericVarLocalSpecialization/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x29fb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Variable_NumericVarLocalSpecialization/Scope FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::_environment0_Variable_NumericVarLocalSpecialization
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a0a
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a0d
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a10
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a18
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Variable_NumericVarLocalSpecialization/Scope FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::_environment0_Variable_NumericVarLocalSpecialization
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Variable_NumericVarLocalSpecialization/objectLiteralWrite::__js_call__(class Modules.Variable_NumericVarLocalSpecialization/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a2a
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Variable_NumericVarLocalSpecialization/Scope FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::_environment0_Variable_NumericVarLocalSpecialization
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Variable_NumericVarLocalSpecialization/objectLiteralWrite::__js_call__(class Modules.Variable_NumericVarLocalSpecialization/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a38
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite::ConstructCore
-
-} // end of class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_9080E29A_objectLiteralWrite
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2a47
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2a4f
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2a52
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a55
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a5d
-		// Header size: 1
-		// Code size: 23 (0x17)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: ldarg.2
-		IL_0006: ldc.i4.0
-		IL_0007: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_000c: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-		IL_0011: call object Modules.Variable_NumericVarLocalSpecialization/labeledBreak::__js_call__(object, bool)
-		IL_0016: ret
-	} // end of method FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a75
-		// Header size: 1
-		// Code size: 19 (0x13)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: ldarg.2
-		IL_0002: ldc.i4.0
-		IL_0003: call instance object [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments::GetArgument(int32)
-		IL_0008: call bool [JavaScriptRuntime]JavaScriptRuntime.TypeUtilities::ToBoolean(object)
-		IL_000d: call object Modules.Variable_NumericVarLocalSpecialization/labeledBreak::__js_call__(object, bool)
-		IL_0012: ret
-	} // end of method FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2a89
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak::ConstructCore
-
-} // end of class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_8D5FA591_labeledBreak
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_A3543986_optionalWrite
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2a98
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_A3543986_optionalWrite::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2aa0
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A3543986_optionalWrite::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2aa3
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_A3543986_optionalWrite::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2aa6
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_A3543986_optionalWrite::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2aae
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Variable_NumericVarLocalSpecialization/optionalWrite::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_A3543986_optionalWrite::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2aba
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Variable_NumericVarLocalSpecialization/optionalWrite::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_A3543986_optionalWrite::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ac2
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_A3543986_optionalWrite::ConstructCore
-
-} // end of class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_A3543986_optionalWrite
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_3B56324F_shadowedSource
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor () cil managed 
-	{
-		// Method begins at RVA 0x2ad1
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_3B56324F_shadowedSource::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2ad9
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3B56324F_shadowedSource::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2adc
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_3B56324F_shadowedSource::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object ResolveThisArgumentCore (
-			object thisArgument
-		) cil managed 
-	{
-		// Method begins at RVA 0x2adf
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.1
-		IL_0001: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ResolveOrdinaryThisArgument(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_3B56324F_shadowedSource::ResolveThisArgumentCore
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2ae7
-		// Header size: 1
-		// Code size: 11 (0xb)
-		.maxstack 8
-
-		IL_0000: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_0005: call object Modules.Variable_NumericVarLocalSpecialization/shadowedSource::__js_call__(object)
-		IL_000a: ret
-	} // end of method FunctionObject_FunctionDeclaration_3B56324F_shadowedSource::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2af3
-		// Header size: 1
-		// Code size: 7 (0x7)
-		.maxstack 8
-
-		IL_0000: ldarg.3
-		IL_0001: call object Modules.Variable_NumericVarLocalSpecialization/shadowedSource::__js_call__(object)
-		IL_0006: ret
-	} // end of method FunctionObject_FunctionDeclaration_3B56324F_shadowedSource::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2afb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_3B56324F_shadowedSource::ConstructCore
-
-} // end of class FunctionObjects.Variable_NumericVarLocalSpecialization_09DDDF1C.FunctionObject_FunctionDeclaration_3B56324F_shadowedSource
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ObjectDestructuring_Captured.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_ObjectDestructuring_Captured.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_85C461C3_compute
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Variable_ObjectDestructuring_Captured/Scope _environment0_Variable_ObjectDestructuring_Captured
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Variable_ObjectDestructuring_Captured/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21d3
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Variable_ObjectDestructuring_Captured/Scope Modules.Variable_ObjectDestructuring_Captured/compute/FunctionObject_FunctionDeclaration_85C461C3_compute::_environment0_Variable_ObjectDestructuring_Captured
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_85C461C3_compute::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21e2
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_85C461C3_compute::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21e5
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_85C461C3_compute::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21e8
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Variable_ObjectDestructuring_Captured/Scope Modules.Variable_ObjectDestructuring_Captured/compute/FunctionObject_FunctionDeclaration_85C461C3_compute::_environment0_Variable_ObjectDestructuring_Captured
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Variable_ObjectDestructuring_Captured/compute::__js_call__(class Modules.Variable_ObjectDestructuring_Captured/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_85C461C3_compute::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21fa
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Variable_ObjectDestructuring_Captured/Scope Modules.Variable_ObjectDestructuring_Captured/compute/FunctionObject_FunctionDeclaration_85C461C3_compute::_environment0_Variable_ObjectDestructuring_Captured
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Variable_ObjectDestructuring_Captured/compute::__js_call__(class Modules.Variable_ObjectDestructuring_Captured/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_85C461C3_compute::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2208
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_85C461C3_compute::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_85C461C3_compute
+
 
 		// Methods
 		.method public hidebysig static 
@@ -117,7 +224,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_ObjectDestructuring_Captured/Scope,
-			[1] class FunctionObjects.Variable_ObjectDestructuring_Captured_D85095BB.FunctionObject_FunctionDeclaration_85C461C3_compute,
+			[1] class Modules.Variable_ObjectDestructuring_Captured/compute/FunctionObject_FunctionDeclaration_85C461C3_compute,
 			[2] class [JavaScriptRuntime]JavaScriptRuntime.JsObject,
 			[3] object[],
 			[4] object,
@@ -137,13 +244,13 @@
 		IL_0012: ldc.i4.0
 		IL_0013: ldelem.ref
 		IL_0014: castclass Modules.Variable_ObjectDestructuring_Captured/Scope
-		IL_0019: newobj instance void FunctionObjects.Variable_ObjectDestructuring_Captured_D85095BB.FunctionObject_FunctionDeclaration_85C461C3_compute::.ctor(class Modules.Variable_ObjectDestructuring_Captured/Scope)
+		IL_0019: newobj instance void Modules.Variable_ObjectDestructuring_Captured/compute/FunctionObject_FunctionDeclaration_85C461C3_compute::.ctor(class Modules.Variable_ObjectDestructuring_Captured/Scope)
 		IL_001e: ldc.i4.0
 		IL_001f: conv.r8
 		IL_0020: ldstr "compute"
 		IL_0025: ldc.i4.0
 		IL_0026: ldc.i4.1
-		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_ObjectDestructuring_Captured_D85095BB.FunctionObject_FunctionDeclaration_85C461C3_compute>(!!0, float64, string, bool, bool)
+		IL_0027: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_ObjectDestructuring_Captured/compute/FunctionObject_FunctionDeclaration_85C461C3_compute>(!!0, float64, string, bool, bool)
 		IL_002c: stloc.1
 		IL_002d: nop
 		IL_002e: call class [JavaScriptRuntime]JavaScriptRuntime.JsObject [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::CreateObjectLiteral()
@@ -227,113 +334,6 @@
 	} // end of method Variable_ObjectDestructuring_Captured::__js_module_init__
 
 } // end of class Modules.Variable_ObjectDestructuring_Captured
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_ObjectDestructuring_Captured_D85095BB.FunctionObject_FunctionDeclaration_85C461C3_compute
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Variable_ObjectDestructuring_Captured/Scope _environment0_Variable_ObjectDestructuring_Captured
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Variable_ObjectDestructuring_Captured/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21d3
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Variable_ObjectDestructuring_Captured/Scope FunctionObjects.Variable_ObjectDestructuring_Captured_D85095BB.FunctionObject_FunctionDeclaration_85C461C3_compute::_environment0_Variable_ObjectDestructuring_Captured
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_85C461C3_compute::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21e2
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_85C461C3_compute::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21e5
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_85C461C3_compute::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21e8
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Variable_ObjectDestructuring_Captured/Scope FunctionObjects.Variable_ObjectDestructuring_Captured_D85095BB.FunctionObject_FunctionDeclaration_85C461C3_compute::_environment0_Variable_ObjectDestructuring_Captured
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Variable_ObjectDestructuring_Captured/compute::__js_call__(class Modules.Variable_ObjectDestructuring_Captured/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_85C461C3_compute::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21fa
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Variable_ObjectDestructuring_Captured/Scope FunctionObjects.Variable_ObjectDestructuring_Captured_D85095BB.FunctionObject_FunctionDeclaration_85C461C3_compute::_environment0_Variable_ObjectDestructuring_Captured
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Variable_ObjectDestructuring_Captured/compute::__js_call__(class Modules.Variable_ObjectDestructuring_Captured/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_85C461C3_compute::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2208
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_85C461C3_compute::ConstructCore
-
-} // end of class FunctionObjects.Variable_ObjectDestructuring_Captured_D85095BB.FunctionObject_FunctionDeclaration_85C461C3_compute
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_TemporalDeadZoneCapturedRead.verified.txt
+++ b/tests/Jroc.Tests/Variable/Snapshots/GeneratorTests.Variable_TemporalDeadZoneCapturedRead.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_586E5692_readValue
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.Variable_TemporalDeadZoneCapturedRead/Scope _environment0_Variable_TemporalDeadZoneCapturedRead
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.Variable_TemporalDeadZoneCapturedRead/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x21cb
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.Variable_TemporalDeadZoneCapturedRead/Scope Modules.Variable_TemporalDeadZoneCapturedRead/readValue/FunctionObject_FunctionDeclaration_586E5692_readValue::_environment0_Variable_TemporalDeadZoneCapturedRead
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_586E5692_readValue::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x21da
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_586E5692_readValue::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x21dd
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_586E5692_readValue::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x21e0
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Variable_TemporalDeadZoneCapturedRead/Scope Modules.Variable_TemporalDeadZoneCapturedRead/readValue/FunctionObject_FunctionDeclaration_586E5692_readValue::_environment0_Variable_TemporalDeadZoneCapturedRead
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.Variable_TemporalDeadZoneCapturedRead/readValue::__js_call__(class Modules.Variable_TemporalDeadZoneCapturedRead/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_586E5692_readValue::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x21f2
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.Variable_TemporalDeadZoneCapturedRead/Scope Modules.Variable_TemporalDeadZoneCapturedRead/readValue/FunctionObject_FunctionDeclaration_586E5692_readValue::_environment0_Variable_TemporalDeadZoneCapturedRead
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.Variable_TemporalDeadZoneCapturedRead/readValue::__js_call__(class Modules.Variable_TemporalDeadZoneCapturedRead/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_586E5692_readValue::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2200
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_586E5692_readValue::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_586E5692_readValue
+
 
 		// Methods
 		.method public hidebysig static 
@@ -164,7 +271,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.Variable_TemporalDeadZoneCapturedRead/Scope,
-			[1] class FunctionObjects.Variable_TemporalDeadZoneCapturedRead_860F532E.FunctionObject_FunctionDeclaration_586E5692_readValue,
+			[1] class Modules.Variable_TemporalDeadZoneCapturedRead/readValue/FunctionObject_FunctionDeclaration_586E5692_readValue,
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
@@ -187,13 +294,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.Variable_TemporalDeadZoneCapturedRead/Scope
-		IL_001b: newobj instance void FunctionObjects.Variable_TemporalDeadZoneCapturedRead_860F532E.FunctionObject_FunctionDeclaration_586E5692_readValue::.ctor(class Modules.Variable_TemporalDeadZoneCapturedRead/Scope)
+		IL_001b: newobj instance void Modules.Variable_TemporalDeadZoneCapturedRead/readValue/FunctionObject_FunctionDeclaration_586E5692_readValue::.ctor(class Modules.Variable_TemporalDeadZoneCapturedRead/Scope)
 		IL_0020: ldc.i4.0
 		IL_0021: conv.r8
 		IL_0022: ldstr "readValue"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.Variable_TemporalDeadZoneCapturedRead_860F532E.FunctionObject_FunctionDeclaration_586E5692_readValue>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.Variable_TemporalDeadZoneCapturedRead/readValue/FunctionObject_FunctionDeclaration_586E5692_readValue>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: nop
 		IL_0030: nop
@@ -271,113 +378,6 @@
 	} // end of method Variable_TemporalDeadZoneCapturedRead::__js_module_init__
 
 } // end of class Modules.Variable_TemporalDeadZoneCapturedRead
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.Variable_TemporalDeadZoneCapturedRead_860F532E.FunctionObject_FunctionDeclaration_586E5692_readValue
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.Variable_TemporalDeadZoneCapturedRead/Scope _environment0_Variable_TemporalDeadZoneCapturedRead
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.Variable_TemporalDeadZoneCapturedRead/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x21cb
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.Variable_TemporalDeadZoneCapturedRead/Scope FunctionObjects.Variable_TemporalDeadZoneCapturedRead_860F532E.FunctionObject_FunctionDeclaration_586E5692_readValue::_environment0_Variable_TemporalDeadZoneCapturedRead
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_586E5692_readValue::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x21da
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_586E5692_readValue::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x21dd
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_586E5692_readValue::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x21e0
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Variable_TemporalDeadZoneCapturedRead/Scope FunctionObjects.Variable_TemporalDeadZoneCapturedRead_860F532E.FunctionObject_FunctionDeclaration_586E5692_readValue::_environment0_Variable_TemporalDeadZoneCapturedRead
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.Variable_TemporalDeadZoneCapturedRead/readValue::__js_call__(class Modules.Variable_TemporalDeadZoneCapturedRead/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_586E5692_readValue::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x21f2
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.Variable_TemporalDeadZoneCapturedRead/Scope FunctionObjects.Variable_TemporalDeadZoneCapturedRead_860F532E.FunctionObject_FunctionDeclaration_586E5692_readValue::_environment0_Variable_TemporalDeadZoneCapturedRead
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.Variable_TemporalDeadZoneCapturedRead/readValue::__js_call__(class Modules.Variable_TemporalDeadZoneCapturedRead/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_586E5692_readValue::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2200
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_586E5692_readValue::ConstructCore
-
-} // end of class FunctionObjects.Variable_TemporalDeadZoneCapturedRead_860F532E.FunctionObject_FunctionDeclaration_586E5692_readValue
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object

--- a/tests/Jroc.Tests/WeakRef/Snapshots/GeneratorTests.WeakRef_Deref_KeptObjects.verified.txt
+++ b/tests/Jroc.Tests/WeakRef/Snapshots/GeneratorTests.WeakRef_Deref_KeptObjects.verified.txt
@@ -31,6 +31,113 @@
 
 		} // end of class Scope
 
+		.class nested public auto ansi sealed beforefieldinit FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef
+			extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
+		{
+			// Fields
+			.field private initonly class Modules.WeakRef_Deref_KeptObjects/Scope _environment0_WeakRef_Deref_KeptObjects
+
+			// Methods
+			.method public hidebysig specialname rtspecialname 
+				instance void .ctor (
+					class Modules.WeakRef_Deref_KeptObjects/Scope capture0
+				) cil managed 
+			{
+				// Method begins at RVA 0x2344
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
+				IL_0006: ldarg.0
+				IL_0007: ldarg.1
+				IL_0008: stfld class Modules.WeakRef_Deref_KeptObjects/Scope Modules.WeakRef_Deref_KeptObjects/createWeakRef/FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::_environment0_WeakRef_Deref_KeptObjects
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::.ctor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_IsConstructor () cil managed 
+			{
+				// Method begins at RVA 0x2353
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.1
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::get_IsConstructor
+
+			.method public hidebysig specialname virtual 
+				instance bool get_RequiresInvocationContext () cil managed 
+			{
+				// Method begins at RVA 0x2356
+				// Header size: 1
+				// Code size: 2 (0x2)
+				.maxstack 8
+
+				IL_0000: ldc.i4.0
+				IL_0001: ret
+			} // end of method FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::get_RequiresInvocationContext
+
+			.method family hidebysig virtual 
+				instance object CallCore (
+					object thisArgument,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
+				) cil managed 
+			{
+				// Method begins at RVA 0x2359
+				// Header size: 1
+				// Code size: 17 (0x11)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.WeakRef_Deref_KeptObjects/Scope Modules.WeakRef_Deref_KeptObjects/createWeakRef/FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::_environment0_WeakRef_Deref_KeptObjects
+				IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
+				IL_000b: call object Modules.WeakRef_Deref_KeptObjects/createWeakRef::__js_call__(class Modules.WeakRef_Deref_KeptObjects/Scope, object)
+				IL_0010: ret
+			} // end of method FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::CallCore
+
+			.method family hidebysig virtual 
+				instance object ConstructBodyCore (
+					object receiver,
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x236b
+				// Header size: 1
+				// Code size: 13 (0xd)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldfld class Modules.WeakRef_Deref_KeptObjects/Scope Modules.WeakRef_Deref_KeptObjects/createWeakRef/FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::_environment0_WeakRef_Deref_KeptObjects
+				IL_0006: ldarg.3
+				IL_0007: call object Modules.WeakRef_Deref_KeptObjects/createWeakRef::__js_call__(class Modules.WeakRef_Deref_KeptObjects/Scope, object)
+				IL_000c: ret
+			} // end of method FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::ConstructBodyCore
+
+			.method family hidebysig virtual 
+				instance object ConstructCore (
+					[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
+					object newTarget
+				) cil managed 
+			{
+				// Method begins at RVA 0x2379
+				// Header size: 1
+				// Code size: 14 (0xe)
+				.maxstack 8
+
+				IL_0000: ldarg.0
+				IL_0001: ldarg.1
+				IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
+				IL_0007: ldarg.2
+				IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
+				IL_000d: ret
+			} // end of method FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::ConstructCore
+
+		} // end of class FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef
+
 
 		// Methods
 		.method public hidebysig static 
@@ -343,7 +450,7 @@
 		.maxstack 8
 		.locals init (
 			[0] class Modules.WeakRef_Deref_KeptObjects/Scope,
-			[1] class FunctionObjects.WeakRef_Deref_KeptObjects_F1393EDE.FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef,
+			[1] class Modules.WeakRef_Deref_KeptObjects/createWeakRef/FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef,
 			[2] class [System.Runtime]System.Exception,
 			[3] object,
 			[4] object,
@@ -368,13 +475,13 @@
 		IL_0014: ldc.i4.0
 		IL_0015: ldelem.ref
 		IL_0016: castclass Modules.WeakRef_Deref_KeptObjects/Scope
-		IL_001b: newobj instance void FunctionObjects.WeakRef_Deref_KeptObjects_F1393EDE.FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::.ctor(class Modules.WeakRef_Deref_KeptObjects/Scope)
+		IL_001b: newobj instance void Modules.WeakRef_Deref_KeptObjects/createWeakRef/FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::.ctor(class Modules.WeakRef_Deref_KeptObjects/Scope)
 		IL_0020: ldc.i4.0
 		IL_0021: conv.r8
 		IL_0022: ldstr "createWeakRef"
 		IL_0027: ldc.i4.0
 		IL_0028: ldc.i4.1
-		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class FunctionObjects.WeakRef_Deref_KeptObjects_F1393EDE.FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef>(!!0, float64, string, bool, bool)
+		IL_0029: call !!0 [JavaScriptRuntime]JavaScriptRuntime.Function::InitializeFunctionInstance<class Modules.WeakRef_Deref_KeptObjects/createWeakRef/FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef>(!!0, float64, string, bool, bool)
 		IL_002e: stloc.1
 		IL_002f: nop
 		IL_0030: nop
@@ -514,113 +621,6 @@
 	} // end of method WeakRef_Deref_KeptObjects::__js_module_init__
 
 } // end of class Modules.WeakRef_Deref_KeptObjects
-
-.class private auto ansi sealed beforefieldinit FunctionObjects.WeakRef_Deref_KeptObjects_F1393EDE.FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef
-	extends [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject
-{
-	// Fields
-	.field private initonly class Modules.WeakRef_Deref_KeptObjects/Scope _environment0_WeakRef_Deref_KeptObjects
-
-	// Methods
-	.method public hidebysig specialname rtspecialname 
-		instance void .ctor (
-			class Modules.WeakRef_Deref_KeptObjects/Scope capture0
-		) cil managed 
-	{
-		// Method begins at RVA 0x2344
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: call instance void [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject::.ctor()
-		IL_0006: ldarg.0
-		IL_0007: ldarg.1
-		IL_0008: stfld class Modules.WeakRef_Deref_KeptObjects/Scope FunctionObjects.WeakRef_Deref_KeptObjects_F1393EDE.FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::_environment0_WeakRef_Deref_KeptObjects
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::.ctor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_IsConstructor () cil managed 
-	{
-		// Method begins at RVA 0x2353
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.1
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::get_IsConstructor
-
-	.method public hidebysig specialname virtual 
-		instance bool get_RequiresInvocationContext () cil managed 
-	{
-		// Method begins at RVA 0x2356
-		// Header size: 1
-		// Code size: 2 (0x2)
-		.maxstack 8
-
-		IL_0000: ldc.i4.0
-		IL_0001: ret
-	} // end of method FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::get_RequiresInvocationContext
-
-	.method family hidebysig virtual 
-		instance object CallCore (
-			object thisArgument,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments
-		) cil managed 
-	{
-		// Method begins at RVA 0x2359
-		// Header size: 1
-		// Code size: 17 (0x11)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.WeakRef_Deref_KeptObjects/Scope FunctionObjects.WeakRef_Deref_KeptObjects_F1393EDE.FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::_environment0_WeakRef_Deref_KeptObjects
-		IL_0006: call object [JavaScriptRuntime]JavaScriptRuntime.RuntimeServices::GetCurrentNewTarget()
-		IL_000b: call object Modules.WeakRef_Deref_KeptObjects/createWeakRef::__js_call__(class Modules.WeakRef_Deref_KeptObjects/Scope, object)
-		IL_0010: ret
-	} // end of method FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::CallCore
-
-	.method family hidebysig virtual 
-		instance object ConstructBodyCore (
-			object receiver,
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x236b
-		// Header size: 1
-		// Code size: 13 (0xd)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldfld class Modules.WeakRef_Deref_KeptObjects/Scope FunctionObjects.WeakRef_Deref_KeptObjects_F1393EDE.FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::_environment0_WeakRef_Deref_KeptObjects
-		IL_0006: ldarg.3
-		IL_0007: call object Modules.WeakRef_Deref_KeptObjects/createWeakRef::__js_call__(class Modules.WeakRef_Deref_KeptObjects/Scope, object)
-		IL_000c: ret
-	} // end of method FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::ConstructBodyCore
-
-	.method family hidebysig virtual 
-		instance object ConstructCore (
-			[in] valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments& modreq([System.Runtime]System.Runtime.InteropServices.InAttribute) arguments,
-			object newTarget
-		) cil managed 
-	{
-		// Method begins at RVA 0x2379
-		// Header size: 1
-		// Code size: 14 (0xe)
-		.maxstack 8
-
-		IL_0000: ldarg.0
-		IL_0001: ldarg.1
-		IL_0002: ldobj [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments
-		IL_0007: ldarg.2
-		IL_0008: call object [JavaScriptRuntime]JavaScriptRuntime.Function::ConstructGeneratedFunctionObject(class [JavaScriptRuntime]JavaScriptRuntime.JsFunctionObject, valuetype [JavaScriptRuntime]JavaScriptRuntime.JsCallArguments, object)
-		IL_000d: ret
-	} // end of method FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef::ConstructCore
-
-} // end of class FunctionObjects.WeakRef_Deref_KeptObjects_F1393EDE.FunctionObject_FunctionDeclaration_7A1B9D8E_createWeakRef
 
 .class private auto ansi beforefieldinit Program
 	extends [System.Runtime]System.Object


### PR DESCRIPTION
## Summary

- nest every generated function-object wrapper below its canonical callable or class owner
- eliminate the detached `FunctionObjects.*` namespace for ordinary functions and class methods
- assert the nested metadata shape for declarations, nested functions, arrows, and class methods

Closes #1734